### PR TITLE
feat(accounts): support xAI and Kimi OAuth accounts

### DIFF
--- a/.changeset/bright-accounts-xai-kimi.md
+++ b/.changeset/bright-accounts-xai-kimi.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-accounts": minor
+---
+
+Add named subscription OAuth account management for xAI and Kimi For Coding.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ These extensions are part of my daily Pi setup:
 | Extension | Why I use it |
 | --- | --- |
 | [`pi-btw`](./packages/pi-btw) | Ask a quick side question without polluting the main context. |
-| [`pi-accounts`](./packages/pi-accounts) | Switch between my multiple Codex accounts. |
+| [`pi-accounts`](./packages/pi-accounts) | Switch between named subscription OAuth accounts. |
 | [`pi-caffeinate`](./packages/pi-caffeinate) | Keep my machine awake so Pi can keep working. |
 | [`pi-codex-compact`](./packages/pi-codex-compact) | Spend a little more for better compaction quality. |
 | [`pi-stamp`](./packages/pi-stamp) | See useful details for each response, such as its timestamp. |
@@ -84,7 +84,7 @@ The deprecated combined `pi-workflow` package has no atomic Plan-to-Goal replace
 
 | Package | Use it for | Install |
 | --- | --- | --- |
-| [`pi-accounts`](./packages/pi-accounts) | Switch named OpenAI Codex, Anthropic, and GitHub Copilot subscription OAuth accounts with `/account`. | `pi install npm:@narumitw/pi-accounts` |
+| [`pi-accounts`](./packages/pi-accounts) | Switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, and xAI subscription OAuth accounts with `/accounts`. | `pi install npm:@narumitw/pi-accounts` |
 | [`pi-usage`](./packages/pi-usage) | View current-account Codex subscription limits or OpenRouter API-key spend limits with `/usage`. | `pi install npm:@narumitw/pi-usage` |
 | [`pi-sync`](./packages/pi-sync) | Sync allowlisted Pi settings and optional sessions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |
 

