### PR TITLE
feat(cbmem): add private codebase memory package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6071,8 +6071,16 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.5.10",
+				"@earendil-works/pi-ai": "0.84.3",
+				"@earendil-works/pi-coding-agent": "0.84.3",
 				"@types/node": "26.2.0",
+				"typebox": "1.3.18",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-ai": "*",
+				"@earendil-works/pi-coding-agent": "*",
+				"typebox": "*"
 			}
 		},
 		"packages/pi-chat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6069,10 +6069,14 @@
 			"name": "@narumitw/pi-cbmem",
 			"version": "0.0.0",
 			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.59.0"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.10",
 				"@earendil-works/pi-ai": "0.84.3",
 				"@earendil-works/pi-coding-agent": "0.84.3",
+				"@earendil-works/pi-tui": "0.84.3",
 				"@types/node": "26.2.0",
 				"typebox": "1.3.18",
 				"typescript": "7.0.2"
@@ -6080,6 +6084,7 @@
 			"peerDependencies": {
 				"@earendil-works/pi-ai": "*",
 				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*",
 				"typebox": "*"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,6 +1880,10 @@
 			"resolved": "packages/pi-caffeinate",
 			"link": true
 		},
+		"node_modules/@narumitw/pi-cbmem": {
+			"resolved": "packages/pi-cbmem",
+			"link": true
+		},
 		"node_modules/@narumitw/pi-chat": {
 			"resolved": "packages/pi-chat",
 			"link": true
@@ -6059,6 +6063,16 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"packages/pi-cbmem": {
+			"name": "@narumitw/pi-cbmem",
+			"version": "0.0.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.5.10",
+				"@types/node": "26.2.0",
+				"typescript": "7.0.2"
 			}
 		},
 		"packages/pi-chat": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
 			"./packages/pi-tool/src/index.ts",
 			"./packages/pi-usage/src/index.ts",
 			"./packages/pi-worktree/src/index.ts"
+		],
+		"skills": [
+			"./packages/pi-cbmem/skills"
 		]
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 			"./packages/pi-accounts/src/index.ts",
 			"./packages/pi-btw/src/index.ts",
 			"./packages/pi-caffeinate/src/index.ts",
+			"./packages/pi-cbmem/src/index.ts",
 			"./packages/pi-chrome-devtools/src/index.ts",
 			"./packages/pi-codex-compact/src/index.ts",
 			"./packages/pi-file-context/src/index.ts",

--- a/packages/pi-cbmem/LICENSE
+++ b/packages/pi-cbmem/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -1,0 +1,106 @@
+# 🧠 pi-cbmem — Codebase Memory Tools for Pi
+
+[![npm: private](https://img.shields.io/badge/npm-private-lightgrey)](#-install) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+pi-cbmem is a private package that bundles the local Codebase Memory extension and its knowledge-graph operating skill.
+
+## ✨ Features
+
+- Registers all 15 Codebase Memory graph, search, indexing, coverage, trace, and architecture tools.
+- Invokes the local `codebase-memory-mcp` CLI with cancellation support.
+- Bundles the `codebase-memory` skill for evidence-tier and graph-first workflows.
+- Keeps the extension and skill available through one package declaration.
+
+## 📦 Install
+
+This package is private and is not published to npm.
+
+Install it from this repository checkout:
+
+```bash
+pi install ./packages/pi-cbmem
+```
+
+Try it without adding a persistent package setting:
+
+```bash
+pi --no-extensions -e ./packages/pi-cbmem
+```
+
+The package uses its source entrypoint and does not require a build before local loading.
+
+Pi extensions run with your user permissions.
+
+Review the source before loading the package.
+
+## 🚀 Quick start
+
+Install `codebase-memory-mcp` at `~/.local/bin/codebase-memory-mcp`, load the package, and ask Pi a structural codebase question.
+
+The bundled skill tells Pi to check the active graph project before exploration and to verify material claims with graph snippets and index-coverage evidence.
+
+## 🛠️ Tools
+
+The extension registers these tools:
+
+- `index_repository`
+- `search_graph`
+- `query_graph`
+- `trace_path`
+- `get_code_snippet`
+- `get_graph_schema`
+- `get_architecture`
+- `search_code`
+- `list_projects`
+- `delete_project`
+- `index_status`
+- `check_index_coverage`
+- `detect_changes`
+- `manage_adr`
+- `ingest_traces`
+
+Each tool delegates to `codebase-memory-mcp cli <tool> <json-args>` and returns the last JSON line written to standard output.
+
+## 🔒 Security and privacy
+
+The Codebase Memory binary runs with the Pi process environment and user permissions.
+
+Tool calls can read and index repositories, inspect source, persist graph data, manage architecture decisions and traces, or delete indexed projects.
+
+Repository content returned by graph tools can be sent to the selected model provider as tool output.
+
+The extension starts one local CLI child process per tool call and does not start background work during extension factory load.
+
+## 🚧 Limitations
+
+The package expects the binary at `~/.local/bin/codebase-memory-mcp` for the current user.
+
+It does not install or update the Codebase Memory binary.
+
+The extension preserves the installer-generated `name` and `run` tool bridge expected by the current Pi environment.
+
+## 🗂️ Package layout
+
+```text
+packages/pi-cbmem/
+├── src/
+│   ├── index.ts                    # Thin Pi entrypoint
+│   └── cbmem.ts                    # Codebase Memory CLI tool bridge
+├── skills/codebase-memory/
+│   └── SKILL.md                    # Graph-first operating guidance
+├── test/
+│   └── cbmem.test.ts               # Tool registration coverage
+├── package.json                    # Private Pi extension and skill declarations
+├── tsconfig.json
+├── README.md
+└── LICENSE
+```
+
+## 🔎 Keywords
+
+Pi, Codebase Memory, code knowledge graph, MCP, call graph, architecture, impact analysis, source indexing.
+
+## 📄 License
+
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -73,7 +73,11 @@ The Codebase Memory binary runs with the Pi process environment and user permiss
 
 Tool calls can read and index repositories, inspect source, persist graph data, manage architecture decisions and traces, or delete indexed projects.
 
+Deleting a project or replacing its Architecture Decision Records requires explicit confirmation in TUI or RPC mode and is rejected in non-interactive modes.
+
 Repository content returned by graph tools can be sent to the selected model provider as tool output.
+
+Terminal controls are removed only from the TUI rendering boundary; the validated raw result remains available to the model.
 
 The extension starts one local CLI child process per tool call in the active session directory and does not start background work during extension factory load.
 
@@ -94,6 +98,7 @@ packages/pi-cbmem/
 ├── src/
 │   ├── index.ts                    # Thin Pi entrypoint
 │   ├── cbmem.ts                    # Bounded Codebase Memory CLI runner
+│   ├── render-result.ts            # Terminal-safe result rendering
 │   └── tool-definitions.ts         # Pi tool metadata and TypeBox schemas
 ├── skills/codebase-memory/
 │   └── SKILL.md                    # Graph-first operating guidance

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -7,7 +7,7 @@ pi-cbmem is a private package that bundles the local Codebase Memory extension a
 ## ✨ Features
 
 - Registers all 15 Codebase Memory graph, search, indexing, coverage, trace, and architecture tools.
-- Invokes the local `codebase-memory-mcp` CLI with cancellation support.
+- Invokes the local `codebase-memory-mcp` CLI with cancellation, failure reporting, and bounded output.
 - Bundles the `codebase-memory` skill for evidence-tier and graph-first workflows.
 - Keeps the extension and skill available through one package declaration.
 
@@ -59,7 +59,13 @@ The extension registers these tools:
 - `manage_adr`
 - `ingest_traces`
 
-Each tool delegates to `codebase-memory-mcp cli <tool> <json-args>` and returns the last JSON line written to standard output.
+Each tool sends JSON arguments to `codebase-memory-mcp cli <tool>` over standard input and returns the last JSON response written to standard output.
+
+Tool output is capped at Pi's 50 KB or 2,000-line limit, whichever is reached first.
+
+The result states when additional CLI output was omitted.
+
+Spawn failures, nonzero exits, and missing JSON responses are reported as failed tool calls.
 
 ## 🔒 Security and privacy
 
@@ -69,7 +75,9 @@ Tool calls can read and index repositories, inspect source, persist graph data, 
 
 Repository content returned by graph tools can be sent to the selected model provider as tool output.
 
-The extension starts one local CLI child process per tool call and does not start background work during extension factory load.
+The extension starts one local CLI child process per tool call in the active session directory and does not start background work during extension factory load.
+
+Cancelling a tool call terminates its child process.
 
 ## 🚧 Limitations
 
@@ -77,7 +85,7 @@ The package expects the binary at `~/.local/bin/codebase-memory-mcp` for the cur
 
 It does not install or update the Codebase Memory binary.
 
-The extension preserves the installer-generated `name` and `run` tool bridge expected by the current Pi environment.
+The extension exposes static tool schemas that match the bundled Codebase Memory skill and delegates final argument validation to the installed CLI.
 
 ## 🗂️ Package layout
 
@@ -85,7 +93,8 @@ The extension preserves the installer-generated `name` and `run` tool bridge exp
 packages/pi-cbmem/
 ├── src/
 │   ├── index.ts                    # Thin Pi entrypoint
-│   └── cbmem.ts                    # Codebase Memory CLI tool bridge
+│   ├── cbmem.ts                    # Bounded Codebase Memory CLI runner
+│   └── tool-definitions.ts         # Pi tool metadata and TypeBox schemas
 ├── skills/codebase-memory/
 │   └── SKILL.md                    # Graph-first operating guidance
 ├── test/

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -61,11 +61,11 @@ The extension registers these tools:
 
 Each tool sends JSON arguments to `codebase-memory-mcp cli <tool>` over standard input and returns the last JSON response written to standard output.
 
-Tool output is capped at Pi's 50 KB or 2,000-line limit, whichever is reached first.
+Validated JSON output over 2,000 lines is truncated with an explicit omission notice.
 
-The result states when additional CLI output was omitted.
+Standard output over 50 KB fails safely because the complete JSON response cannot be validated within the bounded capture.
 
-Spawn failures, nonzero exits, and missing JSON responses are reported as failed tool calls.
+Spawn failures, nonzero exits, oversized output, and missing JSON responses are reported as failed tool calls.
 
 ## 🔒 Security and privacy
 

--- a/packages/pi-cbmem/package.json
+++ b/packages/pi-cbmem/package.json
@@ -35,9 +35,17 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"typebox": "*"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.10",
+		"@earendil-works/pi-ai": "0.84.3",
+		"@earendil-works/pi-coding-agent": "0.84.3",
 		"@types/node": "26.2.0",
+		"typebox": "1.3.18",
 		"typescript": "7.0.2"
 	},
 	"repository": {

--- a/packages/pi-cbmem/package.json
+++ b/packages/pi-cbmem/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "@narumitw/pi-cbmem",
+	"version": "0.0.0",
+	"description": "Private Pi package for Codebase Memory knowledge graph tools and guidance.",
+	"type": "module",
+	"license": "MIT",
+	"private": true,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"codebase-memory",
+		"knowledge-graph",
+		"mcp"
+	],
+	"files": [
+		"src",
+		"skills",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		],
+		"skills": [
+			"./skills"
+		]
+	},
+	"piExtension": {
+		"lifecycle": "stable"
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.10",
+		"@types/node": "26.2.0",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "packages/pi-cbmem"
+	}
+}

