### PR TITLE
feat(starship): add thinking styles and provider aliases

### DIFF
--- a/.changeset/starship-thinking-provider-aliases.md
+++ b/.changeset/starship-thinking-provider-aliases.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-starship": minor
+---
+
+Add per-level `thinking` styles that preserve the existing `style` fallback, and add exact terminal-safe `provider_aliases` for provider display names.

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -200,6 +200,7 @@ icons = { "foo:*" = "🧪", "third_party/key" = "◎", fallback = "•" }
 Every module table supports `format`, `symbol`, and `disabled`.
 Most modules also support one `style`.
 The exceptions are `git_metrics` (`added_style` and `deleted_style`), `username` (`style_user` and `style_root`), and the threshold-selected `context` and `cost` `display` arrays described below.
+`thinking` retains its `style` fallback and also accepts the per-level overrides documented below.
 Module-specific options are catalog-owned and type-checked; unknown options warn and stay inactive.
 Version formats replace `$raw`.
 Detection arrays replace defaults when non-empty and inspect only one listing of the current directory.
@@ -264,6 +265,22 @@ An invalid root format falls back to the built-in root format; an invalid module
 
 The background-free direct defaults are: `brand = "bold white"`, `provider`/`model` = `"bold blue"`, `thinking`/`git_branch`/`turn` = `"bold purple"`, `directory`/`git_worktree` = `"cyan bold"`, `github_pr = "bold blue"`, `git_commit = "green bold"`, `git_state`/`activity`/`time` = `"bold yellow"`, `git_status = "red bold"`, `tokens = "bold cyan"`, `cache = "bold green"`, `extension_status = "dimmed white"`, `direnv = "bold bright-yellow"`, and `fill = "bold black"`.
 Context, cost, Git metrics, and username use the state/multi-style defaults below.
+
+### Thinking level styles
+
+`thinking` can override its appearance for `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max` independently:
+
+```toml
+[thinking]
+style = "bold purple"
+style_low = "bold blue"
+style_high = "bold yellow"
+style_max = "bold red"
+```
+
+The matching `style_<level>` wins when it is non-empty.
+Every unset or empty level override uses the existing `style`, including levels added by a future Pi release.
+Invalid fallback and level styles warn and fall back independently without changing other levels.
 
 ### State-selected styles
 
@@ -421,7 +438,7 @@ Hostname trimming runs before exact alias lookup, matching Starship.
 These transformations affect display only.
 Collectors retain bounded, control-sanitized source metadata.
 
-### Model aliases and truncation
+### Model and provider aliases and model truncation
 
 The model module accepts exact `model_aliases`, Starship-style `truncation_length` and `truncation_symbol` options, plus the Pi-specific `truncation_direction` option:
 
@@ -440,6 +457,16 @@ When no alias matches, truncation runs after the built-in Claude/GPT shortening 
 It always changes display only—the provider model ID is untouched.
 Terminal control sequences in model IDs and truncation symbols are removed at render time.
 An empty symbol truncates without a marker.
+
+The provider module accepts exact display aliases without changing the selected provider or model:
+
+```toml
+[provider]
+provider_aliases = { "openai-codex" = "codex", "amazon-bedrock" = "bedrock" }
+```
+
+An empty alias hides only the provider text.
+Provider names and aliases are stripped of terminal controls at render time.
 For example, `middle` can retain both a Hugging Face model family and its variant, while `start` is useful when a llama.cpp server reports an absolute model path.
 pi-starship treats model IDs as opaque strings and does not parse paths, repositories, GGUF suffixes, or quantization names.
 

