### PR TITLE
feat(accounts): support OpenRouter and Radius OAuth

### DIFF
--- a/.changeset/bright-accounts-xai-kimi.md
+++ b/.changeset/bright-accounts-xai-kimi.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-accounts": minor
 ---
 
-Add named subscription OAuth account management for xAI and Kimi For Coding.
+Add named OAuth account management for xAI, Kimi For Coding, OpenRouter, and Radius.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The deprecated combined `pi-workflow` package has no atomic Plan-to-Goal replace
 
 | Package | Use it for | Install |
 | --- | --- | --- |
-| [`pi-accounts`](./packages/pi-accounts) | Switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, and xAI subscription OAuth accounts with `/accounts`. | `pi install npm:@narumitw/pi-accounts` |
+| [`pi-accounts`](./packages/pi-accounts) | Switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts with `/accounts`. | `pi install npm:@narumitw/pi-accounts` |
 | [`pi-usage`](./packages/pi-usage) | View current-account Codex subscription limits or OpenRouter API-key spend limits with `/usage`. | `pi install npm:@narumitw/pi-usage` |
 | [`pi-sync`](./packages/pi-sync) | Sync allowlisted Pi settings and optional sessions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |
 

--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -1,14 +1,14 @@
-# 🔐 pi-accounts — Switch Between Subscription OAuth Accounts
+# 🔐 pi-accounts — Switch Between OAuth Accounts
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-accounts)](https://www.npmjs.com/package/@narumitw/pi-accounts) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Save and switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, and xAI subscription accounts without replacing Pi's built-in provider integrations.
+Save and switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts without replacing Pi's built-in provider integrations.
 
 Each selection overrides only the chosen provider, and selecting `default` restores Pi's normal authentication without deleting saved accounts.
 
 ## ✨ Features
 
-- Manages named OpenAI Codex, Anthropic Claude Pro/Max, GitHub Copilot, Kimi For Coding, and xAI OAuth accounts through `/accounts`.
+- Manages named OpenAI Codex, Anthropic Claude Pro/Max, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts through `/accounts`.
 - Keeps an independent selected account—or Pi's default login—for each provider.
 - Applies provider-specific credentials, endpoints, headers, and model availability through Pi's built-in providers.
 - Refreshes rotating credentials safely and verifies effective runtime authentication before reporting success.
@@ -24,6 +24,8 @@ Each selection overrides only the chosen provider, and selecting `default` resto
 | Anthropic | `anthropic` | Claude Pro/Max OAuth without interfering with Anthropic API-key auth after returning to `default` |
 | GitHub Copilot | `github-copilot` | Individual or Enterprise login, credential-derived API endpoint, and account-specific available models |
 | Kimi For Coding | `kimi-coding` | Kimi Code subscription OAuth with provider-owned Bearer-header authentication |
+| OpenRouter | `openrouter` | OpenRouter OAuth that mints a persistent account API key without managing manually entered API-key profiles |
+| Radius | `radius` | Gateway-bound OAuth with credential-specific dynamic model-catalog refresh and selected-model rebinding |
 | xAI | `xai` | SuperGrok or X Premium OAuth with the native xAI provider and model catalog |
 
 > [!WARNING]
@@ -98,6 +100,8 @@ Active accounts:
   GitHub Copilot: enterprise
   Kimi For Coding: fast
   OpenAI Codex: default
+  OpenRouter: credits
+  Radius: work
   xAI: personal
 
 What do you want to do?
@@ -153,6 +157,15 @@ Kimi's provider-owned OAuth returns an `Authorization: Bearer` header instead of
 The extension applies that header and installs a non-secret runtime selector to displace Pi's default Kimi credential.
 Activation verifies the effective Bearer header and fails closed before a turn if Pi does not retain it.
 
+OpenRouter's provider-owned OAuth returns a persistent API key represented as an OAuth credential with an empty refresh token.
+The extension preserves that exact provider credential and does not treat it as a manually managed API-key profile.
+
+Radius OAuth is bound to the active `radius` provider's configured gateway.
+The extension refreshes Radius's dynamic model catalog when the session or effective named credential changes, rebinds a retained selected model to its refreshed endpoint, and fails closed if the selected model disappears or catalog publication fails.
+Selecting `default` refreshes the Radius catalog against Pi's restored credential after a named account was active.
+Shutdown removes named Radius authentication and makes a bounded attempt to restore the default catalog; Pi's next catalog refresh remains the recovery path if the gateway is unavailable during shutdown.
+Custom gateways configured for the `radius` provider ID are supported, while arbitrary Radius provider aliases are not.
+
 ## 🗄️ Storage and migration
 
 The canonical file is:
@@ -176,8 +189,8 @@ On first load, if `pi-accounts.json` does not exist and released `pi-codex-accou
 
 If both files exist, `pi-accounts.json` is canonical and the legacy file is not imported again.
 The retained legacy refresh token may become stale after `pi-accounts` rotates it, so rollback can require a new Codex login.
-Older `pi-accounts` releases that predate xAI and Kimi support reject files containing those provider sections.
-Back up the file and remove the `xai` and `kimi-coding` sections only after stopping Pi before downgrading.
+Older `pi-accounts` releases that predate these providers reject files containing their provider sections.
+Back up the file and remove the `kimi-coding`, `openrouter`, `radius`, and `xai` sections only after stopping Pi before downgrading.
 
 ### Rollback
 
@@ -191,8 +204,8 @@ It is excluded from active workspace checks, version bumps, and publishing.
 
 ## 🚧 Limitations
 
-- This package manages only subscription OAuth accounts.
-  It does not store or switch API-key profiles.
+- This package manages only provider-owned OAuth accounts.
+  It does not store or switch manually entered API-key profiles.
 - Continue using Pi's `auth.json`, environment variables, or `!command` secret-manager resolution for API keys.
 - It does not rotate accounts automatically, evade quotas, or report usage.
 - It does not support arbitrary custom providers.
@@ -216,7 +229,8 @@ packages/pi-accounts/
 ├── test/
 │   ├── accounts-storage.test.ts
 │   ├── accounts.test.ts
-│   └── build-runtime.test.ts
+│   ├── build-runtime.test.ts
+│   └── radius.test.ts
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json
@@ -235,7 +249,7 @@ The package exposes its Pi extension through `package.json`:
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, OAuth accounts, OpenAI Codex, ChatGPT Plus, ChatGPT Pro, Anthropic, Claude Pro, Claude Max, GitHub Copilot, GitHub Enterprise, Kimi For Coding, Kimi Code, xAI, Grok, SuperGrok, X Premium, subscription account switching.
+Pi extension, Pi coding agent, OAuth accounts, OpenAI Codex, ChatGPT Plus, ChatGPT Pro, Anthropic, Claude Pro, Claude Max, GitHub Copilot, GitHub Enterprise, Kimi For Coding, Kimi Code, OpenRouter, Radius, xAI, Grok, SuperGrok, X Premium, account switching.
 
 ## 📄 License
 

--- a/packages/pi-accounts/package.json
+++ b/packages/pi-accounts/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-accounts",
 	"version": "0.49.11",
-	"description": "Pi extension for switching named subscription OAuth accounts across supported providers.",
+	"description": "Pi extension for switching named provider-owned OAuth accounts.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -16,6 +16,8 @@
 		"claude",
 		"github-copilot",
 		"kimi",
+		"openrouter",
+		"radius",
 		"xai",
 		"grok"
 	],

--- a/packages/pi-accounts/src/account-store.ts
+++ b/packages/pi-accounts/src/account-store.ts
@@ -197,7 +197,7 @@ export function normalizeStoredCredential(
 	if (typeof cloned.access !== "string" || !cloned.access) {
 		throw new Error(`Invalid accounts data: ${accountName} credential is missing access token.`);
 	}
-	if (typeof cloned.refresh !== "string" || !cloned.refresh) {
+	if (typeof cloned.refresh !== "string") {
 		throw new Error(`Invalid accounts data: ${accountName} credential is missing refresh token.`);
 	}
 	if (typeof cloned.expires !== "number" || !Number.isFinite(cloned.expires)) {

--- a/packages/pi-accounts/src/accounts.ts
+++ b/packages/pi-accounts/src/accounts.ts
@@ -51,6 +51,12 @@ export type AccountsDependencies = {
 	closeCodexWebSockets?: (sessionId?: string) => unknown | Promise<unknown>;
 };
 
+type SyncProvider = (
+	providerId: AccountProviderId,
+	ctx: ExtensionContext,
+	ownerSignal?: AbortSignal,
+) => Promise<EnsureActiveProviderAuthResult>;
+
 export default function accountsExtension(
 	pi: ExtensionAPI,
 	dependencies: AccountsDependencies = {},
@@ -77,6 +83,7 @@ export default function accountsExtension(
 	const syncProvider = (
 		providerId: AccountProviderId,
 		ctx: ExtensionContext,
+		ownerSignal?: AbortSignal,
 		model = ctx.model,
 	): Promise<EnsureActiveProviderAuthResult> => {
 		let task!: Promise<EnsureActiveProviderAuthResult>;
@@ -84,7 +91,7 @@ export default function accountsExtension(
 			const adapter = requireAdapter(adapters, providerId);
 			const coordinator = coordinators.get(providerId);
 			if (!coordinator) throw new Error(`Missing runtime coordinator for ${providerId}.`);
-			let result = await coordinator.ensureActive(ctx, store);
+			let result = await coordinator.ensureActive(ctx, store, Date.now(), ownerSignal);
 			let identity: string | undefined;
 			let latest = syncTasks.get(providerId);
 			if (latest && latest !== task) return latest;
@@ -162,7 +169,7 @@ export default function accountsExtension(
 
 	pi.on("model_select", async (event, ctx) => {
 		const providerId = toProviderId(event.model.provider);
-		if (providerId) await syncProvider(providerId, ctx, event.model);
+		if (providerId) await syncProvider(providerId, ctx, undefined, event.model);
 		else updateStatus(ctx, results, event.model);
 	});
 
@@ -205,8 +212,8 @@ export default function accountsExtension(
 		abortProviders.clear();
 		await Promise.allSettled(
 			[...coordinators.values()].map(async (coordinator) => {
-				coordinator.invalidate(ctx);
-				await coordinator.clear(ctx);
+				coordinator.invalidate(ctx, false);
+				await coordinator.clear(ctx, true);
 			}),
 		);
 		setStatus(ctx, undefined);
@@ -217,14 +224,11 @@ function createAccountCommand(
 	pi: ExtensionAPI,
 	store: AccountStore,
 	adapters: Map<AccountProviderId, AccountProviderAdapter>,
-	syncProvider: (
-		providerId: AccountProviderId,
-		ctx: ExtensionContext,
-	) => Promise<EnsureActiveProviderAuthResult>,
+	syncProvider: SyncProvider,
 	getMenuOwner: () => { signal: AbortSignal; isCurrent(): boolean },
 ) {
 	return {
-		description: "Open the interactive subscription account manager",
+		description: "Open the interactive OAuth account manager",
 		handler: async (_args: string, ctx: ExtensionCommandContext) => {
 			await showAccountsMenu(pi, ctx, store, adapters, syncProvider, getMenuOwner());
 		},
@@ -248,10 +252,7 @@ async function showAccountsMenu(
 	ctx: ExtensionCommandContext,
 	store: AccountStore,
 	adapters: Map<AccountProviderId, AccountProviderAdapter>,
-	syncProvider: (
-		providerId: AccountProviderId,
-		ctx: ExtensionContext,
-	) => Promise<EnsureActiveProviderAuthResult>,
+	syncProvider: SyncProvider,
 	owner: { signal: AbortSignal; isCurrent(): boolean },
 ): Promise<void> {
 	if (!ctx.hasUI) {
@@ -369,7 +370,7 @@ async function showAccountsMenu(
 				selectedProviderId = itemId;
 				return { kind: "to", screen: "switch-accounts" };
 			},
-			"switch-account": async ({ itemId }) => {
+			"switch-account": async ({ itemId, signal }) => {
 				const providerId = selectedProviderId;
 				if (!providerId) return { kind: "rejected" };
 				const latest = await store.readProviderAsync(providerId);
@@ -383,12 +384,14 @@ async function showAccountsMenu(
 					store,
 					requireAdapter(adapters, providerId),
 					accountName,
+					signal,
 					syncProvider,
+					owner.isCurrent,
 				);
 				return { kind: "close" };
 			},
 			"remove-route": async () => ({ kind: "to", screen: "remove" }),
-			"remove-account": async ({ itemId }) => {
+			"remove-account": async ({ itemId, signal }) => {
 				const states = await readProviderMenuStates(store, adapters);
 				if (!owner.isCurrent()) return { kind: "close" };
 				const option = removeAccountOptions(states, toProviderId(ctx.model?.provider)).find(
@@ -401,7 +404,15 @@ async function showAccountsMenu(
 					`Remove ${option.adapter.displayName} account "${option.accountName}"?`,
 				);
 				if (!confirmed || !owner.isCurrent()) return { kind: "close" };
-				await removeAccount(ctx, store, option.adapter, option.accountName, syncProvider);
+				await removeAccount(
+					ctx,
+					store,
+					option.adapter,
+					option.accountName,
+					signal,
+					syncProvider,
+					owner.isCurrent,
+				);
 				return { kind: "close" };
 			},
 		},
@@ -598,6 +609,10 @@ function providerDisplayName(providerId: AccountProviderId): string {
 			return "Kimi For Coding";
 		case "openai-codex":
 			return "OpenAI Codex";
+		case "openrouter":
+			return "OpenRouter";
+		case "radius":
+			return "Radius";
 		case "xai":
 			return "xAI";
 	}
@@ -610,10 +625,7 @@ async function loginAccount(
 	adapter: AccountProviderAdapter,
 	nameArg: string,
 	signal: AbortSignal,
-	syncProvider: (
-		providerId: AccountProviderId,
-		ctx: ExtensionContext,
-	) => Promise<EnsureActiveProviderAuthResult>,
+	syncProvider: SyncProvider,
 	isCurrent: () => boolean,
 ): Promise<void> {
 	const parsed = parseAccountName(nameArg);
@@ -651,7 +663,7 @@ async function loginAccount(
 				: state,
 		);
 		if (!isCurrent()) return;
-		const result = await syncProvider(adapter.id, ctx);
+		const result = await syncProvider(adapter.id, ctx, signal);
 		if (!isCurrent()) return;
 		await selectDefaultModelIfUnknown(pi, ctx, adapter);
 		if (!isCurrent()) return;
@@ -673,19 +685,23 @@ async function switchAccount(
 	store: AccountStore,
 	adapter: AccountProviderAdapter,
 	nameArg: string,
-	syncProvider: (
-		providerId: AccountProviderId,
-		ctx: ExtensionContext,
-	) => Promise<EnsureActiveProviderAuthResult>,
+	signal: AbortSignal,
+	syncProvider: SyncProvider,
+	isCurrent: () => boolean,
 ): Promise<void> {
+	if (!isCurrent()) return;
 	const name = nameArg.trim();
 	if (!name) {
 		ctx.ui.notify(`Select a ${adapter.displayName} account from /accounts.`, "warning");
 		return;
 	}
 	if (isDefaultPiLoginArg(name)) {
-		await store.updateProvider(adapter.id, (state) => ({ ...state, active: undefined }));
-		const result = await syncProvider(adapter.id, ctx);
+		await store.updateProvider(adapter.id, (state) =>
+			isCurrent() ? { ...state, active: undefined } : state,
+		);
+		if (!isCurrent()) return;
+		const result = await syncProvider(adapter.id, ctx, signal);
+		if (!isCurrent()) return;
 		if (result.status === "error") {
 			ctx.ui.notify(
 				`Could not restore default Pi ${adapter.displayName} login; requests will fail closed: ${result.message}`,
@@ -700,15 +716,17 @@ async function switchAccount(
 	if (!parsed.ok) return ctx.ui.notify(parsed.error, "warning");
 	let found = false;
 	await store.updateProvider(adapter.id, (state) => {
-		if (!getOwnCredential(state.accounts, parsed.name)) return state;
+		if (!isCurrent() || !getOwnCredential(state.accounts, parsed.name)) return state;
 		found = true;
 		return { ...state, active: parsed.name };
 	});
+	if (!isCurrent()) return;
 	if (!found) {
 		ctx.ui.notify(`${adapter.displayName} account "${parsed.name}" was not found.`, "warning");
 		return;
 	}
-	const result = await syncProvider(adapter.id, ctx);
+	const result = await syncProvider(adapter.id, ctx, signal);
+	if (!isCurrent()) return;
 	ctx.ui.notify(
 		formatActivationMessage("Activated", adapter, parsed.name, result),
 		result.status === "active" ? "info" : "error",
@@ -720,29 +738,31 @@ async function removeAccount(
 	store: AccountStore,
 	adapter: AccountProviderAdapter,
 	nameArg: string,
-	syncProvider: (
-		providerId: AccountProviderId,
-		ctx: ExtensionContext,
-	) => Promise<EnsureActiveProviderAuthResult>,
+	signal: AbortSignal,
+	syncProvider: SyncProvider,
+	isCurrent: () => boolean,
 ): Promise<void> {
+	if (!isCurrent()) return;
 	const parsed = parseAccountName(nameArg);
 	if (!parsed.ok) return ctx.ui.notify(parsed.error, "warning");
 	let removed = false;
 	let removedActive = false;
 	await store.updateProvider(adapter.id, (state) => {
-		if (!getOwnCredential(state.accounts, parsed.name)) return state;
+		if (!isCurrent() || !getOwnCredential(state.accounts, parsed.name)) return state;
 		removed = true;
 		removedActive = state.active === parsed.name;
 		const accounts = defineOwnMap(state.accounts);
 		delete accounts[parsed.name];
 		return { active: removedActive ? undefined : state.active, accounts };
 	});
+	if (!isCurrent()) return;
 	if (!removed) {
 		ctx.ui.notify(`${adapter.displayName} account "${parsed.name}" was not found.`, "warning");
 		return;
 	}
 	if (removedActive) {
-		const result = await syncProvider(adapter.id, ctx);
+		const result = await syncProvider(adapter.id, ctx, signal);
+		if (!isCurrent()) return;
 		if (result.status === "error") {
 			ctx.ui.notify(
 				`Removed ${adapter.displayName} account "${parsed.name}", but default auth restoration failed closed: ${result.message}`,

--- a/packages/pi-accounts/src/oauth-credential-source.ts
+++ b/packages/pi-accounts/src/oauth-credential-source.ts
@@ -41,7 +41,7 @@ export function cloneOAuthCredential(credential: OAuthCredential): OAuthCredenti
 		if (!clone || typeof clone !== "object" || Array.isArray(clone)) return undefined;
 		if (clone.type !== "oauth") return undefined;
 		if (typeof clone.access !== "string" || !clone.access) return undefined;
-		if (typeof clone.refresh !== "string" || !clone.refresh) return undefined;
+		if (typeof clone.refresh !== "string") return undefined;
 		if (typeof clone.expires !== "number" || !Number.isFinite(clone.expires)) return undefined;
 		return clone;
 	} catch {

--- a/packages/pi-accounts/src/oauth.ts
+++ b/packages/pi-accounts/src/oauth.ts
@@ -8,6 +8,7 @@ import {
 } from "@earendil-works/pi-ai";
 import {
 	type ExtensionCommandContext,
+	type ExtensionContext,
 	ExtensionSelectorComponent,
 	LoginDialogComponent,
 } from "@earendil-works/pi-coding-agent";
@@ -17,6 +18,8 @@ export const SUPPORTED_PROVIDER_IDS = [
 	"github-copilot",
 	"kimi-coding",
 	"openai-codex",
+	"openrouter",
+	"radius",
 	"xai",
 ] as const;
 
@@ -30,6 +33,8 @@ export type AccountProviderAdapter = {
 	oauth: ProviderOwnedOAuth;
 	requiresApiKeyBridge: boolean;
 	runtimeAuthMode: "api-key" | "authorization-header";
+	refreshModelCatalogAfterAuth?: boolean;
+	resolveOAuth?: (ctx: Pick<ExtensionContext, "modelRegistry">) => ProviderOwnedOAuth;
 	defaultModelId?: string;
 	invalidateConnections?: (sessionId?: string) => unknown | Promise<unknown>;
 };
@@ -85,6 +90,26 @@ export function createBuiltinProviderAdapters(
 			oauth: createLazyProviderOwnedOAuth("kimi-coding", loader),
 		},
 		{
+			id: "openrouter",
+			displayName: "OpenRouter",
+			requiresApiKeyBridge: false,
+			runtimeAuthMode: "api-key",
+			oauth: createLazyProviderOwnedOAuth("openrouter", loader),
+		},
+		{
+			id: "radius",
+			displayName: "Radius",
+			requiresApiKeyBridge: false,
+			runtimeAuthMode: "api-key",
+			refreshModelCatalogAfterAuth: true,
+			resolveOAuth: (ctx) => {
+				const oauth = ctx.modelRegistry.getProvider("radius")?.auth.oauth;
+				if (!oauth) throw new Error("Pi's active Radius OAuth provider is unavailable.");
+				return oauth;
+			},
+			oauth: createLazyProviderOwnedOAuth("radius", loader),
+		},
+		{
 			id: "xai",
 			displayName: "xAI",
 			requiresApiKeyBridge: false,
@@ -92,6 +117,13 @@ export function createBuiltinProviderAdapters(
 			oauth: createLazyProviderOwnedOAuth("xai", loader),
 		},
 	];
+}
+
+export function resolveProviderOAuth(
+	adapter: AccountProviderAdapter,
+	ctx: Pick<ExtensionContext, "modelRegistry">,
+): ProviderOwnedOAuth {
+	return adapter.resolveOAuth?.(ctx) ?? adapter.oauth;
 }
 
 export function createOAuthInteraction(
@@ -111,11 +143,12 @@ export async function loginWithOAuthUI(
 	adapter: AccountProviderAdapter,
 	signal: AbortSignal,
 ): Promise<OAuthCredential> {
+	const oauth = resolveProviderOAuth(adapter, ctx);
 	if (ctx.mode !== "tui") {
-		return adapter.oauth.login(createOAuthInteraction(ctx, adapter.displayName, signal));
+		return oauth.login(createOAuthInteraction(ctx, adapter.displayName, signal));
 	}
 	const result = await ctx.ui.custom<NativeOAuthLoginResult>((tui, _theme, _keybindings, done) => {
-		const flow = new NativeOAuthLoginFlow(tui, adapter, signal, done);
+		const flow = new NativeOAuthLoginFlow(tui, adapter, oauth, signal, done);
 		flow.start();
 		return flow;
 	});
@@ -145,7 +178,8 @@ class NativeOAuthLoginFlow {
 
 	constructor(
 		private readonly tui: ConstructorParameters<typeof LoginDialogComponent>[0],
-		private readonly adapter: AccountProviderAdapter,
+		adapter: AccountProviderAdapter,
+		private readonly oauth: ProviderOwnedOAuth,
 		ownerSignal: AbortSignal,
 		private readonly done: (result: NativeOAuthLoginResult) => void,
 	) {
@@ -173,7 +207,7 @@ class NativeOAuthLoginFlow {
 			this.finish({ ok: false, error: new Error("Login cancelled") });
 			return;
 		}
-		const login = this.adapter.oauth.login({
+		const login = this.oauth.login({
 			signal: this.signal,
 			prompt: (prompt) => this.prompt(prompt),
 			notify: (event) => this.notify(event),

--- a/packages/pi-accounts/src/runtime-auth.ts
+++ b/packages/pi-accounts/src/runtime-auth.ts
@@ -1,11 +1,16 @@
 import type { ModelAuth, OAuthCredential, ProviderHeaders } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { AccountProviderAdapter, AccountProviderId } from "./oauth.js";
+import {
+	type AccountProviderAdapter,
+	type AccountProviderId,
+	resolveProviderOAuth,
+} from "./oauth.js";
 import { cloneOAuthCredential, parseCredentialRequest } from "./oauth-credential-source.js";
 
 export const RUNTIME_FAIL_CLOSED_API_KEY = "pi-accounts-auth-failed";
 const RUNTIME_HEADER_AUTH_SELECTOR = "pi-accounts-header-auth";
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
+const SHUTDOWN_CATALOG_REFRESH_TIMEOUT_MS = 3_000;
 
 type RuntimeAuthStorage = {
 	setRuntimeApiKey(provider: string, apiKey: string): void | Promise<void>;
@@ -62,11 +67,12 @@ export class RuntimeAuthCoordinator {
 	private readonly overlay: RuntimeProviderOverlay;
 	private availableModelIds: ReadonlySet<string> | undefined;
 	private refreshController = new AbortController();
+	private catalogAuthIdentity: string | undefined;
 	private pendingCredentialOffer: PendingCredentialOffer | undefined;
 	private activeCredentialOffer: ActiveCredentialOffer | undefined;
 
 	constructor(
-		pi: ExtensionAPI,
+		private readonly pi: ExtensionAPI,
 		readonly provider: AccountProviderAdapter,
 		private readonly failClosedApiKey = RUNTIME_FAIL_CLOSED_API_KEY,
 	) {
@@ -78,14 +84,20 @@ export class RuntimeAuthCoordinator {
 		ctx: ExtensionContext,
 		store: RuntimeAccountStore,
 		now = Date.now(),
+		ownerSignal?: AbortSignal,
 	): Promise<EnsureActiveProviderAuthResult> {
 		this.clearCredentialOffer();
 		const operation = this.overlay.beginOperation();
 		const runtimeOverride = this.controller.begin(ctx);
-		const refreshSignal = this.refreshController.signal;
+		const operationSignal = this.beginRefreshOperation();
+		const refreshSignal = ownerSignal
+			? AbortSignal.any([operationSignal, ownerSignal])
+			: operationSignal;
 		let state: ProviderAccountState;
 		try {
+			refreshSignal.throwIfAborted();
 			state = await store.readProviderAsync(this.provider.id);
+			refreshSignal.throwIfAborted();
 		} catch (error) {
 			return this.failClosed(ctx, operation, runtimeOverride, "unknown", error);
 		}
@@ -93,10 +105,12 @@ export class RuntimeAuthCoordinator {
 		if (!active) {
 			this.availableModelIds = undefined;
 			try {
-				await this.controller.clear(ctx);
-				this.overlay.remove(ctx, operation);
+				await this.restoreDefault(ctx, operation, refreshSignal);
 				return { status: "inactive", providerId: this.provider.id };
 			} catch (error) {
+				if (!this.overlay.isCurrent(operation)) {
+					return { status: "inactive", providerId: this.provider.id };
+				}
 				return this.failClosed(
 					ctx,
 					this.overlay.beginOperation(),
@@ -122,12 +136,24 @@ export class RuntimeAuthCoordinator {
 				if (!this.overlay.isCurrent(operation)) {
 					return { status: "inactive", providerId: this.provider.id };
 				}
-				return this.ensureActive(ctx, store, now);
+				return this.ensureActive(ctx, store, now, ownerSignal);
 			}
 			this.availableModelIds = undefined;
-			await this.controller.clear(ctx);
-			this.overlay.remove(ctx, operation);
-			return { status: "inactive", providerId: this.provider.id };
+			try {
+				await this.restoreDefault(ctx, operation, refreshSignal);
+				return { status: "inactive", providerId: this.provider.id };
+			} catch (error) {
+				if (!this.overlay.isCurrent(operation)) {
+					return { status: "inactive", providerId: this.provider.id };
+				}
+				return this.failClosed(
+					ctx,
+					this.overlay.beginOperation(),
+					this.controller.begin(ctx),
+					"unknown",
+					error,
+				);
+			}
 		}
 
 		if (credential.expires <= now + REFRESH_SKEW_MS) {
@@ -141,7 +167,10 @@ export class RuntimeAuthCoordinator {
 					if (latestCredential.expires > now + REFRESH_SKEW_MS) return latest;
 					try {
 						refreshSignal.throwIfAborted();
-						const refreshed = await this.provider.oauth.refresh(latestCredential, refreshSignal);
+						const refreshed = await resolveProviderOAuth(this.provider, ctx).refresh(
+							latestCredential,
+							refreshSignal,
+						);
 						refreshSignal.throwIfAborted();
 						credential = refreshed;
 						return {
@@ -161,7 +190,7 @@ export class RuntimeAuthCoordinator {
 				if (!this.overlay.isCurrent(operation)) {
 					return { status: "inactive", providerId: this.provider.id };
 				}
-				return this.ensureActive(ctx, store, now);
+				return this.ensureActive(ctx, store, now, ownerSignal);
 			}
 			if (refreshError !== undefined) {
 				const selection = await this.activeCredentialMatches(store, active, credential);
@@ -179,7 +208,7 @@ export class RuntimeAuthCoordinator {
 					if (!this.overlay.isCurrent(operation)) {
 						return { status: "inactive", providerId: this.provider.id };
 					}
-					return this.ensureActive(ctx, store, now);
+					return this.ensureActive(ctx, store, now, ownerSignal);
 				}
 				return this.failClosed(ctx, operation, runtimeOverride, active, refreshError, credential);
 			}
@@ -188,7 +217,7 @@ export class RuntimeAuthCoordinator {
 		let auth: ModelAuth;
 		let runtimeApiKey: string;
 		try {
-			auth = await this.provider.oauth.toAuth(credential);
+			auth = await resolveProviderOAuth(this.provider, ctx).toAuth(credential);
 			runtimeApiKey = validateModelAuth(auth, this.provider);
 		} catch (error) {
 			const selection = await this.activeCredentialMatches(store, active, credential);
@@ -206,7 +235,7 @@ export class RuntimeAuthCoordinator {
 				if (!this.overlay.isCurrent(operation)) {
 					return { status: "inactive", providerId: this.provider.id };
 				}
-				return this.ensureActive(ctx, store, now);
+				return this.ensureActive(ctx, store, now, ownerSignal);
 			}
 			return this.failClosed(ctx, operation, runtimeOverride, active, error, credential);
 		}
@@ -219,11 +248,12 @@ export class RuntimeAuthCoordinator {
 			if (!this.overlay.isCurrent(operation)) {
 				return { status: "inactive", providerId: this.provider.id };
 			}
-			return this.ensureActive(ctx, store, now);
+			return this.ensureActive(ctx, store, now, ownerSignal);
 		}
 
 		try {
-			const availableModelIds = readAvailableModelIds(credential);
+			refreshSignal.throwIfAborted();
+			let availableModelIds = readAvailableModelIds(credential);
 			if (!this.overlay.apply(ctx, operation, auth, availableModelIds)) {
 				return { status: "inactive", providerId: this.provider.id };
 			}
@@ -232,7 +262,30 @@ export class RuntimeAuthCoordinator {
 			if (applied === "unavailable") {
 				throw new Error(`Pi did not retain the runtime ${this.provider.displayName} credential.`);
 			}
+			refreshSignal.throwIfAborted();
+			const catalogModelIds = await this.refreshModelCatalog(
+				ctx,
+				refreshSignal,
+				`account:${credential.access}`,
+			);
+			if (catalogModelIds) availableModelIds = catalogModelIds;
+			await this.rebindRefreshedModel(ctx, operation);
+			if (!this.overlay.isCurrent(operation)) {
+				return { status: "inactive", providerId: this.provider.id };
+			}
+			const refreshedSelection = await this.activeCredentialMatches(store, active, credential);
+			if (refreshedSelection.error !== undefined) {
+				throw refreshedSelection.error;
+			}
+			if (!refreshedSelection.matches) {
+				if (!this.overlay.isCurrent(operation)) {
+					return { status: "inactive", providerId: this.provider.id };
+				}
+				return this.ensureActive(ctx, store, now, ownerSignal);
+			}
+			refreshSignal.throwIfAborted();
 			await this.verifyOverlay(ctx, auth, availableModelIds);
+			refreshSignal.throwIfAborted();
 			if (!this.overlay.isCurrent(operation)) {
 				return { status: "inactive", providerId: this.provider.id };
 			}
@@ -296,6 +349,69 @@ export class RuntimeAuthCoordinator {
 		this.activeCredentialOffer = undefined;
 	}
 
+	private beginRefreshOperation(): AbortSignal {
+		this.refreshController.abort(new DOMException("Account operation superseded", "AbortError"));
+		this.refreshController = new AbortController();
+		return this.refreshController.signal;
+	}
+
+	private async restoreDefault(
+		ctx: ExtensionContext,
+		operation: number,
+		signal: AbortSignal,
+	): Promise<void> {
+		signal.throwIfAborted();
+		await this.controller.clear(ctx);
+		signal.throwIfAborted();
+		if (this.catalogAuthIdentity !== undefined) {
+			await this.refreshModelCatalog(ctx, signal, "default");
+			await this.rebindRefreshedModel(ctx, operation);
+		}
+		if (!this.overlay.isCurrent(operation)) return;
+		this.overlay.remove(ctx, operation);
+	}
+
+	private async refreshModelCatalog(
+		ctx: ExtensionContext,
+		signal: AbortSignal,
+		authIdentity: string,
+	): Promise<string[] | undefined> {
+		if (!this.provider.refreshModelCatalogAfterAuth) return undefined;
+		if (this.catalogAuthIdentity !== authIdentity) {
+			const result = await ctx.modelRegistry.refresh({
+				allowNetwork: true,
+				providers: [this.provider.id],
+				signal,
+			});
+			signal.throwIfAborted();
+			const error = result.errors.get(this.provider.id);
+			if (error) throw error;
+			if (result.aborted) {
+				throw new Error(`${this.provider.displayName} model catalog refresh was aborted.`);
+			}
+			this.catalogAuthIdentity = authIdentity;
+		}
+		return readProviderModels(ctx, this.provider.id).map((model) => model.id);
+	}
+
+	private async rebindRefreshedModel(ctx: ExtensionContext, operation: number): Promise<void> {
+		if (!this.provider.refreshModelCatalogAfterAuth || ctx.model?.provider !== this.provider.id)
+			return;
+		const refreshed = ctx.modelRegistry.find(this.provider.id, ctx.model.id);
+		if (!refreshed) {
+			throw new Error(
+				`${this.provider.displayName} model ${ctx.model.id} is unavailable after catalog refresh.`,
+			);
+		}
+		if (sameModelDefinition(ctx.model, refreshed)) return;
+		if (!(await this.pi.setModel(refreshed))) {
+			throw new Error(
+				`Pi could not select the refreshed ${this.provider.displayName} model ${refreshed.id}.`,
+			);
+		}
+		if (!this.overlay.isCurrent(operation)) return;
+	}
+
 	async forceFailClosed(
 		ctx: ExtensionContext,
 		accountName: string,
@@ -312,20 +428,35 @@ export class RuntimeAuthCoordinator {
 		);
 	}
 
-	invalidate(ctx: ExtensionContext): void {
+	invalidate(ctx: ExtensionContext, resetCatalogIdentity = true): void {
 		this.clearCredentialOffer();
+		if (resetCatalogIdentity) this.catalogAuthIdentity = undefined;
 		this.overlay.beginOperation();
 		this.controller.invalidate(ctx);
 		this.refreshController.abort(new DOMException("Account refresh invalidated", "AbortError"));
 		this.refreshController = new AbortController();
 	}
 
-	async clear(ctx: ExtensionContext): Promise<void> {
+	async clear(ctx: ExtensionContext, restoreDefaultCatalog = false): Promise<void> {
 		this.clearCredentialOffer();
 		const operation = this.overlay.beginOperation();
 		this.availableModelIds = undefined;
 		await this.controller.clear(ctx);
-		this.overlay.remove(ctx, operation);
+		try {
+			if (restoreDefaultCatalog && this.catalogAuthIdentity !== undefined) {
+				await this.refreshModelCatalog(
+					ctx,
+					AbortSignal.any([
+						this.refreshController.signal,
+						AbortSignal.timeout(SHUTDOWN_CATALOG_REFRESH_TIMEOUT_MS),
+					]),
+					"default",
+				);
+			}
+		} finally {
+			this.overlay.remove(ctx, operation);
+			if (!restoreDefaultCatalog) this.catalogAuthIdentity = undefined;
+		}
 	}
 
 	private async failClosed(
@@ -623,6 +754,15 @@ class RuntimeApiKeyController {
 			this.states.set(target, state);
 		}
 		return state;
+	}
+}
+
+function sameModelDefinition(left: unknown, right: unknown): boolean {
+	if (left === right) return true;
+	try {
+		return JSON.stringify(left) === JSON.stringify(right);
+	} catch {
+		return false;
 	}
 }
 

--- a/packages/pi-accounts/test/accounts-storage.test.ts
+++ b/packages/pi-accounts/test/accounts-storage.test.ts
@@ -55,6 +55,14 @@ test("provider-scoped storage preserves independent active accounts and OAuth me
 				active: "fast",
 				accounts: { fast: credential("kimi") },
 			},
+			openrouter: {
+				active: "router",
+				accounts: { router: credential("openrouter", { refresh: "" }) },
+			},
+			radius: {
+				active: "gateway",
+				accounts: { gateway: credential("radius", { scope: "gateway offline_access" }) },
+			},
 			xai: {
 				active: "grok",
 				accounts: { grok: credential("xai") },
@@ -78,6 +86,10 @@ test("provider-scoped storage preserves independent active accounts and OAuth me
 		"github.example.com",
 	);
 	assert.equal(stored.providers["kimi-coding"]?.accounts.fast?.access, "access-kimi");
+	assert.equal(stored.providers.openrouter?.accounts.router?.access, "access-openrouter");
+	assert.equal(stored.providers.openrouter?.accounts.router?.refresh, "");
+	assert.equal(stored.providers.radius?.accounts.gateway?.access, "access-radius");
+	assert.equal(stored.providers.radius?.accounts.gateway?.scope, "gateway offline_access");
 	assert.equal(stored.providers.xai?.accounts.grok?.access, "access-xai");
 });
 
@@ -119,6 +131,22 @@ test("storage rejects malformed credentials and non-JSON-safe metadata", async (
 			),
 		/missing refresh token/,
 	);
+	assert.throws(
+		() =>
+			parseAccountsData(
+				JSON.stringify({
+					version: 1,
+					providers: {
+						openrouter: {
+							accounts: {
+								work: { type: "oauth", access: "a", refresh: null, expires: 1 },
+							},
+						},
+					},
+				}),
+			),
+		/missing refresh token/,
+	);
 
 	const store = new AccountStore(new InMemoryAccountStorageBackend());
 	await assert.rejects(
@@ -137,6 +165,21 @@ test("storage rejects malformed credentials and non-JSON-safe metadata", async (
 		}),
 		/not JSON-safe/,
 	);
+});
+
+test("OpenRouter and Radius storage rejects malformed provider data", () => {
+	for (const providerId of ["openrouter", "radius"] as const) {
+		assert.throws(
+			() =>
+				parseAccountsData(
+					JSON.stringify({
+						version: 1,
+						providers: { [providerId]: { active: "work", accounts: [] } },
+					}),
+				),
+			/accounts must be an object/,
+		);
+	}
 });
 
 test("missing account storage reads as empty without materializing its directory", async () => {

--- a/packages/pi-accounts/test/accounts.test.ts
+++ b/packages/pi-accounts/test/accounts.test.ts
@@ -21,6 +21,7 @@ import {
 	createBuiltinProviderAdapters,
 	createOAuthInteraction,
 	loginWithOAuthUI,
+	resolveProviderOAuth,
 } from "../src/oauth.js";
 import { OAUTH_CREDENTIAL_SOURCE_CHANNEL } from "../src/oauth-credential-source.js";
 import { RuntimeAuthCoordinator } from "../src/runtime-auth.js";
@@ -52,6 +53,8 @@ function fakeProvider(
 		"github-copilot": "GitHub Copilot",
 		"kimi-coding": "Kimi For Coding",
 		"openai-codex": "OpenAI Codex",
+		openrouter: "OpenRouter",
+		radius: "Radius",
 		xai: "xAI",
 	};
 	return {
@@ -59,6 +62,7 @@ function fakeProvider(
 		displayName: displayNames[id],
 		requiresApiKeyBridge: options.requiresApiKeyBridge ?? id === "openai-codex",
 		runtimeAuthMode: id === "kimi-coding" ? "authorization-header" : "api-key",
+		refreshModelCatalogAfterAuth: id === "radius",
 		oauth: {
 			async login() {
 				return credential(
@@ -92,8 +96,11 @@ function runtimeHarness(mock: ReturnType<typeof createMockPi>) {
 		{ provider: "github-copilot", id: "allowed", baseUrl: "https://default.copilot" },
 		{ provider: "github-copilot", id: "blocked", baseUrl: "https://default.copilot" },
 		{ provider: "kimi-coding", id: "k3", baseUrl: "https://api.kimi.com/coding" },
+		{ provider: "openrouter", id: "openrouter-model", baseUrl: "https://openrouter.ai/api/v1" },
+		{ provider: "radius", id: "radius-model", baseUrl: "https://radius.pi.dev" },
 		{ provider: "xai", id: "grok-4.3", baseUrl: "https://api.x.ai/v1" },
 	];
+	const refreshCalls: Array<{ providers?: readonly string[]; allowNetwork?: boolean }> = [];
 	const runtime = {
 		async setRuntimeApiKey(provider: string, key: string) {
 			keys.set(provider, key);
@@ -132,8 +139,16 @@ function runtimeHarness(mock: ReturnType<typeof createMockPi>) {
 				| undefined;
 			return { ok: true as const, apiKey: keys.get(model.provider), headers: config?.headers };
 		},
+		async refresh(options: {
+			providers?: readonly string[];
+			allowNetwork?: boolean;
+			signal?: AbortSignal;
+		}) {
+			refreshCalls.push(options);
+			return { aborted: options.signal?.aborted ?? false, errors: new Map<string, Error>() };
+		},
 	};
-	return { keys, registry, runtime };
+	return { keys, models, refreshCalls, registry, runtime };
 }
 
 function collectCredentialOffers(
@@ -216,13 +231,33 @@ test("built-in provider adapters preserve each provider's complete OAuth auth sh
 	assert.deepEqual(await byId.get("kimi-coding")?.oauth.toAuth(base), {
 		headers: { Authorization: "Bearer access-contract" },
 	});
+	assert.deepEqual(await byId.get("openrouter")?.oauth.toAuth(base), {
+		apiKey: "access-contract",
+	});
+	assert.deepEqual(await byId.get("radius")?.oauth.toAuth(base), {
+		apiKey: "access-contract",
+	});
+	assert.equal(byId.get("radius")?.refreshModelCatalogAfterAuth, true);
 	assert.deepEqual([...byId.keys()].sort(), [
 		"anthropic",
 		"github-copilot",
 		"kimi-coding",
 		"openai-codex",
+		"openrouter",
+		"radius",
 		"xai",
 	]);
+	const radius = byId.get("radius");
+	assert.ok(radius);
+	const activeRadiusOAuth = fakeProvider("radius").oauth;
+	assert.equal(
+		resolveProviderOAuth(radius, {
+			modelRegistry: {
+				getProvider: () => ({ auth: { oauth: activeRadiusOAuth } }),
+			} as never,
+		}),
+		activeRadiusOAuth,
+	);
 });
 
 test("OAuth interaction preserves provider prompts, cancellation, and notifications", async () => {
@@ -493,6 +528,8 @@ test("accounts menu summarizes all supported providers and prioritizes current p
 			fakeProvider("anthropic"),
 			fakeProvider("github-copilot"),
 			fakeProvider("kimi-coding"),
+			fakeProvider("openrouter"),
+			fakeProvider("radius"),
 			fakeProvider("xai"),
 		],
 	});
@@ -509,6 +546,8 @@ test("accounts menu summarizes all supported providers and prioritizes current p
 	assert.match(selectCalls[0]?.title ?? "", /OpenAI Codex: default/);
 	assert.match(selectCalls[0]?.title ?? "", /GitHub Copilot: default/);
 	assert.match(selectCalls[0]?.title ?? "", /Kimi For Coding: default/);
+	assert.match(selectCalls[0]?.title ?? "", /OpenRouter: default/);
+	assert.match(selectCalls[0]?.title ?? "", /Radius: default/);
 	assert.match(selectCalls[0]?.title ?? "", /xAI: default/);
 	assert.deepEqual(selectCalls[0]?.options, [
 		"Switch Anthropic account",
@@ -647,6 +686,111 @@ test("provider accounts activate independently and default clears only one provi
 	assert.match(notifications.at(-1)?.message ?? "", /default Pi Anthropic login/);
 });
 
+test("session replacement prevents a stale switch menu from mutating accounts", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			anthropic: {
+				active: "work",
+				accounts: { personal: credential("personal"), work: credential("work") },
+			},
+		},
+	});
+	const originalUpdate = store.updateProvider.bind(store);
+	let markUpdateStarted!: () => void;
+	const updateStarted = new Promise<void>((resolve) => {
+		markUpdateStarted = resolve;
+	});
+	let releaseUpdate!: () => void;
+	const updateReleased = new Promise<void>((resolve) => {
+		releaseUpdate = resolve;
+	});
+	store.updateProvider = async (providerId, mutator) => {
+		markUpdateStarted();
+		await updateReleased;
+		return originalUpdate(providerId, mutator);
+	};
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { keys, registry } = runtimeHarness(mock);
+	const oldContext = createInteractiveAccountContext(
+		{ model: { provider: "anthropic", id: "claude" }, modelRegistry: registry },
+		{ selections: ["Switch Anthropic account", "personal"] },
+	).ctx;
+	const newContext = createMockContext({
+		model: { provider: "anthropic", id: "claude" },
+		modelRegistry: registry,
+	}).ctx;
+
+	const stale = mock.commands.get("accounts")?.handler("ignored", oldContext);
+	await updateStarted;
+	await mock.events.get("session_start")?.[0]?.({}, newContext);
+	releaseUpdate();
+	await stale;
+	assert.equal((await store.readProviderAsync("anthropic")).active, "work");
+	assert.equal(keys.get("anthropic"), "access-work");
+});
+
+test("session replacement prevents a stale remove menu from deleting accounts", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			anthropic: { active: "work", accounts: { work: credential("work") } },
+		},
+	});
+	const originalUpdate = store.updateProvider.bind(store);
+	let markUpdateStarted!: () => void;
+	const updateStarted = new Promise<void>((resolve) => {
+		markUpdateStarted = resolve;
+	});
+	let releaseUpdate!: () => void;
+	const updateReleased = new Promise<void>((resolve) => {
+		releaseUpdate = resolve;
+	});
+	store.updateProvider = async (providerId, mutator) => {
+		markUpdateStarted();
+		await updateReleased;
+		return originalUpdate(providerId, mutator);
+	};
+	const mock = createMockPi();
+	accountsExtension(mock.pi, {
+		store,
+		providers: [
+			fakeProvider("openai-codex"),
+			fakeProvider("anthropic"),
+			fakeProvider("github-copilot"),
+		],
+	});
+	const { keys, registry } = runtimeHarness(mock);
+	const oldContext = createInteractiveAccountContext(
+		{ model: { provider: "anthropic", id: "claude" }, modelRegistry: registry },
+		{ selections: ["Remove account", "Anthropic · work"], confirms: [true] },
+	).ctx;
+	const newContext = createMockContext({
+		model: { provider: "anthropic", id: "claude" },
+		modelRegistry: registry,
+	}).ctx;
+
+	const stale = mock.commands.get("accounts")?.handler("ignored", oldContext);
+	await updateStarted;
+	await mock.events.get("session_start")?.[0]?.({}, newContext);
+	releaseUpdate();
+	await stale;
+	const state = await store.readProviderAsync("anthropic");
+	assert.equal(state.active, "work");
+	assert.equal(state.accounts.work?.access, "access-work");
+	assert.equal(keys.get("anthropic"), "access-work");
+});
+
 test("default Codex auth does not invalidate connections on first observation", async () => {
 	const invalidations: Array<string | undefined> = [];
 	const codex = fakeProvider("openai-codex");
@@ -779,7 +923,7 @@ test("an obsolete invalidation failure cannot fail closed a newer successful syn
 	});
 	store.readProviderAsync = async (providerId) => {
 		reads += 1;
-		if (reads === 4) {
+		if (reads === 5) {
 			signalObsoleteRead?.();
 			await obsoleteReadBlocked;
 		}
@@ -867,17 +1011,22 @@ test("generic login stores the full provider-owned credential and activates it",
 	assert.equal(keys.get("github-copilot"), "access-login-github-copilot");
 });
 
-test("xAI and Kimi login routes store and activate named OAuth accounts", async () => {
-	for (const providerId of ["xai", "kimi-coding"] as const) {
+test("xAI, Kimi, OpenRouter, and Radius login routes activate named OAuth accounts", async () => {
+	for (const providerId of ["xai", "kimi-coding", "openrouter", "radius"] as const) {
 		const store = new AccountStore(new InMemoryAccountStorageBackend());
 		const provider = fakeProvider(providerId);
 		const mock = createMockPi();
 		accountsExtension(mock.pi, { store, providers: [provider] });
-		const { registry, keys } = runtimeHarness(mock);
-		const modelId = providerId === "xai" ? "grok-4.3" : "k3";
+		const { registry, keys, refreshCalls } = runtimeHarness(mock);
+		const modelIds = {
+			"kimi-coding": "k3",
+			openrouter: "openrouter-model",
+			radius: "radius-model",
+			xai: "grok-4.3",
+		};
 		const { ctx } = createInteractiveAccountContext(
 			{
-				model: { provider: providerId, id: modelId },
+				model: { provider: providerId, id: modelIds[providerId] },
 				modelRegistry: registry,
 			},
 			{ selections: ["Login new account", provider.displayName], inputs: ["work"] },
@@ -889,8 +1038,9 @@ test("xAI and Kimi login routes store and activate named OAuth accounts", async 
 		assert.equal(state.accounts.work?.access, `access-login-${providerId}`);
 		assert.equal(
 			keys.get(providerId),
-			providerId === "xai" ? "access-login-xai" : "pi-accounts-header-auth",
+			providerId === "kimi-coding" ? "pi-accounts-header-auth" : `access-login-${providerId}`,
 		);
+		assert.equal(refreshCalls.length, providerId === "radius" ? 1 : 0);
 	}
 });
 
@@ -1273,8 +1423,478 @@ test("xAI named OAuth applies its access token and restores default auth", async
 	assert.equal(keys.has("xai"), false);
 });
 
-test("xAI and Kimi refresh expiring named credentials before activation", async () => {
-	for (const providerId of ["xai", "kimi-coding"] as const) {
+test("OpenRouter named OAuth applies its access token and restores default auth", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			openrouter: {
+				active: "work",
+				accounts: { work: credential("openrouter", { refresh: "" }) },
+			},
+		},
+	});
+	const mock = createMockPi();
+	const { keys, refreshCalls, registry } = runtimeHarness(mock);
+	const sessionManager = {};
+	const { ctx } = createMockContext({
+		model: { provider: "openrouter", id: "openrouter-model" },
+		modelRegistry: registry,
+		sessionManager,
+	});
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("openrouter"));
+
+	const active = await coordinator.ensureActive(ctx, store);
+	assert.deepEqual(active, {
+		status: "active",
+		providerId: "openrouter",
+		accountName: "work",
+	});
+	coordinator.publishCredentialOffer(ctx, active, "work:access-openrouter");
+	const offers: StoredOAuthCredential[] = [];
+	coordinator.offerCredential({
+		session: sessionManager,
+		provider: "openrouter",
+		offer: (candidate: StoredOAuthCredential) => offers.push(candidate),
+	});
+	assert.equal(offers[0]?.refresh, "");
+	assert.equal(keys.get("openrouter"), "access-openrouter");
+	assert.deepEqual(refreshCalls, []);
+
+	await store.updateProvider("openrouter", (state) => ({ ...state, active: undefined }));
+	assert.deepEqual(await coordinator.ensureActive(ctx, store), {
+		status: "inactive",
+		providerId: "openrouter",
+	});
+	assert.equal(keys.has("openrouter"), false);
+	assert.deepEqual(refreshCalls, []);
+});
+
+test("OpenRouter activation observes an already cancelled menu operation", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			openrouter: { active: "work", accounts: { work: credential("openrouter") } },
+		},
+	});
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	const { ctx } = createMockContext({ modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("openrouter"));
+	const owner = new AbortController();
+	owner.abort(new DOMException("Menu cancelled", "AbortError"));
+
+	assert.equal(
+		(await coordinator.ensureActive(ctx, store, Date.now(), owner.signal)).status,
+		"error",
+	);
+	assert.equal(keys.get("openrouter"), FAIL_CLOSED_API_KEY);
+});
+
+test("Radius resolves OAuth from Pi's active gateway provider", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const radius = createBuiltinProviderAdapters().find((provider) => provider.id === "radius");
+	assert.ok(radius);
+	const activeOAuth = fakeProvider("radius").oauth;
+	activeOAuth.toAuth = async (current) => ({ apiKey: `gateway:${current.access}` });
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	const modelRegistry = {
+		...registry,
+		getProvider: () => ({ auth: { oauth: activeOAuth } }),
+	};
+	const { ctx } = createMockContext({ modelRegistry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, radius);
+
+	assert.equal((await coordinator.ensureActive(ctx, store)).status, "active");
+	assert.equal(keys.get("radius"), "gateway:access-radius");
+});
+
+test("Radius refreshes its dynamic catalog for named and restored default auth", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	const { keys, models, registry } = runtimeHarness(mock);
+	const refreshKeys: Array<string | undefined> = [];
+	registry.refresh = async (options) => {
+		refreshKeys.push(keys.get("radius"));
+		assert.deepEqual(options.providers, ["radius"]);
+		assert.equal(options.allowNetwork, true);
+		assert.equal(options.signal?.aborted, false);
+		models.splice(
+			models.findIndex((model) => model.provider === "radius"),
+			1,
+			{
+				provider: "radius",
+				id: keys.has("radius") ? "named-radius-model" : "default-radius-model",
+				baseUrl: "https://radius.pi.dev",
+			},
+		);
+		return { aborted: false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+
+	assert.deepEqual(await coordinator.ensureActive(ctx, store), {
+		status: "active",
+		providerId: "radius",
+		accountName: "work",
+	});
+	assert.equal(keys.get("radius"), "access-radius");
+	assert.equal(
+		models.some((model) => model.id === "named-radius-model"),
+		true,
+	);
+	assert.equal((await coordinator.ensureActive(ctx, store)).status, "active");
+	assert.deepEqual(refreshKeys, ["access-radius"]);
+
+	await store.updateProvider("radius", (state) => ({ ...state, active: undefined }));
+	assert.deepEqual(await coordinator.ensureActive(ctx, store), {
+		status: "inactive",
+		providerId: "radius",
+	});
+	assert.equal(keys.has("radius"), false);
+	assert.equal(
+		models.some((model) => model.id === "default-radius-model"),
+		true,
+	);
+	assert.deepEqual(refreshKeys, ["access-radius", undefined]);
+});
+
+test("Radius rebinds a retained selected model to its refreshed endpoint", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	const { models, registry } = runtimeHarness(mock);
+	const selected = registry.find("radius", "radius-model");
+	assert.ok(selected);
+	registry.refresh = async () => {
+		const radius = models.find((model) => model.provider === "radius");
+		assert.ok(radius);
+		radius.baseUrl = "https://account.radius.example";
+		return { aborted: false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ model: selected, modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+
+	assert.equal((await coordinator.ensureActive(ctx, store)).status, "active");
+	assert.equal(mock.setModels.length, 1);
+	assert.equal(
+		(mock.setModels[0] as { baseUrl?: string }).baseUrl,
+		"https://account.radius.example",
+	);
+});
+
+test("Radius fails closed when the selected model disappears from the refreshed catalog", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	const { keys, models, registry } = runtimeHarness(mock);
+	const selected = registry.find("radius", "radius-model");
+	assert.ok(selected);
+	registry.refresh = async () => {
+		models.splice(
+			models.findIndex((model) => model.provider === "radius"),
+			1,
+		);
+		return { aborted: false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ model: selected, modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+
+	const result = await coordinator.ensureActive(ctx, store);
+	assert.equal(result.status, "error");
+	if (result.status === "error") assert.match(result.message, /model radius-model is unavailable/);
+	assert.equal(keys.get("radius"), FAIL_CLOSED_API_KEY);
+});
+
+test("Radius catalog refresh errors fail closed", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	registry.refresh = async () => ({
+		aborted: false,
+		errors: new Map([["radius", new Error("catalog unavailable")]]),
+	});
+	const { ctx } = createMockContext({ modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+
+	const result = await coordinator.ensureActive(ctx, store);
+	assert.equal(result.status, "error");
+	if (result.status === "error") assert.match(result.message, /catalog unavailable/);
+	assert.equal(keys.get("radius"), FAIL_CLOSED_API_KEY);
+});
+
+test("a newer Radius account operation aborts stale catalog refresh work", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius-old") } } },
+	});
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	let firstSignal: AbortSignal | undefined;
+	let markFirstStarted!: () => void;
+	const firstStarted = new Promise<void>((resolve) => {
+		markFirstStarted = resolve;
+	});
+	let refreshes = 0;
+	registry.refresh = async (options) => {
+		refreshes += 1;
+		if (refreshes === 1) {
+			firstSignal = options.signal;
+			markFirstStarted();
+			await new Promise<void>((resolve) => {
+				if (options.signal?.aborted) resolve();
+				else options.signal?.addEventListener("abort", () => resolve(), { once: true });
+			});
+		}
+		return { aborted: options.signal?.aborted ?? false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+
+	const stale = coordinator.ensureActive(ctx, store);
+	await firstStarted;
+	await store.updateProvider("radius", (state) => ({
+		...state,
+		accounts: { work: credential("radius-new") },
+	}));
+	const current = await coordinator.ensureActive(ctx, store);
+	assert.deepEqual(current, {
+		status: "active",
+		providerId: "radius",
+		accountName: "work",
+	});
+	assert.deepEqual(await stale, { status: "inactive", providerId: "radius" });
+	assert.equal(firstSignal?.aborted, true);
+	assert.equal(keys.get("radius"), "access-radius-new");
+});
+
+test("stale Radius default restoration cannot fail close a newer named activation", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			radius: {
+				active: "alpha",
+				accounts: { alpha: credential("radius-alpha"), beta: credential("radius-beta") },
+			},
+		},
+	});
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	let markDefaultStarted!: () => void;
+	const defaultStarted = new Promise<void>((resolve) => {
+		markDefaultStarted = resolve;
+	});
+	let refreshes = 0;
+	registry.refresh = async (options) => {
+		refreshes += 1;
+		if (refreshes === 2) {
+			markDefaultStarted();
+			await new Promise<void>((resolve) => {
+				if (options.signal?.aborted) resolve();
+				else options.signal?.addEventListener("abort", () => resolve(), { once: true });
+			});
+		}
+		return { aborted: options.signal?.aborted ?? false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+	assert.equal((await coordinator.ensureActive(ctx, store)).status, "active");
+
+	await store.updateProvider("radius", (state) => ({ ...state, active: undefined }));
+	const staleDefault = coordinator.ensureActive(ctx, store);
+	await defaultStarted;
+	await store.updateProvider("radius", (state) => ({ ...state, active: "beta" }));
+	const current = await coordinator.ensureActive(ctx, store);
+
+	assert.equal(current.status, "active");
+	assert.deepEqual(await staleDefault, { status: "inactive", providerId: "radius" });
+	assert.equal(keys.get("radius"), "access-radius-beta");
+	assert.equal(refreshes, 3);
+});
+
+test("Radius retries when account selection changes during catalog publication", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			radius: {
+				active: "alpha",
+				accounts: { alpha: credential("radius-alpha"), beta: credential("radius-beta") },
+			},
+		},
+	});
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	let refreshes = 0;
+	registry.refresh = async () => {
+		refreshes += 1;
+		if (refreshes === 1) {
+			await store.updateProvider("radius", (state) => ({ ...state, active: "beta" }));
+		}
+		return { aborted: false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+
+	assert.deepEqual(await coordinator.ensureActive(ctx, store), {
+		status: "active",
+		providerId: "radius",
+		accountName: "beta",
+	});
+	assert.equal(keys.get("radius"), "access-radius-beta");
+	assert.equal(refreshes, 2);
+});
+
+test("Radius menu cancellation aborts post-login catalog work and fails closed", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	const { keys, registry } = runtimeHarness(mock);
+	let markRefreshStarted!: () => void;
+	const refreshStarted = new Promise<void>((resolve) => {
+		markRefreshStarted = resolve;
+	});
+	registry.refresh = async (options) => {
+		markRefreshStarted();
+		await new Promise<void>((resolve) => {
+			if (options.signal?.aborted) resolve();
+			else options.signal?.addEventListener("abort", () => resolve(), { once: true });
+		});
+		return { aborted: options.signal?.aborted ?? false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ modelRegistry: registry });
+	const coordinator = new RuntimeAuthCoordinator(mock.pi, fakeProvider("radius"));
+	const owner = new AbortController();
+
+	const activation = coordinator.ensureActive(ctx, store, Date.now(), owner.signal);
+	await refreshStarted;
+	owner.abort(new DOMException("Menu cancelled", "AbortError"));
+	assert.equal((await activation).status, "error");
+	assert.equal(keys.get("radius"), FAIL_CLOSED_API_KEY);
+});
+
+test("Radius session replacement aborts the stale catalog refresh", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	accountsExtension(mock.pi, { store, providers: [fakeProvider("radius")] });
+	const { keys, registry } = runtimeHarness(mock);
+	let firstSignal: AbortSignal | undefined;
+	let markFirstStarted!: () => void;
+	const firstStarted = new Promise<void>((resolve) => {
+		markFirstStarted = resolve;
+	});
+	let refreshes = 0;
+	registry.refresh = async (options) => {
+		refreshes += 1;
+		if (refreshes === 1) {
+			firstSignal = options.signal;
+			markFirstStarted();
+			await new Promise<void>((resolve) => {
+				if (options.signal?.aborted) resolve();
+				else options.signal?.addEventListener("abort", () => resolve(), { once: true });
+			});
+		}
+		return { aborted: options.signal?.aborted ?? false, errors: new Map<string, Error>() };
+	};
+	const oldContext = createMockContext({ modelRegistry: registry, sessionManager: {} }).ctx;
+	const newContext = createMockContext({ modelRegistry: registry, sessionManager: {} }).ctx;
+
+	const oldStart = mock.events.get("session_start")?.[0]?.({}, oldContext);
+	await firstStarted;
+	await mock.events.get("session_start")?.[0]?.({}, newContext);
+	await oldStart;
+	assert.equal(firstSignal?.aborted, true);
+	assert.equal(refreshes, 2);
+	assert.equal(keys.get("radius"), "access-radius");
+});
+
+test("Radius session shutdown aborts a pending catalog refresh and removes runtime auth", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	accountsExtension(mock.pi, { store, providers: [fakeProvider("radius")] });
+	const { keys, registry } = runtimeHarness(mock);
+	let refreshSignal: AbortSignal | undefined;
+	let markRefreshStarted!: () => void;
+	const refreshStarted = new Promise<void>((resolve) => {
+		markRefreshStarted = resolve;
+	});
+	registry.refresh = async (options) => {
+		refreshSignal = options.signal;
+		markRefreshStarted();
+		await new Promise<void>((resolve) => {
+			if (options.signal?.aborted) resolve();
+			else options.signal?.addEventListener("abort", () => resolve(), { once: true });
+		});
+		return { aborted: options.signal?.aborted ?? false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ modelRegistry: registry });
+
+	const start = mock.events.get("session_start")?.[0]?.({}, ctx);
+	await refreshStarted;
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	await start;
+	assert.equal(refreshSignal?.aborted, true);
+	assert.equal(keys.has("radius"), false);
+});
+
+test("Radius session shutdown restores the default catalog after clearing named auth", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: { radius: { active: "work", accounts: { work: credential("radius") } } },
+	});
+	const mock = createMockPi();
+	accountsExtension(mock.pi, { store, providers: [fakeProvider("radius")] });
+	const { keys, registry } = runtimeHarness(mock);
+	const refreshKeys: Array<string | undefined> = [];
+	registry.refresh = async () => {
+		refreshKeys.push(keys.get("radius"));
+		return { aborted: false, errors: new Map<string, Error>() };
+	};
+	const { ctx } = createMockContext({ modelRegistry: registry });
+
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	assert.equal(keys.get("radius"), "access-radius");
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(keys.has("radius"), false);
+	assert.deepEqual(refreshKeys, ["access-radius", undefined]);
+});
+
+test("new provider adapters refresh expiring named credentials before activation", async () => {
+	for (const providerId of ["xai", "kimi-coding", "openrouter", "radius"] as const) {
 		const store = new AccountStore(new InMemoryAccountStorageBackend());
 		await store.write({
 			version: 1,
@@ -1297,7 +1917,7 @@ test("xAI and Kimi refresh expiring named credentials before activation", async 
 		);
 		assert.equal(
 			keys.get(providerId),
-			providerId === "xai" ? "access-xai-refreshed" : "pi-accounts-header-auth",
+			providerId === "kimi-coding" ? "pi-accounts-header-auth" : `access-${providerId}-refreshed`,
 		);
 	}
 });

--- a/packages/pi-accounts/test/radius.test.ts
+++ b/packages/pi-accounts/test/radius.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryCredentialStore, InMemoryModelsStore } from "@earendil-works/pi-ai";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { AccountStore } from "../src/account-store.js";
+import { createBuiltinProviderAdapters } from "../src/oauth.js";
+import { RuntimeAuthCoordinator } from "../src/runtime-auth.js";
+import { InMemoryAccountStorageBackend } from "../src/storage.js";
+
+test("Radius publishes the selected account catalog through Pi's real model runtime", async () => {
+	const requests: string[] = [];
+	const refreshRequests: string[] = [];
+	const server = createServer(async (request, response) => {
+		if (request.url === "/v1/oauth/token") {
+			let body = "";
+			for await (const chunk of request) body += String(chunk);
+			refreshRequests.push(body);
+			response.writeHead(200, { "content-type": "application/json" });
+			response.end(
+				JSON.stringify({
+					access_token: "access-refreshed",
+					refresh_token: "refresh-refreshed",
+					expires_in: 3_600,
+					scope: "gateway offline_access",
+				}),
+			);
+			return;
+		}
+		if (request.url !== "/v1/config") {
+			response.writeHead(404).end();
+			return;
+		}
+		const authorization = request.headers.authorization ?? "";
+		requests.push(authorization);
+		const account = authorization.endsWith("two") ? "two" : "one";
+		response.writeHead(200, { "content-type": "application/json" });
+		response.end(
+			JSON.stringify({
+				baseUrl: `http://inference.${account}.radius.test/v1`,
+				models: [
+					{
+						id: "radius-model",
+						name: "Radius Model",
+						reasoning: true,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 16_000,
+					},
+				],
+			}),
+		);
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const address = server.address();
+	assert.ok(address && typeof address === "object");
+	const root = await mkdtemp(join(tmpdir(), "pi-accounts-radius-"));
+	try {
+		const modelsPath = join(root, "models.json");
+		await writeFile(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					radius: {
+						baseUrl: `http://127.0.0.1:${address.port}/v1`,
+						oauth: "radius",
+					},
+				},
+			}),
+		);
+		const runtime = await ModelRuntime.create({
+			credentials: new InMemoryCredentialStore(),
+			modelsPath,
+			modelsStore: new InMemoryModelsStore(),
+			refreshOnCreate: false,
+		});
+		const registry = new ModelRegistry(runtime);
+		const selectedModels: unknown[] = [];
+		const pi = {
+			registerProvider: registry.registerProvider.bind(registry),
+			unregisterProvider: registry.unregisterProvider.bind(registry),
+			async setModel(model: unknown) {
+				selectedModels.push(model);
+				return true;
+			},
+		};
+		const radius = createBuiltinProviderAdapters().find((provider) => provider.id === "radius");
+		assert.ok(radius);
+		const coordinator = new RuntimeAuthCoordinator(pi as never, radius);
+		const store = new AccountStore(new InMemoryAccountStorageBackend());
+		await store.write({
+			version: 1,
+			providers: {
+				radius: {
+					active: "work",
+					accounts: {
+						work: {
+							type: "oauth",
+							access: "access-one",
+							refresh: "refresh-one",
+							expires: 0,
+						},
+					},
+				},
+			},
+		});
+		const firstContext = createMockContext({ modelRegistry: registry }).ctx;
+		assert.equal((await coordinator.ensureActive(firstContext, store)).status, "active");
+		const firstModel = registry.find("radius", "radius-model");
+		assert.equal(firstModel?.baseUrl, "http://inference.one.radius.test/v1");
+		assert.deepEqual(requests, ["Bearer access-refreshed"]);
+		assert.equal(refreshRequests.length, 1);
+		assert.match(refreshRequests[0] ?? "", /refresh_token=refresh-one/);
+		assert.equal(
+			(await store.readProviderAsync("radius")).accounts.work?.access,
+			"access-refreshed",
+		);
+
+		assert.equal((await coordinator.ensureActive(firstContext, store)).status, "active");
+		assert.deepEqual(requests, ["Bearer access-refreshed"]);
+		assert.equal(refreshRequests.length, 1);
+
+		await store.updateProvider("radius", (state) => ({
+			...state,
+			accounts: {
+				work: {
+					type: "oauth",
+					access: "access-two",
+					refresh: "refresh-two",
+					expires: Date.now() + 60 * 60 * 1000,
+				},
+			},
+		}));
+		const secondContext = createMockContext({ model: firstModel, modelRegistry: registry }).ctx;
+		assert.equal((await coordinator.ensureActive(secondContext, store)).status, "active");
+		assert.deepEqual(requests, ["Bearer access-refreshed", "Bearer access-two"]);
+		assert.equal(
+			(selectedModels[0] as { baseUrl?: string }).baseUrl,
+			"http://inference.two.radius.test/v1",
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	}
+});