--- a/packages/pi-cbmem/package.json
+++ b/packages/pi-cbmem/package.json
@@ -38,15 +38,20 @@
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*",
 		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.10",
 		"@earendil-works/pi-ai": "0.84.3",
 		"@earendil-works/pi-coding-agent": "0.84.3",
+		"@earendil-works/pi-tui": "0.84.3",
 		"@types/node": "26.2.0",
 		"typebox": "1.3.18",
 		"typescript": "7.0.2"
+	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.59.0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/pi-cbmem/skills/codebase-memory/SKILL.md
+++ b/packages/pi-cbmem/skills/codebase-memory/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: codebase-memory
+description: "Use the codebase knowledge graph for structural code queries. Triggers on: explore the codebase, understand the architecture, what functions exist, show me the structure, who calls this function, what does X call, trace the call chain, find callers of, show dependencies, impact analysis, dead code, unused functions, high fan-out, refactor candidates, code quality audit, graph query syntax, Cypher query examples, edge types, how to use search_graph."
+---
+
+# Codebase Memory — Knowledge Graph Tools
+
+Graph tools return precise structural results in ~500 tokens vs ~80K for grep.
+
+Always prefer MCP graph tools over grep, glob, or file search for code discovery.
+
+## Priority Order
+
+1. `search_graph` — find functions, classes, routes, and variables by pattern.
+2. `trace_path` — trace who calls a function or what it calls.
+3. `get_code_snippet` — read specific function or class source code.
+4. `check_index_coverage` — validate candidate paths and missed ranges before claims.
+5. `query_graph` — run Cypher queries for complex patterns.
+6. `get_architecture` — get a high-level project summary.
+
+## Quick Decision Matrix
+
+| Question | Tool call |
+|----------|----------|
+| Who calls X? | `trace_path(direction="inbound")` |
+| What does X call? | `trace_path(direction="outbound")` |
+| Full call context | `trace_path(direction="both")` |
+| Find by name pattern | `search_graph(name_pattern="...")` |
+| Dead code | `search_graph(max_degree=0, exclude_entry_points=true)` |
+| Cross-service edges | `query_graph` with Cypher |
+| Impact of local changes | `detect_changes()` |
+| Risk-classified trace | `trace_path(risk_labels=true)` |
+| Text search | `search_code` or Grep |
+
+## Exploration Workflow
+
+1. `list_projects` — check whether the project is indexed.
+2. `get_graph_schema` — understand node and edge types.
+3. `search_graph(label="Function", name_pattern=".*Pattern.*")` — find code.
+4. `get_code_snippet(qualified_name="project.path.FuncName")` — read source.
+5. `check_index_coverage(paths=["path/to/file"])` — validate every evidence path.
+
+## Tracing Workflow
+
+1. `search_graph(name_pattern=".*FuncName.*")` — discover the exact name.
+2. `trace_path(function_name="FuncName", direction="both", depth=3)` — trace relationships.
+3. `get_code_snippet(qualified_name="project.path.FuncName")` — verify material source claims.
+4. `check_index_coverage(paths=["path/to/file"])` — validate every evidence path.
+5. `detect_changes()` — map the Git diff to affected symbols.
+
+## When to Fall Back to Grep/Glob
+
+- Search for string literals, error messages, or configuration values.
+- Search non-code files such as Dockerfiles, shell scripts, or configuration files.
+- Fall back when MCP tools return insufficient results.
+
+## Examples
+
+- Find a handler: `search_graph(name_pattern=".*OrderHandler.*")`.
+- Find who calls it: `trace_path(function_name="OrderHandler", direction="inbound")`.
+- Read its source: `get_code_snippet(qualified_name="pkg/orders.OrderHandler")`.
+
+## Evidence Tiers
+
+- **Scout (Tier 1):** quick positive lookup with few calls and targeted source checks.
+  Mark it provisional, and do not make negative or exhaustive claims.
+- **Verify (Tier 2, default):** task-directed graph evidence, relevant trace directions, exact snippets for material claims, and relevant pagination.
+- **Auditor (Tier 3):** bounded-scope full verification with a current generation, complete relevant pagination, both call directions and broader relationships when material, and every limitation disclosed.
+- After candidate paths are known in any tier, call `check_index_coverage` once with every evidence path.
+  Add relevant scopes for negative or exhaustive claims.
+  A clean result means no recorded gap, not proof of completeness.
+  For partial, skipped, excluded, stale, pending, or unknown coverage, read or grep the reported ranges or scope before relying on graph results.
+
+## Session Resets and Subagents
+
+- At session start or after compaction, confirm the nearest graph project and generation with `list_projects` or `index_status`, then choose Scout, Verify, or Auditor.
+- Before spawning a subagent, query the graph and coverage in the parent.
+  Pass the tier, project, generation or freshness, bounded scope, queries and pagination state, qualified symbols, paths, call-chain findings, coverage evidence with ranges and reasons, source fallback already performed, and unresolved questions in the delegated task context.
+- Do not assume subagents inherit MCP access or the parent conversation.
+  If a child lacks MCP tools, it must not call or claim MCP access.
+  It should use the supplied evidence and read or grep exact source, especially every reported missed-coverage range.
+
+## Quality Analysis
+- Dead code: `search_graph(max_degree=0, exclude_entry_points=true)`
+- High fan-out: `search_graph(min_degree=10, relationship="CALLS", direction="outbound")`
+- High fan-in: `search_graph(min_degree=10, relationship="CALLS", direction="inbound")`
+
+## 15 MCP Tools
+`index_repository`, `index_status`, `list_projects`, `delete_project`,
+`search_graph`, `search_code`, `trace_path`, `detect_changes`,
+`query_graph`, `get_graph_schema`, `get_code_snippet`, `get_architecture`,
+`check_index_coverage`, `manage_adr`, `ingest_traces`
+
+## Edge Types
+CALLS, HTTP_CALLS, ASYNC_CALLS, DATA_FLOWS, IMPORTS, DEFINES, DEFINES_METHOD,
+HANDLES, IMPLEMENTS, OVERRIDE, USAGE, CALL_REFERENCE, CONFIGURES, FILE_CHANGES_WITH,
+SIMILAR_TO, SEMANTICALLY_RELATED, CONTAINS_FILE, CONTAINS_FOLDER,
+CONTAINS_PACKAGE
+
+## Cypher Examples (for query_graph)
+```
+MATCH (a)-[r:HTTP_CALLS]->(b) RETURN a.name, b.name, r.url_path, r.confidence LIMIT 20
+MATCH (f:Function) WHERE f.name =~ '.*Handler.*' RETURN f.name, f.file_path
+MATCH (a)-[r:CALLS]->(b) WHERE a.name = 'main' RETURN b.name
+```
+
+## Gotchas
+1. `search_graph(relationship="HTTP_CALLS")` filters nodes by degree — use `query_graph` with Cypher to see actual edges.
+2. `query_graph` has a 100k row ceiling — add a Cypher `LIMIT` for broad queries or use `search_graph` pagination.
+3. `trace_path` needs exact names — use `search_graph(name_pattern=...)` first.
+4. `direction="outbound"` misses cross-service callers — use `direction="both"`.
+5. `search_graph` results default to 50 per page — check `has_more` and use `offset`.

--- a/packages/pi-cbmem/skills/codebase-memory/SKILL.md
+++ b/packages/pi-cbmem/skills/codebase-memory/SKILL.md
@@ -20,33 +20,35 @@ Always prefer MCP graph tools over grep, glob, or file search for code discovery
 
 ## Quick Decision Matrix
 
+Use the exact `project="<name>"` returned by `list_projects` in every project-scoped call.
+
 | Question | Tool call |
 |----------|----------|
-| Who calls X? | `trace_path(direction="inbound")` |
-| What does X call? | `trace_path(direction="outbound")` |
-| Full call context | `trace_path(direction="both")` |
-| Find by name pattern | `search_graph(name_pattern="...")` |
-| Dead code | `search_graph(max_degree=0, exclude_entry_points=true)` |
-| Cross-service edges | `query_graph` with Cypher |
-| Impact of local changes | `detect_changes()` |
-| Risk-classified trace | `trace_path(risk_labels=true)` |
-| Text search | `search_code` or Grep |
+| Who calls X? | `trace_path(project="<name>", direction="inbound")` |
+| What does X call? | `trace_path(project="<name>", direction="outbound")` |
+| Full call context | `trace_path(project="<name>", direction="both")` |
+| Find by name pattern | `search_graph(project="<name>", name_pattern="...")` |
+| Dead code | `search_graph(project="<name>", max_degree=0, exclude_entry_points=true)` |
+| Cross-service edges | `query_graph(project="<name>", query="<cypher>")` |
+| Impact of local changes | `detect_changes(project="<name>")` |
+| Risk-classified trace | `trace_path(project="<name>", risk_labels=true)` |
+| Text search | `search_code(project="<name>", pattern="...")` or Grep |
 
 ## Exploration Workflow
 
