### PR TITLE
fix(subagents): make completions collapsible

### DIFF
--- a/.changeset/promote-subagents-v3.md
+++ b/.changeset/promote-subagents-v3.md
@@ -7,3 +7,5 @@ Replace the legacy orchestration runtime with subagent jobs and authenticated ma
 Remove `/subagents`, extension settings, persisted and retained agents, the previous blocking and underscore-named tools, custom agent catalogs, advanced orchestration, alternate transports, trust-aware cwd policy, and extension-owned worktrees.
 
 Use the bundled `using-pi-subagents` skill with `subagent-spawn`, `subagent-inspect`, `subagent-cancel`, `subagent-wait`, and `subagent-reply` after upgrading, and start a fresh Pi session so stored calls do not request removed tool names.
+
+Completion messages follow Pi's global tool-output expansion state and configured `app.tools.expand` binding.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -69,6 +69,8 @@ The tool returns a `jobId` immediately.
 
 The job runs in the background while the main agent continues useful work until a completion arrives or the result is required.
 
+Completion messages follow Pi's global tool-output expansion state and `app.tools.expand` binding (`Ctrl+O` by default).
+
 If `subagent-wait` reports `reason: "subagent_message"`, answer the visible question with `subagent-reply`, then wait for the job again when needed.
 
 In TUI mode, an above-editor widget shows one compact line for each queued or running job.

--- a/packages/pi-subagents/src/completion-renderer.ts
+++ b/packages/pi-subagents/src/completion-renderer.ts
@@ -1,18 +1,36 @@
 import { type ExtensionAPI, getMarkdownTheme, keyText } from "@earendil-works/pi-coding-agent";