--- a/packages/pi-starship/src/config.ts
+++ b/packages/pi-starship/src/config.ts
@@ -279,6 +279,9 @@ export function normalizeConfig(value: unknown): {
 		);
 		validateLiteralStyles(module.formatAst, palette, `${name}.format`, diagnostics);
 		if (definition.styleDefaults) {
+			if (definition.fallbackStyle) {
+				validateModuleStyleField(name, "style", module, palette, diagnostics);
+			}
 			for (const field of Object.keys(definition.styleDefaults)) {
 				validateModuleStyleField(name, field, module, palette, diagnostics);
 			}
@@ -301,6 +304,7 @@ function normalizeModule(
 	const optionSchemas: Readonly<Record<string, ModuleOptionSchema>> = definition.options ?? {};
 	const known = new Set(["format", "symbol", "disabled", ...Object.keys(optionSchemas)]);
 	if (definition.styleDefaults) {
+		if (definition.fallbackStyle) known.add("style");
 		for (const field of Object.keys(definition.styleDefaults)) known.add(field);
 	} else if (!definition.displayDefaults) known.add("style");
 	if (definition.displayDefaults) known.add("display");
@@ -335,6 +339,11 @@ function normalizeModule(
 		if (typeof value.symbol !== "string") {
 			diagnostics.push(typeDiagnostic(`${name}.symbol`, "string"));
 		} else module.symbol = value.symbol;
+	}
+	if (definition.styleDefaults && definition.fallbackStyle && value.style !== undefined) {
+		if (typeof value.style !== "string") {
+			diagnostics.push(typeDiagnostic(`${name}.style`, "string"));
+		} else module.style = value.style;
 	}
 	if (definition.styleDefaults) {
 		for (const field of Object.keys(definition.styleDefaults)) {

--- a/packages/pi-starship/src/effective-config.ts
+++ b/packages/pi-starship/src/effective-config.ts
@@ -18,6 +18,7 @@ export function projectEffectiveConfig(config: StarshipConfig): TomlTable {
 			symbol: module.symbol,
 		};
 		if (definition.styleDefaults) {
+			if (definition.fallbackStyle) table.style = module.style;
 			for (const field of Object.keys(definition.styleDefaults)) {
 				table[field] = module.styles[field] ?? "";
 			}

--- a/packages/pi-starship/src/modules/provider.ts
+++ b/packages/pi-starship/src/modules/provider.ts
@@ -1,4 +1,7 @@
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { defineModule } from "./types.js";
+
+const PROVIDER_ALIASES_KEY = "provider_aliases";
 
 export const providerModule = defineModule({
 	name: "provider",
@@ -9,5 +12,20 @@ export const providerModule = defineModule({
 		style: "bold blue",
 		disabled: false,
 	},
-	values: ({ runtime }) => (runtime.model ? { provider: runtime.model.provider } : undefined),
+	options: {
+		[PROVIDER_ALIASES_KEY]: { kind: "string-map", default: {} },
+	},
+	values: ({ runtime, options }) => {
+		if (!runtime.model) return undefined;
+		const aliases = options[PROVIDER_ALIASES_KEY];
+		const aliasMap =
+			aliases && typeof aliases === "object" && !Array.isArray(aliases)
+				? (aliases as Readonly<Record<string, string>>)
+				: undefined;
+		const alias =
+			aliasMap && Object.hasOwn(aliasMap, runtime.model.provider)
+				? aliasMap[runtime.model.provider]
+				: undefined;
+		return { provider: sanitizeTerminalText(alias ?? runtime.model.provider) };
+	},
 });

--- a/packages/pi-starship/src/modules/thinking.ts
+++ b/packages/pi-starship/src/modules/thinking.ts
@@ -1,4 +1,19 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { defineModule } from "./types.js";
+
+const THINKING_LEVELS = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const satisfies readonly ThinkingLevel[];
+
+function thinkingLevelOf(value: string): ThinkingLevel | undefined {
+	return THINKING_LEVELS.find((level) => level === value);
+}
 
 export const thinkingModule = defineModule({
 	name: "thinking",
@@ -8,6 +23,15 @@ export const thinkingModule = defineModule({
 		symbol: "🧠",
 		style: "bold purple",
 		disabled: false,
+	},
+	styleDefaults: Object.fromEntries(
+		THINKING_LEVELS.map((level) => [`style_${level}`, ""]),
+	) as Record<`style_${ThinkingLevel}`, string>,
+	fallbackStyle: true,
+	styleVariables: ["style"],
+	resolveStyleVariables: ({ runtime, styles, style }) => {
+		const level = thinkingLevelOf(runtime.thinkingLevel);
+		return { style: (level && styles[`style_${level}`]) || style };
 	},
 	values: ({ runtime }) => ({ level: runtime.thinkingLevel }),
 });

--- a/packages/pi-starship/src/modules/types.ts
+++ b/packages/pi-starship/src/modules/types.ts
@@ -168,6 +168,7 @@ export interface ModuleDefinition<Name extends string> {
 	variables: readonly string[];
 	defaults: ModuleDefaults;
 	styleDefaults?: Readonly<Record<string, string>>;
+	fallbackStyle?: boolean;
 	displayDefaults?: readonly ModuleDisplayConfig[];
 	styleVariables?: readonly string[];
 	resolveStyleVariables?(context: ModuleStyleContext): Readonly<Record<string, string>> | undefined;

--- a/packages/pi-starship/test/config.test.ts
+++ b/packages/pi-starship/test/config.test.ts
@@ -357,6 +357,52 @@ test("model truncation options normalize values and reject invalid directions in
 	assert.equal(oversized.diagnostics[0]?.path, "model.truncation_length");
 });
 
+test("thinking level styles preserve and validate the legacy fallback independently", () => {
+	assert.deepEqual(BUILT_IN_CONFIG.modules.thinking.styles, {
+		style_off: "",
+		style_minimal: "",
+		style_low: "",
+		style_medium: "",
+		style_high: "",
+		style_xhigh: "",
+		style_max: "",
+	});
+
+	const valid = normalizeConfig({
+		thinking: {
+			style: "fg:#010203 bg:#040506 bold",
+			style_high: "italic red",
+		},
+	});
+	assert.equal(valid.config.modules.thinking.style, "fg:#010203 bg:#040506 bold");
+	assert.equal(valid.config.modules.thinking.styles.style_high, "italic red");
+	assert.deepEqual(valid.diagnostics, []);
+
+	const invalid = normalizeConfig({
+		thinking: { style: "not-a-color", style_low: "also-not-a-color", style_high: 7 },
+		username: { style: "blue" },
+	});
+	assert.equal(invalid.config.modules.thinking.style, BUILT_IN_CONFIG.modules.thinking.style);
+	assert.equal(invalid.config.modules.thinking.styles.style_low, "");
+	assert.equal(invalid.config.modules.thinking.styles.style_high, "");
+	assert.deepEqual(
+		invalid.diagnostics.map((item) => item.path),
+		["thinking.style_high", "username.style", "thinking.style", "thinking.style_low"],
+	);
+});
+
+test("provider aliases normalize as exact string mappings", () => {
+	assert.deepEqual(BUILT_IN_CONFIG.modules.provider.options, { provider_aliases: {} });
+	const normalized = normalizeConfig({
+		provider: { provider_aliases: { "openai-codex": "codex", anthropic: "claude" } },
+	});
+	assert.deepEqual(normalized.config.modules.provider.options.provider_aliases, {
+		"openai-codex": "codex",
+		anthropic: "claude",
+	});
+	assert.deepEqual(normalized.diagnostics, []);
+});
+
 test("valid TOML loads root, palette, module, and extension status settings", () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-config-"));
 	const path = join(root, CONFIG_FILE_NAME);

--- a/packages/pi-starship/test/modules.test.ts
+++ b/packages/pi-starship/test/modules.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { sep } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
-import { BUILT_IN_CONFIG, validateConfigDocument } from "../src/config.js";
+import { BUILT_IN_CONFIG, normalizeConfig, validateConfigDocument } from "../src/config.js";
 import { parseFormat } from "../src/format/formatter.js";
 import {
 	formatCount,
@@ -139,6 +139,76 @@ test("built-in root renders exactly the reachable nine module categories without
 		assert.doesNotMatch(plain, omitted);
 	}
 	assert.ok(rendered.chunks.every((chunk) => chunk.style?.background === undefined));
+});
+
+test("thinking level styles override the compatible module fallback", () => {
+	const { config, diagnostics } = normalizeConfig({
+		format: "$thinking",
+		thinking: {
+			format: "[$level]($style)",
+			style: "fg:#010203 bg:#040506 bold",
+			style_high: "italic red",
+		},
+	});
+	assert.deepEqual(diagnostics, []);
+
+	const high = renderStatusline(config, fixture({ thinkingLevel: "high" })).modules.thinking[0];
+	assert.deepEqual(high?.style, {
+		foreground: { kind: "named", name: "red" },
+		italic: true,
+	});
+	const low = renderStatusline(config, fixture({ thinkingLevel: "low" })).modules.thinking[0];
+	assert.deepEqual(low?.style, {
+		foreground: { kind: "rgb", red: 1, green: 2, blue: 3 },
+		background: { kind: "rgb", red: 4, green: 5, blue: 6 },
+		bold: true,
+	});
+	const future = renderStatusline(config, fixture({ thinkingLevel: "future" })).modules.thinking[0];
+	assert.deepEqual(future?.style, low?.style);
+});
+
+test("thinking fallback keeps bundled Powerline preset backgrounds and modifiers", () => {
+	for (const id of [
+		"catppuccin-powerline",
+		"gruvbox-rainbow",
+		"pastel-powerline",
+		"tokyo-night",
+	] as const) {
+		const preset = STARSHIP_PRESETS.find((candidate) => candidate.id === id);
+		assert.ok(preset, id);
+		const loaded = validateConfigDocument(`/presets/${id}.toml`, preset.rawDocument);
+		const style = renderStatusline(loaded.config, fixture()).modules.thinking[0]?.style;
+		assert.notEqual(style?.background, undefined, id);
+		assert.equal(style?.bold, true, id);
+	}
+});
+
+test("provider aliases are exact, empty-capable, and terminal-safe", () => {
+	const aliased = normalizeConfig({
+		format: "$provider",
+		provider: {
+			format: "$provider",
+			provider_aliases: {
+				"openai-codex": "codex\u001b[31m\nsafe",
+				anthropic: "",
+			},
+		},
+	}).config;
+	assert.equal(
+		renderStatusline(aliased, fixture({ model: { provider: "openai-codex", id: "gpt-5.6" } })).ansi,
+		"codex safe",
+	);
+	assert.equal(
+		renderStatusline(aliased, fixture({ model: { provider: "anthropic", id: "claude" } })).ansi,
+		"",
+	);
+	assert.equal(
+		renderStatusline(
+			aliased,
+			fixture({ model: { provider: "openai\u001b[31m\nunsafe", id: "gpt-5.6" } }),
+		).ansi,
+		"openai unsafe",
+	);
 });
 
 test("context supports native percentage/window precision", () => {


### PR DESCRIPTION
## Summary

- add `style_off` through `style_max` overrides for the thinking module while preserving the existing `style` fallback for unset and future levels
- add exact `provider_aliases` for display names and sanitize both aliases and provider names at the terminal boundary
- keep existing bundled preset backgrounds and modifiers unchanged
- intentionally omit the model hash-color and native-theme behavior from #1063

This focused follow-up adapts the thinking-style and provider-alias ideas proposed by @Ptilopsi4 in #1063.

Closes #1063 

## Verification

- `npm --workspace @narumitw/pi-tui-kit run build`
- focused pi-starship tests: 79 passed
- `npm --workspace @narumitw/pi-starship run check`
- all pi-starship tests: 223 passed
- `npm run check`
- `npm test`: 3,096 passed
- `just pack starship`
- `printf '' | pi --print --no-session --no-extensions -e ./packages/pi-starship`