-1. `list_projects` — check whether the project is indexed.
-2. `get_graph_schema` — understand node and edge types.
-3. `search_graph(label="Function", name_pattern=".*Pattern.*")` — find code.
-4. `get_code_snippet(qualified_name="project.path.FuncName")` — read source.
-5. `check_index_coverage(paths=["path/to/file"])` — validate every evidence path.
+1. `list_projects` — check whether the project is indexed and copy its exact name.
+2. `get_graph_schema(project="<name>")` — understand node and edge types.
+3. `search_graph(project="<name>", label="Function", name_pattern=".*Pattern.*")` — find code.
+4. `get_code_snippet(project="<name>", qualified_name="project.path.FuncName")` — read source.
+5. `check_index_coverage(project="<name>", paths=["path/to/file"])` — validate every evidence path.
 
 ## Tracing Workflow
 
-1. `search_graph(name_pattern=".*FuncName.*")` — discover the exact name.
-2. `trace_path(function_name="FuncName", direction="both", depth=3)` — trace relationships.
-3. `get_code_snippet(qualified_name="project.path.FuncName")` — verify material source claims.
-4. `check_index_coverage(paths=["path/to/file"])` — validate every evidence path.
-5. `detect_changes()` — map the Git diff to affected symbols.
+1. `search_graph(project="<name>", name_pattern=".*FuncName.*")` — discover the exact name.
+2. `trace_path(project="<name>", function_name="FuncName", direction="both", depth=3)` — trace relationships.
+3. `get_code_snippet(project="<name>", qualified_name="project.path.FuncName")` — verify material source claims.
+4. `check_index_coverage(project="<name>", paths=["path/to/file"])` — validate every evidence path.
+5. `detect_changes(project="<name>")` — map the Git diff to affected symbols.
 
 ## When to Fall Back to Grep/Glob
 
@@ -56,9 +58,9 @@ Always prefer MCP graph tools over grep, glob, or file search for code discovery
 
 ## Examples
 
-- Find a handler: `search_graph(name_pattern=".*OrderHandler.*")`.
-- Find who calls it: `trace_path(function_name="OrderHandler", direction="inbound")`.
-- Read its source: `get_code_snippet(qualified_name="pkg/orders.OrderHandler")`.
+- Find a handler: `search_graph(project="<name>", name_pattern=".*OrderHandler.*")`.
+- Find who calls it: `trace_path(project="<name>", function_name="OrderHandler", direction="inbound")`.
+- Read its source: `get_code_snippet(project="<name>", qualified_name="pkg/orders.OrderHandler")`.
 
 ## Evidence Tiers
 
@@ -81,9 +83,9 @@ Always prefer MCP graph tools over grep, glob, or file search for code discovery
   It should use the supplied evidence and read or grep exact source, especially every reported missed-coverage range.
 
 ## Quality Analysis
-- Dead code: `search_graph(max_degree=0, exclude_entry_points=true)`
-- High fan-out: `search_graph(min_degree=10, relationship="CALLS", direction="outbound")`
-- High fan-in: `search_graph(min_degree=10, relationship="CALLS", direction="inbound")`
+- Dead code: `search_graph(project="<name>", max_degree=0, exclude_entry_points=true)`
+- High fan-out: `search_graph(project="<name>", min_degree=10, relationship="CALLS", direction="outbound")`
+- High fan-in: `search_graph(project="<name>", min_degree=10, relationship="CALLS", direction="inbound")`
 
 ## 15 MCP Tools
 `index_repository`, `index_status`, `list_projects`, `delete_project`,