-import { Box, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
+import { Box, type Component, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { sanitizeTerminalText } from "./message-broker.js";
 
 export const COMPLETION_MESSAGE_TYPE = "pi-subagents-completion";
 
+function createCompletionBox(
+	children: Component[],
+	outputPad: number,
+	background: (text: string) => string,
+): Component {
+	return {
+		render(width) {
+			if (width <= 0) return [];
+			const maxPadding = Math.floor((width - 1) / 2);
+			const box = new Box(Math.min(Math.max(0, outputPad), maxPadding), 1, background);
+			for (const child of children) box.addChild(child);
+			return box.render(width);
+		},
+		invalidate() {
+			for (const child of children) child.invalidate();
+		},
+	};
+}
+
 export function registerCompletionRenderer(pi: ExtensionAPI): void {
 	pi.registerMessageRenderer(COMPLETION_MESSAGE_TYPE, (message, options, theme) => {
-		const box = new Box(options.outputPad, 1, (text) => theme.bg("customMessageBg", text));
-		box.addChild(
+		const children: Component[] = [
 			new Text(theme.fg("customMessageLabel", theme.bold(`[${COMPLETION_MESSAGE_TYPE}]`)), 0, 0),
-		);
-		box.addChild(new Spacer(1));
+			new Spacer(1),
+		];
 		if (!options.expanded) {
-			box.addChild(
+			children.push(
 				new Text(
 					theme.fg("customMessageText", "Subagent job completion (") +
 						theme.fg("dim", keyText("app.tools.expand")) +
@@ -21,20 +39,22 @@ export function registerCompletionRenderer(pi: ExtensionAPI): void {
 					0,
 				),
 			);
-			return box;
+		} else {
+			const content =
+				typeof message.content === "string"
+					? message.content
+					: message.content
+							.filter((part) => part.type === "text")
+							.map((part) => part.text)
+							.join("\n");
+			children.push(
+				new Markdown(sanitizeTerminalText(content), 0, 0, getMarkdownTheme(), {
+					color: (text) => theme.fg("customMessageText", text),
+				}),
+			);
 		}
-		const content =
-			typeof message.content === "string"
-				? message.content
-				: message.content
-						.filter((part) => part.type === "text")
-						.map((part) => part.text)
-						.join("\n");
-		box.addChild(
-			new Markdown(sanitizeTerminalText(content), 0, 0, getMarkdownTheme(), {
-				color: (text) => theme.fg("customMessageText", text),
-			}),
+		return createCompletionBox(children, options.outputPad, (text) =>
+			theme.bg("customMessageBg", text),
 		);
-		return box;
 	});
 }

--- a/packages/pi-subagents/src/completion-renderer.ts
+++ b/packages/pi-subagents/src/completion-renderer.ts
@@ -1,0 +1,40 @@
+import { type ExtensionAPI, getMarkdownTheme, keyText } from "@earendil-works/pi-coding-agent";
+import { Box, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
+import { sanitizeTerminalText } from "./message-broker.js";
+
+export const COMPLETION_MESSAGE_TYPE = "pi-subagents-completion";
+
+export function registerCompletionRenderer(pi: ExtensionAPI): void {
+	pi.registerMessageRenderer(COMPLETION_MESSAGE_TYPE, (message, options, theme) => {
+		const box = new Box(options.outputPad, 1, (text) => theme.bg("customMessageBg", text));
+		box.addChild(
+			new Text(theme.fg("customMessageLabel", theme.bold(`[${COMPLETION_MESSAGE_TYPE}]`)), 0, 0),
+		);
+		box.addChild(new Spacer(1));
+		if (!options.expanded) {
+			box.addChild(
+				new Text(
+					theme.fg("customMessageText", "Subagent job completion (") +
+						theme.fg("dim", keyText("app.tools.expand")) +
+						theme.fg("customMessageText", " to expand)"),
+					0,
+					0,
+				),
+			);
+			return box;
+		}
+		const content =
+			typeof message.content === "string"
+				? message.content
+				: message.content
+						.filter((part) => part.type === "text")
+						.map((part) => part.text)
+						.join("\n");
+		box.addChild(
+			new Markdown(sanitizeTerminalText(content), 0, 0, getMarkdownTheme(), {
+				color: (text) => theme.fg("customMessageText", text),
+			}),
+		);
+		return box;
+	});
+}

--- a/packages/pi-subagents/src/runtime.ts
+++ b/packages/pi-subagents/src/runtime.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { COMPLETION_MESSAGE_TYPE } from "./completion-renderer.js";
 import type { MessageBroker } from "./message-broker.js";
 import { modelVisibleJson } from "./model-output.js";
 import { runChild as defaultRunChild } from "./process.js";
@@ -14,8 +15,6 @@ import {
 const MAX_ACTIVE_JOBS = 8;
 const MAX_RETAINED_TERMINAL_JOBS = 32;
 const TERMINAL_RETENTION_MS = 24 * 60 * 60 * 1_000;
-const COMPLETION_MESSAGE_TYPE = "pi-subagents-completion";
-
 interface StopRequest {
 	child: ChildResult;
 	deliver: boolean;

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { registerCompletionRenderer } from "./completion-renderer.js";
 import { registerSubagentTools, type SubagentToolsDependencies } from "./tools.js";
 import { createSubagentWidgetController } from "./widget.js";
 
@@ -8,6 +9,7 @@ export default function subagents(
 	pi: ExtensionAPI,
 	dependencies: SubagentsDependencies = {},
 ): void {
+	registerCompletionRenderer(pi);
 	const tools = registerSubagentTools(pi, dependencies);
 	const widget = createSubagentWidgetController(tools.runtime);
 	let activeSession: ExtensionContext["sessionManager"] | undefined;

--- a/packages/pi-subagents/test/build-runtime.test.ts
+++ b/packages/pi-subagents/test/build-runtime.test.ts
@@ -191,6 +191,7 @@ test("Pi's Jiti loader loads the generated extension and child bridge", async ()
 		const main = loadedMain.extensions[0];
 		assert.ok(main?.handlers.has("session_start"));
 		assert.ok(main?.handlers.has("session_shutdown"));
+		assert.deepEqual([...(main?.messageRenderers.keys() ?? [])], ["pi-subagents-completion"]);
 		assert.deepEqual(
 			[...(main?.tools.keys() ?? [])],
 			["subagent-spawn", "subagent-inspect", "subagent-cancel", "subagent-wait", "subagent-reply"],

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -59,6 +59,7 @@ afterEach(async () => {
 
 test("registers five fixed main-agent tools with stable schemas and explicit limits", async () => {
 	const { mock, context } = await setup();
+	assert.ok(mock.messageRenderers.has("pi-subagents-completion"));
 	const tools = mock.tools as unknown as RegisteredTool[];
 	assert.deepEqual(
 		tools.map((candidate) => candidate.name),
@@ -119,6 +120,40 @@ test("registers five fixed main-agent tools with stable schemas and explicit lim
 		),
 		definitions,
 	);
+});
+
+test("completion renderer follows Pi's tool-output expansion state", async () => {
+	const { mock } = await setup();
+	const renderer = mock.messageRenderers.get("pi-subagents-completion");
+	assert.ok(renderer);
+	const message = {
+		customType: "pi-subagents-completion",
+		content: `Subagent job completion:
+{
+  "result": "full child result\u0007"
+}`,
+		display: true,
+		details: { result: "raw details must not render" },
+	};
+	const theme = {
+		fg: (_role: string, text: string) => text,
+		bg: (_role: string, text: string) => text,
+		bold: (text: string) => text,
+	} as Theme;
+	const collapsed = renderer(message, { expanded: false, outputPad: 1 }, theme) as Component;
+	const collapsedLines = collapsed.render(80);
+	const collapsedText = collapsedLines.join("\n");
+	assert.match(collapsedText, /to expand/i);
+	assert.doesNotMatch(collapsedText, /full child result|raw details must not render/i);
+	assert.ok(collapsedLines.every((line) => visibleWidth(line) <= 80));
+
+	const expanded = renderer(message, { expanded: true, outputPad: 1 }, theme) as Component;
+	const expandedLines = expanded.render(80);
+	const expandedText = expandedLines.join("\n");
+	assert.match(expandedText, /full child result/i);
+	assert.equal(expandedText.includes(String.fromCharCode(7)), false);
+	assert.doesNotMatch(expandedText, /to expand|raw details must not render/i);
+	assert.ok(expandedLines.every((line) => visibleWidth(line) <= 80));
 });
 
 test("spawns jobs with default and explicit tools and thinking levels", async () => {

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -154,6 +154,19 @@ test("completion renderer follows Pi's tool-output expansion state", async () =>
 	assert.equal(expandedText.includes(String.fromCharCode(7)), false);
 	assert.doesNotMatch(expandedText, /to expand|raw details must not render/i);
 	assert.ok(expandedLines.every((line) => visibleWidth(line) <= 80));
+
+	for (const [width, outputPad] of [
+		[1, 1],
+		[2, 4],
+		[3, 4],
+	] as const) {
+		for (const expandedState of [false, true]) {
+			const narrow = renderer(message, { expanded: expandedState, outputPad }, theme) as Component;
+			const narrowLines = narrow.render(width);
+			assert.ok(narrowLines.length > 0);
+			assert.ok(narrowLines.every((line) => visibleWidth(line) <= width));
+		}
+	}
 });
 
 test("spawns jobs with default and explicit tools and thinking levels", async () => {


### PR DESCRIPTION
## Summary

- Register a custom renderer for `pi-subagents-completion` messages.
- Show a compact completion summary when Pi's tool output is collapsed and the sanitized full completion when expanded.
- Derive the displayed expansion hint from the configured `app.tools.expand` binding.
- Keep raw completion `details` out of the renderer and preserve the existing model-visible message content.
- Document the shared tool-output expansion behavior.

## Verification

- `npx vitest run packages/pi-subagents/test/*.test.ts` — 51 tests passed
- `npm --workspace @narumitw/pi-subagents run check`
- `npm run check`
- `npm test` — 320 test files and 3,097 tests passed
- `npm run pack:subagents`
- Fenced-code-aware README heading audit
- Pi generated-extension loading smoke
- Generated Jiti loader test confirms completion renderer registration
- Renderer test covers collapsed and expanded output, width limits, terminal sanitization, and exclusion of raw details

A live interactive `Ctrl+O` keypress smoke was not automated; Pi core routes `app.tools.expand` to `setExpanded()` on custom message components, and the deterministic renderer test covers both resulting states.