--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -2,13 +2,13 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-accounts)](https://www.npmjs.com/package/@narumitw/pi-accounts) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Save and switch named OpenAI Codex, Anthropic, and GitHub Copilot subscription accounts without replacing Pi's built-in provider integrations.
+Save and switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, and xAI subscription accounts without replacing Pi's built-in provider integrations.
 
 Each selection overrides only the chosen provider, and selecting `default` restores Pi's normal authentication without deleting saved accounts.
 
 ## ✨ Features
 
-- Manages named OpenAI Codex, Anthropic Claude Pro/Max, and GitHub Copilot OAuth accounts through `/accounts`.
+- Manages named OpenAI Codex, Anthropic Claude Pro/Max, GitHub Copilot, Kimi For Coding, and xAI OAuth accounts through `/accounts`.
 - Keeps an independent selected account—or Pi's default login—for each provider.
 - Applies provider-specific credentials, endpoints, headers, and model availability through Pi's built-in providers.
 - Refreshes rotating credentials safely and verifies effective runtime authentication before reporting success.
@@ -23,6 +23,8 @@ Each selection overrides only the chosen provider, and selecting `default` resto
 | OpenAI Codex | `openai-codex` | ChatGPT Plus/Pro OAuth, OAuth-only native-provider bridge, and Codex WebSocket invalidation |
 | Anthropic | `anthropic` | Claude Pro/Max OAuth without interfering with Anthropic API-key auth after returning to `default` |
 | GitHub Copilot | `github-copilot` | Individual or Enterprise login, credential-derived API endpoint, and account-specific available models |
+| Kimi For Coding | `kimi-coding` | Kimi Code subscription OAuth with provider-owned Bearer-header authentication |
+| xAI | `xai` | SuperGrok or X Premium OAuth with the native xAI provider and model catalog |
 
 > [!WARNING]
 > Anthropic currently treats Claude Pro/Max use through third-party harnesses as **extra usage billed per token**, rather than consumption of the normal plan allowance.
@@ -94,7 +96,9 @@ Current model:
 Active accounts:
   Anthropic: work
   GitHub Copilot: enterprise
+  Kimi For Coding: fast
   OpenAI Codex: default
+  xAI: personal
 
 What do you want to do?
 › Switch Anthropic account
@@ -145,6 +149,10 @@ GitHub Copilot's `availableModelIds` are projected into the active provider mode
 Switching Copilot accounts rebuilds the projection from the complete pre-overlay model catalog.
 A currently selected model that is unavailable to the named account is rejected before the turn starts.
 
+Kimi's provider-owned OAuth returns an `Authorization: Bearer` header instead of an API key.
+The extension applies that header and installs a non-secret runtime selector to displace Pi's default Kimi credential.
+Activation verifies the effective Bearer header and fails closed before a turn if Pi does not retain it.
+
 ## 🗄️ Storage and migration
 
 The canonical file is:
@@ -168,6 +176,8 @@ On first load, if `pi-accounts.json` does not exist and released `pi-codex-accou
 
 If both files exist, `pi-accounts.json` is canonical and the legacy file is not imported again.
 The retained legacy refresh token may become stale after `pi-accounts` rotates it, so rollback can require a new Codex login.
+Older `pi-accounts` releases that predate xAI and Kimi support reject files containing those provider sections.
+Back up the file and remove the `xai` and `kimi-coding` sections only after stopping Pi before downgrading.
 
 ### Rollback
 
@@ -185,7 +195,7 @@ It is excluded from active workspace checks, version bumps, and publishing.
   It does not store or switch API-key profiles.
 - Continue using Pi's `auth.json`, environment variables, or `!command` secret-manager resolution for API keys.
 - It does not rotate accounts automatically, evade quotas, or report usage.
-- It does not support arbitrary custom providers in the first release.
+- It does not support arbitrary custom providers.
 - Live OAuth login and model requests depend on provider service availability and account entitlement.
 
 ## 🗂️ Package layout
@@ -225,7 +235,7 @@ The package exposes its Pi extension through `package.json`:
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, OAuth accounts, OpenAI Codex, ChatGPT Plus, ChatGPT Pro, Anthropic, Claude Pro, Claude Max, GitHub Copilot, GitHub Enterprise, subscription account switching.
+Pi extension, Pi coding agent, OAuth accounts, OpenAI Codex, ChatGPT Plus, ChatGPT Pro, Anthropic, Claude Pro, Claude Max, GitHub Copilot, GitHub Enterprise, Kimi For Coding, Kimi Code, xAI, Grok, SuperGrok, X Premium, subscription account switching.
 
 ## 📄 License
 

--- a/packages/pi-accounts/package.json
+++ b/packages/pi-accounts/package.json
@@ -14,7 +14,10 @@
 		"codex",
 		"anthropic",
 		"claude",
-		"github-copilot"
+		"github-copilot",
+		"kimi",
+		"xai",
+		"grok"
 	],
 	"files": [
 		"src",

--- a/packages/pi-accounts/src/accounts.ts
+++ b/packages/pi-accounts/src/accounts.ts
@@ -61,7 +61,7 @@ export default function accountsExtension(
 		...(dependencies.providers ??
 			createBuiltinProviderAdapters({ closeCodexWebSockets: dependencies.closeCodexWebSockets })),
 	];
-	validateProviderSet(providers);
+	validateProviderSet(providers, dependencies.providers === undefined);
 	const adapters = new Map(providers.map((provider) => [provider.id, provider]));
 	const coordinators = new Map(
 		providers.map((provider) => [provider.id, new RuntimeAuthCoordinator(pi, provider)]),
@@ -425,7 +425,7 @@ async function readProviderMenuStates(
 	adapters: Map<AccountProviderId, AccountProviderAdapter>,
 ): Promise<Map<AccountProviderId, ProviderMenuState>> {
 	const states = new Map<AccountProviderId, ProviderMenuState>();
-	for (const id of SUPPORTED_PROVIDER_IDS) {
+	for (const id of adapters.keys()) {
 		const state = await store.readProviderAsync(id);
 		states.set(id, {
 			id,
@@ -594,8 +594,12 @@ function providerDisplayName(providerId: AccountProviderId): string {
 			return "Anthropic";
 		case "github-copilot":
 			return "GitHub Copilot";
+		case "kimi-coding":
+			return "Kimi For Coding";
 		case "openai-codex":
 			return "OpenAI Codex";
+		case "xai":
+			return "xAI";
 	}
 }
 
@@ -750,12 +754,16 @@ async function removeAccount(
 	ctx.ui.notify(`Removed ${adapter.displayName} account "${parsed.name}".`, "info");
 }
 
-function validateProviderSet(providers: readonly AccountProviderAdapter[]): void {
+function validateProviderSet(
+	providers: readonly AccountProviderAdapter[],
+	requireAll: boolean,
+): void {
 	const ids = new Set<AccountProviderId>();
 	for (const provider of providers) {
 		if (ids.has(provider.id)) throw new Error(`Duplicate account provider: ${provider.id}`);
 		ids.add(provider.id);
 	}
+	if (!requireAll) return;
 	for (const id of SUPPORTED_PROVIDER_IDS) {
 		if (!ids.has(id)) throw new Error(`Missing required account provider: ${id}`);
 	}

--- a/packages/pi-accounts/src/oauth.ts
+++ b/packages/pi-accounts/src/oauth.ts
@@ -12,7 +12,13 @@ import {
 	LoginDialogComponent,
 } from "@earendil-works/pi-coding-agent";
 
-export const SUPPORTED_PROVIDER_IDS = ["anthropic", "github-copilot", "openai-codex"] as const;
+export const SUPPORTED_PROVIDER_IDS = [
+	"anthropic",
+	"github-copilot",
+	"kimi-coding",
+	"openai-codex",
+	"xai",
+] as const;
 
 export type AccountProviderId = (typeof SUPPORTED_PROVIDER_IDS)[number];
 
@@ -23,6 +29,7 @@ export type AccountProviderAdapter = {
 	displayName: string;
 	oauth: ProviderOwnedOAuth;
 	requiresApiKeyBridge: boolean;
+	runtimeAuthMode: "api-key" | "authorization-header";
 	defaultModelId?: string;
 	invalidateConnections?: (sessionId?: string) => unknown | Promise<unknown>;
 };
@@ -51,6 +58,7 @@ export function createBuiltinProviderAdapters(
 			id: "openai-codex",
 			displayName: "OpenAI Codex",
 			requiresApiKeyBridge: true,
+			runtimeAuthMode: "api-key",
 			defaultModelId: "gpt-5.5",
 			invalidateConnections: options.closeCodexWebSockets ?? cleanupSessionResources,
 			oauth: createLazyProviderOwnedOAuth("openai-codex", loader),
@@ -59,13 +67,29 @@ export function createBuiltinProviderAdapters(
 			id: "anthropic",
 			displayName: "Anthropic",
 			requiresApiKeyBridge: false,
+			runtimeAuthMode: "api-key",
 			oauth: createLazyProviderOwnedOAuth("anthropic", loader),
 		},
 		{
 			id: "github-copilot",
 			displayName: "GitHub Copilot",
 			requiresApiKeyBridge: false,
+			runtimeAuthMode: "api-key",
 			oauth: createLazyProviderOwnedOAuth("github-copilot", loader),
+		},
+		{
+			id: "kimi-coding",
+			displayName: "Kimi For Coding",
+			requiresApiKeyBridge: false,
+			runtimeAuthMode: "authorization-header",
+			oauth: createLazyProviderOwnedOAuth("kimi-coding", loader),
+		},
+		{
+			id: "xai",
+			displayName: "xAI",
+			requiresApiKeyBridge: false,
+			runtimeAuthMode: "api-key",
+			oauth: createLazyProviderOwnedOAuth("xai", loader),
 		},
 	];
 }

--- a/packages/pi-accounts/src/runtime-auth.ts
+++ b/packages/pi-accounts/src/runtime-auth.ts
@@ -4,6 +4,7 @@ import type { AccountProviderAdapter, AccountProviderId } from "./oauth.js";
 import { cloneOAuthCredential, parseCredentialRequest } from "./oauth-credential-source.js";
 
 export const RUNTIME_FAIL_CLOSED_API_KEY = "pi-accounts-auth-failed";
+const RUNTIME_HEADER_AUTH_SELECTOR = "pi-accounts-header-auth";
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
 
 type RuntimeAuthStorage = {
@@ -185,9 +186,10 @@ export class RuntimeAuthCoordinator {
 		}
 
 		let auth: ModelAuth;
+		let runtimeApiKey: string;
 		try {
 			auth = await this.provider.oauth.toAuth(credential);
-			validateModelAuth(auth, this.provider.displayName);
+			runtimeApiKey = validateModelAuth(auth, this.provider);
 		} catch (error) {
 			const selection = await this.activeCredentialMatches(store, active, credential);
 			if (selection.error !== undefined) {
@@ -225,7 +227,7 @@ export class RuntimeAuthCoordinator {
 			if (!this.overlay.apply(ctx, operation, auth, availableModelIds)) {
 				return { status: "inactive", providerId: this.provider.id };
 			}
-			const applied = await this.controller.apply(ctx, runtimeOverride, auth.apiKey);
+			const applied = await this.controller.apply(ctx, runtimeOverride, runtimeApiKey);
 			if (applied === "stale") return { status: "inactive", providerId: this.provider.id };
 			if (applied === "unavailable") {
 				throw new Error(`Pi did not retain the runtime ${this.provider.displayName} credential.`);
@@ -396,10 +398,10 @@ export class RuntimeAuthCoordinator {
 		}
 		if (auth.headers) {
 			for (const [name, value] of Object.entries(auth.headers)) {
-				if (value !== null && registered?.headers?.[name] !== value) {
+				if (value !== null && readHeader(registered?.headers, name) !== value) {
 					throw new Error(`Pi did not retain the runtime ${this.provider.displayName} headers.`);
 				}
-				if (value === null && registered?.headers && Object.hasOwn(registered.headers, name)) {
+				if (value === null && hasHeader(registered?.headers, name)) {
 					throw new Error(`Pi did not remove the runtime ${this.provider.displayName} header.`);
 				}
 			}
@@ -415,8 +417,11 @@ export class RuntimeAuthCoordinator {
 				throw new Error(`Pi could not resolve the runtime ${this.provider.displayName} headers.`);
 			}
 			for (const [name, value] of Object.entries(auth.headers)) {
-				if (value !== null && resolved?.headers?.[name] !== value) {
+				if (value !== null && readHeader(resolved?.headers, name) !== value) {
 					throw new Error(`Pi did not apply the runtime ${this.provider.displayName} headers.`);
+				}
+				if (value === null && hasHeader(resolved?.headers, name)) {
+					throw new Error(`Pi did not remove the runtime ${this.provider.displayName} header.`);
 				}
 			}
 		}
@@ -647,26 +652,42 @@ function readProviderModels(
 		}));
 }
 
+function readHeader(
+	headers: ProviderHeaders | Record<string, string> | undefined,
+	name: string,
+): string | null | undefined {
+	const expected = name.toLowerCase();
+	for (const [candidate, value] of Object.entries(headers ?? {})) {
+		if (candidate.toLowerCase() === expected) return value;
+	}
+	return undefined;
+}
+
+function hasHeader(
+	headers: ProviderHeaders | Record<string, string> | undefined,
+	name: string,
+): boolean {
+	const expected = name.toLowerCase();
+	return Object.keys(headers ?? {}).some((candidate) => candidate.toLowerCase() === expected);
+}
+
 function mergeConfigHeaders(
 	previous: Record<string, string> | undefined,
 	headers: Record<string, string | null>,
 ): Record<string, string> {
 	const result = { ...(previous ?? {}) };
 	for (const [name, value] of Object.entries(headers)) {
-		if (value === null) delete result[name];
-		else result[name] = value;
+		for (const existing of Object.keys(result)) {
+			if (existing.toLowerCase() === name.toLowerCase()) delete result[existing];
+		}
+		if (value !== null) result[name] = value;
 	}
 	return result;
 }
 
-function validateModelAuth(
-	auth: unknown,
-	providerName: string,
-): asserts auth is ModelAuth & { apiKey: string } {
+function validateModelAuth(auth: unknown, provider: AccountProviderAdapter): string {
+	const providerName = provider.displayName;
 	if (!isRecord(auth)) throw new Error(`${providerName} OAuth returned invalid request auth.`);
-	if (typeof auth.apiKey !== "string" || !auth.apiKey) {
-		throw new Error(`${providerName} OAuth returned no API key.`);
-	}
 	if (auth.baseUrl !== undefined) {
 		if (typeof auth.baseUrl !== "string") {
 			throw new Error(`${providerName} OAuth returned an invalid endpoint.`);
@@ -694,6 +715,26 @@ function validateModelAuth(
 			}
 		}
 	}
+	if (provider.runtimeAuthMode === "api-key") {
+		if (typeof auth.apiKey !== "string" || !auth.apiKey) {
+			throw new Error(`${providerName} OAuth returned no API key.`);
+		}
+		return auth.apiKey;
+	}
+	if (auth.apiKey !== undefined) {
+		throw new Error(`${providerName} OAuth returned unexpected API-key authentication.`);
+	}
+	const authorizationHeaders = isRecord(auth.headers)
+		? Object.entries(auth.headers).filter(([name]) => name.toLowerCase() === "authorization")
+		: [];
+	if (
+		authorizationHeaders.length !== 1 ||
+		typeof authorizationHeaders[0]?.[1] !== "string" ||
+		!/^Bearer\s+\S+$/u.test(authorizationHeaders[0][1])
+	) {
+		throw new Error(`${providerName} OAuth returned no valid Bearer authorization header.`);
+	}
+	return RUNTIME_HEADER_AUTH_SELECTOR;
 }
 
 function readAvailableModelIds(credential: OAuthCredential): string[] | undefined {

--- a/packages/pi-accounts/test/accounts-storage.test.ts
+++ b/packages/pi-accounts/test/accounts-storage.test.ts
@@ -51,6 +51,14 @@ test("provider-scoped storage preserves independent active accounts and OAuth me
 					}),
 				},
 			},
+			"kimi-coding": {
+				active: "fast",
+				accounts: { fast: credential("kimi") },
+			},
+			xai: {
+				active: "grok",
+				accounts: { grok: credential("xai") },
+			},
 		},
 	});
 
@@ -69,6 +77,8 @@ test("provider-scoped storage preserves independent active accounts and OAuth me
 		stored.providers["github-copilot"]?.accounts.personal?.enterpriseUrl,
 		"github.example.com",
 	);
+	assert.equal(stored.providers["kimi-coding"]?.accounts.fast?.access, "access-kimi");
+	assert.equal(stored.providers.xai?.accounts.grok?.access, "access-xai");
 });
 
 test("parsed provider and account maps treat prototype-like names as own properties", () => {

--- a/packages/pi-accounts/test/accounts.test.ts
+++ b/packages/pi-accounts/test/accounts.test.ts
@@ -1,7 +1,8 @@
 // Cohesion justification: this account-manager integration matrix shares credential/provider
 // fixtures and cross-covers menus, OAuth, replacement, switching, persistence, and lifecycle safety.
 import assert from "node:assert/strict";
-import { initTheme } from "@earendil-works/pi-coding-agent";
+import { InMemoryCredentialStore, type ModelAuth } from "@earendil-works/pi-ai";
+import { initTheme, ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { beforeAll, test } from "vitest";
 import {
 	createCustomSelectorHarness,
@@ -46,11 +47,18 @@ function fakeProvider(
 		requiresApiKeyBridge?: boolean;
 	} = {},
 ): AccountProviderAdapter {
+	const displayNames: Record<AccountProviderAdapter["id"], string> = {
+		anthropic: "Anthropic",
+		"github-copilot": "GitHub Copilot",
+		"kimi-coding": "Kimi For Coding",
+		"openai-codex": "OpenAI Codex",
+		xai: "xAI",
+	};
 	return {
 		id,
-		displayName:
-			id === "openai-codex" ? "OpenAI Codex" : id === "anthropic" ? "Anthropic" : "GitHub Copilot",
+		displayName: displayNames[id],
 		requiresApiKeyBridge: options.requiresApiKeyBridge ?? id === "openai-codex",
+		runtimeAuthMode: id === "kimi-coding" ? "authorization-header" : "api-key",
 		oauth: {
 			async login() {
 				return credential(
@@ -62,7 +70,15 @@ function fakeProvider(
 				return { ...current, access: `${current.access}-refreshed`, expires: Date.now() + 60_000 };
 			},
 			async toAuth(current) {
-				return { apiKey: current.access, baseUrl: options.baseUrl, headers: options.headers };
+				return id === "kimi-coding"
+					? {
+							baseUrl: options.baseUrl,
+							headers: {
+								Authorization: `Bearer ${current.access}`,
+								...options.headers,
+							},
+						}
+					: { apiKey: current.access, baseUrl: options.baseUrl, headers: options.headers };
 			},
 		},
 	};
@@ -75,6 +91,8 @@ function runtimeHarness(mock: ReturnType<typeof createMockPi>) {
 		{ provider: "anthropic", id: "claude", baseUrl: "https://anthropic.example" },
 		{ provider: "github-copilot", id: "allowed", baseUrl: "https://default.copilot" },
 		{ provider: "github-copilot", id: "blocked", baseUrl: "https://default.copilot" },
+		{ provider: "kimi-coding", id: "k3", baseUrl: "https://api.kimi.com/coding" },
+		{ provider: "xai", id: "grok-4.3", baseUrl: "https://api.x.ai/v1" },
 	];
 	const runtime = {
 		async setRuntimeApiKey(provider: string, key: string) {
@@ -192,6 +210,19 @@ test("built-in provider adapters preserve each provider's complete OAuth auth sh
 		apiKey: copilotCredential.access,
 		baseUrl: "https://api.business.githubcopilot.com",
 	});
+	assert.deepEqual(await byId.get("xai")?.oauth.toAuth(base), {
+		apiKey: "access-contract",
+	});
+	assert.deepEqual(await byId.get("kimi-coding")?.oauth.toAuth(base), {
+		headers: { Authorization: "Bearer access-contract" },
+	});
+	assert.deepEqual([...byId.keys()].sort(), [
+		"anthropic",
+		"github-copilot",
+		"kimi-coding",
+		"openai-codex",
+		"xai",
+	]);
 });
 
 test("OAuth interaction preserves provider prompts, cancellation, and notifications", async () => {
@@ -461,6 +492,8 @@ test("accounts menu summarizes all supported providers and prioritizes current p
 			fakeProvider("openai-codex"),
 			fakeProvider("anthropic"),
 			fakeProvider("github-copilot"),
+			fakeProvider("kimi-coding"),
+			fakeProvider("xai"),
 		],
 	});
 	const { registry } = runtimeHarness(mock);
@@ -475,6 +508,8 @@ test("accounts menu summarizes all supported providers and prioritizes current p
 	assert.match(selectCalls[0]?.title ?? "", /Anthropic: work/);
 	assert.match(selectCalls[0]?.title ?? "", /OpenAI Codex: default/);
 	assert.match(selectCalls[0]?.title ?? "", /GitHub Copilot: default/);
+	assert.match(selectCalls[0]?.title ?? "", /Kimi For Coding: default/);
+	assert.match(selectCalls[0]?.title ?? "", /xAI: default/);
 	assert.deepEqual(selectCalls[0]?.options, [
 		"Switch Anthropic account",
 		"Login new account",
@@ -832,6 +867,33 @@ test("generic login stores the full provider-owned credential and activates it",
 	assert.equal(keys.get("github-copilot"), "access-login-github-copilot");
 });
 
+test("xAI and Kimi login routes store and activate named OAuth accounts", async () => {
+	for (const providerId of ["xai", "kimi-coding"] as const) {
+		const store = new AccountStore(new InMemoryAccountStorageBackend());
+		const provider = fakeProvider(providerId);
+		const mock = createMockPi();
+		accountsExtension(mock.pi, { store, providers: [provider] });
+		const { registry, keys } = runtimeHarness(mock);
+		const modelId = providerId === "xai" ? "grok-4.3" : "k3";
+		const { ctx } = createInteractiveAccountContext(
+			{
+				model: { provider: providerId, id: modelId },
+				modelRegistry: registry,
+			},
+			{ selections: ["Login new account", provider.displayName], inputs: ["work"] },
+		);
+
+		await mock.commands.get("accounts")?.handler("ignored", ctx);
+		const state = await store.readProviderAsync(providerId);
+		assert.equal(state.active, "work");
+		assert.equal(state.accounts.work?.access, `access-login-${providerId}`);
+		assert.equal(
+			keys.get(providerId),
+			providerId === "xai" ? "access-login-xai" : "pi-accounts-header-auth",
+		);
+	}
+});
+
 test("session shutdown aborts idle OAuth login before stale credentials can publish", async () => {
 	const store = new AccountStore(new InMemoryAccountStorageBackend());
 	let loginStarted!: () => void;
@@ -1169,6 +1231,222 @@ test("session replacement invalidates a pending credential offer before old work
 		collectCredentialOffers(mock, newSession, "github-copilot")[0]?.access,
 		"access-work",
 	);
+});
+
+test("xAI named OAuth applies its access token and restores default auth", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { xai: { active: "work", accounts: { work: credential("xai") } } },
+	});
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	const sessionManager = {};
+	const { ctx } = createMockContext({
+		model: { provider: "xai", id: "grok-4.3" },
+		modelRegistry: registry,
+		sessionManager,
+	});
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("xai"));
+
+	const active = await coordinator.ensureActive(ctx, store);
+	assert.deepEqual(active, {
+		status: "active",
+		providerId: "xai",
+		accountName: "work",
+	});
+	coordinator.publishCredentialOffer(ctx, active, "work:access-xai");
+	assert.equal(keys.get("xai"), "access-xai");
+	const offers: StoredOAuthCredential[] = [];
+	coordinator.offerCredential({
+		session: sessionManager,
+		provider: "xai",
+		offer: (candidate: StoredOAuthCredential) => offers.push(candidate),
+	});
+	assert.equal(offers[0]?.access, "access-xai");
+
+	await store.updateProvider("xai", (state) => ({ ...state, active: undefined }));
+	assert.deepEqual(await coordinator.ensureActive(ctx, store), {
+		status: "inactive",
+		providerId: "xai",
+	});
+	assert.equal(keys.has("xai"), false);
+});
+
+test("xAI and Kimi refresh expiring named credentials before activation", async () => {
+	for (const providerId of ["xai", "kimi-coding"] as const) {
+		const store = new AccountStore(new InMemoryAccountStorageBackend());
+		await store.write({
+			version: 1,
+			providers: {
+				[providerId]: {
+					active: "work",
+					accounts: { work: { ...credential(providerId), expires: 0 } },
+				},
+			},
+		});
+		const mock = createMockPi();
+		const { keys, registry } = runtimeHarness(mock);
+		const { ctx } = createMockContext({ modelRegistry: registry });
+		const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider(providerId));
+
+		assert.equal((await coordinator.ensureActive(ctx, store)).status, "active");
+		assert.equal(
+			(await store.readProviderAsync(providerId)).accounts.work?.access,
+			`access-${providerId}-refreshed`,
+		);
+		assert.equal(
+			keys.get(providerId),
+			providerId === "xai" ? "access-xai-refreshed" : "pi-accounts-header-auth",
+		);
+	}
+});
+
+test("Kimi named OAuth displaces default auth with its Bearer header and restores it", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			"kimi-coding": { active: "work", accounts: { work: credential("kimi") } },
+		},
+	});
+	const mock = createMockPi();
+	mock.rawPi.registerProvider("kimi-coding", {
+		headers: { authorization: "Bearer default", Existing: "yes" },
+	});
+	const { keys, registry } = runtimeHarness(mock);
+	const { ctx } = createMockContext({
+		model: { provider: "kimi-coding", id: "k3" },
+		modelRegistry: registry,
+	});
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("kimi-coding"));
+
+	assert.deepEqual(await coordinator.ensureActive(ctx, store), {
+		status: "active",
+		providerId: "kimi-coding",
+		accountName: "work",
+	});
+	assert.equal(keys.get("kimi-coding"), "pi-accounts-header-auth");
+	assert.deepEqual(mock.providers.get("kimi-coding"), {
+		headers: { Existing: "yes", Authorization: "Bearer access-kimi" },
+	});
+
+	await store.updateProvider("kimi-coding", (state) => ({ ...state, active: undefined }));
+	assert.deepEqual(await coordinator.ensureActive(ctx, store), {
+		status: "inactive",
+		providerId: "kimi-coding",
+	});
+	assert.equal(keys.has("kimi-coding"), false);
+	assert.deepEqual(mock.providers.get("kimi-coding"), {
+		headers: { authorization: "Bearer default", Existing: "yes" },
+	});
+});
+
+test("Kimi named auth resolves through Pi with the selector and Bearer header", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			"kimi-coding": { active: "work", accounts: { work: credential("kimi") } },
+		},
+	});
+	const runtime = await ModelRuntime.create({
+		credentials: new InMemoryCredentialStore(),
+		modelsPath: null,
+		refreshOnCreate: false,
+	});
+	const registry = new ModelRegistry(runtime);
+	const pi = {
+		registerProvider: registry.registerProvider.bind(registry),
+		unregisterProvider: registry.unregisterProvider.bind(registry),
+	};
+	const model = registry.find("kimi-coding", "k3");
+	assert.ok(model);
+	const { ctx } = createMockContext({ model, modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(pi as never, fakeProvider("kimi-coding"));
+
+	assert.equal((await coordinator.ensureActive(ctx, store)).status, "active");
+	assert.deepEqual(await registry.getApiKeyAndHeaders(model), {
+		ok: true,
+		apiKey: "pi-accounts-header-auth",
+		headers: { Authorization: "Bearer access-kimi" },
+		env: undefined,
+	});
+
+	await store.updateProvider("kimi-coding", (state) => ({ ...state, active: undefined }));
+	assert.equal((await coordinator.ensureActive(ctx, store)).status, "inactive");
+	assert.equal(registry.getRegisteredProviderConfig("kimi-coding"), undefined);
+});
+
+test("Kimi session shutdown cancels ownership and restores default auth", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			"kimi-coding": { active: "work", accounts: { work: credential("kimi") } },
+		},
+	});
+	const mock = createMockPi();
+	mock.rawPi.registerProvider("kimi-coding", { headers: { Existing: "yes" } });
+	accountsExtension(mock.pi, { store, providers: [fakeProvider("kimi-coding")] });
+	const { keys, registry } = runtimeHarness(mock);
+	const sessionManager = {};
+	const { ctx } = createMockContext({
+		model: { provider: "kimi-coding", id: "k3" },
+		modelRegistry: registry,
+		sessionManager,
+	});
+
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	assert.equal(keys.get("kimi-coding"), "pi-accounts-header-auth");
+	assert.equal(
+		collectCredentialOffers(mock, sessionManager, "kimi-coding")[0]?.access,
+		"access-kimi",
+	);
+	assert.deepEqual(mock.providers.get("kimi-coding"), {
+		headers: { Existing: "yes", Authorization: "Bearer access-kimi" },
+	});
+
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(keys.has("kimi-coding"), false);
+	assert.deepEqual(collectCredentialOffers(mock, sessionManager, "kimi-coding"), []);
+	assert.deepEqual(mock.providers.get("kimi-coding"), { headers: { Existing: "yes" } });
+});
+
+test("Kimi malformed header auth fails closed without retaining a named Bearer token", async () => {
+	const invalidAuth: ModelAuth[] = [
+		{},
+		{ headers: { Authorization: "" } },
+		{ headers: { Authorization: "Bearer token\r\nInjected: yes" } },
+		{ headers: { Authorization: "Bearer first", authorization: "Bearer second" } },
+		{ apiKey: "unexpected", headers: { Authorization: "Bearer token" } },
+	];
+	for (const auth of invalidAuth) {
+		const store = new AccountStore(new InMemoryAccountStorageBackend());
+		await store.write({
+			version: 1,
+			providers: {
+				"kimi-coding": { active: "work", accounts: { work: credential("kimi") } },
+			},
+		});
+		const mock = createMockPi();
+		const { keys, registry } = runtimeHarness(mock);
+		const { ctx } = createMockContext({
+			model: { provider: "kimi-coding", id: "k3" },
+			modelRegistry: registry,
+		});
+		const kimi = fakeProvider("kimi-coding");
+		kimi.oauth.toAuth = async () => auth;
+		const coordinator = new RuntimeAuthCoordinator(mock.pi, kimi);
+
+		const result = await coordinator.ensureActive(ctx, store);
+		assert.equal(result.status, "error");
+		assert.equal(keys.get("kimi-coding"), FAIL_CLOSED_API_KEY);
+		assert.equal(
+			JSON.stringify(mock.providers.get("kimi-coding") ?? {}).includes("Bearer access-kimi"),
+			false,
+		);
+	}
 });
 
 test("providers without account-specific overlays leave existing registrations untouched", async () => {

--- a/test/accounts-usage-coexistence.test.ts
+++ b/test/accounts-usage-coexistence.test.ts
@@ -38,11 +38,18 @@ function credential(suffix: string): StoredOAuthCredential {
 }
 
 function provider(id: AccountProviderAdapter["id"]): AccountProviderAdapter {
+	const displayNames: Record<AccountProviderAdapter["id"], string> = {
+		anthropic: "Anthropic",
+		"github-copilot": "GitHub Copilot",
+		"kimi-coding": "Kimi For Coding",
+		"openai-codex": "OpenAI Codex",
+		xai: "xAI",
+	};
 	return {
 		id,
-		displayName:
-			id === "openai-codex" ? "OpenAI Codex" : id === "anthropic" ? "Anthropic" : "GitHub Copilot",
+		displayName: displayNames[id],
 		requiresApiKeyBridge: id === "openai-codex",
+		runtimeAuthMode: id === "kimi-coding" ? "authorization-header" : "api-key",
 		oauth: {
 			async login() {
 				return credential(id);
@@ -51,7 +58,9 @@ function provider(id: AccountProviderAdapter["id"]): AccountProviderAdapter {
 				return current;
 			},
 			async toAuth(current) {
-				return { apiKey: current.access };
+				return id === "kimi-coding"
+					? { headers: { Authorization: `Bearer ${current.access}` } }
+					: { apiKey: current.access };
 			},
 		},
 	};


### PR DESCRIPTION
## Summary

- add named xAI and Kimi For Coding subscription OAuth accounts using Pi AI's built-in provider flows
- apply xAI access tokens through runtime API-key auth and Kimi Bearer tokens through a verified provider-header overlay
- persist both provider sections, extend account menus and lifecycle coverage, and document compatibility and security behavior
- add a minor Changeset for `@narumitw/pi-accounts`

## Validation

- `npm run check`
- `npm test` (3,103 tests)
- `just pack accounts`
- package load smoke with `pi --no-extensions -e ./packages/pi-accounts --list-models xai`
- semantic audit against `docs/extension-conventions.md` and `docs/extension-settings.md`

## Notes

- Live xAI/Kimi OAuth login and paid model requests were not run.
- Pi does not yet expose a public full runtime `ModelAuth` override, so this retains the package's existing private runtime API-key bridge. Kimi uses a non-secret selector key plus its provider-owned Authorization header and fails closed if verification fails.