@@ -105,8 +107,8 @@ MATCH (a)-[r:CALLS]->(b) WHERE a.name = 'main' RETURN b.name
 ```
 
 ## Gotchas
-1. `search_graph(relationship="HTTP_CALLS")` filters nodes by degree — use `query_graph` with Cypher to see actual edges.
+1. `search_graph(project="<name>", relationship="HTTP_CALLS")` filters nodes by degree — use `query_graph` with Cypher to see actual edges.
 2. `query_graph` has a 100k row ceiling — add a Cypher `LIMIT` for broad queries or use `search_graph` pagination.
-3. `trace_path` needs exact names — use `search_graph(name_pattern=...)` first.
+3. `trace_path` needs exact names — use `search_graph(project="<name>", name_pattern=...)` first.
 4. `direction="outbound"` misses cross-service callers — use `direction="both"`.
 5. `search_graph` results default to 50 per page — check `has_more` and use `offset`.

--- a/packages/pi-cbmem/skills/codebase-memory/SKILL.md
+++ b/packages/pi-cbmem/skills/codebase-memory/SKILL.md
@@ -24,14 +24,14 @@ Use the exact `project="<name>"` returned by `list_projects` in every project-sc
 
 | Question | Tool call |
 |----------|----------|
-| Who calls X? | `trace_path(project="<name>", direction="inbound")` |
-| What does X call? | `trace_path(project="<name>", direction="outbound")` |
-| Full call context | `trace_path(project="<name>", direction="both")` |
+| Who calls X? | `trace_path(project="<name>", function_name="X", direction="inbound")` |
+| What does X call? | `trace_path(project="<name>", function_name="X", direction="outbound")` |
+| Full call context | `trace_path(project="<name>", function_name="X", direction="both")` |
 | Find by name pattern | `search_graph(project="<name>", name_pattern="...")` |
 | Dead code | `search_graph(project="<name>", max_degree=0, exclude_entry_points=true)` |
 | Cross-service edges | `query_graph(project="<name>", query="<cypher>")` |
 | Impact of local changes | `detect_changes(project="<name>")` |
-| Risk-classified trace | `trace_path(project="<name>", risk_labels=true)` |
+| Risk-classified trace | `trace_path(project="<name>", function_name="X", risk_labels=true)` |
 | Text search | `search_code(project="<name>", pattern="...")` or Grep |
 
 ## Exploration Workflow
@@ -84,8 +84,8 @@ Use the exact `project="<name>"` returned by `list_projects` in every project-sc
 
 ## Quality Analysis
 - Dead code: `search_graph(project="<name>", max_degree=0, exclude_entry_points=true)`
-- High fan-out: `search_graph(project="<name>", min_degree=10, relationship="CALLS", direction="outbound")`
-- High fan-in: `search_graph(project="<name>", min_degree=10, relationship="CALLS", direction="inbound")`
+- High fan-out: `query_graph(project="<name>", query="MATCH (f)-[:CALLS]->() WITH f, count(*) AS n WHERE n >= 10 RETURN f.name, n ORDER BY n DESC LIMIT 20")`
+- High fan-in: `query_graph(project="<name>", query="MATCH ()-[:CALLS]->(f) WITH f, count(*) AS n WHERE n >= 10 RETURN f.name, n ORDER BY n DESC LIMIT 20")`
 
 ## 15 MCP Tools
 `index_repository`, `index_status`, `list_projects`, `delete_project`,
@@ -109,6 +109,6 @@ MATCH (a)-[r:CALLS]->(b) WHERE a.name = 'main' RETURN b.name
 ## Gotchas
 1. `search_graph(project="<name>", relationship="HTTP_CALLS")` filters nodes by degree — use `query_graph` with Cypher to see actual edges.
 2. `query_graph` has a 100k row ceiling — add a Cypher `LIMIT` for broad queries or use `search_graph` pagination.
-3. `trace_path` needs exact names — use `search_graph(project="<name>", name_pattern=...)` first.
+3. `trace_path` needs exact names — use `search_graph(project="<name>", name_pattern="...")` first.
 4. `direction="outbound"` misses cross-service callers — use `direction="both"`.
 5. `search_graph` results default to 50 per page — check `has_more` and use `offset`.

--- a/packages/pi-cbmem/src/cbmem.ts
+++ b/packages/pi-cbmem/src/cbmem.ts
@@ -1,8 +1,14 @@
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+	AgentToolResult,
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+import { renderCodebaseMemoryResult } from "./render-result.js";
 import { type BridgeToolDefinition, TOOL_DEFINITIONS, type ToolName } from "./tool-definitions.js";
 
 export { TOOL_NAMES } from "./tool-definitions.js";
@@ -172,22 +178,74 @@ export async function callCodebaseMemory(
 	});
 }
 
-export default function cbmem(pi: ExtensionAPI): void {
-	for (const definition of TOOL_DEFINITIONS) registerBridgeTool(pi, definition);
+export default function cbmem(pi: ExtensionAPI, binary = BIN): void {
+	for (const definition of TOOL_DEFINITIONS) registerBridgeTool(pi, definition, binary);
 }
 
-function registerBridgeTool(pi: ExtensionAPI, definition: BridgeToolDefinition): void {
+function registerBridgeTool(
+	pi: ExtensionAPI,
+	definition: BridgeToolDefinition,
+	binary: string,
+): void {
 	pi.registerTool({
 		...definition,
+		renderResult: renderCodebaseMemoryResult,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-			return await callCodebaseMemory(
-				definition.name as ToolName,
-				params as Record<string, unknown>,
-				signal,
-				ctx.cwd,
-			);
+			const tool = definition.name as ToolName;
+			const args = params as Record<string, unknown>;
+			await confirmDestructiveCall(tool, args, signal, ctx);
+			return await callCodebaseMemory(tool, args, signal, ctx.cwd, binary);
 		},
 	});
+}
+
+async function confirmDestructiveCall(
+	tool: ToolName,
+	args: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+	ctx: ExtensionContext,
+): Promise<void> {
+	const prompt = destructivePrompt(tool, args);
+	if (!prompt) return;
+
+	signal?.throwIfAborted();
+	if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+		throw new Error(
+			`Codebase Memory ${tool} requires user confirmation in TUI or RPC mode before it can run.`,
+		);
+	}
+	const confirmed = await ctx.ui.confirm(prompt.title, prompt.message, { signal });
+	signal?.throwIfAborted();
+	if (!confirmed) {
+		throw new DOMException(`Codebase Memory ${tool} was cancelled by the user.`, "AbortError");
+	}
+}
+
+function destructivePrompt(
+	tool: ToolName,
+	args: Record<string, unknown>,
+): { title: string; message: string } | undefined {
+	const project = safeArgument(args.project, "unknown project");
+	if (tool === "delete_project") {
+		return {
+			title: "Delete Codebase Memory project?",
+			message: `Project: ${project}\nThis permanently removes the project's Codebase Memory index.`,
+		};
+	}
+	if (tool === "manage_adr" && args.mode === "update") {
+		const contentBytes =
+			typeof args.content === "string" ? Buffer.byteLength(args.content, "utf8") : 0;
+		return {
+			title: "Replace Codebase Memory ADRs?",
+			message: `Project: ${project}\nReplace the complete ADR document with ${contentBytes} bytes of content.`,
+		};
+	}
+	return undefined;
+}
+
+function safeArgument(value: unknown, fallback: string): string {
+	if (typeof value !== "string") return fallback;
+	return sanitizeTerminalText(value) || fallback;
 }
 
 function extractLastJson(output: string): string {

--- a/packages/pi-cbmem/src/cbmem.ts
+++ b/packages/pi-cbmem/src/cbmem.ts
@@ -138,9 +138,17 @@ export async function callCodebaseMemory(
 				fail(cliFailure(tool, code, stderr));
 				return;
 			}
+			if (stdout.truncated) {
+				fail(
+					new Error(
+						`codebase-memory-mcp ${tool} exceeded ${formatSize(DEFAULT_MAX_BYTES)} before a complete JSON response could be validated`,
+					),
+				);
+				return;
+			}
 
 			try {
-				const response = stdout.truncated ? stdout.text : extractLastJson(stdout.text);
+				const response = extractLastJson(stdout.text);
 				const bounded = boundOutput(response, stdout);
 				succeed({
 					content: [{ type: "text", text: bounded.text }],

--- a/packages/pi-cbmem/src/cbmem.ts
+++ b/packages/pi-cbmem/src/cbmem.ts
@@ -1,79 +1,280 @@
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
+import { type BridgeToolDefinition, TOOL_DEFINITIONS, type ToolName } from "./tool-definitions.js";
+
+export { TOOL_NAMES } from "./tool-definitions.js";
 
 const BIN = join(homedir(), ".local", "bin", "codebase-memory-mcp");
+const STDERR_MAX_BYTES = 8 * 1024;
+const FORCE_KILL_DELAY_MS = 250;
 
-export const TOOL_NAMES = [
-	"index_repository",
-	"search_graph",
-	"query_graph",
-	"trace_path",
-	"get_code_snippet",
-	"get_graph_schema",
-	"get_architecture",
-	"search_code",
-	"list_projects",
-	"delete_project",
-	"index_status",
-	"check_index_coverage",
-	"detect_changes",
-	"manage_adr",
-	"ingest_traces",
-] as const;
+export interface CbmemToolDetails {
+	truncated: boolean;
+	totalBytes: number;
+	totalLines: number;
+}
 
-type ToolName = (typeof TOOL_NAMES)[number];
-type ToolArguments = Record<string, unknown> | undefined;
-type ToolContext = { signal?: AbortSignal } | undefined;
-type ToolDefinition = {
-	name: ToolName;
-	run: (args: ToolArguments, ctx: ToolContext) => Promise<unknown>;
-};
-type ExtensionAPI = {
-	registerTool: (tool: ToolDefinition) => void;
-};
+class BoundedPrefixCollector {
+	readonly maxBytes: number;
+	text = "";
+	totalBytes = 0;
+	newlines = 0;
+	endsWithNewline = false;
+	truncated = false;
 
-async function call(tool: ToolName, args: ToolArguments, signal?: AbortSignal): Promise<unknown> {
-	return new Promise((resolve) => {
-		const child = spawn(BIN, ["cli", tool, JSON.stringify(args ?? {})], {
-			stdio: ["ignore", "pipe", "pipe"],
+	constructor(maxBytes: number) {
+		this.maxBytes = maxBytes;
+	}
+
+	append(chunk: string): void {
+		const chunkBytes = Buffer.byteLength(chunk, "utf8");
+		this.totalBytes += chunkBytes;
+		this.newlines += countOccurrences(chunk, "\n");
+		if (chunk.length > 0) this.endsWithNewline = chunk.endsWith("\n");
+
+		const remaining = this.maxBytes - Buffer.byteLength(this.text, "utf8");
+		if (remaining <= 0) {
+			if (chunkBytes > 0) this.truncated = true;
+			return;
+		}
+		const kept = takeUtf8Prefix(chunk, remaining, Number.POSITIVE_INFINITY);
+		this.text += kept;
+		if (kept.length !== chunk.length) this.truncated = true;
+	}
+
+	get totalLines(): number {
+		if (this.totalBytes === 0) return 0;
+		return this.newlines + (this.endsWithNewline ? 0 : 1);
+	}
+}
+
+class BoundedTailCollector {
+	readonly maxBytes: number;
+	text = "";
+	truncated = false;
+
+	constructor(maxBytes: number) {
+		this.maxBytes = maxBytes;
+	}
+
+	append(chunk: string): void {
+		this.text += chunk;
+		if (Buffer.byteLength(this.text, "utf8") <= this.maxBytes) return;
+		this.text = takeUtf8Suffix(this.text, this.maxBytes);
+		this.truncated = true;
+	}
+}
+
+export async function callCodebaseMemory(
+	tool: ToolName,
+	args: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+	cwd: string,
+	binary = BIN,
+): Promise<AgentToolResult<CbmemToolDetails>> {
+	signal?.throwIfAborted();
+	const input = JSON.stringify(args);
+
+	return await new Promise((resolve, reject) => {
+		const stdout = new BoundedPrefixCollector(DEFAULT_MAX_BYTES);
+		const stderr = new BoundedTailCollector(STDERR_MAX_BYTES);
+		const child = spawn(binary, ["cli", tool], {
+			cwd,
+			stdio: ["pipe", "pipe", "pipe"],
 			env: { ...process.env, CBM_LOG_LEVEL: "error" },
 		});
-		let out = "";
-		const onAbort = () => {
-			if (!child.killed) child.kill();
+		let settled = false;
+		let forceKillTimer: NodeJS.Timeout | undefined;
+
+		const cleanup = () => {
+			signal?.removeEventListener("abort", onAbort);
+			if (forceKillTimer) clearTimeout(forceKillTimer);
 		};
+		const fail = (error: unknown) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+			reject(error);
+		};
+		const succeed = (result: AgentToolResult<CbmemToolDetails>) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(result);
+		};
+		const onAbort = () => {
+			if (child.exitCode !== null || child.signalCode !== null) return;
+			child.kill("SIGTERM");
+			forceKillTimer = setTimeout(() => {
+				if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+			}, FORCE_KILL_DELAY_MS);
+			forceKillTimer.unref();
+		};
+
 		signal?.addEventListener("abort", onAbort, { once: true });
-		child.stdout.on("data", (data) => {
-			out += data.toString();
+		if (signal?.aborted) onAbort();
+
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => stdout.append(chunk));
+		child.stderr.on("data", (chunk: string) => stderr.append(chunk));
+		child.stdout.on("error", fail);
+		child.stderr.on("error", fail);
+		child.stdin.on("error", () => {
+			// Spawn and exit errors are reported by the child process events below.
 		});
-		child.on("error", (error) => {
-			signal?.removeEventListener("abort", onAbort);
-			resolve({ error: error.message });
-		});
-		child.on("close", () => {
-			signal?.removeEventListener("abort", onAbort);
-			const lines = out
-				.split("\n")
-				.map((line) => line.trim())
-				.filter(Boolean);
-			for (let index = lines.length - 1; index >= 0; index--) {
-				try {
-					return resolve(JSON.parse(lines[index]));
-				} catch {
-					// Keep scanning for the last JSON response.
-				}
+		child.on("error", fail);
+		child.on("close", (code) => {
+			if (settled) return;
+			if (signal?.aborted) {
+				fail(abortReason(signal));
+				return;
 			}
-			resolve({ error: "no JSON response from codebase-memory-mcp" });
+			if (code !== 0) {
+				fail(cliFailure(tool, code, stderr));
+				return;
+			}
+
+			try {
+				const response = stdout.truncated ? stdout.text : extractLastJson(stdout.text);
+				const bounded = boundOutput(response, stdout);
+				succeed({
+					content: [{ type: "text", text: bounded.text }],
+					details: {
+						truncated: bounded.truncated,
+						totalBytes: stdout.totalBytes,
+						totalLines: stdout.totalLines,
+					},
+				});
+			} catch (error) {
+				const diagnostic = stderr.text.trim();
+				const suffix = diagnostic ? `: ${diagnostic}` : "";
+				fail(
+					new Error(`codebase-memory-mcp ${tool} returned no JSON response${suffix}`, {
+						cause: error,
+					}),
+				);
+			}
 		});
+		child.stdin.end(input);
 	});
 }
 
 export default function cbmem(pi: ExtensionAPI): void {
-	for (const name of TOOL_NAMES) {
-		pi.registerTool({
-			name,
-			run: (args, ctx) => call(name, args, ctx?.signal),
-		});
+	for (const definition of TOOL_DEFINITIONS) registerBridgeTool(pi, definition);
+}
+
+function registerBridgeTool(pi: ExtensionAPI, definition: BridgeToolDefinition): void {
+	pi.registerTool({
+		...definition,
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			return await callCodebaseMemory(
+				definition.name as ToolName,
+				params as Record<string, unknown>,
+				signal,
+				ctx.cwd,
+			);
+		},
+	});
+}
+
+function extractLastJson(output: string): string {
+	const trimmed = output.trim();
+	if (!trimmed) throw new Error("empty stdout");
+	try {
+		JSON.parse(trimmed);
+		return trimmed;
+	} catch {
+		const lines = trimmed.split("\n");
+		for (let index = lines.length - 1; index >= 0; index--) {
+			const line = lines[index].trim();
+			if (!line) continue;
+			try {
+				JSON.parse(line);
+				return line;
+			} catch {
+				// Keep scanning for the last complete JSON response.
+			}
+		}
+		throw new Error("stdout did not contain JSON");
 	}
+}
+
+function boundOutput(
+	text: string,
+	collector: BoundedPrefixCollector,
+): { text: string; truncated: boolean } {
+	const textBytes = Buffer.byteLength(text, "utf8");
+	const textLines = countLines(text);
+	const truncated =
+		collector.truncated || textBytes > DEFAULT_MAX_BYTES || textLines > DEFAULT_MAX_LINES;
+	if (!truncated) return { text, truncated: false };
+
+	const notice = `[Output truncated: Codebase Memory produced ${collector.totalLines} lines (${formatSize(collector.totalBytes)}); additional output was omitted.]`;
+	const separator = "\n";
+	const body = takeUtf8Prefix(
+		text,
+		Math.max(0, DEFAULT_MAX_BYTES - Buffer.byteLength(notice + separator, "utf8")),
+		Math.max(0, DEFAULT_MAX_LINES - 1),
+	);
+	return {
+		text: body ? `${body}${body.endsWith("\n") ? "" : separator}${notice}` : notice,
+		truncated: true,
+	};
+}
+
+function cliFailure(tool: ToolName, code: number | null, stderr: BoundedTailCollector): Error {
+	const diagnostic = stderr.text.trim();
+	const truncation = stderr.truncated ? "[earlier stderr omitted] " : "";
+	const suffix = diagnostic ? `: ${truncation}${diagnostic}` : "";
+	return new Error(`codebase-memory-mcp ${tool} exited with code ${code ?? "unknown"}${suffix}`);
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("Codebase Memory tool call was aborted", "AbortError");
+}
+
+function takeUtf8Prefix(text: string, maxBytes: number, maxLines: number): string {
+	let bytes = 0;
+	let lines = text ? 1 : 0;
+	let result = "";
+	for (const character of text) {
+		const nextLines = character === "\n" ? lines + 1 : lines;
+		const characterBytes = Buffer.byteLength(character, "utf8");
+		if (bytes + characterBytes > maxBytes || nextLines > maxLines) break;
+		result += character;
+		bytes += characterBytes;
+		lines = nextLines;
+	}
+	return result;
+}
+
+function takeUtf8Suffix(text: string, maxBytes: number): string {
+	let bytes = 0;
+	const characters = Array.from(text);
+	let start = characters.length;
+	while (start > 0) {
+		const characterBytes = Buffer.byteLength(characters[start - 1], "utf8");
+		if (bytes + characterBytes > maxBytes) break;
+		bytes += characterBytes;
+		start--;
+	}
+	return characters.slice(start).join("");
+}
+
+function countOccurrences(text: string, character: string): number {
+	let count = 0;
+	for (const value of text) if (value === character) count++;
+	return count;
+}
+
+function countLines(text: string): number {
+	if (!text) return 0;
+	return countOccurrences(text, "\n") + (text.endsWith("\n") ? 0 : 1);
 }

--- a/packages/pi-cbmem/src/cbmem.ts
+++ b/packages/pi-cbmem/src/cbmem.ts
@@ -1,0 +1,79 @@
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const BIN = join(homedir(), ".local", "bin", "codebase-memory-mcp");
+
+export const TOOL_NAMES = [
+	"index_repository",
+	"search_graph",
+	"query_graph",
+	"trace_path",
+	"get_code_snippet",
+	"get_graph_schema",
+	"get_architecture",
+	"search_code",
+	"list_projects",
+	"delete_project",
+	"index_status",
+	"check_index_coverage",
+	"detect_changes",
+	"manage_adr",
+	"ingest_traces",
+] as const;
+
+type ToolName = (typeof TOOL_NAMES)[number];
+type ToolArguments = Record<string, unknown> | undefined;
+type ToolContext = { signal?: AbortSignal } | undefined;
+type ToolDefinition = {
+	name: ToolName;
+	run: (args: ToolArguments, ctx: ToolContext) => Promise<unknown>;
+};
+type ExtensionAPI = {
+	registerTool: (tool: ToolDefinition) => void;
+};
+
+async function call(tool: ToolName, args: ToolArguments, signal?: AbortSignal): Promise<unknown> {
+	return new Promise((resolve) => {
+		const child = spawn(BIN, ["cli", tool, JSON.stringify(args ?? {})], {
+			stdio: ["ignore", "pipe", "pipe"],
+			env: { ...process.env, CBM_LOG_LEVEL: "error" },
+		});
+		let out = "";
+		const onAbort = () => {
+			if (!child.killed) child.kill();
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+		child.stdout.on("data", (data) => {
+			out += data.toString();
+		});
+		child.on("error", (error) => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve({ error: error.message });
+		});
+		child.on("close", () => {
+			signal?.removeEventListener("abort", onAbort);
+			const lines = out
+				.split("\n")
+				.map((line) => line.trim())
+				.filter(Boolean);
+			for (let index = lines.length - 1; index >= 0; index--) {
+				try {
+					return resolve(JSON.parse(lines[index]));
+				} catch {
+					// Keep scanning for the last JSON response.
+				}
+			}
+			resolve({ error: "no JSON response from codebase-memory-mcp" });
+		});
+	});
+}
+
+export default function cbmem(pi: ExtensionAPI): void {
+	for (const name of TOOL_NAMES) {
+		pi.registerTool({
+			name,
+			run: (args, ctx) => call(name, args, ctx?.signal),
+		});
+	}
+}

--- a/packages/pi-cbmem/src/index.ts
+++ b/packages/pi-cbmem/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./cbmem.js";

--- a/packages/pi-cbmem/src/render-result.ts
+++ b/packages/pi-cbmem/src/render-result.ts
@@ -1,0 +1,28 @@
+import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+
+interface RenderTheme {
+	fg(color: "toolOutput" | "warning", text: string): string;
+}
+
+export function renderCodebaseMemoryResult(
+	result: AgentToolResult<unknown>,
+	options: ToolRenderResultOptions,
+	theme: RenderTheme,
+): Text {
+	const rawText = result.content
+		.flatMap((content) => (content.type === "text" ? [content.text] : []))
+		.join("\n");
+	const displayText = sanitizeMultilineTerminalText(rawText);
+	const color = options.isPartial ? "warning" : "toolOutput";
+	return new Text(theme.fg(color, displayText), 0, 0);
+}
+
+function sanitizeMultilineTerminalText(value: string): string {
+	return value
+		.replace(/\r\n?/gu, "\n")
+		.split("\n")
+		.map((line) => sanitizeTerminalText(line))
+		.join("\n");
+}

--- a/packages/pi-cbmem/src/tool-definitions.ts
+++ b/packages/pi-cbmem/src/tool-definitions.ts
@@ -10,7 +10,7 @@ export type BridgeToolDefinition = Pick<
 >;
 
 const Project = Type.String({ description: "Indexed project name from list_projects." });
-const outputLimit = `Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}, whichever is reached first.`;
+const outputLimit = `Output is limited to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}; byte-oversized responses fail validation instead of returning partial JSON.`;
 
 export const TOOL_DEFINITIONS = [
 	{

--- a/packages/pi-cbmem/src/tool-definitions.ts
+++ b/packages/pi-cbmem/src/tool-definitions.ts
@@ -1,0 +1,233 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
+import type { TSchema } from "typebox";
+import { Type } from "typebox";
+
+export type BridgeToolDefinition = Pick<
+	ToolDefinition<TSchema>,
+	"name" | "label" | "description" | "parameters"
+>;
+
+const Project = Type.String({ description: "Indexed project name from list_projects." });
+const outputLimit = `Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}, whichever is reached first.`;
+
+export const TOOL_DEFINITIONS = [
+	{
+		name: "index_repository",
+		label: "Index Repository",
+		description: `Index a repository in the Codebase Memory graph. ${outputLimit}`,
+		parameters: Type.Object({
+			repo_path: Type.String({ description: "Path to the repository." }),
+			mode: Type.Optional(
+				StringEnum(["full", "moderate", "fast", "cross-repo-intelligence"] as const),
+			),
+			target_projects: Type.Optional(Type.Array(Type.String())),
+			name: Type.Optional(Type.String({ description: "Override the derived project name." })),
+			persistence: Type.Optional(Type.Boolean()),
+		}),
+	},
+	{
+		name: "search_graph",
+		label: "Search Graph",
+		description: `Search indexed symbols by text, name, file, relationship, or degree. ${outputLimit}`,
+		parameters: Type.Object({
+			project: Project,
+			query: Type.Optional(Type.String({ description: "Natural-language or keyword search." })),
+			label: Type.Optional(Type.String()),
+			name_pattern: Type.Optional(Type.String()),
+			qn_pattern: Type.Optional(Type.String()),
+			file_pattern: Type.Optional(Type.String()),
+			relationship: Type.Optional(Type.String()),
+			min_degree: Type.Optional(Type.Integer()),
+			max_degree: Type.Optional(Type.Integer()),
+			exclude_entry_points: Type.Optional(Type.Boolean()),
+			include_connected: Type.Optional(Type.Boolean()),
+			semantic_query: Type.Optional(Type.Array(Type.String())),
+			limit: Type.Optional(Type.Integer()),
+			offset: Type.Optional(Type.Integer()),
+			format: Type.Optional(StringEnum(["tree", "json"] as const)),
+			fields: Type.Optional(Type.Array(Type.String())),
+			detail: Type.Optional(StringEnum(["ids", "default"] as const)),
+		}),
+	},
+	{
+		name: "query_graph",
+		label: "Query Graph",
+		description: `Execute a Cypher query against the code or missed-coverage graph. ${outputLimit}`,
+		parameters: Type.Object({
+			query: Type.String({ description: "Cypher query." }),
+			project: Project,
+			graph: Type.Optional(StringEnum(["code", "missed"] as const)),
+			max_rows: Type.Optional(Type.Integer()),
+		}),
+	},
+	{
+		name: "trace_path",
+		label: "Trace Path",
+		description: `Trace callers, callees, data flow, or cross-service paths. ${outputLimit}`,
+		parameters: Type.Object({
+			function_name: Type.String(),
+			project: Project,
+			direction: Type.Optional(StringEnum(["inbound", "outbound", "both"] as const)),
+			depth: Type.Optional(Type.Integer()),
+			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
+			cursor: Type.Optional(Type.String()),
+			mode: Type.Optional(StringEnum(["calls", "data_flow", "cross_service"] as const)),
+			parameter_name: Type.Optional(Type.String()),
+			edge_types: Type.Optional(Type.Array(Type.String())),
+			risk_labels: Type.Optional(Type.Boolean()),
+			include_tests: Type.Optional(Type.Boolean()),
+			format: Type.Optional(StringEnum(["tree", "json"] as const)),
+			include_evidence: Type.Optional(Type.Boolean()),
+		}),
+	},
+	{
+		name: "get_code_snippet",
+		label: "Get Code Snippet",
+		description: `Read source for an indexed symbol by qualified name. ${outputLimit}`,
+		parameters: Type.Object({
+			qualified_name: Type.String(),
+			project: Project,
+			include_neighbors: Type.Optional(Type.Boolean()),
+		}),
+	},
+	{
+		name: "get_graph_schema",
+		label: "Get Graph Schema",
+		description: `Get graph node labels and edge types. ${outputLimit}`,
+		parameters: Type.Object({ project: Project }),
+	},
+	{
+		name: "get_architecture",
+		label: "Get Architecture",
+		description: `Summarize architecture, dependencies, boundaries, clusters, or hotspots. ${outputLimit}`,
+		parameters: Type.Object({
+			project: Project,
+			path: Type.Optional(Type.String()),
+			aspects: Type.Optional(
+				Type.Array(
+					StringEnum([
+						"all",
+						"overview",
+						"structure",
+						"dependencies",
+						"routes",
+						"languages",
+						"packages",
+						"entry_points",
+						"hotspots",
+						"boundaries",
+						"layers",
+						"file_tree",
+						"clusters",
+						"cycles",
+					] as const),
+				),
+			),
+		}),
+	},
+	{
+		name: "search_code",
+		label: "Search Code",
+		description: `Search source text and enrich matches with graph context. ${outputLimit}`,
+		parameters: Type.Object({
+			pattern: Type.String(),
+			project: Project,
+			file_pattern: Type.Optional(Type.String()),
+			path_filter: Type.Optional(Type.String()),
+			mode: Type.Optional(StringEnum(["compact", "full", "files"] as const)),
+			context: Type.Optional(Type.Integer()),
+			regex: Type.Optional(Type.Boolean()),
+			debug: Type.Optional(Type.Boolean()),
+			limit: Type.Optional(Type.Integer({ minimum: 1 })),
+		}),
+	},
+	{
+		name: "list_projects",
+		label: "List Projects",
+		description: `List indexed Codebase Memory projects. ${outputLimit}`,
+		parameters: Type.Object({
+			offset: Type.Optional(Type.Integer({ minimum: 0 })),
+			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+			include_details: Type.Optional(Type.Boolean()),
+			metadata_only: Type.Optional(Type.Boolean()),
+		}),
+	},
+	{
+		name: "delete_project",
+		label: "Delete Project",
+		description: `Delete a project from the Codebase Memory index. ${outputLimit}`,
+		parameters: Type.Object({ project: Project }),
+	},
+	{
+		name: "index_status",
+		label: "Index Status",
+		description: `Get project index health, Git context, and coverage gaps. ${outputLimit}`,
+		parameters: Type.Object({
+			project: Project,
+			verbose: Type.Optional(Type.Boolean()),
+		}),
+	},
+	{
+		name: "check_index_coverage",
+		label: "Check Index Coverage",
+		description: `Check best-effort index coverage for exact paths or bounded scopes. ${outputLimit}`,
+		parameters: Type.Object({
+			project: Project,
+			paths: Type.Optional(Type.Array(Type.String(), { maxItems: 128 })),
+			scopes: Type.Optional(Type.Array(Type.String(), { maxItems: 32 })),
+			scope_limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+			scope_offset: Type.Optional(Type.Integer({ minimum: 0 })),
+		}),
+	},
+	{
+		name: "detect_changes",
+		label: "Detect Changes",
+		description: `Map a Git diff to changed files and impacted graph symbols. ${outputLimit}`,
+		parameters: Type.Object({
+			project: Project,
+			scope: Type.Optional(StringEnum(["files", "impact"] as const)),
+			direction: Type.Optional(StringEnum(["inbound", "outbound", "both"] as const)),
+			depth: Type.Optional(Type.Integer()),
+			limit: Type.Optional(Type.Integer({ maximum: 5000 })),
+			base_branch: Type.Optional(Type.String()),
+			since: Type.Optional(Type.String()),
+			format: Type.Optional(StringEnum(["tree", "json"] as const)),
+		}),
+	},
+	{
+		name: "manage_adr",
+		label: "Manage ADR",
+		description: `Read or replace Architecture Decision Records. ${outputLimit}`,
+		parameters: Type.Object(
+			{
+				project: Project,
+				mode: Type.Optional(StringEnum(["get", "update", "sections"] as const)),
+				content: Type.Optional(Type.String()),
+			},
+			{ additionalProperties: false },
+		),
+	},
+	{
+		name: "ingest_traces",
+		label: "Ingest Traces",
+		description: `Ingest runtime caller-to-callee traces into the graph. ${outputLimit}`,
+		parameters: Type.Object({
+			traces: Type.Array(
+				Type.Object(
+					{
+						caller: Type.Optional(Type.String()),
+						callee: Type.Optional(Type.String()),
+						count: Type.Optional(Type.Integer()),
+					},
+					{ additionalProperties: false },
+				),
+			),
+			project: Project,
+		}),
+	},
+] as const satisfies readonly BridgeToolDefinition[];
+
+export type ToolName = (typeof TOOL_DEFINITIONS)[number]["name"];
+export const TOOL_NAMES: readonly ToolName[] = TOOL_DEFINITIONS.map(({ name }) => name);

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -233,6 +233,9 @@ test("bundled skill enforces graph-first evidence and valid project-scoped calls
 	}
 	assert.doesNotMatch(skill, /delegate_task|Hermes/i);
 
+	const documentedCalls = (tool: string) => [
+		...skill.matchAll(new RegExp(`\\b${tool}\\(([^)]*)\\)`, "g")),
+	];
 	for (const tool of [
 		"search_graph",
 		"trace_path",
@@ -243,13 +246,21 @@ test("bundled skill enforces graph-first evidence and valid project-scoped calls
 		"check_index_coverage",
 		"detect_changes",
 	]) {
-		const calls = [...skill.matchAll(new RegExp(`\\b${tool}\\(([^)]*)\\)`, "g"))];
+		const calls = documentedCalls(tool);
 		assert.ok(calls.length > 0, `expected at least one documented ${tool} call`);
 		assert.ok(
 			calls.every((call) => call[1]?.includes('project="<name>"')),
 			`expected every documented ${tool} call to include project`,
 		);
 	}
+	assert.ok(
+		documentedCalls("trace_path").every((call) => call[1]?.includes("function_name=")),
+		"expected every documented trace_path call to include function_name",
+	);
+	assert.ok(
+		documentedCalls("search_graph").every((call) => !call[1]?.includes("direction=")),
+		"expected documented search_graph calls to omit its unsupported direction argument",
+	);
 });
 
 function resultText(result: Awaited<ReturnType<typeof callCodebaseMemory>>): string {

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -40,6 +40,9 @@ process.stdin.on("end", () => {
     case "large":
       process.stdout.write(JSON.stringify({ payload: "界".repeat(30000), tail: "must-not-appear" }));
       return;
+    case "largeMalformed":
+      process.stdout.write("not-json".repeat(10000));
+      return;
     case "manyLines":
       process.stdout.write(JSON.stringify({ rows: Array.from({ length: 2500 }, (_, i) => i) }, null, 2));
       return;
@@ -85,7 +88,7 @@ test("cbmem registers complete Pi tool definitions", () => {
 	);
 	for (const tool of registered) {
 		assert.ok(tool.label);
-		assert.match(tool.description, /truncated/i);
+		assert.match(tool.description, /output is limited/i);
 		assert.equal((tool.parameters as { type?: unknown }).type, "object");
 		assert.equal(typeof tool.execute, "function");
 	}
@@ -105,20 +108,27 @@ test("CLI calls use the session cwd and preserve split UTF-8 output", async () =
 	assert.equal(result.details.truncated, false);
 });
 
-test("CLI output is bounded by Pi's byte and line limits", async () => {
-	for (const testMode of ["large", "manyLines"]) {
-		const result = await callCodebaseMemory(
-			"query_graph",
-			{ testMode },
-			undefined,
-			fixtureDirectory,
-			fixtureBinary,
+test("validated CLI output is bounded by Pi's line limit", async () => {
+	const result = await callCodebaseMemory(
+		"query_graph",
+		{ testMode: "manyLines" },
+		undefined,
+		fixtureDirectory,
+		fixtureBinary,
+	);
+	const text = resultText(result);
+	assert.equal(result.details.truncated, true);
+	assert.match(text, /additional output was omitted/);
+	assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
+	assert.ok(countLines(text) <= DEFAULT_MAX_LINES);
+});
+
+test("byte-oversized stdout rejects before returning partial JSON", async () => {
+	for (const testMode of ["large", "largeMalformed"]) {
+		await assert.rejects(
+			callCodebaseMemory("query_graph", { testMode }, undefined, fixtureDirectory, fixtureBinary),
+			/exceeded 50(?:\.0)?KB before a complete JSON response could be validated/,
 		);
-		const text = resultText(result);
-		assert.equal(result.details.truncated, true);
-		assert.match(text, /additional output was omitted/);
-		assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
-		assert.ok(countLines(text) <= DEFAULT_MAX_LINES);
 	}
 });
 
@@ -203,7 +213,7 @@ test("aborting a running call terminates its child", async () => {
 	assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
 });
 
-test("bundled skill enforces graph-first evidence and extension-neutral handoff", async () => {
+test("bundled skill enforces graph-first evidence and valid project-scoped calls", async () => {
 	const skill = await readFile(
 		path.join(packageDirectory, "skills", "codebase-memory", "SKILL.md"),
 		"utf8",
@@ -222,6 +232,24 @@ test("bundled skill enforces graph-first evidence and extension-neutral handoff"
 		assert.match(skill, evidence);
 	}
 	assert.doesNotMatch(skill, /delegate_task|Hermes/i);
+
+	for (const tool of [
+		"search_graph",
+		"trace_path",
+		"get_code_snippet",
+		"get_graph_schema",
+		"query_graph",
+		"search_code",
+		"check_index_coverage",
+		"detect_changes",
+	]) {
+		const calls = [...skill.matchAll(new RegExp(`\\b${tool}\\(([^)]*)\\)`, "g"))];
+		assert.ok(calls.length > 0, `expected at least one documented ${tool} call`);
+		assert.ok(
+			calls.every((call) => call[1]?.includes('project="<name>"')),
+			`expected every documented ${tool} call to include project`,
+		);
+	}
 });
 
 function resultText(result: Awaited<ReturnType<typeof callCodebaseMemory>>): string {

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -8,6 +8,7 @@ import {
 	DEFAULT_MAX_BYTES,
 	DEFAULT_MAX_LINES,
 	type ExtensionAPI,
+	type ExtensionContext,
 	type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { afterAll, beforeAll, test } from "vitest";
@@ -94,7 +95,98 @@ test("cbmem registers complete Pi tool definitions", () => {
 		assert.match(tool.description, /output is limited/i);
 		assert.equal((tool.parameters as { type?: unknown }).type, "object");
 		assert.equal(typeof tool.execute, "function");
+		assert.equal(typeof tool.renderResult, "function");
 	}
+});
+
+test("destructive tools require observable confirmation before spawning", async () => {
+	const tools = registerTools(fixtureBinary);
+	const confirmations: Array<{ title: string; message: string }> = [];
+	const acceptedContext = toolContext(async (title, message) => {
+		confirmations.push({ title, message });
+		return true;
+	});
+	const unsafeProject = "demo\u001b[31m-red\u001b[0m\u202e";
+
+	await executeTool(tools, "delete_project", { project: unsafeProject }, acceptedContext);
+	await executeTool(
+		tools,
+		"manage_adr",
+		{ project: unsafeProject, mode: "update", content: "replacement" },
+		acceptedContext,
+	);
+	await executeTool(tools, "manage_adr", { project: unsafeProject, mode: "get" }, acceptedContext);
+
+	assert.equal(confirmations.length, 2);
+	assert.match(confirmations[0]?.title ?? "", /Delete Codebase Memory project/);
+	assert.match(confirmations[0]?.message ?? "", /Project: demo-red/);
+	assert.match(confirmations[1]?.title ?? "", /Replace Codebase Memory ADRs/);
+	assert.match(confirmations[1]?.message ?? "", /11 bytes/);
+	for (const confirmation of confirmations) {
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: Verify terminal-control sanitization.
+		assert.doesNotMatch(`${confirmation.title}\n${confirmation.message}`, /\u001b|\u202e/u);
+	}
+
+	const unavailableTools = registerTools(path.join(fixtureDirectory, "missing-binary"));
+	const declinedContext = toolContext(async () => false);
+	for (const [name, params] of [
+		["delete_project", { project: "demo" }],
+		["manage_adr", { project: "demo", mode: "update", content: "replacement" }],
+	] as const) {
+		await assert.rejects(
+			executeTool(unavailableTools, name, params, declinedContext),
+			(error: Error) => error.name === "AbortError",
+		);
+	}
+
+	const nonUiContext = toolContext(async () => {
+		throw new Error("confirmation must not be attempted without observable UI");
+	}, "print");
+	await assert.rejects(
+		executeTool(unavailableTools, "delete_project", { project: "demo" }, nonUiContext),
+		/requires user confirmation in TUI or RPC mode/,
+	);
+
+	const controller = new AbortController();
+	const cancelledContext = toolContext(async (_title, _message, options) => {
+		assert.equal(options?.signal, controller.signal);
+		controller.abort();
+		return true;
+	});
+	await assert.rejects(
+		executeTool(
+			unavailableTools,
+			"delete_project",
+			{ project: "demo" },
+			cancelledContext,
+			controller.signal,
+		),
+		(error: Error) => error.name === "AbortError",
+	);
+});
+
+test("tool result rendering sanitizes display text without changing model-visible output", () => {
+	const tool = registerTools(fixtureBinary).find(({ name }) => name === "search_graph");
+	assert.ok(tool?.renderResult);
+	const raw =
+		"safe \u001b[31mred\u001b[0m \u001b]8;;https://example.invalid\u0007link\u001b]8;;\u0007 \u009b31mcyan\u009b0m \u202espoof";
+	const result = {
+		content: [{ type: "text" as const, text: raw }],
+		details: { truncated: false, totalBytes: raw.length, totalLines: 1 },
+	};
+	const theme = { fg: (_color: string, text: string) => text };
+	const rendered = tool.renderResult(
+		result,
+		{ expanded: true, isPartial: false },
+		theme as never,
+		{} as never,
+	);
+	const display = rendered.render(200).join("\n");
+
+	assert.equal(result.content[0]?.text, raw);
+	assert.match(display, /safe red link cyan spoof/);
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Verify terminal-control sanitization.
+	assert.doesNotMatch(display, /\u001b|\u009b|\u202e/u);
 });
 
 test("CLI calls use the session cwd and preserve split UTF-8 output", async () => {
@@ -218,10 +310,13 @@ test("aborting a running call terminates its child", async () => {
 });
 
 test("bundled skill enforces graph-first evidence and valid project-scoped calls", async () => {
-	const skill = await readFile(
-		path.join(packageDirectory, "skills", "codebase-memory", "SKILL.md"),
-		"utf8",
-	);
+	const skillDirectory = path.join(packageDirectory, "skills");
+	const skill = await readFile(path.join(skillDirectory, "codebase-memory", "SKILL.md"), "utf8");
+	const rootManifest = JSON.parse(
+		await readFile(path.resolve(packageDirectory, "..", "..", "package.json"), "utf8"),
+	) as { pi?: { skills?: string[] } };
+
+	assert.ok(rootManifest.pi?.skills?.includes("./packages/pi-cbmem/skills"));
 
 	for (const evidence of [
 		/always prefer MCP graph tools/i,
@@ -266,6 +361,41 @@ test("bundled skill enforces graph-first evidence and valid project-scoped calls
 		"expected documented search_graph calls to omit its unsupported direction argument",
 	);
 });
+
+function registerTools(binary: string): ToolDefinition[] {
+	const tools: ToolDefinition[] = [];
+	const api = {
+		registerTool(tool: ToolDefinition) {
+			tools.push(tool);
+		},
+	} as unknown as ExtensionAPI;
+	cbmem(api, binary);
+	return tools;
+}
+
+function toolContext(
+	confirm: (title: string, message: string, options?: { signal?: AbortSignal }) => Promise<boolean>,
+	mode: "tui" | "rpc" | "print" | "json" = "tui",
+): ExtensionContext {
+	return {
+		cwd: fixtureDirectory,
+		mode,
+		hasUI: mode === "tui" || mode === "rpc",
+		ui: { confirm },
+	} as unknown as ExtensionContext;
+}
+
+async function executeTool(
+	tools: ToolDefinition[],
+	name: string,
+	params: Record<string, unknown>,
+	ctx: ExtensionContext,
+	signal?: AbortSignal,
+) {
+	const tool = tools.find((candidate) => candidate.name === name);
+	assert.ok(tool, `expected registered tool ${name}`);
+	return await tool.execute("test-call", params, signal, undefined, ctx);
+}
 
 function resultText(result: Awaited<ReturnType<typeof callCodebaseMemory>>): string {
 	const content = result.content[0];

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -1,30 +1,210 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { watch } from "node:fs";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { test } from "vitest";
-import cbmem, { TOOL_NAMES } from "../src/cbmem.js";
+import {
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	type ExtensionAPI,
+	type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { afterAll, beforeAll, test } from "vitest";
+import cbmem, { callCodebaseMemory, TOOL_NAMES } from "../src/cbmem.js";
 
 const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+let fixtureDirectory: string;
+let fixtureBinary: string;
 
-test("cbmem registers every Codebase Memory tool", () => {
-	const registered: Array<{ name: string; run: unknown }> = [];
+beforeAll(async () => {
+	fixtureDirectory = await mkdtemp(path.join(tmpdir(), "pi-cbmem-test-"));
+	fixtureBinary = path.join(fixtureDirectory, "codebase-memory-mcp.cjs");
+	await writeFile(
+		fixtureBinary,
+		`#!/usr/bin/env node
+const fs = require("node:fs");
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  const args = JSON.parse(input || "{}");
+  switch (args.testMode) {
+    case "splitUtf8": {
+      const output = Buffer.from(JSON.stringify({ cwd: process.cwd(), text: "你好🙂" }));
+      const split = output.indexOf(Buffer.from("你")) + 1;
+      process.stdout.write(output.subarray(0, split));
+      setImmediate(() => process.stdout.end(output.subarray(split)));
+      return;
+    }
+    case "large":
+      process.stdout.write(JSON.stringify({ payload: "界".repeat(30000), tail: "must-not-appear" }));
+      return;
+    case "manyLines":
+      process.stdout.write(JSON.stringify({ rows: Array.from({ length: 2500 }, (_, i) => i) }, null, 2));
+      return;
+    case "stderr":
+      process.stderr.write("x".repeat(100000));
+      process.stderr.write("\\nimportant failure");
+      process.exitCode = 7;
+      return;
+    case "noJson":
+      process.stdout.write("not a JSON response");
+      return;
+    case "wait":
+      fs.writeFileSync(args.readyPath, String(process.pid));
+      setInterval(() => {}, 1000);
+      return;
+    default:
+      process.stdout.write(JSON.stringify({ ok: true }));
+  }
+});
+`,
+		{ mode: 0o700 },
+	);
+	await chmod(fixtureBinary, 0o700);
+});
 
-	cbmem({
-		registerTool(tool) {
+afterAll(async () => {
+	await rm(fixtureDirectory, { recursive: true, force: true });
+});
+
+test("cbmem registers complete Pi tool definitions", () => {
+	const registered: ToolDefinition[] = [];
+	const api = {
+		registerTool(tool: ToolDefinition) {
 			registered.push(tool);
 		},
-	});
+	} as unknown as ExtensionAPI;
+
+	cbmem(api);
 
 	assert.deepEqual(
 		registered.map((tool) => tool.name),
 		TOOL_NAMES,
 	);
-	assert.ok(registered.every((tool) => typeof tool.run === "function"));
+	for (const tool of registered) {
+		assert.ok(tool.label);
+		assert.match(tool.description, /truncated/i);
+		assert.equal((tool.parameters as { type?: unknown }).type, "object");
+		assert.equal(typeof tool.execute, "function");
+	}
 });
 
-test("bundled skill enforces graph-first evidence and safe subagent handoff", () => {
-	const skill = readFileSync(
+test("CLI calls use the session cwd and preserve split UTF-8 output", async () => {
+	const cwd = await mkdtemp(path.join(fixtureDirectory, "cwd-"));
+	const result = await callCodebaseMemory(
+		"list_projects",
+		{ testMode: "splitUtf8" },
+		undefined,
+		cwd,
+		fixtureBinary,
+	);
+
+	assert.deepEqual(JSON.parse(resultText(result)), { cwd, text: "你好🙂" });
+	assert.equal(result.details.truncated, false);
+});
+
+test("CLI output is bounded by Pi's byte and line limits", async () => {
+	for (const testMode of ["large", "manyLines"]) {
+		const result = await callCodebaseMemory(
+			"query_graph",
+			{ testMode },
+			undefined,
+			fixtureDirectory,
+			fixtureBinary,
+		);
+		const text = resultText(result);
+		assert.equal(result.details.truncated, true);
+		assert.match(text, /additional output was omitted/);
+		assert.ok(Buffer.byteLength(text, "utf8") <= DEFAULT_MAX_BYTES);
+		assert.ok(countLines(text) <= DEFAULT_MAX_LINES);
+	}
+});
+
+test("CLI spawn, exit, and response failures reject", async () => {
+	await assert.rejects(
+		callCodebaseMemory(
+			"list_projects",
+			{},
+			undefined,
+			fixtureDirectory,
+			path.join(fixtureDirectory, "missing-binary"),
+		),
+		/ENOENT/,
+	);
+
+	await assert.rejects(
+		callCodebaseMemory(
+			"list_projects",
+			{ testMode: "stderr" },
+			undefined,
+			fixtureDirectory,
+			fixtureBinary,
+		),
+		(error: Error) => {
+			assert.match(error.message, /exited with code 7/);
+			assert.match(error.message, /important failure/);
+			assert.match(error.message, /earlier stderr omitted/);
+			assert.ok(Buffer.byteLength(error.message, "utf8") < 9 * 1024);
+			return true;
+		},
+	);
+
+	await assert.rejects(
+		callCodebaseMemory(
+			"list_projects",
+			{ testMode: "noJson" },
+			undefined,
+			fixtureDirectory,
+			fixtureBinary,
+		),
+		/no JSON response/,
+	);
+});
+
+test("pre-aborted calls reject before spawning", async () => {
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		callCodebaseMemory(
+			"delete_project",
+			{},
+			controller.signal,
+			fixtureDirectory,
+			path.join(fixtureDirectory, "missing-binary"),
+		),
+		(error: Error) => error.name === "AbortError",
+	);
+});
+
+test("aborting a running call terminates its child", async () => {
+	const readyPath = path.join(fixtureDirectory, `ready-${Date.now()}`);
+	const controller = new AbortController();
+	const watcher = watch(fixtureDirectory);
+	const ready = new Promise<void>((resolve) => {
+		watcher.on("change", (_event, filename) => {
+			if (filename === path.basename(readyPath)) resolve();
+		});
+	});
+	const pending = callCodebaseMemory(
+		"index_repository",
+		{ testMode: "wait", readyPath },
+		controller.signal,
+		fixtureDirectory,
+		fixtureBinary,
+	);
+
+	await ready;
+	watcher.close();
+	const pid = Number(await readFile(readyPath, "utf8"));
+	controller.abort();
+	await assert.rejects(pending, (error: Error) => error.name === "AbortError");
+	assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+});
+
+test("bundled skill enforces graph-first evidence and extension-neutral handoff", async () => {
+	const skill = await readFile(
 		path.join(packageDirectory, "skills", "codebase-memory", "SKILL.md"),
 		"utf8",
 	);
@@ -41,4 +221,16 @@ test("bundled skill enforces graph-first evidence and safe subagent handoff", ()
 	]) {
 		assert.match(skill, evidence);
 	}
+	assert.doesNotMatch(skill, /delegate_task|Hermes/i);
 });
+
+function resultText(result: Awaited<ReturnType<typeof callCodebaseMemory>>): string {
+	const content = result.content[0];
+	assert.equal(content?.type, "text");
+	return content.text;
+}
+
+function countLines(text: string): number {
+	if (!text) return 0;
+	return text.split("\n").length - (text.endsWith("\n") ? 1 : 0);
+}

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+import cbmem, { TOOL_NAMES } from "../src/cbmem.js";
+
+const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("cbmem registers every Codebase Memory tool", () => {
+	const registered: Array<{ name: string; run: unknown }> = [];
+
+	cbmem({
+		registerTool(tool) {
+			registered.push(tool);
+		},
+	});
+
+	assert.deepEqual(
+		registered.map((tool) => tool.name),
+		TOOL_NAMES,
+	);
+	assert.ok(registered.every((tool) => typeof tool.run === "function"));
+});
+
+test("bundled skill enforces graph-first evidence and safe subagent handoff", () => {
+	const skill = readFileSync(
+		path.join(packageDirectory, "skills", "codebase-memory", "SKILL.md"),
+		"utf8",
+	);
+
+	for (const evidence of [
+		/always prefer MCP graph tools/i,
+		/## Priority Order/,
+		/## When to Fall Back to Grep\/Glob/,
+		/Scout \(Tier 1\)/,
+		/Verify \(Tier 2, default\)/,
+		/Auditor \(Tier 3\)/,
+		/check_index_coverage` once with every evidence path/,
+		/Do not assume subagents inherit MCP access/i,
+	]) {
+		assert.match(skill, evidence);
+	}
+});

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -54,10 +54,13 @@ process.stdin.on("end", () => {
     case "noJson":
       process.stdout.write("not a JSON response");
       return;
-    case "wait":
-      fs.writeFileSync(args.readyPath, String(process.pid));
+    case "wait": {
+      const readyTempPath = args.readyPath + ".tmp";
+      fs.writeFileSync(readyTempPath, String(process.pid));
+      fs.renameSync(readyTempPath, args.readyPath);
       setInterval(() => {}, 1000);
       return;
+    }
     default:
       process.stdout.write(JSON.stringify({ ok: true }));
   }
@@ -208,9 +211,10 @@ test("aborting a running call terminates its child", async () => {
 	await ready;
 	watcher.close();
 	const pid = Number(await readFile(readyPath, "utf8"));
+	assert.ok(Number.isSafeInteger(pid) && pid > 0, `expected a valid child PID, received ${pid}`);
 	controller.abort();
 	await assert.rejects(pending, (error: Error) => error.name === "AbortError");
-	assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+	await waitForProcessExit(pid);
 });
 
 test("bundled skill enforces graph-first evidence and valid project-scoped calls", async () => {
@@ -272,4 +276,22 @@ function resultText(result: Awaited<ReturnType<typeof callCodebaseMemory>>): str
 function countLines(text: string): number {
 	if (!text) return 0;
 	return text.split("\n").length - (text.endsWith("\n") ? 1 : 0);
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+	const deadline = Date.now() + 1_000;
+	while (processExists(pid) && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	assert.equal(processExists(pid), false, `expected process ${pid} to exit after cancellation`);
+}
+
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+		throw error;
+	}
 }

--- a/packages/pi-cbmem/tsconfig.json
+++ b/packages/pi-cbmem/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"types": ["node"],
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add the private stable `@narumitw/pi-cbmem` package.
- Bundle the Codebase Memory CLI tool bridge and a graph-first `codebase-memory` skill with evidence tiers, coverage checks, fallback rules, and subagent handoff guidance.
- Add package documentation, registration coverage, and workspace lockfile metadata.

## Verification

- `npm run check`
- `npm test` (398 test files, 3,558 tests)
- `npm pack --workspace @narumitw/pi-cbmem --dry-run --json`
- `pi --no-extensions --no-skills -e ./packages/pi-cbmem --mode rpc </dev/null`

## Release

No Changeset is included because the package is private.
