### PR TITLE
refactor(subagents): rename bundled skill

### DIFF
--- a/.changeset/promote-subagents-v3.md
+++ b/.changeset/promote-subagents-v3.md
@@ -6,4 +6,4 @@ Replace the legacy orchestration runtime with bounded background jobs and authen
 
 Remove `/subagents`, extension settings, persisted and retained agents, the previous blocking and underscore-named tools, custom agent catalogs, advanced orchestration, alternate transports, trust-aware cwd policy, and extension-owned worktrees.
 
-Use `subagent-spawn`, `subagent-inspect`, `subagent-cancel`, `subagent-wait`, and `subagent-reply` after upgrading, and start a fresh Pi session so stored calls do not request removed tool names.
+Use the bundled `using-pi-subagents` skill with `subagent-spawn`, `subagent-inspect`, `subagent-cancel`, `subagent-wait`, and `subagent-reply` after upgrading, and start a fresh Pi session so stored calls do not request removed tool names.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -4,7 +4,7 @@
 
 Pi Subagents starts bounded background Pi jobs and lets each child ask the main agent necessary questions through an authenticated loopback broker.
 
-A bundled `subagents` skill owns delegation strategy, least-privilege tool selection, parallel-work guidance, timeout selection, question handling, result review, and writer safety.
+A bundled `using-pi-subagents` skill owns delegation strategy, least-privilege tool selection, parallel-work guidance, timeout selection, question handling, result review, and writer safety.
 
 ## ✨ Features
 
@@ -61,7 +61,7 @@ Review the source before installing or invoking the extension.
 
 ## 🚀 Quick start
 
-Ask Pi to use the bundled `subagents` skill when deciding whether to delegate.
+Ask Pi to use the bundled `using-pi-subagents` skill when deciding whether to delegate, or invoke `/skill:using-pi-subagents` directly.
 
 Start one bounded background job with `subagent-spawn`.
 
@@ -250,7 +250,7 @@ packages/pi-subagents/
 ├── docs/                        # Concise tools and design references
 ├── scripts/                     # Deterministic runtime builder
 ├── src/                         # Extension, broker, child bridge, and subprocess runtime
-├── skills/subagents/           # Delegation and messaging operating manual
+├── skills/using-pi-subagents/  # Delegation and messaging operating manual
 ├── test/                        # Protocol, lifecycle, process, and policy tests
 ├── package.json                 # Pi extension and skill declarations
 └── README.md                    # User guide and safety boundaries

--- a/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
+++ b/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: subagents
+name: using-pi-subagents
 description: Operate bounded pi-subagents jobs safely, including direct-work decisions, least-privilege tool selection, thinking-level selection, background delegation, question replies, parallel starts, timeout selection, waiting, cancellation, result handling, verification, and writer isolation.
 license: MIT
 ---
 
-# Subagents
+# Using Pi Subagents
 
 Use this skill when deciding whether or how to delegate with the `subagent-*` tools.
 

--- a/packages/pi-subagents/test/package.test.ts
+++ b/packages/pi-subagents/test/package.test.ts
@@ -34,9 +34,10 @@ test("package declares one generated extension and one bundled operating skill",
 
 test("bundled skill documents every minimal-runtime operating responsibility", () => {
 	const skill = readFileSync(
-		path.join(packageDirectory, "skills", "subagents", "SKILL.md"),
+		path.join(packageDirectory, "skills", "using-pi-subagents", "SKILL.md"),
 		"utf8",
 	);
+	assert.match(skill, /^name: using-pi-subagents$/m);
 	for (const evidence of [
 		/prefer direct work/i,
 		/subagent-spawn/i,


### PR DESCRIPTION
## Summary

- Rename the bundled `subagents` skill to `using-pi-subagents`.
- Update the skill directory, frontmatter, README, migration changeset, and package test.
- Document direct invocation through `/skill:using-pi-subagents`.

## Verification

- `npx vitest run packages/pi-subagents/test/package.test.ts`
- `npm --workspace @narumitw/pi-subagents run check`
- `npm run check`
- `npm test` — 320 test files and 3,096 tests passed
- Fenced-code-aware README heading audit
- `npm run pack:subagents` — tarball contains `skills/using-pi-subagents/SKILL.md`
- Pi generated-extension loading smoke
- Pi skill discovery smoke for `using-pi-subagents`
