### PR TITLE
docs(subagents): clarify delegation gate

### DIFF
--- a/.changeset/clarify-subagent-delegation.md
+++ b/.changeset/clarify-subagent-delegation.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": patch
+---
+
+Require independent work or a concrete context-isolation benefit before the bundled skill delegates to a subagent.

--- a/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
+++ b/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
@@ -10,11 +10,13 @@ Use this skill when deciding whether or how to delegate with the `subagent-*` to
 
 ## Prefer direct work
 
+Only use a subagent when the work can be split into independent tasks, or when context isolation provides a concrete benefit.
+
+Otherwise, do the work directly.
+
 Keep planning, critical-path work, integration, deterministic checks, authorization decisions, and the final answer in the main agent.
 
 Do the work directly when it is simple, latency-sensitive, tightly coupled to the current context, likely to need user clarification, or faster than preparing and verifying a delegation.
-
-Do not delegate merely to avoid work the main agent can complete safely and promptly.
 
 Nested subagents are unsupported.
 


### PR DESCRIPTION
## Summary

- Require independent work or a concrete context-isolation benefit before using a subagent.
- Direct the main agent to work directly when neither condition applies.
- Remove the redundant delegation warning and add a patch changeset.

## Verification

- `npx vitest run packages/pi-subagents/test/package.test.ts` — 2 tests passed
- `npm --workspace @narumitw/pi-subagents run check`
- `npm run check`
- `npm test` — 321 test files and 3,122 tests passed
- `npm run pack:subagents` — bundled skill included in the dry-run tarball