--- a/test/accounts-usage-coexistence.test.ts
+++ b/test/accounts-usage-coexistence.test.ts
@@ -43,6 +43,8 @@ function provider(id: AccountProviderAdapter["id"]): AccountProviderAdapter {
 		"github-copilot": "GitHub Copilot",
 		"kimi-coding": "Kimi For Coding",
 		"openai-codex": "OpenAI Codex",
+		openrouter: "OpenRouter",
+		radius: "Radius",
 		xai: "xAI",
 	};
 	return {


### PR DESCRIPTION
## Summary

- add named OpenRouter OAuth accounts while preserving OpenRouter's provider-owned permanent credential with an empty refresh token
- add gateway-aware Radius OAuth accounts using Pi's active Radius provider and publish credential-specific dynamic model catalogs before activation succeeds
- deduplicate Radius catalog refreshes by effective credential, rebind retained selected models, restore default catalogs, and fail closed on catalog or model mismatches
- harden cancellation, stale account operations, session replacement, switch/remove disposal, and bounded shutdown cleanup
- update provider menus, storage coverage, documentation, keywords, downgrade guidance, and the existing minor Changeset

## Validation

- `npm run check`
- `npm test` (321 files, 3,121 tests)
- focused accounts/coexistence suite (4 files, 85 tests)
- real `ModelRuntime` integration against a local Radius OAuth/config gateway
- `just pack accounts`
- package load smoke with `pi --no-extensions -e ./packages/pi-accounts --list-models openrouter`
- semantic audit against `docs/extension-conventions.md` and `docs/extension-settings.md`

## Notes

- Live OpenRouter/Radius OAuth login and paid model requests were not run.
- Pi still has no public session-scoped full `ModelAuth` override, so this retains `pi-accounts`' existing private runtime API-key bridge.
- Radius shutdown removes named runtime auth and makes a bounded attempt to restore the default catalog; a later Pi catalog refresh remains the recovery path if the gateway is unavailable during shutdown.
