### PR TITLE
feat(subagents): add custom agent profiles

### DIFF
--- a/.changeset/add-subagent-profiles.md
+++ b/.changeset/add-subagent-profiles.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-subagents": minor
+---
+
+Add optional named agent profiles from Pi's user `pi-subagents.json` with prompt, tool, timeout, and thinking-level defaults, plus a `/subagents` TUI manager for complete profile lifecycle management.

--- a/.changeset/add-subagent-profiles.md
+++ b/.changeset/add-subagent-profiles.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-subagents": minor
 ---
 
-Add optional named agent profiles from Pi's user `pi-subagents.json` with prompt, tool, timeout, and thinking-level defaults, plus a `/subagents` TUI manager for complete profile lifecycle management.
+Add optional named role profiles from Pi's user `pi-subagents.json` with prompt, tool, timeout, and thinking-level defaults, plus a `/subagents` TUI manager for complete profile lifecycle management.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6429,6 +6429,9 @@
 			"name": "@narumitw/pi-subagents",
 			"version": "2.1.4",
 			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.59.0"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.10",
 				"@earendil-works/pi-ai": "0.84.3",

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -2,27 +2,31 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-subagents)](https://www.npmjs.com/package/@narumitw/pi-subagents) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Pi Subagents runs Pi jobs in separate child processes and lets each child ask the main agent necessary questions through an authenticated loopback broker.
+Pi Subagents starts Pi subagent jobs and lets each child ask the main agent necessary questions through an authenticated loopback broker.
 
-The bundled `using-pi-subagents` skill explains when to delegate, how to limit child capabilities, and how to verify results safely.
+A bundled `using-pi-subagents` skill owns delegation strategy, least-privilege tool selection, parallel-work guidance, timeout selection, question handling, result review, and writer safety.
 
 ## ✨ Features
 
-- Runs each job in an isolated Pi child process and returns its job ID immediately.
-- Uses the task to define the child's specialization and the tool list to limit its capabilities.
-- Defaults work tools to `read`, `grep`, `find`, and `ls`.
-- Inherits the main agent's effective model and uses its thinking level by default.
-- Gives every child fixed `subagent_ask` and `subagent_wait` tools for necessary questions.
-- Lets the main agent answer with `subagent_reply` without cancelling the job.
-- Publishes one asynchronous terminal completion and shows active-job progress above the editor.
-- Exposes privacy-filtered metadata without task text, output, prompts, selected tools, or broker credentials.
-- Cancels session-owned work and closes the broker during replacement, reload, or shutdown.
+- Starts one isolated Pi child process per job.
+- Lets each task define the child's assignment and each effective tool list define its capabilities.
+- Loads optional user-defined agent prompts and execution defaults from Pi's user directory.
+- Provides a `/subagents` TUI manager to create, edit, rename, and delete profiles.
+- Defaults child work tools to `read`, `grep`, `find`, and `ls`.
+- Inherits the main agent's effective model and defaults to its thinking level.
+- Gives every child fixed `subagent_ask` and `subagent_wait` communication tools.
+- Lets the main agent answer a pending child question with `subagent_reply`.
+- Interrupts a parent job wait when a question needs a main-agent response without cancelling the job.
+- Publishes one guarded asynchronous completion and releases child resources at terminal state.
+- Shows each active job's state, elapsed time, timeout, and selected work tools above the editor.
+- Exposes privacy-filtered job metadata without leaking task text, output, prompts, selected tools, or broker credentials.
+- Cancels active session-owned work and closes the loopback broker during replacement, reload, or shutdown.
 
 ## 📦 Install
 
-The version 3 runtime documented here is not yet published to npm.
+The version 3 runtime is not published to npm yet.
 
-The npm package still contains the legacy 2.x runtime and does not provide the tools below.
+The npm package remains on the legacy 2.x runtime and does not provide the tools documented below.
 
 Install the repository source as one Pi package:
 
@@ -61,19 +65,35 @@ Review the source before installing or invoking the extension.
 
 Ask Pi to use the bundled `using-pi-subagents` skill when deciding whether to delegate, or invoke `/skill:using-pi-subagents` directly.
 
-Call `subagent_spawn` with a self-contained task and only the work tools that task needs.
+Run `/subagents` in Pi TUI mode to manage optional named profiles.
 
-The call returns a `jobId` immediately, and the job continues in the background.
+Start one subagent job with `subagent_spawn`.
 
-Continue useful main-agent work until the result is required or a completion arrives.
+The tool returns a `jobId` immediately.
 
-If `subagent_wait` returns `reason: "subagent_message"`, answer the visible question with `subagent_reply` and wait for the job again only when needed.
+The job runs in the background while the main agent continues useful work until a completion arrives or the result is required.
 
-Completion messages follow Pi's global tool-output expansion state and the `app.tools.expand` binding (`Ctrl+O` by default).
+Completion messages follow Pi's global tool-output expansion state and `app.tools.expand` binding (`Ctrl+O` by default).
 
-In TUI mode, the above-editor widget shows each queued or running job's ID, state, elapsed time, timeout, and selected work tools.
+If `subagent_wait` reports `reason: "subagent_message"`, answer the visible question with `subagent_reply`, then wait for the job again when needed.
 
-The widget omits the fixed communication tools, disappears when no jobs remain active, and clears when the session ends.
+In TUI mode, an above-editor widget shows one compact line for each queued or running job.
+
+Each line includes the job ID, current state, elapsed execution time, configured timeout or `no timeout`, and selected work tools.
+
+The fixed `subagent_ask` and child `subagent_wait` communication tools are omitted from the widget because every child receives them.
+
+The widget disappears when no jobs remain active and is cleared during session replacement, reload, or shutdown.
+
+## 💬 Commands
+
+`/subagents` opens the TUI profile manager and accepts no arguments.
+
+The menu lists profiles and provides Create, Task prompt, Tools, Timeout, Thinking level, Rename, Delete, Status, and Help flows.
+
+Tool changes save immediately, while Delete requires an exact confirmation summary.
+
+The command rejects print and JSON modes and reports an observable unsupported-mode warning in RPC mode.
 
 ## 🛠️ Tools
 
@@ -81,7 +101,7 @@ The main Pi session exposes five fixed tools:
 
 | Tool | Parameters | Purpose |
 | --- | --- | --- |
-| `subagent_spawn` | `task`, optional `tools`, `thinkingLevel`, `timeout` | Start one subagent job and return its `jobId`. |
+| `subagent_spawn` | `task`, optional `agent`, `tools`, `thinkingLevel`, `timeout` | Start one subagent job and return its `jobId`. |
 | `subagent_inspect` | none | List privacy-filtered retained-job metadata. |
 | `subagent_cancel` | `jobId` | Idempotently cancel one queued or running job. |
 | `subagent_wait` | `jobId`, optional `timeout` | Wait for a job or return early for a pending child question. |
@@ -94,9 +114,13 @@ Every child exposes these communication tools in addition to its selected work t
 | `subagent_ask` | `message` | Send one question to the main agent and return a `requestId`. |
 | `subagent_wait` | `requestId`, optional `timeout` | Wait for the main agent's plain-text reply. |
 
-Execution and wait timeouts use seconds, accept finite numbers greater than zero through 2,147,483.647, and have no default.
+Execution and wait timeouts use seconds and accept finite numbers greater than zero through 2,147,483.647.
 
-Omitting a job execution timeout lets the child run until it exits, is cancelled, the session shuts down, or the Pi process exits.
+An omitted job execution timeout uses the selected profile value, or no timeout when no profile is selected.
+
+An unprofiled job without an execution timeout runs until it exits, is cancelled, the session shuts down, or the Pi process exits.
+
+Wait timeouts have no default.
 
 A wait timeout or caller cancellation stops only that wait and does not cancel its job or question request.
 
@@ -112,19 +136,79 @@ The terminal states are `completed`, `partial`, `failed`, `timed_out`, and `canc
 
 See [`docs/tools.md`](./docs/tools.md) for the concise schema reference.
 
-## ⚙️ Job configuration
+## ⚙️ Settings
 
-The task should state the child's role, objective, scope, constraints, and expected result.
+Agent profiles are optional named child prompts and execution defaults stored in `<getAgentDir()>/pi-subagents.json`, normally `~/.pi/agent/pi-subagents.json`.
 
-The optional `tools` list limits what the child can do.
+The file is a top-level JSON object keyed by lowercase kebab-case agent names of at most 64 characters.
+
+Each selected profile requires `task`, `tools`, `timeout`, and `thinkingLevel`.
+
+Unknown fields inside otherwise valid profiles are preserved when the manager changes an owned field.
+
+Profile tasks are limited to 50 KiB of UTF-8 text, and profile tool lists accept the same names and limits as explicit spawn tools.
+
+A profile timeout and thinking level accept the same values as their explicit spawn counterparts.
+
+Example:
+
+```json
+{
+  "reviewer": {
+    "task": "Review independently without editing files and return findings with exact evidence.",
+    "tools": ["read", "grep", "find", "ls"],
+    "timeout": 300,
+    "thinkingLevel": "high"
+  }
+}
+```
+
+Pass the profile name through `agent`:
+
+```json
+{
+  "agent": "reviewer",
+  "task": "Review packages/pi-subagents."
+}
+```
+
+The profile `task` is appended to the child system prompt, while the spawn `task` remains the assignment.
+
+Profile `tools`, `timeout`, and `thinkingLevel` values are defaults.
+
+Explicit spawn arguments override those defaults.
+
+Create starts with a generic task prompt, `read`, `grep`, `find`, and `ls`, a 300-second timeout, and the current effective thinking level.
+
+An omitted, empty, or whitespace-only `agent` does not read the file and preserves the ordinary spawn behavior.
+
+A selected spawn reads the file again, so saved changes apply to the next profiled job without `/reload`.
+
+The `/subagents` manager creates this file only after an explicit Create action and reloads the latest valid document before every mutation.
+
+Manager writes use a private temporary file and atomic rename, and successful publications use mode `0600` on POSIX.
+
+Malformed JSON or any invalid profile blocks every manager mutation instead of being overwritten.
+
+Manager operations are ordered within one Pi process because each small settings mutation completes synchronously.
+
+Separate Pi processes have no merge lock, so simultaneous valid writes may replace one another even though readers never see partial JSON.
+
+The extension does not load project overrides.
+
+A missing file, invalid JSON, unknown agent, or invalid profile fails before a selected job is queued.
+
+The spawn task defines the child's objective, scope, constraints, and expected result.
+
+The effective `tools` list defines what the child can do.
 
 Accepted names are `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`.
 
 Unavailable or extension-only tool names are rejected before a job is queued.
 
-Omitting `tools` selects `read`, `grep`, `find`, and `ls`.
+Omitting `tools` uses the selected profile list, or `read`, `grep`, `find`, and `ls` when no profile is selected.
 
-Passing an empty list gives the child no work tools.
+Passing an explicit empty list overrides a profile and gives the child no work tools.
 
 The runtime always adds `subagent_ask` and child `subagent_wait` and removes duplicate names.
 
@@ -134,13 +218,13 @@ Adding `bash` or `powershell` grants unrestricted command execution and can also
 
 The optional `thinkingLevel` accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
 
-Omitting `thinkingLevel` captures the main agent's effective level when `subagent_spawn` executes.
+Omitting `thinkingLevel` uses the selected profile level, or captures the main agent's effective level when no profile is selected.
 
 The child inherits the main agent's effective provider and model when `subagent_spawn` executes.
 
-Spawn rejects providers registered by a parent extension because child processes disable unrelated extensions.
+Spawn rejects providers registered by a parent extension because children disable unrelated extensions.
 
-Spawn also rejects process-local runtime API keys, including a parent-only `--api-key` value.
+Spawn also rejects process-local runtime API keys such as a parent-only `--api-key` value.
 
 Use stored or environment credentials that child processes can read.
 
@@ -158,9 +242,7 @@ The child bridge reads and closes that descriptor before model tool execution.
 
 Each child communication tool call uses one request-scoped connection, while a response wait uses an abortable long poll.
 
-The first accepted `subagent_reply` wins.
-
-Repeated replies acknowledge the existing answer without replacing it.
+The first accepted `subagent_reply` wins, and repeated replies acknowledge the existing answer without replacing it.
 
 A child may retry `subagent_wait` after a wait timeout because the underlying request remains active.
 
@@ -176,9 +258,7 @@ Session replacement and shutdown cancel active work, suppress stale completion d
 
 ## 🔀 Migrating from 2.x
 
-Version 3.0 replaces the previous orchestration runtime.
-
-It does not migrate legacy settings, persisted jobs, retained conversations, or recovery state.
+Version 3.0 replaces the previous orchestration runtime and does not migrate its settings, persisted jobs, retained conversations, or recovery state.
 
 Finish or record any required work before upgrading, then start a fresh Pi session so stored calls do not request removed tool names.
 
@@ -192,21 +272,33 @@ Use these replacements where the new job model supports the previous intent:
 | `subagent_manage` cancellation | `subagent_cancel` |
 | Child-to-main questions | Child `subagent_ask` and `subagent_wait`, plus main `subagent_reply` |
 
-The `/subagents` command, extension settings, `subagent_send`, `subagent_mailbox`, `subagent_consult`, custom agent catalogs, retained follow-ups, advanced orchestration, alternate transports, trust-aware cwd policy, and extension-owned worktrees have no direct replacement.
+The legacy `/subagents` job-control interface, persisted custom agent catalogs, `subagent_send`, `subagent_mailbox`, `subagent_consult`, retained follow-ups, advanced orchestration, alternate transports, trust-aware cwd policy, and extension-owned worktrees are not migrated.
 
-Describe the child's specialization in `task` and grant only the required work tools through `tools`.
+The new `/subagents` command manages only version 3 user profiles.
+
+Recreate any needed named prompts and execution defaults through the new manager or manually in `pi-subagents.json`.
+
+Describe each job's assignment in the spawn `task` and grant only the required work tools through the profile or explicit `tools`.
 
 ## 🔒 Security and privacy
 
 The selected work tools run in the current working directory.
 
-The default list contains no shell or file-mutation tool.
+The default list is read-only by capability because it contains no shell or file-mutation tool.
 
-It is not a filesystem sandbox because its read tools can inspect files available to the user account.
+This default is not a filesystem sandbox because the allowed read tools can inspect files available to the user account.
 
 Selecting `bash`, `powershell`, `edit`, or `write` permits workspace mutation with the Pi process environment and user permissions.
 
 Every child disables session persistence, unrelated extensions, skills, and prompt templates.
+
+A selected agent adds only its validated local `task` string to that child's system prompt.
+
+Agent profiles are trusted user configuration rather than a security boundary, and selecting a profile can enable its configured work tools.
+
+The profile manager validates every profile before writing and never repairs malformed settings by replacing them with defaults.
+
+Do not store credentials or other secrets in profile tasks or extra fields.
 
 Provider selection therefore supports Pi's child-visible built-in and configured providers, not providers registered only by a parent extension.
 
@@ -228,11 +320,11 @@ Parallel writers require disjoint ownership or workspace isolation outside this 
 
 ## 🚧 Limitations
 
-The extension does not load arbitrary extension tools or parent-registered model providers in child processes.
+The extension does not load arbitrary extension tools or parent-registered model providers into child processes.
 
 Process-local runtime API keys are not forwarded to children.
 
-The extension does not provide custom agents, per-job models, custom system prompts, peer-to-peer child messaging, retained conversations, user-directed follow-up work, mailboxes, Agent Teams, chains, fan-in aggregators, panels, workflow DAGs, dynamic scheduling, verification orchestration, nested subagents, or extension-owned semantic memory.
+The extension does not provide bundled agents, project profiles, per-job models, arbitrary per-call system prompts, peer-to-peer child messaging, retained conversations, user-directed follow-up work, mailboxes, Agent Teams, chains, fan-in aggregators, panels, workflow DAGs, dynamic scheduling, verification orchestration, nested subagents, cross-process settings locking, or extension-owned semantic memory.
 
 Child questions use request-response coordination, not a retained conversational session.
 

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -294,6 +294,8 @@ Every child disables session persistence, unrelated extensions, skills, and prom
 
 A selected agent adds only its validated local `task` string to that child's system prompt.
 
+The runtime passes that string through a private temporary prompt file so path-like text remains literal, then removes the file after the child settles.
+
 Agent profiles are trusted user configuration rather than a security boundary, and selecting a profile can enable its configured work tools.
 
 The profile manager validates every profile before writing and never repairs malformed settings by replacing them with defaults.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -10,7 +10,7 @@ A bundled `using-pi-subagents` skill owns delegation strategy, least-privilege t
 
 - Starts one isolated Pi child process per job.
 - Lets each task define the child's assignment and each effective tool list define its capabilities.
-- Loads optional user-defined agent prompts and execution defaults from Pi's user directory.
+- Loads optional user-defined role prompts and execution defaults from Pi's user directory.
 - Provides a `/subagents` TUI manager to create, edit, rename, and delete profiles.
 - Defaults child work tools to `read`, `grep`, `find`, and `ls`.
 - Inherits the main agent's effective model and defaults to its thinking level.
@@ -101,7 +101,7 @@ The main Pi session exposes five fixed tools:
 
 | Tool | Parameters | Purpose |
 | --- | --- | --- |
-| `subagent_spawn` | `task`, optional `agent`, `tools`, `thinkingLevel`, `timeout` | Start one subagent job and return its `jobId`. |
+| `subagent_spawn` | `task`, optional `role`, `tools`, `thinkingLevel`, `timeout` | Start one subagent job and return its `jobId`. |
 | `subagent_inspect` | none | List privacy-filtered retained-job metadata. |
 | `subagent_cancel` | `jobId` | Idempotently cancel one queued or running job. |
 | `subagent_wait` | `jobId`, optional `timeout` | Wait for a job or return early for a pending child question. |
@@ -138,9 +138,9 @@ See [`docs/tools.md`](./docs/tools.md) for the concise schema reference.
 
 ## ⚙️ Settings
 
-Agent profiles are optional named child prompts and execution defaults stored in `<getAgentDir()>/pi-subagents.json`, normally `~/.pi/agent/pi-subagents.json`.
+Role profiles are optional named child prompts and execution defaults stored in `<getAgentDir()>/pi-subagents.json`, normally `~/.pi/agent/pi-subagents.json`.
 
-The file is a top-level JSON object keyed by lowercase kebab-case agent names of at most 64 characters.
+The file is a top-level JSON object keyed by lowercase kebab-case role names of at most 64 characters.
 
 Each selected profile requires `task`, `tools`, `timeout`, and `thinkingLevel`.
 
@@ -163,11 +163,11 @@ Example:
 }
 ```
 
-Pass the profile name through `agent`:
+Pass the profile name through `role`:
 
 ```json
 {
-  "agent": "reviewer",
+  "role": "reviewer",
   "task": "Review packages/pi-subagents."
 }
 ```
@@ -180,7 +180,7 @@ Explicit spawn arguments override those defaults.
 
 Create starts with a generic task prompt, `read`, `grep`, `find`, and `ls`, a 300-second timeout, and the current effective thinking level.
 
-An omitted, empty, or whitespace-only `agent` does not read the file and preserves the ordinary spawn behavior.
+An omitted, empty, or whitespace-only `role` does not read the file and preserves the ordinary spawn behavior.
 
 A selected spawn reads the file again, so saved changes apply to the next profiled job without `/reload`.
 
@@ -196,7 +196,7 @@ Separate Pi processes have no merge lock, so simultaneous valid writes may repla
 
 The extension does not load project overrides.
 
-A missing file, invalid JSON, unknown agent, or invalid profile fails before a selected job is queued.
+A missing file, invalid JSON, unknown role, or invalid profile fails before a selected job is queued.
 
 The spawn task defines the child's objective, scope, constraints, and expected result.
 
@@ -292,11 +292,11 @@ Selecting `bash`, `powershell`, `edit`, or `write` permits workspace mutation wi
 
 Every child disables session persistence, unrelated extensions, skills, and prompt templates.
 
-A selected agent adds only its validated local `task` string to that child's system prompt.
+A selected role adds only its validated local `task` string to that child's system prompt.
 
 The runtime passes that string through a private temporary prompt file so path-like text remains literal, then removes the file after the child settles.
 
-Agent profiles are trusted user configuration rather than a security boundary, and selecting a profile can enable its configured work tools.
+Role profiles are trusted user configuration rather than a security boundary, and selecting a profile can enable its configured work tools.
 
 The profile manager validates every profile before writing and never repairs malformed settings by replacing them with defaults.
 

--- a/packages/pi-subagents/docs/design-principles.md
+++ b/packages/pi-subagents/docs/design-principles.md
@@ -12,9 +12,9 @@ That isolation is not a limitation—it is the point.
 
 Fresh does not mean empty.
 
-The subagent still receives Pi's standard system prompt, the main agent's effective model, applicable project context, its selected tools, and one explicit task.
+The subagent still receives Pi's standard system prompt, the main agent's effective model, applicable project context, its effective tools, one explicit assignment, and an optional user-defined agent prompt.
 
-The task defines the child's specialization, while the selected tools define its authority.
+The assignment and optional agent prompt define the child's specialization, while the effective tools define its authority.
 
 Give each subagent a self-contained task containing only the context needed to complete that task.
 

--- a/packages/pi-subagents/docs/design-principles.md
+++ b/packages/pi-subagents/docs/design-principles.md
@@ -12,9 +12,9 @@ That isolation is not a limitation—it is the point.
 
 Fresh does not mean empty.
 
-The subagent still receives Pi's standard system prompt, the main agent's effective model, applicable project context, its effective tools, one explicit assignment, and an optional user-defined agent prompt.
+The subagent still receives Pi's standard system prompt, the main agent's effective model, applicable project context, its effective tools, one explicit assignment, and an optional user-defined role prompt.
 
-The assignment and optional agent prompt define the child's specialization, while the effective tools define its authority.
+The assignment and optional role prompt define the child's specialization, while the effective tools define its authority.
 
 Give each subagent a self-contained task containing only the context needed to complete that task.
 

--- a/packages/pi-subagents/docs/tools.md
+++ b/packages/pi-subagents/docs/tools.md
@@ -5,14 +5,14 @@
 | Parameter | Type | Required | Constraint / default |
 | --- | --- | --- | --- |
 | `task` | `string` | Yes | Self-contained assignment, up to 50 KiB of UTF-8 text. |
-| `agent` | `string` | No | Lowercase kebab-case name from `<getAgentDir()>/pi-subagents.json`; empty, whitespace-only, or omitted selects no profile. |
+| `role` | `string` | No | Lowercase kebab-case name from `<getAgentDir()>/pi-subagents.json`; empty, whitespace-only, or omitted selects no profile. |
 | `tools` | `string[]` | No | Up to 64 names from `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`; defaults to the selected profile, then `read`, `grep`, `find`, and `ls`. |
 | `thinkingLevel` | `string` | No | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; defaults to the selected profile, then the main agent's effective level. |
 | `timeout` | `number` | No | Seconds; `> 0` through `2,147,483.647`; defaults to the selected profile, otherwise no timeout. |
 
 Starts one task-specialized subagent job with the effective tool capabilities and returns its job ID immediately.
 
-A selected agent requires `task`, `tools`, `timeout`, and `thinkingLevel` in the user JSON object.
+A selected role requires `task`, `tools`, `timeout`, and `thinkingLevel` in the user JSON object.
 
 The `/subagents` TUI manager owns profile creation, field updates, rename, deletion, validation, and atomic user-file publication.
 

--- a/packages/pi-subagents/docs/tools.md
+++ b/packages/pi-subagents/docs/tools.md
@@ -4,14 +4,27 @@
 
 | Parameter | Type | Required | Constraint / default |
 | --- | --- | --- | --- |
-| `task` | `string` | Yes | Self-contained task, up to 50 KiB of UTF-8 text. |
-| `tools` | `string[]` | No | Up to 64 names from `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`; defaults to `read`, `grep`, `find`, and `ls`. |
-| `thinkingLevel` | `string` | No | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; defaults to the main agent's effective thinking level. |
-| `timeout` | `number` | No | Seconds; `> 0` through `2,147,483.647`; no default timeout. |
+| `task` | `string` | Yes | Self-contained assignment, up to 50 KiB of UTF-8 text. |
+| `agent` | `string` | No | Lowercase kebab-case name from `<getAgentDir()>/pi-subagents.json`; empty, whitespace-only, or omitted selects no profile. |
+| `tools` | `string[]` | No | Up to 64 names from `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`; defaults to the selected profile, then `read`, `grep`, `find`, and `ls`. |
+| `thinkingLevel` | `string` | No | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; defaults to the selected profile, then the main agent's effective level. |
+| `timeout` | `number` | No | Seconds; `> 0` through `2,147,483.647`; defaults to the selected profile, otherwise no timeout. |
 
-Starts one task-specialized subagent job with the selected tool capabilities and returns its job ID immediately.
+Starts one task-specialized subagent job with the effective tool capabilities and returns its job ID immediately.
 
-The runtime always adds `subagent_ask` and `subagent_wait` to the selected tools.
+A selected agent requires `task`, `tools`, `timeout`, and `thinkingLevel` in the user JSON object.
+
+The `/subagents` TUI manager owns profile creation, field updates, rename, deletion, validation, and atomic user-file publication.
+
+Unknown profile fields are preserved by manager mutations.
+
+Its non-empty `task` is limited to 50 KiB and appended to the child system prompt.
+
+Explicit spawn `tools`, `timeout`, and `thinkingLevel` values override profile defaults.
+
+Profile selection reads the file for each spawn and rejects missing, malformed, unknown, or invalid selected definitions before queueing.
+
+The runtime always adds `subagent_ask` and `subagent_wait` to the effective tools.
 
 The child inherits the main agent's effective provider and model at spawn time.
 

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -39,6 +39,9 @@
 		"typecheck": "tsc --noEmit",
 		"prepack": "npm run build"
 	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.59.0"
+	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*",

--- a/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
+++ b/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
@@ -26,7 +26,7 @@ Use `subagent_spawn` for one subagent job.
 
 The task defines the child's assignment, objective, constraints, and expected result.
 
-Use `agent` only when the user requests or has established a named profile in Pi's user `pi-subagents.json`.
+Use `role` only when the user requests or has established a named profile in Pi's user `pi-subagents.json`.
 
 When the user asks to manage profiles, direct them to the argument-free `/subagents` TUI manager.
 
@@ -34,7 +34,7 @@ A selected profile supplies a child prompt plus `tools`, `timeout`, and `thinkin
 
 Explicit spawn values override profile defaults.
 
-Omit `agent` for ordinary delegation, and do not treat a profile as authorization or a reason to bypass the delegation gate.
+Omit `role` for ordinary delegation, and do not treat a profile as authorization or a reason to bypass the delegation gate.
 
 The effective tools define what the child can do.
 

--- a/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
+++ b/packages/pi-subagents/skills/using-pi-subagents/SKILL.md
@@ -24,13 +24,23 @@ Nested subagents are unsupported.
 
 Use `subagent_spawn` for one subagent job.
 
-The task defines the child's specialization, objective, constraints, and expected result.
+The task defines the child's assignment, objective, constraints, and expected result.
 
-The selected tools define what the child can do.
+Use `agent` only when the user requests or has established a named profile in Pi's user `pi-subagents.json`.
+
+When the user asks to manage profiles, direct them to the argument-free `/subagents` TUI manager.
+
+A selected profile supplies a child prompt plus `tools`, `timeout`, and `thinkingLevel` defaults.
+
+Explicit spawn values override profile defaults.
+
+Omit `agent` for ordinary delegation, and do not treat a profile as authorization or a reason to bypass the delegation gate.
+
+The effective tools define what the child can do.
 
 Select only from `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`.
 
-Omit `tools` for the read-only default of `read`, `grep`, `find`, and `ls`.
+Omit `tools` to use a selected profile's list, then the read-only default of `read`, `grep`, `find`, and `ls`.
 
 Pass an explicit empty list when the child needs no work tools.
 
@@ -48,7 +58,7 @@ Spawn rejects model providers registered only by a parent extension and process-
 
 Use a child-visible provider with Pi's stored credentials or inherited environment credentials.
 
-Omit `thinkingLevel` to follow the main agent's effective thinking level.
+Omit `thinkingLevel` to use a selected profile's level, then the main agent's effective thinking level.
 
 Set `thinkingLevel` explicitly only when the task justifies a different level.
 
@@ -88,9 +98,9 @@ Grant the implementation task only the work tools it needs.
 
 Set `timeout` in seconds to the shortest realistic execution deadline for the task.
 
-Execution timeouts accept positive finite numbers and have no default.
+Execution timeouts accept positive finite numbers and have no built-in default.
 
-Omit `timeout` only when the child may run until completion, explicit cancellation, session shutdown, or process exit.
+Omit `timeout` to use a selected profile's deadline, or to let an unprofiled child run until completion, explicit cancellation, session shutdown, or process exit.
 
 Use short deadlines for extraction and focused review, moderate deadlines for ordinary multi-file work, and longer deadlines only when the scoped work genuinely requires them.
 

--- a/packages/pi-subagents/src/agent-profiles.ts
+++ b/packages/pi-subagents/src/agent-profiles.ts
@@ -153,7 +153,13 @@ export function renameAgentProfile(
 ): AgentProfilesLoadResult {
 	const name = requireAgentName(nameValue);
 	const nextName = requireAgentName(nextNameValue);
-	if (name === nextName) return requireMutableDocument(options);
+	if (name === nextName) {
+		const loaded = requireMutableDocument(options);
+		if (!Object.hasOwn(loaded.profiles, name)) {
+			throw new Error(`Subagent agent "${name}" does not exist.`);
+		}
+		return loaded;
+	}
 	return mutateAgentProfiles((document) => {
 		if (!Object.hasOwn(document, name)) {
 			throw new Error(`Subagent agent "${name}" does not exist.`);
@@ -247,7 +253,9 @@ function mutateAgentProfiles(
 	return readAgentProfiles(settingsPath);
 }
 
-function requireMutableDocument(options: AgentProfilesMutationOptions): AgentProfilesLoadResult {
+function requireMutableDocument(
+	options: AgentProfilesMutationOptions,
+): Exclude<AgentProfilesLoadResult, { kind: "invalid" }> {
 	const settingsPath = options.settingsPath ?? agentProfilesPath();
 	const loaded = readAgentProfiles(settingsPath);
 	if (loaded.kind === "invalid") {

--- a/packages/pi-subagents/src/agent-profiles.ts
+++ b/packages/pi-subagents/src/agent-profiles.ts
@@ -1,0 +1,354 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { resolveTimeoutMs } from "./process.js";
+import {
+	CHILD_CORE_TOOL_NAMES,
+	MAX_SUBAGENT_TASK_BYTES,
+	MAX_SUBAGENT_TOOLS,
+	SUBAGENT_THINKING_LEVELS,
+	type SubagentThinkingLevel,
+} from "./types.js";
+
+export const MAX_AGENT_NAME_LENGTH = 64;
+export const DEFAULT_AGENT_TASK = "Complete the assigned task and report the result.";
+export const DEFAULT_AGENT_TIMEOUT = 300;
+const AGENT_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const CHILD_CORE_TOOL_SET = new Set<string>(CHILD_CORE_TOOL_NAMES);
+const THINKING_LEVEL_SET = new Set<string>(SUBAGENT_THINKING_LEVELS);
+
+export interface AgentProfile {
+	task: string;
+	tools: string[];
+	timeout: number;
+	thinkingLevel: SubagentThinkingLevel;
+}
+
+export type AgentProfilesLoadResult =
+	| { kind: "missing"; profiles: Record<string, AgentProfile>; document: Record<string, unknown> }
+	| { kind: "loaded"; profiles: Record<string, AgentProfile>; document: Record<string, unknown> }
+	| { kind: "invalid"; reason: string };
+
+interface AgentProfilesFileSystem {
+	mkdirSync: typeof mkdirSync;
+	writeFileSync: typeof writeFileSync;
+	renameSync: typeof renameSync;
+	rmSync: typeof rmSync;
+}
+
+export interface AgentProfilesMutationOptions {
+	settingsPath?: string;
+	fileSystem?: Partial<AgentProfilesFileSystem>;
+	expectedProfileDocument?: unknown;
+}
+
+export interface AgentProfileStore {
+	settingsPath: string;
+	read(): AgentProfilesLoadResult;
+	create(name: string, profile: AgentProfile): AgentProfilesLoadResult;
+	update(name: string, patch: Partial<AgentProfile>): AgentProfilesLoadResult;
+	rename(name: string, nextName: string): AgentProfilesLoadResult;
+	delete(name: string, expectedProfileDocument?: unknown): AgentProfilesLoadResult;
+}
+
+export function agentProfilesPath(): string {
+	return path.join(getAgentDir(), "pi-subagents.json");
+}
+
+export function createAgentProfileStore(settingsPath = agentProfilesPath()): AgentProfileStore {
+	const options = { settingsPath };
+	return {
+		settingsPath,
+		read: () => readAgentProfiles(settingsPath),
+		create: (name, profile) => createAgentProfile(name, profile, options),
+		update: (name, patch) => updateAgentProfile(name, patch, options),
+		rename: (name, nextName) => renameAgentProfile(name, nextName, options),
+		delete: (name, expectedProfileDocument) =>
+			deleteAgentProfile(name, { ...options, expectedProfileDocument }),
+	};
+}
+
+export function readAgentProfiles(settingsPath = agentProfilesPath()): AgentProfilesLoadResult {
+	let source: string;
+	try {
+		source = readFileSync(settingsPath, "utf8");
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return { kind: "missing", profiles: {}, document: {} };
+		}
+		return { kind: "invalid", reason: `${displayPath(settingsPath)}: ${formatError(error)}` };
+	}
+
+	let document: unknown;
+	try {
+		document = JSON.parse(source);
+	} catch (error) {
+		return {
+			kind: "invalid",
+			reason: `${displayPath(settingsPath)}: invalid JSON: ${formatError(error)}`,
+		};
+	}
+	const normalized = normalizeAgentProfilesDocument(document);
+	return normalized
+		? { kind: "loaded", profiles: normalized, document: document as Record<string, unknown> }
+		: {
+				kind: "invalid",
+				reason: `${displayPath(settingsPath)}: invalid agent profile document`,
+			};
+}
+
+export function loadAgentProfile(value: unknown): AgentProfile | undefined {
+	const name = normalizeOptionalAgentName(value);
+	if (!name) return undefined;
+	const settingsPath = agentProfilesPath();
+	const loaded = readAgentProfiles(settingsPath);
+	if (loaded.kind === "invalid") throw new Error(loaded.reason);
+	if (loaded.kind === "missing") {
+		throw new Error(
+			`Subagent agent "${name}" is unavailable because ${displayPath(settingsPath)} does not exist.`,
+		);
+	}
+	if (!Object.hasOwn(loaded.profiles, name)) {
+		throw new Error(`Subagent agent "${name}" is not defined in ${displayPath(settingsPath)}.`);
+	}
+	return cloneProfile(loaded.profiles[name] as AgentProfile);
+}
+
+export function createAgentProfile(
+	nameValue: unknown,
+	profile: AgentProfile,
+	options: AgentProfilesMutationOptions = {},
+): AgentProfilesLoadResult {
+	const name = requireAgentName(nameValue);
+	return mutateAgentProfiles((document) => {
+		if (Object.hasOwn(document, name)) {
+			throw new Error(`Subagent agent "${name}" already exists.`);
+		}
+		document[name] = cloneProfile(profile);
+	}, options);
+}
+
+export function updateAgentProfile(
+	nameValue: unknown,
+	patch: Partial<AgentProfile>,
+	options: AgentProfilesMutationOptions = {},
+): AgentProfilesLoadResult {
+	const name = requireAgentName(nameValue);
+	return mutateAgentProfiles((document) => {
+		const current = ownRecord(document[name]);
+		if (!current) throw new Error(`Subagent agent "${name}" does not exist.`);
+		document[name] = {
+			...current,
+			...patch,
+			...(patch.tools ? { tools: [...patch.tools] } : {}),
+		};
+	}, options);
+}
+
+export function renameAgentProfile(
+	nameValue: unknown,
+	nextNameValue: unknown,
+	options: AgentProfilesMutationOptions = {},
+): AgentProfilesLoadResult {
+	const name = requireAgentName(nameValue);
+	const nextName = requireAgentName(nextNameValue);
+	if (name === nextName) return requireMutableDocument(options);
+	return mutateAgentProfiles((document) => {
+		if (!Object.hasOwn(document, name)) {
+			throw new Error(`Subagent agent "${name}" does not exist.`);
+		}
+		if (Object.hasOwn(document, nextName)) {
+			throw new Error(`Subagent agent "${nextName}" already exists.`);
+		}
+		document[nextName] = document[name];
+		delete document[name];
+	}, options);
+}
+
+export function deleteAgentProfile(
+	nameValue: unknown,
+	options: AgentProfilesMutationOptions = {},
+): AgentProfilesLoadResult {
+	const name = requireAgentName(nameValue);
+	return mutateAgentProfiles((document) => {
+		if (!Object.hasOwn(document, name)) {
+			throw new Error(`Subagent agent "${name}" does not exist.`);
+		}
+		if (
+			options.expectedProfileDocument !== undefined &&
+			JSON.stringify(document[name]) !== JSON.stringify(options.expectedProfileDocument)
+		) {
+			throw new Error(`Subagent agent "${name}" changed after the delete review.`);
+		}
+		delete document[name];
+	}, options);
+}
+
+export function normalizeAgentProfile(value: unknown): AgentProfile | undefined {
+	const candidate = ownRecord(value);
+	if (!candidate) return undefined;
+	const task = normalizeTask(candidate.task);
+	const tools = normalizeTools(candidate.tools);
+	const timeout = normalizeTimeout(candidate.timeout);
+	const thinkingLevel = normalizeThinkingLevel(candidate.thinkingLevel);
+	if (!task || !tools || timeout === undefined || !thinkingLevel) return undefined;
+	return { task, tools, timeout, thinkingLevel };
+}
+
+export function requireAgentName(value: unknown): string {
+	if (typeof value !== "string") throw new Error("Subagent agent name must be a string.");
+	const name = value.trim();
+	if (name.length > MAX_AGENT_NAME_LENGTH || !AGENT_NAME_PATTERN.test(name)) {
+		throw new Error("Subagent agent name must be lowercase kebab-case with at most 64 characters.");
+	}
+	return name;
+}
+
+function normalizeOptionalAgentName(value: unknown): string | undefined {
+	if (value === undefined || value === "") return undefined;
+	if (typeof value !== "string") throw new Error("Subagent agent must be a string.");
+	if (!value.trim()) return undefined;
+	return requireAgentName(value);
+}
+
+function normalizeAgentProfilesDocument(value: unknown): Record<string, AgentProfile> | undefined {
+	const document = ownRecord(value);
+	if (!document) return undefined;
+	const profiles: Record<string, AgentProfile> = {};
+	for (const [name, candidate] of Object.entries(document)) {
+		try {
+			requireAgentName(name);
+		} catch {
+			return undefined;
+		}
+		const profile = normalizeAgentProfile(candidate);
+		if (!profile) return undefined;
+		profiles[name] = profile;
+	}
+	return profiles;
+}
+
+function mutateAgentProfiles(
+	mutate: (document: Record<string, unknown>) => void,
+	options: AgentProfilesMutationOptions,
+): AgentProfilesLoadResult {
+	const settingsPath = options.settingsPath ?? agentProfilesPath();
+	const loaded = readAgentProfiles(settingsPath);
+	if (loaded.kind === "invalid") {
+		throw new Error(`Cannot save invalid subagent agent profiles: ${loaded.reason}`);
+	}
+	const document = structuredClone(loaded.document);
+	mutate(document);
+	if (!normalizeAgentProfilesDocument(document)) {
+		throw new Error("Refusing to save invalid subagent agent profiles.");
+	}
+	publishAgentProfiles(settingsPath, document, options.fileSystem);
+	return readAgentProfiles(settingsPath);
+}
+
+function requireMutableDocument(options: AgentProfilesMutationOptions): AgentProfilesLoadResult {
+	const settingsPath = options.settingsPath ?? agentProfilesPath();
+	const loaded = readAgentProfiles(settingsPath);
+	if (loaded.kind === "invalid") {
+		throw new Error(`Cannot save invalid subagent agent profiles: ${loaded.reason}`);
+	}
+	return loaded;
+}
+
+function publishAgentProfiles(
+	settingsPath: string,
+	document: Record<string, unknown>,
+	overrides: Partial<AgentProfilesFileSystem> = {},
+): void {
+	const fileSystem = { mkdirSync, writeFileSync, renameSync, rmSync, ...overrides };
+	const temporaryPath = path.join(
+		path.dirname(settingsPath),
+		`.${path.basename(settingsPath)}.${randomUUID()}.tmp`,
+	);
+	try {
+		fileSystem.mkdirSync(path.dirname(settingsPath), { recursive: true });
+		fileSystem.writeFileSync(temporaryPath, `${JSON.stringify(document, null, 2)}\n`, {
+			encoding: "utf8",
+			flag: "wx",
+			mode: 0o600,
+		});
+		fileSystem.renameSync(temporaryPath, settingsPath);
+	} finally {
+		try {
+			fileSystem.rmSync(temporaryPath, { force: true });
+		} catch {
+			// Best-effort cleanup must not replace the publication result.
+		}
+	}
+}
+
+function normalizeTask(value: unknown): string | undefined {
+	if (typeof value !== "string" || !value.trim()) return undefined;
+	const task = value.trim();
+	if (task.includes("\0") || Buffer.byteLength(task, "utf8") > MAX_SUBAGENT_TASK_BYTES) {
+		return undefined;
+	}
+	return task;
+}
+
+function normalizeTools(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || value.length > MAX_SUBAGENT_TOOLS) return undefined;
+	const tools: string[] = [];
+	for (const candidate of value) {
+		if (typeof candidate !== "string") return undefined;
+		const tool = candidate.trim();
+		if (!CHILD_CORE_TOOL_SET.has(tool)) return undefined;
+		if (!tools.includes(tool)) tools.push(tool);
+	}
+	return tools;
+}
+
+function normalizeTimeout(value: unknown): number | undefined {
+	if (typeof value !== "number") return undefined;
+	try {
+		resolveTimeoutMs(value);
+		return value;
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizeThinkingLevel(value: unknown): SubagentThinkingLevel | undefined {
+	return typeof value === "string" && THINKING_LEVEL_SET.has(value)
+		? (value as SubagentThinkingLevel)
+		: undefined;
+}
+
+function cloneProfile(profile: AgentProfile): AgentProfile {
+	return { ...profile, tools: [...profile.tools] };
+}
+
+function ownRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function displayPath(value: string): string {
+	return JSON.stringify(value);
+}
+
+function formatError(error: unknown): string {
+	const value = error instanceof Error ? error.message : String(error);
+	return [...value]
+		.filter((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			if (character === "\n" || character === "\t") return true;
+			if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) return false;
+			return !(
+				(codePoint >= 0x202a && codePoint <= 0x202e) ||
+				(codePoint >= 0x2066 && codePoint <= 0x2069)
+			);
+		})
+		.join("");
+}

--- a/packages/pi-subagents/src/agent-profiles.ts
+++ b/packages/pi-subagents/src/agent-profiles.ts
@@ -94,7 +94,7 @@ export function readAgentProfiles(settingsPath = agentProfilesPath()): AgentProf
 		? { kind: "loaded", profiles: normalized, document: document as Record<string, unknown> }
 		: {
 				kind: "invalid",
-				reason: `${displayPath(settingsPath)}: invalid agent profile document`,
+				reason: `${displayPath(settingsPath)}: invalid role profile document`,
 			};
 }
 
@@ -106,11 +106,11 @@ export function loadAgentProfile(value: unknown): AgentProfile | undefined {
 	if (loaded.kind === "invalid") throw new Error(loaded.reason);
 	if (loaded.kind === "missing") {
 		throw new Error(
-			`Subagent agent "${name}" is unavailable because ${displayPath(settingsPath)} does not exist.`,
+			`Subagent role "${name}" is unavailable because ${displayPath(settingsPath)} does not exist.`,
 		);
 	}
 	if (!Object.hasOwn(loaded.profiles, name)) {
-		throw new Error(`Subagent agent "${name}" is not defined in ${displayPath(settingsPath)}.`);
+		throw new Error(`Subagent role "${name}" is not defined in ${displayPath(settingsPath)}.`);
 	}
 	return cloneProfile(loaded.profiles[name] as AgentProfile);
 }
@@ -123,7 +123,7 @@ export function createAgentProfile(
 	const name = requireAgentName(nameValue);
 	return mutateAgentProfiles((document) => {
 		if (Object.hasOwn(document, name)) {
-			throw new Error(`Subagent agent "${name}" already exists.`);
+			throw new Error(`Subagent role "${name}" already exists.`);
 		}
 		document[name] = cloneProfile(profile);
 	}, options);
@@ -137,7 +137,7 @@ export function updateAgentProfile(
 	const name = requireAgentName(nameValue);
 	return mutateAgentProfiles((document) => {
 		const current = ownRecord(document[name]);
-		if (!current) throw new Error(`Subagent agent "${name}" does not exist.`);
+		if (!current) throw new Error(`Subagent role "${name}" does not exist.`);
 		document[name] = {
 			...current,
 			...patch,
@@ -156,16 +156,16 @@ export function renameAgentProfile(
 	if (name === nextName) {
 		const loaded = requireMutableDocument(options);
 		if (!Object.hasOwn(loaded.profiles, name)) {
-			throw new Error(`Subagent agent "${name}" does not exist.`);
+			throw new Error(`Subagent role "${name}" does not exist.`);
 		}
 		return loaded;
 	}
 	return mutateAgentProfiles((document) => {
 		if (!Object.hasOwn(document, name)) {
-			throw new Error(`Subagent agent "${name}" does not exist.`);
+			throw new Error(`Subagent role "${name}" does not exist.`);
 		}
 		if (Object.hasOwn(document, nextName)) {
-			throw new Error(`Subagent agent "${nextName}" already exists.`);
+			throw new Error(`Subagent role "${nextName}" already exists.`);
 		}
 		document[nextName] = document[name];
 		delete document[name];
@@ -179,13 +179,13 @@ export function deleteAgentProfile(
 	const name = requireAgentName(nameValue);
 	return mutateAgentProfiles((document) => {
 		if (!Object.hasOwn(document, name)) {
-			throw new Error(`Subagent agent "${name}" does not exist.`);
+			throw new Error(`Subagent role "${name}" does not exist.`);
 		}
 		if (
 			options.expectedProfileDocument !== undefined &&
 			JSON.stringify(document[name]) !== JSON.stringify(options.expectedProfileDocument)
 		) {
-			throw new Error(`Subagent agent "${name}" changed after the delete review.`);
+			throw new Error(`Subagent role "${name}" changed after the delete review.`);
 		}
 		delete document[name];
 	}, options);
@@ -203,17 +203,17 @@ export function normalizeAgentProfile(value: unknown): AgentProfile | undefined 
 }
 
 export function requireAgentName(value: unknown): string {
-	if (typeof value !== "string") throw new Error("Subagent agent name must be a string.");
+	if (typeof value !== "string") throw new Error("Subagent role name must be a string.");
 	const name = value.trim();
 	if (name.length > MAX_AGENT_NAME_LENGTH || !AGENT_NAME_PATTERN.test(name)) {
-		throw new Error("Subagent agent name must be lowercase kebab-case with at most 64 characters.");
+		throw new Error("Subagent role name must be lowercase kebab-case with at most 64 characters.");
 	}
 	return name;
 }
 
 function normalizeOptionalAgentName(value: unknown): string | undefined {
 	if (value === undefined || value === "") return undefined;
-	if (typeof value !== "string") throw new Error("Subagent agent must be a string.");
+	if (typeof value !== "string") throw new Error("Subagent role must be a string.");
 	if (!value.trim()) return undefined;
 	return requireAgentName(value);
 }
@@ -242,12 +242,12 @@ function mutateAgentProfiles(
 	const settingsPath = options.settingsPath ?? agentProfilesPath();
 	const loaded = readAgentProfiles(settingsPath);
 	if (loaded.kind === "invalid") {
-		throw new Error(`Cannot save invalid subagent agent profiles: ${loaded.reason}`);
+		throw new Error(`Cannot save invalid subagent role profiles: ${loaded.reason}`);
 	}
 	const document = structuredClone(loaded.document);
 	mutate(document);
 	if (!normalizeAgentProfilesDocument(document)) {
-		throw new Error("Refusing to save invalid subagent agent profiles.");
+		throw new Error("Refusing to save invalid subagent role profiles.");
 	}
 	publishAgentProfiles(settingsPath, document, options.fileSystem);
 	return readAgentProfiles(settingsPath);
@@ -259,7 +259,7 @@ function requireMutableDocument(
 	const settingsPath = options.settingsPath ?? agentProfilesPath();
 	const loaded = readAgentProfiles(settingsPath);
 	if (loaded.kind === "invalid") {
-		throw new Error(`Cannot save invalid subagent agent profiles: ${loaded.reason}`);
+		throw new Error(`Cannot save invalid subagent role profiles: ${loaded.reason}`);
 	}
 	return loaded;
 }

--- a/packages/pi-subagents/src/menu.ts
+++ b/packages/pi-subagents/src/menu.ts
@@ -1,4 +1,18 @@
-import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	KeybindingsManager,
+	Theme,
+} from "@earendil-works/pi-coding-agent";
+import {
+	Editor,
+	type EditorTheme,
+	type Focusable,
+	Key,
+	matchesKey,
+	type TUI,
+	truncateToWidth,
+} from "@earendil-works/pi-tui";
 import type { MenuContext } from "@narumitw/pi-tui-kit";
 import {
 	type AgentProfile,
@@ -39,11 +53,12 @@ type Screen =
 	| "main"
 	| "profiles"
 	| "profile"
+	| "profile-settings"
+	| "task"
 	| "create"
 	| "rename"
 	| "timeout"
 	| "tools"
-	| "thinking"
 	| "delete"
 	| "status"
 	| "help"
@@ -53,6 +68,9 @@ type Action =
 	| "open-profile"
 	| "create"
 	| "edit-task"
+	| "open-task"
+	| "open-tools"
+	| "open-timeout"
 	| "rename"
 	| "set-timeout"
 	| "toggle-tool"
@@ -99,7 +117,7 @@ export async function showSubagentsMenu(
 	},
 ): Promise<void> {
 	if (ctx.mode !== "tui") throw new Error("The subagents profile manager requires Pi TUI mode.");
-	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	const { defineMenu, runCustomInteraction, runMenu } = await import("@narumitw/pi-tui-kit");
 	if (!isCurrent(options.owner)) return;
 	let selectedName: string | undefined;
 	const settingsPath = safeLine(options.store.settingsPath);
@@ -178,21 +196,68 @@ export async function showSubagentsMenu(
 						`Task: ${taskSummary(profile.task)}`,
 					],
 					items: [
-						{ id: "task", label: "Task prompt…", action: "edit-task" },
-						{ id: "tools", label: `Tools (${profile.tools.length})`, to: "tools" },
 						{
-							id: "timeout",
-							label: `Timeout (${profile.timeout}s)`,
-							to: "timeout",
-						},
-						{
-							id: "thinking",
-							label: `Thinking level (${profile.thinkingLevel})`,
-							to: "thinking",
+							id: "profile-settings",
+							label: "Profile settings…",
+							description: "Edit task, tools, timeout, and thinking level",
+							to: "profile-settings",
 						},
 						{ id: "rename", label: "Rename…", to: "rename" },
 						{ id: "delete", label: "Delete…", to: "delete" },
 					],
+					hint: "back",
+				};
+			},
+			"profile-settings": ({ state }) => {
+				const profile = selectedProfile(state);
+				if (!selectedName || !profile) return missingProfileScreen();
+				return {
+					// Kit's standard settings screen preserves injected keybindings and search focus.
+					// It also rolls back rejected saves, which the installed Pi SettingsList cannot expose.
+					kind: "settings",
+					title: `Profile settings · ${selectedName}`,
+					lines: ["Changes save immediately. Escape does not roll them back."],
+					items: [
+						{
+							id: "task",
+							label: "Task prompt",
+							description: "Append trusted user instructions to the child system prompt.",
+							currentValue: taskSummary(profile.task),
+							action: "open-task",
+						},
+						{
+							id: "tools",
+							label: "Tools",
+							description: "Choose the default child work capabilities.",
+							currentValue: profile.tools.join(", ") || "none",
+							action: "open-tools",
+						},
+						{
+							id: "timeout",
+							label: "Timeout",
+							description: "Set the default execution deadline in seconds.",
+							currentValue: `${profile.timeout}s`,
+							action: "open-timeout",
+						},
+						{
+							id: "thinking",
+							label: "Thinking level",
+							description: "Set the default child thinking level.",
+							currentValue: profile.thinkingLevel,
+							values: [...SUBAGENT_THINKING_LEVELS],
+							action: "set-thinking",
+						},
+					],
+				};
+			},
+			task: ({ state }) => {
+				const profile = selectedProfile(state);
+				if (!selectedName || !profile) return missingProfileScreen();
+				return {
+					kind: "actions",
+					title: `Task prompt · ${selectedName}`,
+					lines: [`Current: ${taskSummary(profile.task)}`],
+					items: [{ id: "edit-task", label: "Edit task prompt…", action: "edit-task" }],
 					hint: "back",
 				};
 			},
@@ -239,18 +304,6 @@ export async function showSubagentsMenu(
 					viewportSize: 8,
 					hint: "back",
 					doneLabel: "Back",
-				};
-			},
-			thinking: ({ state }) => {
-				const current = selectedProfile(state)?.thinkingLevel;
-				return {
-					kind: "choice",
-					title: `Thinking level · ${selectedName ?? "unknown"}`,
-					items: SUBAGENT_THINKING_LEVELS.map((level) => ({ id: level, label: level })),
-					action: "set-thinking",
-					currentItemId: current,
-					initialItemId: current,
-					hint: "back",
 				};
 			},
 			delete: ({ state }) => {
@@ -329,21 +382,34 @@ export async function showSubagentsMenu(
 				selectedName = name;
 				return { kind: "to", screen: "profile" };
 			},
+			"open-task": () => ({ kind: "to", screen: "task" }),
 			"edit-task": async ({ ctx: actionCtx, signal }) => {
 				const current = requireSelectedProfile(options.store, selectedName);
 				let draft = current.task;
 				while (isCurrent(options.owner) && !signal.aborted) {
-					const edited = await actionCtx.ui.editor(
-						`Task prompt · ${selectedName ?? "unknown"}`,
-						draft,
-					);
-					if (edited === undefined) return { kind: "stay" };
+					const edited = await runCustomInteraction<string | undefined>(actionCtx, {
+						signal,
+						isCurrent: () => isCurrent(options.owner),
+						create: ({ tui, theme, keybindings, complete }) =>
+							new TaskPromptEditor({
+								tui,
+								theme,
+								keybindings,
+								title: `Task prompt · ${selectedName ?? "unknown"}`,
+								draft,
+								onSubmit: complete,
+								onCancel: () => complete(undefined),
+							}),
+					});
+					if (edited.kind === "stale") return { kind: "rejected" };
+					if (edited.kind !== "completed") return { kind: "back" };
+					if (edited.value === undefined) return { kind: "back" };
 					if (signal.aborted || !isCurrent(options.owner)) return { kind: "rejected" };
 					try {
-						options.store.update(requireSelectedName(selectedName), { task: edited });
-						return { kind: "stay" };
+						options.store.update(requireSelectedName(selectedName), { task: edited.value });
+						return { kind: "back" };
 					} catch (error) {
-						draft = edited;
+						draft = edited.value;
 						actionCtx.ui.notify(
 							`Task prompt was not saved: ${safeLine(formatError(error))}`,
 							"error",
@@ -352,6 +418,8 @@ export async function showSubagentsMenu(
 				}
 				return { kind: "rejected" };
 			},
+			"open-tools": () => ({ kind: "to", screen: "tools" }),
+			"open-timeout": () => ({ kind: "to", screen: "timeout" }),
 			rename: ({ value }) => {
 				assertCurrent(options.owner);
 				const currentName = requireSelectedName(selectedName);
@@ -364,7 +432,7 @@ export async function showSubagentsMenu(
 				assertCurrent(options.owner);
 				const timeout = Number(value);
 				options.store.update(requireSelectedName(selectedName), { timeout });
-				return { kind: "to", screen: "profile" };
+				return { kind: "back" };
 			},
 			"toggle-tool": ({ itemId, selected }) => {
 				assertCurrent(options.owner);
@@ -380,15 +448,15 @@ export async function showSubagentsMenu(
 				options.store.update(profileName, { tools });
 				return { kind: "stay" };
 			},
-			"set-thinking": ({ itemId }) => {
+			"set-thinking": ({ value }) => {
 				assertCurrent(options.owner);
-				if (!SUBAGENT_THINKING_LEVELS.includes(itemId as SubagentThinkingLevel)) {
+				if (!SUBAGENT_THINKING_LEVELS.includes(value as SubagentThinkingLevel)) {
 					return { kind: "rejected" };
 				}
 				options.store.update(requireSelectedName(selectedName), {
-					thinkingLevel: itemId as SubagentThinkingLevel,
+					thinkingLevel: value as SubagentThinkingLevel,
 				});
-				return { kind: "to", screen: "profile" };
+				return { kind: "stay" };
 			},
 			delete: ({ state }) => {
 				assertCurrent(options.owner);
@@ -414,6 +482,280 @@ export async function showSubagentsMenu(
 			}
 		},
 	});
+}
+
+interface TaskPromptEditorOptions {
+	tui: TUI;
+	theme: Theme;
+	keybindings: KeybindingsManager;
+	title: string;
+	draft: string;
+	onSubmit(value: string): void;
+	onCancel(): void;
+}
+
+class TaskPromptEditor implements Focusable {
+	private readonly editor: RawPreservingEditor;
+	private finished = false;
+
+	constructor(private readonly options: TaskPromptEditorOptions) {
+		const editorTheme: EditorTheme = {
+			borderColor: (text) => options.theme.fg("accent", text),
+			selectList: {
+				selectedPrefix: (text) => options.theme.fg("accent", text),
+				selectedText: (text) => options.theme.fg("accent", text),
+				description: (text) => options.theme.fg("muted", text),
+				scrollInfo: (text) => options.theme.fg("dim", text),
+				noMatch: (text) => options.theme.fg("warning", text),
+			},
+		};
+		this.editor = new RawPreservingEditor(options.tui, editorTheme);
+		this.editor.setText(options.draft);
+		this.editor.onChange = () => options.tui.requestRender();
+	}
+
+	get focused(): boolean {
+		return this.editor.focused;
+	}
+
+	set focused(value: boolean) {
+		this.editor.focused = value;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const border = this.options.theme.fg("border", "─".repeat(safeWidth));
+		const title = truncateToWidth(
+			this.options.theme.fg("accent", this.options.theme.bold(safeLine(this.options.title))),
+			safeWidth,
+			"",
+		);
+		const hint = truncateToWidth(
+			this.options.theme.fg("muted", taskEditorHint(this.options.keybindings)),
+			safeWidth,
+			"",
+		);
+		return [border, "", title, "", ...this.editor.render(safeWidth), "", hint, "", border];
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	handleInput(data: string): void {
+		if (this.finished) return;
+		if (matchesKey(data, Key.ctrl("c"))) {
+			this.cancel();
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.select.cancel")) {
+			this.cancel();
+			return;
+		}
+		if (this.options.keybindings.matches(data, "tui.input.newLine")) {
+			this.editor.insertTextAtCursor("\n");
+		} else if (this.options.keybindings.matches(data, "tui.input.submit")) {
+			this.finished = true;
+			this.editor.focused = false;
+			this.options.onSubmit(this.editor.getExpandedText());
+		} else {
+			this.editor.handleInput(data);
+		}
+		this.options.tui.requestRender();
+	}
+
+	dispose(): void {
+		this.finished = true;
+		this.editor.focused = false;
+	}
+
+	private cancel(): void {
+		this.finished = true;
+		this.editor.focused = false;
+		this.options.onCancel();
+	}
+}
+
+class RawPreservingEditor implements Focusable {
+	private readonly editor: Editor;
+	private readonly rawByMarker = new Map<string, string>();
+	private markerCodePoint = 0xe000;
+	private pasteBuffer: string | undefined;
+
+	constructor(tui: TUI, theme: EditorTheme) {
+		this.editor = new Editor(tui, theme, { paddingX: 0 });
+		this.editor.disableSubmit = true;
+	}
+
+	get focused(): boolean {
+		return this.editor.focused;
+	}
+
+	set focused(value: boolean) {
+		this.editor.focused = value;
+	}
+
+	set onChange(handler: (() => void) | undefined) {
+		this.editor.onChange = handler;
+	}
+
+	handleInput(data: string): void {
+		if (this.pasteBuffer !== undefined) {
+			this.pasteBuffer += data;
+			this.flushPasteBuffer();
+			return;
+		}
+		if (matchesKey(data, Key.backspace)) {
+			this.editor.handleInput(data);
+			return;
+		}
+		const pasteStart = data.indexOf(BRACKETED_PASTE_START);
+		if (pasteStart >= 0) {
+			if (pasteStart > 0) this.editor.handleInput(data.slice(0, pasteStart));
+			this.pasteBuffer = data.slice(pasteStart + BRACKETED_PASTE_START.length);
+			this.flushPasteBuffer();
+			return;
+		}
+		if (
+			[...data].some(
+				(character) => isUnsafeDirectEditorCharacter(character) || this.rawByMarker.has(character),
+			)
+		) {
+			this.editor.handleInput(this.encode(data));
+			return;
+		}
+		this.editor.handleInput(data);
+	}
+
+	insertTextAtCursor(value: string): void {
+		this.editor.insertTextAtCursor(this.encode(value));
+	}
+
+	render(width: number): string[] {
+		return this.editor
+			.render(width)
+			.map((line) =>
+				[...line].map((character) => (this.rawByMarker.has(character) ? " " : character)).join(""),
+			);
+	}
+
+	invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	setText(value: string): void {
+		this.rawByMarker.clear();
+		this.markerCodePoint = 0xe000;
+		this.pasteBuffer = undefined;
+		this.editor.setText(this.encode(value));
+	}
+
+	getExpandedText(): string {
+		return this.decode(this.editor.getExpandedText());
+	}
+
+	private flushPasteBuffer(): void {
+		if (this.pasteBuffer === undefined) return;
+		const pasteEnd = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
+		if (pasteEnd < 0) return;
+		const raw = this.pasteBuffer.slice(0, pasteEnd);
+		const remaining = this.pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
+		this.pasteBuffer = undefined;
+		this.editor.handleInput(`${BRACKETED_PASTE_START}${this.encode(raw)}${BRACKETED_PASTE_END}`);
+		if (remaining) this.handleInput(remaining);
+	}
+
+	private encode(value: string): string {
+		const forbidden = new Set([
+			...value,
+			...this.editor.getExpandedText(),
+			...this.rawByMarker.keys(),
+		]);
+		return [...value]
+			.map((character) => {
+				if (!isUnsafeEditorCharacter(character) && !this.rawByMarker.has(character)) {
+					return character;
+				}
+				const marker = this.nextMarker(forbidden);
+				this.rawByMarker.set(marker, character);
+				forbidden.add(marker);
+				return marker;
+			})
+			.join("");
+	}
+
+	private decode(value: string): string {
+		return [...value].map((character) => this.rawByMarker.get(character) ?? character).join("");
+	}
+
+	private nextMarker(forbidden: ReadonlySet<string>): string {
+		for (;;) {
+			if (this.markerCodePoint === 0xf900) this.markerCodePoint = 0xf0000;
+			if (this.markerCodePoint === 0xffffe) this.markerCodePoint = 0x100000;
+			if (this.markerCodePoint > 0x10fffd) {
+				throw new Error("Task prompt editor exhausted its safe input markers.");
+			}
+			const marker = String.fromCodePoint(this.markerCodePoint++);
+			if (!forbidden.has(marker)) return marker;
+		}
+	}
+}
+
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+
+function isUnsafeDirectEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		(codePoint >= 0x7f && codePoint <= 0x9f) ||
+		codePoint === 0x2028 ||
+		codePoint === 0x2029 ||
+		isBidiControl(codePoint)
+	);
+}
+
+function isUnsafeEditorCharacter(character: string): boolean {
+	const codePoint = character.codePointAt(0) ?? 0;
+	return (
+		character !== "\n" &&
+		(codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			codePoint === 0x2028 ||
+			codePoint === 0x2029 ||
+			isBidiControl(codePoint))
+	);
+}
+
+function isBidiControl(codePoint: number): boolean {
+	return (
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}
+
+function taskEditorHint(keybindings: KeybindingsManager): string {
+	return [
+		formatHintKeys(keybindings.getKeys("tui.input.submit"), "save"),
+		formatHintKeys(keybindings.getKeys("tui.input.newLine"), "newline"),
+		formatHintKeys([...keybindings.getKeys("tui.select.cancel"), "ctrl+c"], "cancel"),
+	]
+		.filter(Boolean)
+		.join(" · ");
+}
+
+function formatHintKeys(keys: readonly string[], label: string): string {
+	const names = [...new Set(keys.map(formatHintKey).filter(Boolean))];
+	return names.length > 0 ? `${names.join("/")} ${label}` : "";
+}
+
+function formatHintKey(value: string): string {
+	const key = safeLine(value).toLowerCase();
+	if (key === "escape") return "esc";
+	if (key === "return") return "enter";
+	return key;
 }
 
 function requireSelectedName(name: string | undefined): string {

--- a/packages/pi-subagents/src/menu.ts
+++ b/packages/pi-subagents/src/menu.ts
@@ -79,7 +79,7 @@ type Action =
 
 export function registerSubagentsCommand(pi: ExtensionAPI, options: SubagentsCommandOptions): void {
 	pi.registerCommand("subagents", {
-		description: "Manage user-defined subagent profiles",
+		description: "Manage user-defined subagent role profiles",
 		handler: async (args, ctx) => {
 			if (args.trim()) {
 				const message = "/subagents does not accept arguments.";
@@ -149,7 +149,7 @@ export async function showSubagentsMenu(
 						{
 							id: "settings",
 							label: "Settings",
-							description: "Create and manage agent profiles",
+							description: "Create and manage role profiles",
 							to: state.loaded.kind === "invalid" ? "invalid" : "profiles",
 						},
 						{ id: "status", label: "Status", to: "status" },
@@ -162,7 +162,7 @@ export async function showSubagentsMenu(
 				const names = Object.keys(state.profiles).sort();
 				return {
 					kind: "actions",
-					title: "Subagent profiles",
+					title: "Subagent roles",
 					lines: [
 						names.length === 0
 							? `No profiles · ${settingsPath}`
@@ -263,7 +263,7 @@ export async function showSubagentsMenu(
 			},
 			create: () => ({
 				kind: "input",
-				title: "Create subagent profile",
+				title: "Create subagent role",
 				lines: ["Enter a unique lowercase kebab-case name."],
 				placeholder: "reviewer",
 				action: "create",
@@ -356,7 +356,7 @@ export async function showSubagentsMenu(
 			}),
 			invalid: ({ state }) => ({
 				kind: "detail",
-				title: "Subagent profiles · Read only",
+				title: "Subagent roles · Read only",
 				lines: [
 					`Fix the settings file before using the manager: ${settingsPath}`,
 					safeLine(state.loaded.kind === "invalid" ? state.loaded.reason : "Settings are valid."),
@@ -476,7 +476,7 @@ export async function showSubagentsMenu(
 		onError: (_menuCtx: MenuContext, error: unknown) => {
 			if (isCurrent(options.owner)) {
 				ctx.ui.notify(
-					`Subagent profiles were not changed: ${safeLine(formatError(error))}`,
+					`Subagent role profiles were not changed: ${safeLine(formatError(error))}`,
 					"error",
 				);
 			}
@@ -759,7 +759,7 @@ function formatHintKey(value: string): string {
 }
 
 function requireSelectedName(name: string | undefined): string {
-	if (!name) throw new Error("No subagent profile is selected.");
+	if (!name) throw new Error("No subagent role profile is selected.");
 	return name;
 }
 
@@ -768,7 +768,7 @@ function requireSelectedProfile(store: AgentProfileStore, name: string | undefin
 	const loaded = store.read();
 	if (loaded.kind === "invalid") throw new Error(loaded.reason);
 	if (!Object.hasOwn(loaded.profiles, selectedName)) {
-		throw new Error(`Subagent agent "${selectedName}" does not exist.`);
+		throw new Error(`Subagent role "${selectedName}" does not exist.`);
 	}
 	return loaded.profiles[selectedName] as AgentProfile;
 }
@@ -818,8 +818,8 @@ function toolDescription(name: (typeof CHILD_CORE_TOOL_NAMES)[number]): string {
 function missingProfileScreen() {
 	return {
 		kind: "detail" as const,
-		title: "Subagent profile unavailable",
-		lines: ["The selected profile no longer exists."],
+		title: "Subagent role unavailable",
+		lines: ["The selected role profile no longer exists."],
 		hint: "back" as const,
 	};
 }

--- a/packages/pi-subagents/src/menu.ts
+++ b/packages/pi-subagents/src/menu.ts
@@ -1,0 +1,493 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { MenuContext } from "@narumitw/pi-tui-kit";
+import {
+	type AgentProfile,
+	type AgentProfileStore,
+	type AgentProfilesLoadResult,
+	createAgentProfileStore,
+	DEFAULT_AGENT_TASK,
+	DEFAULT_AGENT_TIMEOUT,
+	requireAgentName,
+} from "./agent-profiles.js";
+import { sanitizeTerminalText } from "./message-broker.js";
+import type { ActiveJobDisplay } from "./runtime.js";
+import {
+	CHILD_CORE_TOOL_NAMES,
+	DEFAULT_SUBAGENT_TOOLS,
+	SUBAGENT_THINKING_LEVELS,
+	type SubagentThinkingLevel,
+} from "./types.js";
+
+export interface SubagentsMenuOwner {
+	signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export interface SubagentsCommandOptions {
+	getOwner(ctx: ExtensionCommandContext): SubagentsMenuOwner | undefined;
+	getActiveJobs(): ActiveJobDisplay[];
+	store?: AgentProfileStore;
+}
+
+interface MenuState {
+	loaded: AgentProfilesLoadResult;
+	profiles: Record<string, AgentProfile>;
+	activeJobs: ActiveJobDisplay[];
+}
+
+type Screen =
+	| "main"
+	| "profiles"
+	| "profile"
+	| "create"
+	| "rename"
+	| "timeout"
+	| "tools"
+	| "thinking"
+	| "delete"
+	| "status"
+	| "help"
+	| "invalid";
+
+type Action =
+	| "open-profile"
+	| "create"
+	| "edit-task"
+	| "rename"
+	| "set-timeout"
+	| "toggle-tool"
+	| "set-thinking"
+	| "delete";
+
+export function registerSubagentsCommand(pi: ExtensionAPI, options: SubagentsCommandOptions): void {
+	pi.registerCommand("subagents", {
+		description: "Manage user-defined subagent profiles",
+		handler: async (args, ctx) => {
+			if (args.trim()) {
+				const message = "/subagents does not accept arguments.";
+				if (ctx.hasUI) {
+					ctx.ui.notify(message, "warning");
+					return;
+				}
+				throw new Error(message);
+			}
+			if (ctx.mode !== "tui") {
+				const message = "/subagents requires Pi TUI mode.";
+				if (ctx.hasUI) {
+					ctx.ui.notify(message, "warning");
+					return;
+				}
+				throw new Error(message);
+			}
+			const owner = options.getOwner(ctx);
+			if (!owner || owner.signal.aborted || !owner.isCurrent()) return;
+			await showSubagentsMenu(ctx, {
+				owner,
+				getActiveJobs: options.getActiveJobs,
+				store: options.store ?? createAgentProfileStore(),
+			});
+		},
+	});
+}
+
+export async function showSubagentsMenu(
+	ctx: ExtensionCommandContext,
+	options: {
+		owner: SubagentsMenuOwner;
+		getActiveJobs(): ActiveJobDisplay[];
+		store: AgentProfileStore;
+	},
+): Promise<void> {
+	if (ctx.mode !== "tui") throw new Error("The subagents profile manager requires Pi TUI mode.");
+	const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
+	if (!isCurrent(options.owner)) return;
+	let selectedName: string | undefined;
+	const settingsPath = safeLine(options.store.settingsPath);
+	const getState = (): MenuState => {
+		const loaded = options.store.read();
+		return {
+			loaded,
+			profiles: loaded.kind === "invalid" ? {} : loaded.profiles,
+			activeJobs: options.getActiveJobs(),
+		};
+	};
+	const selectedProfile = (state: MenuState): AgentProfile | undefined =>
+		selectedName && Object.hasOwn(state.profiles, selectedName)
+			? state.profiles[selectedName]
+			: undefined;
+
+	const menu = defineMenu<MenuState, Screen, Action, ExtensionCommandContext>({
+		start: "main",
+		screens: {
+			main: ({ state }) => {
+				const profileCount = Object.keys(state.profiles).length;
+				return {
+					kind: "actions",
+					title: "Pi Subagents",
+					lines: [
+						`Profiles: ${state.loaded.kind === "invalid" ? "invalid settings" : profileCount} · Active jobs: ${state.activeJobs.length}`,
+					],
+					items: [
+						{
+							id: "settings",
+							label: "Settings",
+							description: "Create and manage agent profiles",
+							to: state.loaded.kind === "invalid" ? "invalid" : "profiles",
+						},
+						{ id: "status", label: "Status", to: "status" },
+						{ id: "help", label: "Help", to: "help" },
+					],
+					hint: "close",
+				};
+			},
+			profiles: ({ state }) => {
+				const names = Object.keys(state.profiles).sort();
+				return {
+					kind: "actions",
+					title: "Subagent profiles",
+					lines: [
+						names.length === 0
+							? `No profiles · ${settingsPath}`
+							: `${names.length} ${names.length === 1 ? "profile" : "profiles"} · ${settingsPath}`,
+					],
+					items: [
+						{
+							id: "create",
+							label: "Create profile…",
+							description: "Start with safe defaults",
+							to: "create",
+						},
+						...names.map((name) => ({
+							id: `profile:${name}`,
+							label: name,
+							description: profileSummary(state.profiles[name] as AgentProfile),
+							action: "open-profile" as const,
+						})),
+					],
+					hint: "back",
+				};
+			},
+			profile: ({ state }) => {
+				const profile = selectedProfile(state);
+				if (!selectedName || !profile) return missingProfileScreen();
+				return {
+					kind: "actions",
+					title: `Profile · ${selectedName}`,
+					lines: [
+						`Tools: ${profile.tools.join(", ") || "none"} · Timeout: ${profile.timeout}s · Thinking: ${profile.thinkingLevel}`,
+						`Task: ${taskSummary(profile.task)}`,
+					],
+					items: [
+						{ id: "task", label: "Task prompt…", action: "edit-task" },
+						{ id: "tools", label: `Tools (${profile.tools.length})`, to: "tools" },
+						{
+							id: "timeout",
+							label: `Timeout (${profile.timeout}s)`,
+							to: "timeout",
+						},
+						{
+							id: "thinking",
+							label: `Thinking level (${profile.thinkingLevel})`,
+							to: "thinking",
+						},
+						{ id: "rename", label: "Rename…", to: "rename" },
+						{ id: "delete", label: "Delete…", to: "delete" },
+					],
+					hint: "back",
+				};
+			},
+			create: () => ({
+				kind: "input",
+				title: "Create subagent profile",
+				lines: ["Enter a unique lowercase kebab-case name."],
+				placeholder: "reviewer",
+				action: "create",
+				hint: "back",
+			}),
+			rename: () => ({
+				kind: "input",
+				title: `Rename profile · ${selectedName ?? "unknown"}`,
+				lines: ["Enter the complete new lowercase kebab-case name."],
+				placeholder: selectedName ?? "reviewer",
+				action: "rename",
+				hint: "back",
+			}),
+			timeout: ({ state }) => ({
+				kind: "input",
+				title: `Execution timeout · ${selectedName ?? "unknown"}`,
+				lines: [
+					`Current: ${selectedProfile(state)?.timeout ?? "unavailable"} seconds`,
+					"Enter a finite number greater than zero through 2147483.647.",
+				],
+				placeholder: String(selectedProfile(state)?.timeout ?? DEFAULT_AGENT_TIMEOUT),
+				action: "set-timeout",
+				hint: "back",
+			}),
+			tools: ({ state }) => {
+				const profile = selectedProfile(state);
+				return {
+					kind: "multiSelect",
+					title: `Tools · ${selectedName ?? "unknown"}`,
+					lines: ["Changes save immediately. Escape does not roll them back."],
+					items: CHILD_CORE_TOOL_NAMES.map((name) => ({
+						id: `tool:${name}`,
+						label: name,
+						selected: profile?.tools.includes(name) ?? false,
+						description: toolDescription(name),
+					})),
+					action: "toggle-tool",
+					viewportSize: 8,
+					hint: "back",
+					doneLabel: "Back",
+				};
+			},
+			thinking: ({ state }) => {
+				const current = selectedProfile(state)?.thinkingLevel;
+				return {
+					kind: "choice",
+					title: `Thinking level · ${selectedName ?? "unknown"}`,
+					items: SUBAGENT_THINKING_LEVELS.map((level) => ({ id: level, label: level })),
+					action: "set-thinking",
+					currentItemId: current,
+					initialItemId: current,
+					hint: "back",
+				};
+			},
+			delete: ({ state }) => {
+				const profile = selectedProfile(state);
+				if (!selectedName || !profile) return missingProfileScreen();
+				return {
+					kind: "review",
+					title: `Delete profile · ${selectedName}?`,
+					lines: ["Review managed values and unknown field names. This cannot be undone."],
+					content: JSON.stringify(
+						{
+							name: selectedName,
+							...profile,
+							unknownFields:
+								state.loaded.kind === "invalid"
+									? []
+									: unknownProfileFields(state.loaded.document[selectedName]),
+						},
+						null,
+						2,
+					),
+					format: { kind: "code", language: "json" },
+					viewportSize: "adaptive",
+					confirm: { id: "confirm-delete", label: "Delete profile", action: "delete" },
+					hint: "back",
+				};
+			},
+			status: ({ state }) => ({
+				kind: "detail",
+				title: "Pi Subagents status",
+				lines: [
+					`Settings: ${settingsPath}`,
+					`Settings state: ${state.loaded.kind}`,
+					`Profiles: ${Object.keys(state.profiles).length}`,
+					`Active jobs: ${state.activeJobs.length}`,
+					"Cross-process writes use atomic replacement but no merge lock.",
+				],
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "Pi Subagents help",
+				lines: [
+					"Profiles provide a child task prompt plus tools, timeout, and thinking-level defaults.",
+					"Explicit subagent_spawn values override profile defaults.",
+					"Profiles are trusted user settings, not authorization boundaries.",
+					`Settings file: ${settingsPath}`,
+				],
+				hint: "back",
+			}),
+			invalid: ({ state }) => ({
+				kind: "detail",
+				title: "Subagent profiles · Read only",
+				lines: [
+					`Fix the settings file before using the manager: ${settingsPath}`,
+					safeLine(state.loaded.kind === "invalid" ? state.loaded.reason : "Settings are valid."),
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			"open-profile": ({ itemId }) => {
+				selectedName = itemId.startsWith("profile:") ? itemId.slice("profile:".length) : undefined;
+				return selectedName ? { kind: "to", screen: "profile" } : { kind: "rejected" };
+			},
+			create: ({ value, ctx: actionCtx }) => {
+				assertCurrent(options.owner);
+				const name = requireAgentName(value);
+				const thinkingLevel = effectiveThinkingLevel(actionCtx.thinkingLevel);
+				options.store.create(name, {
+					task: DEFAULT_AGENT_TASK,
+					tools: [...DEFAULT_SUBAGENT_TOOLS],
+					timeout: DEFAULT_AGENT_TIMEOUT,
+					thinkingLevel,
+				});
+				selectedName = name;
+				return { kind: "to", screen: "profile" };
+			},
+			"edit-task": async ({ ctx: actionCtx, signal }) => {
+				const current = requireSelectedProfile(options.store, selectedName);
+				let draft = current.task;
+				while (isCurrent(options.owner) && !signal.aborted) {
+					const edited = await actionCtx.ui.editor(
+						`Task prompt · ${selectedName ?? "unknown"}`,
+						draft,
+					);
+					if (edited === undefined) return { kind: "stay" };
+					if (signal.aborted || !isCurrent(options.owner)) return { kind: "rejected" };
+					try {
+						options.store.update(requireSelectedName(selectedName), { task: edited });
+						return { kind: "stay" };
+					} catch (error) {
+						draft = edited;
+						actionCtx.ui.notify(
+							`Task prompt was not saved: ${safeLine(formatError(error))}`,
+							"error",
+						);
+					}
+				}
+				return { kind: "rejected" };
+			},
+			rename: ({ value }) => {
+				assertCurrent(options.owner);
+				const currentName = requireSelectedName(selectedName);
+				const nextName = requireAgentName(value);
+				options.store.rename(currentName, nextName);
+				selectedName = nextName;
+				return { kind: "to", screen: "profile" };
+			},
+			"set-timeout": ({ value }) => {
+				assertCurrent(options.owner);
+				const timeout = Number(value);
+				options.store.update(requireSelectedName(selectedName), { timeout });
+				return { kind: "to", screen: "profile" };
+			},
+			"toggle-tool": ({ itemId, selected }) => {
+				assertCurrent(options.owner);
+				const name = itemId.startsWith("tool:") ? itemId.slice("tool:".length) : "";
+				if (!CHILD_CORE_TOOL_NAMES.includes(name as (typeof CHILD_CORE_TOOL_NAMES)[number])) {
+					return { kind: "rejected" };
+				}
+				const profileName = requireSelectedName(selectedName);
+				const profile = requireSelectedProfile(options.store, profileName);
+				const tools = selected
+					? [...new Set([...profile.tools, name])]
+					: profile.tools.filter((tool) => tool !== name);
+				options.store.update(profileName, { tools });
+				return { kind: "stay" };
+			},
+			"set-thinking": ({ itemId }) => {
+				assertCurrent(options.owner);
+				if (!SUBAGENT_THINKING_LEVELS.includes(itemId as SubagentThinkingLevel)) {
+					return { kind: "rejected" };
+				}
+				options.store.update(requireSelectedName(selectedName), {
+					thinkingLevel: itemId as SubagentThinkingLevel,
+				});
+				return { kind: "to", screen: "profile" };
+			},
+			delete: ({ state }) => {
+				assertCurrent(options.owner);
+				const name = requireSelectedName(selectedName);
+				if (state.loaded.kind === "invalid") throw new Error(state.loaded.reason);
+				options.store.delete(name, state.loaded.document[name]);
+				selectedName = undefined;
+				return { kind: "to", screen: "profiles" };
+			},
+		},
+	});
+
+	await runMenu(ctx, menu, {
+		getState,
+		signal: options.owner.signal,
+		isCurrent: options.owner.isCurrent,
+		onError: (_menuCtx: MenuContext, error: unknown) => {
+			if (isCurrent(options.owner)) {
+				ctx.ui.notify(
+					`Subagent profiles were not changed: ${safeLine(formatError(error))}`,
+					"error",
+				);
+			}
+		},
+	});
+}
+
+function requireSelectedName(name: string | undefined): string {
+	if (!name) throw new Error("No subagent profile is selected.");
+	return name;
+}
+
+function requireSelectedProfile(store: AgentProfileStore, name: string | undefined): AgentProfile {
+	const selectedName = requireSelectedName(name);
+	const loaded = store.read();
+	if (loaded.kind === "invalid") throw new Error(loaded.reason);
+	if (!Object.hasOwn(loaded.profiles, selectedName)) {
+		throw new Error(`Subagent agent "${selectedName}" does not exist.`);
+	}
+	return loaded.profiles[selectedName] as AgentProfile;
+}
+
+function effectiveThinkingLevel(value: string | undefined): SubagentThinkingLevel {
+	return SUBAGENT_THINKING_LEVELS.includes(value as SubagentThinkingLevel)
+		? (value as SubagentThinkingLevel)
+		: "medium";
+}
+
+function isCurrent(owner: SubagentsMenuOwner): boolean {
+	return !owner.signal.aborted && owner.isCurrent();
+}
+
+function assertCurrent(owner: SubagentsMenuOwner): void {
+	if (!isCurrent(owner)) throw new Error("The subagents menu is stale.");
+}
+
+function profileSummary(profile: AgentProfile): string {
+	return `${profile.tools.length} tools · ${profile.timeout}s · ${profile.thinkingLevel}`;
+}
+
+function taskSummary(task: string): string {
+	const normalized = safeLine(task).replace(/\s+/gu, " ").trim();
+	return normalized.length <= 120 ? normalized : `${normalized.slice(0, 119)}…`;
+}
+
+function unknownProfileFields(value: unknown): string[] {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return [];
+	const known = new Set(["task", "tools", "timeout", "thinkingLevel"]);
+	return Object.keys(value).filter((field) => !known.has(field));
+}
+
+function toolDescription(name: (typeof CHILD_CORE_TOOL_NAMES)[number]): string {
+	switch (name) {
+		case "bash":
+		case "powershell":
+			return "Unrestricted command execution; can modify files";
+		case "edit":
+		case "write":
+			return "Explicit workspace mutation";
+		default:
+			return "Read-only work tool";
+	}
+}
+
+function missingProfileScreen() {
+	return {
+		kind: "detail" as const,
+		title: "Subagent profile unavailable",
+		lines: ["The selected profile no longer exists."],
+		hint: "back" as const,
+	};
+}
+
+function safeLine(value: string): string {
+	return sanitizeTerminalText(value)
+		.replace(/[\n\t]+/gu, " ")
+		.trim();
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-subagents/src/process.ts
+++ b/packages/pi-subagents/src/process.ts
@@ -54,7 +54,7 @@ export async function runChild(request: ChildRequest): Promise<ChildResult> {
 	if (request.signal.aborted) return cancelledResult();
 	let promptDirectory: string | undefined;
 	try {
-		const promptFile = request.agentPrompt ? writeAgentPromptFile(request.agentPrompt) : undefined;
+		const promptFile = request.rolePrompt ? writeRolePromptFile(request.rolePrompt) : undefined;
 		promptDirectory = promptFile?.directory;
 		const invocation = resolvePiInvocation(buildPiArgs(request, promptFile?.filePath));
 		return await executeProcess(invocation, request);
@@ -72,7 +72,7 @@ export async function runChild(request: ChildRequest): Promise<ChildResult> {
 	}
 }
 
-export function buildPiArgs(request: ChildRequest, agentPromptPath?: string): string[] {
+export function buildPiArgs(request: ChildRequest, rolePromptPath?: string): string[] {
 	const args = [
 		"--mode",
 		"json",
@@ -89,10 +89,10 @@ export function buildPiArgs(request: ChildRequest, agentPromptPath?: string): st
 		request.thinkingLevel,
 		request.projectTrusted ? "--approve" : "--no-approve",
 	];
-	if (request.agentPrompt && !agentPromptPath) {
-		throw new Error("A temporary agent prompt file is required for profiled child execution.");
+	if (request.rolePrompt && !rolePromptPath) {
+		throw new Error("A temporary role prompt file is required for profiled child execution.");
 	}
-	if (agentPromptPath) args.push("--append-system-prompt", agentPromptPath);
+	if (rolePromptPath) args.push("--append-system-prompt", rolePromptPath);
 	const tools = [...new Set([...request.tools, ...CHILD_COMMUNICATION_TOOL_NAMES])];
 	args.push("--tools", tools.join(","));
 	args.push(`Task: ${request.task}`);
@@ -103,7 +103,7 @@ export function childCommunicationBridgePath(): string {
 	return fileURLToPath(new URL("./child-communication-bridge.ts", import.meta.url));
 }
 
-function writeAgentPromptFile(prompt: string): { directory: string; filePath: string } {
+function writeRolePromptFile(prompt: string): { directory: string; filePath: string } {
 	const directory = fs.mkdtempSync(
 		path.join(os.tmpdir(), `pi-subagents-prompt-${globalThis.process.pid}-`),
 	);

--- a/packages/pi-subagents/src/process.ts
+++ b/packages/pi-subagents/src/process.ts
@@ -83,6 +83,7 @@ export function buildPiArgs(request: ChildRequest): string[] {
 		request.thinkingLevel,
 		request.projectTrusted ? "--approve" : "--no-approve",
 	];
+	if (request.agentPrompt) args.push("--append-system-prompt", request.agentPrompt);
 	const tools = [...new Set([...request.tools, ...CHILD_COMMUNICATION_TOOL_NAMES])];
 	args.push("--tools", tools.join(","));
 	args.push(`Task: ${request.task}`);

--- a/packages/pi-subagents/src/process.ts
+++ b/packages/pi-subagents/src/process.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
@@ -51,8 +52,11 @@ interface AssistantEvent {
 
 export async function runChild(request: ChildRequest): Promise<ChildResult> {
 	if (request.signal.aborted) return cancelledResult();
+	let promptDirectory: string | undefined;
 	try {
-		const invocation = resolvePiInvocation(buildPiArgs(request));
+		const promptFile = request.agentPrompt ? writeAgentPromptFile(request.agentPrompt) : undefined;
+		promptDirectory = promptFile?.directory;
+		const invocation = resolvePiInvocation(buildPiArgs(request, promptFile?.filePath));
 		return await executeProcess(invocation, request);
 	} catch (error) {
 		if (request.signal.aborted) return cancelledResult();
@@ -63,10 +67,12 @@ export async function runChild(request: ChildRequest): Promise<ChildResult> {
 			limitations: [],
 			truncated: false,
 		};
+	} finally {
+		if (promptDirectory) removeAgentPromptDirectory(promptDirectory);
 	}
 }
 
-export function buildPiArgs(request: ChildRequest): string[] {
+export function buildPiArgs(request: ChildRequest, agentPromptPath?: string): string[] {
 	const args = [
 		"--mode",
 		"json",
@@ -83,7 +89,10 @@ export function buildPiArgs(request: ChildRequest): string[] {
 		request.thinkingLevel,
 		request.projectTrusted ? "--approve" : "--no-approve",
 	];
-	if (request.agentPrompt) args.push("--append-system-prompt", request.agentPrompt);
+	if (request.agentPrompt && !agentPromptPath) {
+		throw new Error("A temporary agent prompt file is required for profiled child execution.");
+	}
+	if (agentPromptPath) args.push("--append-system-prompt", agentPromptPath);
 	const tools = [...new Set([...request.tools, ...CHILD_COMMUNICATION_TOOL_NAMES])];
 	args.push("--tools", tools.join(","));
 	args.push(`Task: ${request.task}`);
@@ -92,6 +101,28 @@ export function buildPiArgs(request: ChildRequest): string[] {
 
 export function childCommunicationBridgePath(): string {
 	return fileURLToPath(new URL("./child-communication-bridge.ts", import.meta.url));
+}
+
+function writeAgentPromptFile(prompt: string): { directory: string; filePath: string } {
+	const directory = fs.mkdtempSync(
+		path.join(os.tmpdir(), `pi-subagents-prompt-${globalThis.process.pid}-`),
+	);
+	const filePath = path.join(directory, "prompt.md");
+	try {
+		fs.writeFileSync(filePath, prompt, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		return { directory, filePath };
+	} catch (error) {
+		removeAgentPromptDirectory(directory);
+		throw error;
+	}
+}
+
+function removeAgentPromptDirectory(directory: string): void {
+	try {
+		fs.rmSync(directory, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup must not replace the child result or launch error.
+	}
 }
 
 async function executeProcess(

--- a/packages/pi-subagents/src/runtime.ts
+++ b/packages/pi-subagents/src/runtime.ts
@@ -49,7 +49,7 @@ export interface ActiveJobDisplay {
 
 export interface StartJobInput {
 	task: string;
-	agentPrompt?: string;
+	rolePrompt?: string;
 	tools: string[];
 	model: string;
 	thinkingLevel: SubagentThinkingLevel;
@@ -155,7 +155,7 @@ export class SubagentRuntime {
 			try {
 				child = await this.runChild({
 					task: input.task,
-					...(input.agentPrompt ? { agentPrompt: input.agentPrompt } : {}),
+					...(input.rolePrompt ? { rolePrompt: input.rolePrompt } : {}),
 					tools: [...input.tools],
 					model: input.model,
 					thinkingLevel: input.thinkingLevel,

--- a/packages/pi-subagents/src/runtime.ts
+++ b/packages/pi-subagents/src/runtime.ts
@@ -49,6 +49,7 @@ export interface ActiveJobDisplay {
 
 export interface StartJobInput {
 	task: string;
+	agentPrompt?: string;
 	tools: string[];
 	model: string;
 	thinkingLevel: SubagentThinkingLevel;
@@ -154,6 +155,7 @@ export class SubagentRuntime {
 			try {
 				child = await this.runChild({
 					task: input.task,
+					...(input.agentPrompt ? { agentPrompt: input.agentPrompt } : {}),
 					tools: [...input.tools],
 					model: input.model,
 					thinkingLevel: input.thinkingLevel,

--- a/packages/pi-subagents/src/subagents.ts
+++ b/packages/pi-subagents/src/subagents.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { registerCompletionRenderer } from "./completion-renderer.js";
+import { registerSubagentsCommand } from "./menu.js";
 import { registerSubagentTools, type SubagentToolsDependencies } from "./tools.js";
 import { createSubagentWidgetController } from "./widget.js";
 
@@ -14,12 +15,33 @@ export default function subagents(
 	const widget = createSubagentWidgetController(tools.runtime);
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
 	let sessionGeneration = 0;
+	let menuController: AbortController | undefined;
+
+	registerSubagentsCommand(pi, {
+		getOwner: (ctx) => {
+			const controller = menuController;
+			const session = ctx.sessionManager;
+			const generation = sessionGeneration;
+			if (!controller || session !== activeSession) return undefined;
+			return {
+				signal: controller.signal,
+				isCurrent: () =>
+					!controller.signal.aborted &&
+					generation === sessionGeneration &&
+					session === activeSession,
+			};
+		},
+		getActiveJobs: () => tools.runtime.activeJobsForDisplay(),
+	});
 
 	pi.on("session_start", async (_event, ctx) => {
+		menuController?.abort(new DOMException("Subagents session replaced", "AbortError"));
+		const controller = new AbortController();
+		menuController = controller;
 		activeSession = ctx.sessionManager;
 		const generation = ++sessionGeneration;
 		await tools.startSession();
-		if (generation !== sessionGeneration) return;
+		if (generation !== sessionGeneration || controller.signal.aborted) return;
 		widget.start(ctx);
 	});
 
@@ -27,6 +49,8 @@ export default function subagents(
 		if (ctx.sessionManager !== activeSession) return;
 		sessionGeneration++;
 		activeSession = undefined;
+		menuController?.abort(new DOMException("Subagents session stopped", "AbortError"));
+		menuController = undefined;
 		widget.shutdown(ctx);
 		await tools.shutdown();
 	});

--- a/packages/pi-subagents/src/tools.ts
+++ b/packages/pi-subagents/src/tools.ts
@@ -1,6 +1,7 @@
 import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
+import { loadAgentProfile, MAX_AGENT_NAME_LENGTH } from "./agent-profiles.js";
 import {
 	type BrokerQuestion,
 	MAX_IDENTIFIER_LENGTH,
@@ -15,12 +16,12 @@ import { type RuntimeDependencies, SubagentRuntime } from "./runtime.js";
 import {
 	CHILD_CORE_TOOL_NAMES,
 	DEFAULT_SUBAGENT_TOOLS,
+	MAX_SUBAGENT_TASK_BYTES,
+	MAX_SUBAGENT_TOOLS,
 	SUBAGENT_THINKING_LEVELS,
 	type SubagentThinkingLevel,
 } from "./types.js";
 
-const MAX_TASK_BYTES = 50 * 1024;
-const MAX_TOOLS = 64;
 const QUESTION_MESSAGE_TYPE = "pi-subagents-question";
 const CHILD_CORE_TOOL_SET = new Set<string>(CHILD_CORE_TOOL_NAMES);
 const THINKING_LEVEL_SET = new Set<string>(SUBAGENT_THINKING_LEVELS);
@@ -28,9 +29,16 @@ const THINKING_LEVEL_SET = new Set<string>(SUBAGENT_THINKING_LEVELS);
 const SpawnParameters = Type.Object(
 	{
 		task: Type.String({
-			description: "Self-contained task, constraints, and expected result. Maximum 50 KiB.",
-			maxLength: MAX_TASK_BYTES,
+			description: "Self-contained assignment, constraints, and expected result. Maximum 50 KiB.",
+			maxLength: MAX_SUBAGENT_TASK_BYTES,
 		}),
+		agent: Type.Optional(
+			Type.String({
+				description:
+					"User-defined agent name from Pi's pi-subagents.json. Empty, whitespace-only, or omitted uses no agent profile.",
+				maxLength: MAX_AGENT_NAME_LENGTH,
+			}),
+		),
 		tools: Type.Optional(
 			Type.Array(
 				StringEnum(CHILD_CORE_TOOL_NAMES, {
@@ -38,18 +46,22 @@ const SpawnParameters = Type.Object(
 				}),
 				{
 					description:
-						"Child work tools. Defaults to read, grep, find, and ls. Communication tools are always added.",
-					maxItems: MAX_TOOLS,
+						"Child work tools. Defaults to the selected agent profile, then read, grep, find, and ls. Communication tools are always added.",
+					maxItems: MAX_SUBAGENT_TOOLS,
 				},
 			),
 		),
 		thinkingLevel: Type.Optional(
 			StringEnum(SUBAGENT_THINKING_LEVELS, {
-				description: "Child thinking level. Defaults to the main agent's effective level.",
+				description:
+					"Child thinking level. Defaults to the selected agent profile, then the main agent's effective level.",
 			}),
 		),
 		timeout: Type.Optional(
-			Type.Number({ description: "Timeout in seconds (optional, no default timeout)" }),
+			Type.Number({
+				description:
+					"Execution timeout in seconds. Defaults to the selected agent profile, otherwise no timeout.",
+			}),
 		),
 	},
 	{ additionalProperties: false },
@@ -118,7 +130,7 @@ export function registerSubagentTools(
 		name: "subagent_spawn",
 		label: "Subagent · Spawn",
 		description:
-			"Use subagent_spawn to start one Pi subagent job and return its jobId immediately. The task defines the child's specialization, and the selected tools define its capabilities. The job may ask the main agent questions and publishes one asynchronous completion when terminal.",
+			"Use subagent_spawn to start one Pi subagent job and return its jobId immediately. An optional user-defined agent supplies a child prompt and execution defaults, the task defines the assignment, and the effective tools define the child's capabilities. The job may ask the main agent questions and publishes one asynchronous completion when terminal.",
 		promptSnippet: "Use subagent_spawn to start one Pi subagent job",
 		parameters: SpawnParameters,
 		prepareArguments: prepareSpawnArguments,
@@ -126,20 +138,23 @@ export function registerSubagentTools(
 			throwIfAborted(signal, "Subagent spawn was cancelled");
 			assertNotNested();
 			const task = validateTask(params.task, "subagent_spawn");
-			const tools = resolveTools(params.tools);
+			const agent = loadAgentProfile(params.agent);
+			const tools = resolveTools(params.tools ?? agent?.tools);
 			const model = resolveChildModel(ctx);
 			const thinkingLevel = resolveThinkingLevel(
-				params.thinkingLevel ?? ctx.thinkingLevel ?? pi.getThinkingLevel(),
+				params.thinkingLevel ?? agent?.thinkingLevel ?? ctx.thinkingLevel ?? pi.getThinkingLevel(),
 			);
-			resolveTimeoutMs(params.timeout);
+			const timeout = params.timeout ?? agent?.timeout;
+			resolveTimeoutMs(timeout);
 			return toolResult(
 				runtime.start({
 					task,
+					...(agent ? { agentPrompt: agent.task } : {}),
 					tools,
 					model,
 					thinkingLevel,
 					cwd: ctx.cwd,
-					timeout: params.timeout,
+					timeout,
 					projectTrusted: ctx.isProjectTrusted(),
 				}),
 			);
@@ -258,16 +273,16 @@ function deliverQuestion(pi: ExtensionAPI, question: BrokerQuestion): void {
 function validateTask(value: string, toolName: string): string {
 	const task = requiredString(value, "task");
 	if (task.includes("\0")) throw new Error(`${toolName} task must not contain NUL bytes.`);
-	if (Buffer.byteLength(task, "utf8") > MAX_TASK_BYTES) {
-		throw new Error(`${toolName} task must be at most ${MAX_TASK_BYTES} UTF-8 bytes.`);
+	if (Buffer.byteLength(task, "utf8") > MAX_SUBAGENT_TASK_BYTES) {
+		throw new Error(`${toolName} task must be at most ${MAX_SUBAGENT_TASK_BYTES} UTF-8 bytes.`);
 	}
 	return task;
 }
 
 function resolveTools(value: unknown): string[] {
 	if (value === undefined) return [...DEFAULT_SUBAGENT_TOOLS];
-	if (!Array.isArray(value) || value.length > MAX_TOOLS) {
-		throw new Error(`Subagent tools must be an array of at most ${MAX_TOOLS} names.`);
+	if (!Array.isArray(value) || value.length > MAX_SUBAGENT_TOOLS) {
+		throw new Error(`Subagent tools must be an array of at most ${MAX_SUBAGENT_TOOLS} names.`);
 	}
 	const tools: string[] = [];
 	for (const candidate of value) {

--- a/packages/pi-subagents/src/tools.ts
+++ b/packages/pi-subagents/src/tools.ts
@@ -32,10 +32,10 @@ const SpawnParameters = Type.Object(
 			description: "Self-contained assignment, constraints, and expected result. Maximum 50 KiB.",
 			maxLength: MAX_SUBAGENT_TASK_BYTES,
 		}),
-		agent: Type.Optional(
+		role: Type.Optional(
 			Type.String({
 				description:
-					"User-defined agent name from Pi's pi-subagents.json. Empty, whitespace-only, or omitted uses no agent profile.",
+					"User-defined role name from Pi's pi-subagents.json. Empty, whitespace-only, or omitted uses no role profile.",
 				maxLength: MAX_AGENT_NAME_LENGTH,
 			}),
 		),
@@ -46,7 +46,7 @@ const SpawnParameters = Type.Object(
 				}),
 				{
 					description:
-						"Child work tools. Defaults to the selected agent profile, then read, grep, find, and ls. Communication tools are always added.",
+						"Child work tools. Defaults to the selected role profile, then read, grep, find, and ls. Communication tools are always added.",
 					maxItems: MAX_SUBAGENT_TOOLS,
 				},
 			),
@@ -54,13 +54,13 @@ const SpawnParameters = Type.Object(
 		thinkingLevel: Type.Optional(
 			StringEnum(SUBAGENT_THINKING_LEVELS, {
 				description:
-					"Child thinking level. Defaults to the selected agent profile, then the main agent's effective level.",
+					"Child thinking level. Defaults to the selected role profile, then the main agent's effective level.",
 			}),
 		),
 		timeout: Type.Optional(
 			Type.Number({
 				description:
-					"Execution timeout in seconds. Defaults to the selected agent profile, otherwise no timeout.",
+					"Execution timeout in seconds. Defaults to the selected role profile, otherwise no timeout.",
 			}),
 		),
 	},
@@ -130,7 +130,7 @@ export function registerSubagentTools(
 		name: "subagent_spawn",
 		label: "Subagent · Spawn",
 		description:
-			"Use subagent_spawn to start one Pi subagent job and return its jobId immediately. An optional user-defined agent supplies a child prompt and execution defaults, the task defines the assignment, and the effective tools define the child's capabilities. The job may ask the main agent questions and publishes one asynchronous completion when terminal.",
+			"Use subagent_spawn to start one Pi subagent job and return its jobId immediately. An optional user-defined role supplies a child prompt and execution defaults, the task defines the assignment, and the effective tools define the child's capabilities. The job may ask the main agent questions and publishes one asynchronous completion when terminal.",
 		promptSnippet: "Use subagent_spawn to start one Pi subagent job",
 		parameters: SpawnParameters,
 		prepareArguments: prepareSpawnArguments,
@@ -138,18 +138,18 @@ export function registerSubagentTools(
 			throwIfAborted(signal, "Subagent spawn was cancelled");
 			assertNotNested();
 			const task = validateTask(params.task, "subagent_spawn");
-			const agent = loadAgentProfile(params.agent);
-			const tools = resolveTools(params.tools ?? agent?.tools);
+			const role = loadAgentProfile(params.role);
+			const tools = resolveTools(params.tools ?? role?.tools);
 			const model = resolveChildModel(ctx);
 			const thinkingLevel = resolveThinkingLevel(
-				params.thinkingLevel ?? agent?.thinkingLevel ?? ctx.thinkingLevel ?? pi.getThinkingLevel(),
+				params.thinkingLevel ?? role?.thinkingLevel ?? ctx.thinkingLevel ?? pi.getThinkingLevel(),
 			);
-			const timeout = params.timeout ?? agent?.timeout;
+			const timeout = params.timeout ?? role?.timeout;
 			resolveTimeoutMs(timeout);
 			return toolResult(
 				runtime.start({
 					task,
-					...(agent ? { agentPrompt: agent.task } : {}),
+					...(role ? { rolePrompt: role.task } : {}),
 					tools,
 					model,
 					thinkingLevel,

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -1,5 +1,8 @@
 import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
 
+export const MAX_SUBAGENT_TASK_BYTES = 50 * 1024;
+export const MAX_SUBAGENT_TOOLS = 64;
+
 export const JOB_STATES = [
 	"queued",
 	"running",
@@ -58,6 +61,7 @@ export interface BrokerCredentials {
 
 export interface ChildRequest {
 	task: string;
+	agentPrompt?: string;
 	tools: string[];
 	model: string;
 	thinkingLevel: SubagentThinkingLevel;

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -61,7 +61,7 @@ export interface BrokerCredentials {
 
 export interface ChildRequest {
 	task: string;
-	agentPrompt?: string;
+	rolePrompt?: string;
 	tools: string[];
 	model: string;
 	thinkingLevel: SubagentThinkingLevel;

--- a/packages/pi-subagents/test/agent-profiles.test.ts
+++ b/packages/pi-subagents/test/agent-profiles.test.ts
@@ -200,6 +200,8 @@ test("rejects duplicate, missing, and invalid mutation targets", () => {
 	assert.throws(() => renameAgentProfile("reviewer", "debugger"), /already exists/i);
 	assert.throws(() => updateAgentProfile("missing", { timeout: 1 }), /does not exist/i);
 	assert.throws(() => deleteAgentProfile("missing"), /does not exist/i);
+	assert.throws(() => renameAgentProfile("missing", "missing"), /does not exist/i);
+	assert.equal(renameAgentProfile("reviewer", "reviewer").kind, "loaded");
 	assert.throws(() => renameAgentProfile("reviewer", "Not Valid"), /lowercase kebab-case/i);
 	assert.throws(() => updateAgentProfile("reviewer", { timeout: 0 }), /Refusing to save invalid/i);
 });

--- a/packages/pi-subagents/test/agent-profiles.test.ts
+++ b/packages/pi-subagents/test/agent-profiles.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-test("missing settings are side-effect free and empty agent names do not read them", () => {
+test("missing settings are side-effect free and empty role names do not read them", () => {
 	assert.deepEqual(readAgentProfiles(), { kind: "missing", profiles: {}, document: {} });
 	assert.equal(loadAgentProfile(undefined), undefined);
 	assert.equal(loadAgentProfile(""), undefined);
@@ -152,7 +152,7 @@ test("publication failure preserves the previous file and cleans temporary files
 	assert.deepEqual(readdirSync(directory), ["pi-subagents.json"]);
 });
 
-test("rejects missing, malformed, unknown, and invalid selected agents", () => {
+test("rejects missing, malformed, unknown, and invalid selected roles", () => {
 	assert.throws(() => loadAgentProfile(null), /must be a string/i);
 	assert.throws(() => loadAgentProfile("Reviewer"), /lowercase kebab-case/i);
 	assert.throws(() => loadAgentProfile("missing"), /does not exist/i);
@@ -161,7 +161,7 @@ test("rejects missing, malformed, unknown, and invalid selected agents", () => {
 	assert.throws(() => loadAgentProfile("reviewer"), /invalid JSON/i);
 
 	writeAgents([]);
-	assert.throws(() => loadAgentProfile("reviewer"), /invalid agent profile document/i);
+	assert.throws(() => loadAgentProfile("reviewer"), /invalid role profile document/i);
 
 	writeAgents({});
 	assert.throws(() => loadAgentProfile("reviewer"), /is not defined/i);
@@ -179,7 +179,7 @@ test("rejects missing, malformed, unknown, and invalid selected agents", () => {
 		{ task: "Review", tools: [], timeout: 30, thinkingLevel: "turbo" },
 	]) {
 		writeAgents({ reviewer: candidate });
-		assert.throws(() => loadAgentProfile("reviewer"), /invalid agent profile document/i);
+		assert.throws(() => loadAgentProfile("reviewer"), /invalid role profile document/i);
 	}
 });
 

--- a/packages/pi-subagents/test/agent-profiles.test.ts
+++ b/packages/pi-subagents/test/agent-profiles.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import {
+	agentProfilesPath,
+	createAgentProfile,
+	deleteAgentProfile,
+	loadAgentProfile,
+	readAgentProfiles,
+	renameAgentProfile,
+	updateAgentProfile,
+} from "../src/agent-profiles.js";
+
+let directory: string;
+let previousAgentDirectory: string | undefined;
+
+beforeEach(() => {
+	directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agents-"));
+	previousAgentDirectory = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+});
+
+afterEach(() => {
+	if (previousAgentDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDirectory;
+	rmSync(directory, { recursive: true, force: true });
+	vi.restoreAllMocks();
+});
+
+test("missing settings are side-effect free and empty agent names do not read them", () => {
+	assert.deepEqual(readAgentProfiles(), { kind: "missing", profiles: {}, document: {} });
+	assert.equal(loadAgentProfile(undefined), undefined);
+	assert.equal(loadAgentProfile(""), undefined);
+	assert.equal(loadAgentProfile("   "), undefined);
+	assert.equal(existsSync(agentProfilesPath()), false);
+});
+
+test("loads profiles from the current Pi directory and preserves unknown fields", () => {
+	writeAgents({
+		reviewer: {
+			task: "Review independently.",
+			tools: ["read", "grep", "read"],
+			timeout: 120,
+			thinkingLevel: "high",
+			future: { enabled: true },
+		},
+	});
+	assert.deepEqual(loadAgentProfile("reviewer"), {
+		task: "Review independently.",
+		tools: ["read", "grep"],
+		timeout: 120,
+		thinkingLevel: "high",
+	});
+
+	updateAgentProfile("reviewer", { timeout: 30 });
+	const document = readDocument();
+	assert.deepEqual(document.reviewer, {
+		task: "Review independently.",
+		tools: ["read", "grep", "read"],
+		timeout: 30,
+		thinkingLevel: "high",
+		future: { enabled: true },
+	});
+});
+
+test("creates, updates, renames, and deletes profiles through atomic publications", () => {
+	const nestedPath = path.join(directory, "nested", "pi-subagents.json");
+	createAgentProfile("reviewer", profile(), { settingsPath: nestedPath });
+	assert.equal(existsSync(nestedPath), true);
+	assert.deepEqual(readAgentProfiles(nestedPath).kind, "loaded");
+	if (process.platform !== "win32") assert.equal(statSync(nestedPath).mode & 0o777, 0o600);
+
+	updateAgentProfile("reviewer", { tools: [], thinkingLevel: "low" }, { settingsPath: nestedPath });
+	renameAgentProfile("reviewer", "careful-reviewer", { settingsPath: nestedPath });
+	assert.deepEqual(readAgentProfiles(nestedPath), {
+		kind: "loaded",
+		profiles: {
+			"careful-reviewer": {
+				task: "Review independently.",
+				tools: [],
+				timeout: 120,
+				thinkingLevel: "low",
+			},
+		},
+		document: {
+			"careful-reviewer": {
+				task: "Review independently.",
+				tools: [],
+				timeout: 120,
+				thinkingLevel: "low",
+			},
+		},
+	});
+
+	deleteAgentProfile("careful-reviewer", { settingsPath: nestedPath });
+	assert.deepEqual(readAgentProfiles(nestedPath), {
+		kind: "loaded",
+		profiles: {},
+		document: {},
+	});
+	assert.deepEqual(readdirSync(path.dirname(nestedPath)), ["pi-subagents.json"]);
+});
+
+test("blocks mutations when existing settings are malformed or invalid", () => {
+	writeFileSync(agentProfilesPath(), "{", "utf8");
+	assert.match(readAgentProfiles().kind, /invalid/u);
+	assert.throws(() => createAgentProfile("reviewer", profile()), /Cannot save invalid/i);
+	assert.equal(readFileSync(agentProfilesPath(), "utf8"), "{");
+
+	writeAgents({ reviewer: { ...profile(), timeout: 0 } });
+	assert.throws(() => updateAgentProfile("reviewer", { timeout: 30 }), /Cannot save invalid/i);
+	assert.equal((readDocument().reviewer as { timeout: number }).timeout, 0);
+});
+
+test("settings diagnostics escape terminal controls in paths", () => {
+	const unsafePath = path.join(directory, "bad\u001b[31m.json");
+	writeFileSync(unsafePath, "{", "utf8");
+	const loaded = readAgentProfiles(unsafePath);
+	assert.equal(loaded.kind, "invalid");
+	assert.equal(loaded.reason.includes("\u001b"), false);
+});
+
+test("publication failure preserves the previous file and cleans temporary files", () => {
+	writeAgents({ reviewer: profile() });
+	const previous = readFileSync(agentProfilesPath(), "utf8");
+	assert.throws(
+		() =>
+			updateAgentProfile(
+				"reviewer",
+				{ timeout: 30 },
+				{
+					fileSystem: {
+						renameSync: () => {
+							throw new Error("injected rename failure");
+						},
+					},
+				},
+			),
+		/injected rename failure/i,
+	);
+	assert.equal(readFileSync(agentProfilesPath(), "utf8"), previous);
+	assert.deepEqual(readdirSync(directory), ["pi-subagents.json"]);
+});
+
+test("rejects missing, malformed, unknown, and invalid selected agents", () => {
+	assert.throws(() => loadAgentProfile(null), /must be a string/i);
+	assert.throws(() => loadAgentProfile("Reviewer"), /lowercase kebab-case/i);
+	assert.throws(() => loadAgentProfile("missing"), /does not exist/i);
+
+	writeFileSync(agentProfilesPath(), "{", "utf8");
+	assert.throws(() => loadAgentProfile("reviewer"), /invalid JSON/i);
+
+	writeAgents([]);
+	assert.throws(() => loadAgentProfile("reviewer"), /invalid agent profile document/i);
+
+	writeAgents({});
+	assert.throws(() => loadAgentProfile("reviewer"), /is not defined/i);
+	assert.throws(() => loadAgentProfile("constructor"), /is not defined/i);
+
+	for (const candidate of [
+		"not an object",
+		{ tools: [], timeout: 30, thinkingLevel: "high" },
+		{ task: "x".repeat(50 * 1024 + 1), tools: [], timeout: 30, thinkingLevel: "high" },
+		{ task: "Review", timeout: 30, thinkingLevel: "high" },
+		{ task: "Review", tools: ["shell"], timeout: 30, thinkingLevel: "high" },
+		{ task: "Review", tools: [], thinkingLevel: "high" },
+		{ task: "Review", tools: [], timeout: 0, thinkingLevel: "high" },
+		{ task: "Review", tools: [], timeout: 30 },
+		{ task: "Review", tools: [], timeout: 30, thinkingLevel: "turbo" },
+	]) {
+		writeAgents({ reviewer: candidate });
+		assert.throws(() => loadAgentProfile("reviewer"), /invalid agent profile document/i);
+	}
+});
+
+test("delete rejects a profile changed after its review", () => {
+	writeAgents({ reviewer: profile() });
+	const reviewed = readDocument().reviewer;
+	updateAgentProfile("reviewer", { task: "Changed after review." });
+	assert.throws(
+		() => deleteAgentProfile("reviewer", { expectedProfileDocument: reviewed }),
+		/changed after the delete review/i,
+	);
+	assert.equal(loadAgentProfile("reviewer")?.task, "Changed after review.");
+});
+
+test("rejects duplicate, missing, and invalid mutation targets", () => {
+	writeAgents({ reviewer: profile(), debugger: profile() });
+	assert.throws(() => createAgentProfile("reviewer", profile()), /already exists/i);
+	assert.throws(() => renameAgentProfile("reviewer", "debugger"), /already exists/i);
+	assert.throws(() => updateAgentProfile("missing", { timeout: 1 }), /does not exist/i);
+	assert.throws(() => deleteAgentProfile("missing"), /does not exist/i);
+	assert.throws(() => renameAgentProfile("reviewer", "Not Valid"), /lowercase kebab-case/i);
+	assert.throws(() => updateAgentProfile("reviewer", { timeout: 0 }), /Refusing to save invalid/i);
+});
+
+function profile() {
+	return {
+		task: "Review independently.",
+		tools: ["read", "grep"],
+		timeout: 120,
+		thinkingLevel: "high" as const,
+	};
+}
+
+function writeAgents(value: unknown): void {
+	writeFileSync(agentProfilesPath(), `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function readDocument(): Record<string, unknown> {
+	return JSON.parse(readFileSync(agentProfilesPath(), "utf8")) as Record<string, unknown>;
+}

--- a/packages/pi-subagents/test/build-runtime.test.ts
+++ b/packages/pi-subagents/test/build-runtime.test.ts
@@ -201,7 +201,8 @@ test("Pi's Jiti loader loads the generated extension and child bridge", async ()
 		const spawnParameters = main?.tools.get("subagent_spawn")?.definition.parameters as
 			| { properties?: Record<string, unknown> }
 			| undefined;
-		assert.ok(spawnParameters?.properties?.agent);
+		assert.ok(spawnParameters?.properties?.role);
+		assert.equal(spawnParameters?.properties?.agent, undefined);
 		assert.ok(main?.commands.has("subagents"));
 
 		const tui = createTuiHarness({ width: 48, rows: 14 });

--- a/packages/pi-subagents/test/build-runtime.test.ts
+++ b/packages/pi-subagents/test/build-runtime.test.ts
@@ -13,7 +13,9 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { DefaultResourceLoader, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
 
 const packageRoot = resolve("packages/pi-subagents");
 const builderUrl = pathToFileURL(join(packageRoot, "scripts/build-runtime.mjs")).href;
@@ -196,6 +198,25 @@ test("Pi's Jiti loader loads the generated extension and child bridge", async ()
 			[...(main?.tools.keys() ?? [])],
 			["subagent_spawn", "subagent_inspect", "subagent_cancel", "subagent_wait", "subagent_reply"],
 		);
+		const spawnParameters = main?.tools.get("subagent_spawn")?.definition.parameters as
+			| { properties?: Record<string, unknown> }
+			| undefined;
+		assert.ok(spawnParameters?.properties?.agent);
+		assert.ok(main?.commands.has("subagents"));
+
+		const tui = createTuiHarness({ width: 48, rows: 14 });
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		for (const handler of main?.handlers.get("session_start") ?? []) {
+			await handler({ type: "session_start", reason: "startup" }, context.ctx);
+		}
+		const menuRun = main?.commands.get("subagents")?.handler("", context.ctx);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Pi Subagents/u);
+		tui.press("ctrl+c");
+		await menuRun;
+		for (const handler of main?.handlers.get("session_shutdown") ?? []) {
+			await handler({ type: "session_shutdown", reason: "quit" }, context.ctx);
+		}
 
 		const childLoader = new DefaultResourceLoader({
 			cwd: root,

--- a/packages/pi-subagents/test/menu.test.ts
+++ b/packages/pi-subagents/test/menu.test.ts
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness, type TuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { afterEach, beforeEach, test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { createAgentProfileStore } from "../src/agent-profiles.js";
+import { showSubagentsMenu } from "../src/menu.js";
+import subagents from "../src/subagents.js";
+
+let directory: string;
+let previousAgentDirectory: string | undefined;
+
+beforeEach(() => {
+	directory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-menu-"));
+	previousAgentDirectory = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+});
+
+afterEach(() => {
+	if (previousAgentDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDirectory;
+	rmSync(directory, { recursive: true, force: true });
+});
+
+test("profile manager creates, edits, renames, and deletes one complete profile", async () => {
+	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
+	const tui = createTuiHarness({ width: 48, rows: 18 });
+	const editorDrafts: string[] = [];
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		thinkingLevel: "high",
+		custom: tui.custom,
+		editor: async (_title: string, draft: string) => {
+			editorDrafts.push(draft);
+			return "Review the assigned scope and return exact evidence.";
+		},
+	});
+	const controller = new AbortController();
+	const running = showSubagentsMenu(context.ctx, {
+		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
+		getActiveJobs: () => [],
+		store,
+	});
+	await tui.waitForOpen();
+	assertWidth(tui, 48);
+
+	await activate(tui, "Settings");
+	await activate(tui, "Create profile");
+	tui.setFocused(true);
+	tui.type("reviewer");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.equal(store.read().kind, "loaded");
+	assert.match(tui.render().join("\n"), /Profile · reviewer/u);
+
+	await activate(tui, "Task prompt");
+	assert.deepEqual(editorDrafts, ["Complete the assigned task and report the result."]);
+	assert.equal(
+		profile(store, "reviewer").task,
+		"Review the assigned scope and return exact evidence.",
+	);
+
+	await activate(tui, "Tools");
+	await activate(tui, "bash");
+	assert.deepEqual(profile(store, "reviewer").tools, ["read", "grep", "find", "ls", "bash"]);
+	tui.press("tui.select.cancel");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+
+	await activate(tui, "Timeout");
+	tui.setFocused(true);
+	tui.type("45");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.equal(profile(store, "reviewer").timeout, 45);
+
+	await activate(tui, "Thinking level");
+	tui.press("home");
+	tui.press("tui.select.down");
+	tui.press("tui.select.down");
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.equal(profile(store, "reviewer").thinkingLevel, "low");
+
+	await activate(tui, "Rename");
+	tui.setFocused(true);
+	tui.type("careful-reviewer");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.equal(profile(store, "careful-reviewer").timeout, 45);
+
+	await activate(tui, "Delete");
+	assert.match(tui.render().join("\n"), /This cannot be\s+undone/u);
+	assert.match(tui.render().join("\n"), /"name": "careful-reviewer"/u);
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	const loaded = store.read();
+	if (loaded.kind === "invalid") assert.fail(loaded.reason);
+	assert.deepEqual(Object.keys(loaded.profiles), []);
+
+	tui.press("ctrl+c");
+	await running;
+});
+
+test("invalid settings stay read-only and render safely with remapped bindings", async () => {
+	const settingsPath = path.join(directory, "pi-subagents.json");
+	writeFileSync(settingsPath, "{", "utf8");
+	const store = createAgentProfileStore(settingsPath);
+	const mapping: Record<string, string> = {
+		"tui.select.up": "k",
+		"tui.select.down": "j",
+		"tui.select.pageUp": "u",
+		"tui.select.pageDown": "d",
+		"tui.select.confirm": "y",
+		"tui.select.cancel": "q",
+	};
+	const keybindings: Pick<KeybindingsManager, "matches" | "getKeys"> = {
+		matches: (data, binding) => data === mapping[binding],
+		getKeys: (binding) => (mapping[binding] ? [mapping[binding] as never] : []),
+	};
+	const tui = createTuiHarness({ width: 32, rows: 12, keybindings });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const controller = new AbortController();
+	const running = showSubagentsMenu(context.ctx, {
+		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
+		getActiveJobs: () => [],
+		store,
+	});
+	await tui.waitForOpen();
+	tui.send("y");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	const frame = tui.render().join("\n");
+	assert.match(frame, /Read only/u);
+	assert.match(frame, /q back/u);
+	assertWidth(tui, 32);
+	tui.send("q");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	tui.press("ctrl+c");
+	await running;
+	assert.equal(store.read().kind, "invalid");
+});
+
+test("profile manager reports save failures and keeps the accepted state", async () => {
+	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
+	store.create("reviewer", {
+		task: "Review.",
+		tools: ["read"],
+		timeout: 30,
+		thinkingLevel: "medium",
+	});
+	const failingStore = {
+		...store,
+		update: () => {
+			throw new Error("injected save failure");
+		},
+	};
+	const tui = createTuiHarness({ width: 48, rows: 16 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const controller = new AbortController();
+	const running = showSubagentsMenu(context.ctx, {
+		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
+		getActiveJobs: () => [],
+		store: failingStore,
+	});
+	await tui.waitForOpen();
+	await activate(tui, "Settings");
+	await activate(tui, "reviewer");
+	await activate(tui, "Tools");
+	await activate(tui, "bash");
+	assert.deepEqual(profile(store, "reviewer").tools, ["read"]);
+	assert.match(context.notifications[0]?.message ?? "", /injected save failure/i);
+	tui.press("ctrl+c");
+	await running;
+});
+
+test("session shutdown disposes the registered command menu", async () => {
+	const mock = createMockPi();
+	const tui = createTuiHarness({ width: 48, rows: 16 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	subagents(mock.pi);
+	for (const handler of mock.events.get("session_start") ?? []) {
+		await handler({ type: "session_start", reason: "startup" }, context.ctx);
+	}
+	const running = mock.commands.get("subagents")?.handler("", context.ctx);
+	await tui.waitForOpen();
+	for (const handler of mock.events.get("session_shutdown") ?? []) {
+		await handler({ type: "session_shutdown", reason: "quit" }, context.ctx);
+	}
+	await running;
+	assert.equal(tui.isOpen, false);
+});
+
+test("invalid task edits reopen with the rejected draft before saving", async () => {
+	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
+	store.create("reviewer", {
+		task: "Original task.",
+		tools: ["read"],
+		timeout: 30,
+		thinkingLevel: "medium",
+	});
+	const drafts: string[] = [];
+	const responses = ["", "Corrected task."];
+	const tui = createTuiHarness({ width: 48, rows: 16 });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+		editor: async (_title: string, draft: string) => {
+			drafts.push(draft);
+			return responses.shift();
+		},
+	});
+	const controller = new AbortController();
+	const running = showSubagentsMenu(context.ctx, {
+		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
+		getActiveJobs: () => [],
+		store,
+	});
+	await tui.waitForOpen();
+	await activate(tui, "Settings");
+	await activate(tui, "reviewer");
+	await activate(tui, "Task prompt");
+	assert.deepEqual(drafts, ["Original task.", ""]);
+	assert.equal(profile(store, "reviewer").task, "Corrected task.");
+	assert.match(context.notifications[0]?.message ?? "", /Task prompt was not saved/i);
+	tui.press("ctrl+c");
+	await running;
+});
+
+test("owner replacement while the task editor is open does not save stale text", async () => {
+	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
+	store.create("reviewer", {
+		task: "Original task.",
+		tools: ["read"],
+		timeout: 30,
+		thinkingLevel: "medium",
+	});
+	let finishEditor!: (value: string | undefined) => void;
+	const editorResult = new Promise<string | undefined>((resolve) => {
+		finishEditor = resolve;
+	});
+	const tui = createTuiHarness({ width: 48, rows: 16 });
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+		editor: async () => editorResult,
+	});
+	const controller = new AbortController();
+	const running = showSubagentsMenu(context.ctx, {
+		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
+		getActiveJobs: () => [],
+		store,
+	});
+	await tui.waitForOpen();
+	await activate(tui, "Settings");
+	await activate(tui, "reviewer");
+	selectRow(tui, "Task prompt");
+	tui.press("tui.select.confirm");
+	await Promise.resolve();
+	controller.abort(new DOMException("Session replaced", "AbortError"));
+	finishEditor("Stale task must not save.");
+	await tui.waitForPending();
+	await running;
+	assert.equal(profile(store, "reviewer").task, "Original task.");
+});
+
+async function activate(tui: TuiHarness, label: string): Promise<void> {
+	selectRow(tui, label);
+	tui.press("tui.select.confirm");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+}
+
+function selectRow(tui: TuiHarness, label: string): void {
+	for (let attempt = 0; attempt < 30; attempt++) {
+		const selected = tui
+			.render()
+			.find((line) => (line.includes("→") || line.includes("›")) && line.includes(label));
+		if (selected) return;
+		tui.press("tui.select.down");
+	}
+	assert.fail(`Could not select row: ${label}\n${tui.render().join("\n")}`);
+}
+
+function profile(store: ReturnType<typeof createAgentProfileStore>, name: string) {
+	const loaded = store.read();
+	if (loaded.kind === "invalid") assert.fail(loaded.reason);
+	const value = loaded.profiles[name];
+	assert.ok(value);
+	return value;
+}
+
+function assertWidth(tui: TuiHarness, width: number): void {
+	assert.equal(
+		tui.render().every((line) => visibleWidth(line) <= width),
+		true,
+	);
+}

--- a/packages/pi-subagents/test/menu.test.ts
+++ b/packages/pi-subagents/test/menu.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createTuiHarness, type TuiHarness } from "@narumitw/pi-tui-kit/testing";
@@ -29,16 +30,11 @@ afterEach(() => {
 test("profile manager creates, edits, renames, and deletes one complete profile", async () => {
 	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
 	const tui = createTuiHarness({ width: 48, rows: 18 });
-	const editorDrafts: string[] = [];
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
 		thinkingLevel: "high",
 		custom: tui.custom,
-		editor: async (_title: string, draft: string) => {
-			editorDrafts.push(draft);
-			return "Review the assigned scope and return exact evidence.";
-		},
 	});
 	const controller = new AbortController();
 	const running = showSubagentsMenu(context.ctx, {
@@ -59,11 +55,18 @@ test("profile manager creates, edits, renames, and deletes one complete profile"
 	assert.equal(store.read().kind, "loaded");
 	assert.match(tui.render().join("\n"), /Profile · reviewer/u);
 
+	await activate(tui, "Profile settings");
+	assert.match(tui.render().join("\n"), /Type to search/u);
 	await activate(tui, "Task prompt");
-	assert.deepEqual(editorDrafts, ["Complete the assigned task and report the result."]);
+	await activate(tui, "Edit task prompt");
+	assert.match(tui.render().join("\n"), /Complete the assigned task/u);
+	paste(tui, " Review the assigned scope and return exact evidence.");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
 	assert.equal(
 		profile(store, "reviewer").task,
-		"Review the assigned scope and return exact evidence.",
+		"Complete the assigned task and report the result. Review the assigned scope and return exact evidence.",
 	);
 
 	await activate(tui, "Tools");
@@ -82,14 +85,11 @@ test("profile manager creates, edits, renames, and deletes one complete profile"
 	assert.equal(profile(store, "reviewer").timeout, 45);
 
 	await activate(tui, "Thinking level");
-	tui.press("home");
-	tui.press("tui.select.down");
-	tui.press("tui.select.down");
-	tui.press("tui.select.confirm");
+	assert.equal(profile(store, "reviewer").thinkingLevel, "xhigh");
+
+	tui.press("tui.select.cancel");
 	await tui.waitForPending();
 	await tui.waitForOpen();
-	assert.equal(profile(store, "reviewer").thinkingLevel, "low");
-
 	await activate(tui, "Rename");
 	tui.setFocused(true);
 	tui.type("careful-reviewer");
@@ -152,6 +152,56 @@ test("invalid settings stay read-only and render safely with remapped bindings",
 	assert.equal(store.read().kind, "invalid");
 });
 
+test("profile settings and task editing honor remapped standard bindings", async () => {
+	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
+	store.create("reviewer", {
+		task: "x",
+		tools: ["read"],
+		timeout: 30,
+		thinkingLevel: "medium",
+	});
+	const mapping: Record<string, string> = {
+		"tui.select.up": "k",
+		"tui.select.down": "j",
+		"tui.select.pageUp": "u",
+		"tui.select.pageDown": "d",
+		"tui.select.confirm": "y",
+		"tui.select.cancel": "q",
+		"tui.input.submit": "s",
+		"tui.input.newLine": "n",
+	};
+	const keybindings: Pick<KeybindingsManager, "matches" | "getKeys"> = {
+		matches: (data, binding) => data === mapping[binding],
+		getKeys: (binding) => (mapping[binding] ? [mapping[binding] as never] : []),
+	};
+	const tui = createTuiHarness({ width: 40, rows: 14, keybindings });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const controller = new AbortController();
+	const running = showSubagentsMenu(context.ctx, {
+		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
+		getActiveJobs: () => [],
+		store,
+	});
+	await tui.waitForOpen();
+	await activateWithBindings(tui, "Settings", "j", "y");
+	await activateWithBindings(tui, "reviewer", "j", "y");
+	await activateWithBindings(tui, "Profile settings", "j", "y");
+	await activateWithBindings(tui, "Thinking level", "j", "y");
+	assert.equal(profile(store, "reviewer").thinkingLevel, "high");
+	await activateWithBindings(tui, "Task prompt", "j", "y");
+	await activateWithBindings(tui, "Edit task prompt", "j", "y");
+	tui.send("n");
+	paste(tui, "after");
+	tui.send("s");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.equal(profile(store, "reviewer").task, "x\nafter");
+	assert.match(stripVTControlCharacters(tui.render().join("\n")), /q\s*to go back|q\s*cancel/iu);
+	assertWidth(tui, 40);
+	tui.press("ctrl+c");
+	await running;
+});
+
 test("profile manager reports save failures and keeps the accepted state", async () => {
 	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
 	store.create("reviewer", {
@@ -177,6 +227,7 @@ test("profile manager reports save failures and keeps the accepted state", async
 	await tui.waitForOpen();
 	await activate(tui, "Settings");
 	await activate(tui, "reviewer");
+	await activate(tui, "Profile settings");
 	await activate(tui, "Tools");
 	await activate(tui, "bash");
 	assert.deepEqual(profile(store, "reviewer").tools, ["read"]);
@@ -202,26 +253,16 @@ test("session shutdown disposes the registered command menu", async () => {
 	assert.equal(tui.isOpen, false);
 });
 
-test("invalid task edits reopen with the rejected draft before saving", async () => {
+test("invalid task edits reopen with the raw rejected draft and safe rendering", async () => {
 	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
 	store.create("reviewer", {
-		task: "Original task.",
+		task: "x",
 		tools: ["read"],
 		timeout: 30,
 		thinkingLevel: "medium",
 	});
-	const drafts: string[] = [];
-	const responses = ["", "Corrected task."];
 	const tui = createTuiHarness({ width: 48, rows: 16 });
-	const context = createMockContext({
-		mode: "tui",
-		hasUI: true,
-		custom: tui.custom,
-		editor: async (_title: string, draft: string) => {
-			drafts.push(draft);
-			return responses.shift();
-		},
-	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 	const controller = new AbortController();
 	const running = showSubagentsMenu(context.ctx, {
 		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
@@ -231,15 +272,27 @@ test("invalid task edits reopen with the rejected draft before saving", async ()
 	await tui.waitForOpen();
 	await activate(tui, "Settings");
 	await activate(tui, "reviewer");
+	await activate(tui, "Profile settings");
 	await activate(tui, "Task prompt");
-	assert.deepEqual(drafts, ["Original task.", ""]);
-	assert.equal(profile(store, "reviewer").task, "Corrected task.");
+	await activate(tui, "Edit task prompt");
+	tui.send("\u007f");
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
 	assert.match(context.notifications[0]?.message ?? "", /Task prompt was not saved/i);
+
+	const corrected = "Corrected\u001b[31m task.\nNext line.";
+	paste(tui, corrected);
+	assert.match(stripVTControlCharacters(tui.render().join("\n")), /Corrected \[31m task/u);
+	tui.press("tui.input.submit");
+	await tui.waitForPending();
+	await tui.waitForOpen();
+	assert.equal(profile(store, "reviewer").task, corrected);
 	tui.press("ctrl+c");
 	await running;
 });
 
-test("owner replacement while the task editor is open does not save stale text", async () => {
+test("owner replacement settles and disposes an open task editor without saving", async () => {
 	const store = createAgentProfileStore(path.join(directory, "pi-subagents.json"));
 	store.create("reviewer", {
 		task: "Original task.",
@@ -247,17 +300,8 @@ test("owner replacement while the task editor is open does not save stale text",
 		timeout: 30,
 		thinkingLevel: "medium",
 	});
-	let finishEditor!: (value: string | undefined) => void;
-	const editorResult = new Promise<string | undefined>((resolve) => {
-		finishEditor = resolve;
-	});
 	const tui = createTuiHarness({ width: 48, rows: 16 });
-	const context = createMockContext({
-		mode: "tui",
-		hasUI: true,
-		custom: tui.custom,
-		editor: async () => editorResult,
-	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
 	const controller = new AbortController();
 	const running = showSubagentsMenu(context.ctx, {
 		owner: { signal: controller.signal, isCurrent: () => !controller.signal.aborted },
@@ -267,15 +311,31 @@ test("owner replacement while the task editor is open does not save stale text",
 	await tui.waitForOpen();
 	await activate(tui, "Settings");
 	await activate(tui, "reviewer");
-	selectRow(tui, "Task prompt");
-	tui.press("tui.select.confirm");
-	await Promise.resolve();
+	await activate(tui, "Profile settings");
+	await activate(tui, "Task prompt");
+	await activate(tui, "Edit task prompt");
+	paste(tui, " Stale task must not save.");
 	controller.abort(new DOMException("Session replaced", "AbortError"));
-	finishEditor("Stale task must not save.");
-	await tui.waitForPending();
 	await running;
+	assert.equal(tui.isOpen, false);
 	assert.equal(profile(store, "reviewer").task, "Original task.");
 });
+
+function paste(tui: TuiHarness, text: string): void {
+	tui.send(`\u001b[200~${text}\u001b[201~`);
+}
+
+async function activateWithBindings(
+	tui: TuiHarness,
+	label: string,
+	down: string,
+	confirm: string,
+): Promise<void> {
+	selectRowWithInput(tui, label, down);
+	tui.send(confirm);
+	await tui.waitForPending();
+	await tui.waitForOpen();
+}
 
 async function activate(tui: TuiHarness, label: string): Promise<void> {
 	selectRow(tui, label);
@@ -285,12 +345,16 @@ async function activate(tui: TuiHarness, label: string): Promise<void> {
 }
 
 function selectRow(tui: TuiHarness, label: string): void {
+	selectRowWithInput(tui, label, "\u001b[B");
+}
+
+function selectRowWithInput(tui: TuiHarness, label: string, down: string): void {
 	for (let attempt = 0; attempt < 30; attempt++) {
 		const selected = tui
 			.render()
 			.find((line) => (line.includes("→") || line.includes("›")) && line.includes(label));
 		if (selected) return;
-		tui.press("tui.select.down");
+		tui.send(down);
 	}
 	assert.fail(`Could not select row: ${label}\n${tui.render().join("\n")}`);
 }

--- a/packages/pi-subagents/test/package.test.ts
+++ b/packages/pi-subagents/test/package.test.ts
@@ -16,6 +16,7 @@ test("package declares one generated extension and one bundled operating skill",
 		files: string[];
 		pi: { extensions: string[]; skills: string[] };
 		piExtension: { lifecycle: string };
+		dependencies: Record<string, string>;
 		peerDependencies: Record<string, string>;
 		repository: { directory: string };
 	};
@@ -26,6 +27,7 @@ test("package declares one generated extension and one bundled operating skill",
 	assert.deepEqual(manifest.pi.extensions, ["./dist/index.ts"]);
 	assert.deepEqual(manifest.pi.skills, ["./skills"]);
 	assert.equal(manifest.piExtension.lifecycle, "stable");
+	assert.equal(manifest.dependencies["@narumitw/pi-tui-kit"], "^0.59.0");
 	assert.equal(manifest.peerDependencies["@earendil-works/pi-ai"], "*");
 	assert.equal(manifest.peerDependencies["@earendil-works/pi-coding-agent"], "*");
 	assert.ok(manifest.files.includes("src"));
@@ -44,12 +46,16 @@ test("bundled skill documents every minimal-runtime operating responsibility", (
 	for (const evidence of [
 		/prefer direct work/i,
 		/subagent_spawn/i,
+		/Pi's user `pi-subagents\.json`/i,
+		/argument-free `\/subagents` TUI manager/i,
+		/profile supplies.*`tools`.*`timeout`.*`thinkingLevel`/i,
+		/explicit spawn values override profile defaults/i,
 		/default of `read`, `grep`, `find`, and `ls`/i,
 		/select only from `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`/i,
 		/smallest sufficient tool set/i,
 		/`bash` and `powershell` as unrestricted command execution/i,
 		/inherits the main agent's effective provider and model/i,
-		/omit `thinkingLevel` to follow the main agent/i,
+		/omit `thinkingLevel`.*profile.*main agent/is,
 		/self-contained tasks/i,
 		/shortest realistic execution deadline/i,
 		/parallel tool batch/i,

--- a/packages/pi-subagents/test/process.test.ts
+++ b/packages/pi-subagents/test/process.test.ts
@@ -66,6 +66,10 @@ test("buildPiArgs isolates the child and preserves selected communication tools"
 
 	const noWorkTools = buildPiArgs(childRequest({ tools: [] }));
 	assert.equal(noWorkTools[noWorkTools.indexOf("--tools") + 1], "subagent_ask,subagent_wait");
+
+	const profiled = buildPiArgs(childRequest({ agentPrompt: "Review independently." }));
+	assert.equal(profiled[profiled.indexOf("--append-system-prompt") + 1], "Review independently.");
+	assert.equal(profiled.at(-1), "Task: task");
 });
 
 test("runChild classifies completed and partial subprocess output", async () => {

--- a/packages/pi-subagents/test/process.test.ts
+++ b/packages/pi-subagents/test/process.test.ts
@@ -68,14 +68,14 @@ test("buildPiArgs isolates the child and preserves selected communication tools"
 	assert.equal(noWorkTools[noWorkTools.indexOf("--tools") + 1], "subagent_ask,subagent_wait");
 
 	const profiled = buildPiArgs(
-		childRequest({ agentPrompt: "Review independently." }),
+		childRequest({ rolePrompt: "Review independently." }),
 		"/tmp/profile-prompt.md",
 	);
 	assert.equal(profiled[profiled.indexOf("--append-system-prompt") + 1], "/tmp/profile-prompt.md");
 	assert.equal(profiled.at(-1), "Task: task");
 	assert.throws(
-		() => buildPiArgs(childRequest({ agentPrompt: "Review independently." })),
-		/temporary agent prompt file/i,
+		() => buildPiArgs(childRequest({ rolePrompt: "Review independently." })),
+		/temporary role prompt file/i,
 	);
 });
 
@@ -94,7 +94,7 @@ console.log(JSON.stringify({
   message: { role: "assistant", content: [{ type: "text", text }], stopReason: "stop" }
 }));
 `);
-	const result = await runChild(childRequest({ agentPrompt: "README.md" }));
+	const result = await runChild(childRequest({ rolePrompt: "README.md" }));
 	assert.equal(result.state, "completed");
 	const evidence = JSON.parse(result.result ?? "{}") as {
 		promptPath: string;
@@ -114,14 +114,14 @@ test("runChild cleans profile prompt files after launch failure, timeout, and ca
 	const removedCwd = path.join(directory, "removed-profiled-cwd");
 	mkdirSync(removedCwd);
 	rmSync(removedCwd, { recursive: true });
-	const failed = await runChild(childRequest({ agentPrompt: "Review.", cwd: removedCwd }));
+	const failed = await runChild(childRequest({ rolePrompt: "Review.", cwd: removedCwd }));
 	assert.equal(failed.state, "failed");
 
-	const timedOut = await runChild(childRequest({ agentPrompt: "Review.", timeout: 0.025 }));
+	const timedOut = await runChild(childRequest({ rolePrompt: "Review.", timeout: 0.025 }));
 	assert.equal(timedOut.state, "timed_out");
 
 	const controller = new AbortController();
-	const work = runChild(childRequest({ agentPrompt: "Review.", signal: controller.signal }));
+	const work = runChild(childRequest({ rolePrompt: "Review.", signal: controller.signal }));
 	setTimeout(() => controller.abort(), 25);
 	assert.equal((await work).state, "cancelled");
 	assert.deepEqual(promptDirectories(), before);

--- a/packages/pi-subagents/test/process.test.ts
+++ b/packages/pi-subagents/test/process.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, test, vi } from "vitest";
@@ -67,9 +67,64 @@ test("buildPiArgs isolates the child and preserves selected communication tools"
 	const noWorkTools = buildPiArgs(childRequest({ tools: [] }));
 	assert.equal(noWorkTools[noWorkTools.indexOf("--tools") + 1], "subagent_ask,subagent_wait");
 
-	const profiled = buildPiArgs(childRequest({ agentPrompt: "Review independently." }));
-	assert.equal(profiled[profiled.indexOf("--append-system-prompt") + 1], "Review independently.");
+	const profiled = buildPiArgs(
+		childRequest({ agentPrompt: "Review independently." }),
+		"/tmp/profile-prompt.md",
+	);
+	assert.equal(profiled[profiled.indexOf("--append-system-prompt") + 1], "/tmp/profile-prompt.md");
 	assert.equal(profiled.at(-1), "Task: task");
+	assert.throws(
+		() => buildPiArgs(childRequest({ agentPrompt: "Review independently." })),
+		/temporary agent prompt file/i,
+	);
+});
+
+test("runChild passes path-like profile prompts as literal private files and cleans them", async () => {
+	writeFileSync(path.join(directory, "README.md"), "wrong file contents", "utf8");
+	installFakePi(`
+const promptIndex = process.argv.indexOf("--append-system-prompt");
+const promptPath = process.argv[promptIndex + 1];
+const text = JSON.stringify({
+  promptPath,
+  prompt: fs.readFileSync(promptPath, "utf8"),
+  privateMode: process.platform === "win32" || (fs.statSync(promptPath).mode & 0o777) === 0o600,
+});
+console.log(JSON.stringify({
+  type: "message_end",
+  message: { role: "assistant", content: [{ type: "text", text }], stopReason: "stop" }
+}));
+`);
+	const result = await runChild(childRequest({ agentPrompt: "README.md" }));
+	assert.equal(result.state, "completed");
+	const evidence = JSON.parse(result.result ?? "{}") as {
+		promptPath: string;
+		prompt: string;
+		privateMode: boolean;
+	};
+	assert.notEqual(evidence.promptPath, "README.md");
+	assert.equal(evidence.prompt, "README.md");
+	assert.equal(evidence.privateMode, true);
+	assert.equal(existsSync(evidence.promptPath), false);
+});
+
+test("runChild cleans profile prompt files after launch failure, timeout, and cancellation", async () => {
+	const before = promptDirectories();
+	installFakePi("setInterval(() => {}, 1000);\n");
+
+	const removedCwd = path.join(directory, "removed-profiled-cwd");
+	mkdirSync(removedCwd);
+	rmSync(removedCwd, { recursive: true });
+	const failed = await runChild(childRequest({ agentPrompt: "Review.", cwd: removedCwd }));
+	assert.equal(failed.state, "failed");
+
+	const timedOut = await runChild(childRequest({ agentPrompt: "Review.", timeout: 0.025 }));
+	assert.equal(timedOut.state, "timed_out");
+
+	const controller = new AbortController();
+	const work = runChild(childRequest({ agentPrompt: "Review.", signal: controller.signal }));
+	setTimeout(() => controller.abort(), 25);
+	assert.equal((await work).state, "cancelled");
+	assert.deepEqual(promptDirectories(), before);
 });
 
 test("runChild classifies completed and partial subprocess output", async () => {
@@ -278,6 +333,13 @@ test("Windows process-tree termination bounds a hung taskkill helper", async () 
 	assert.deepEqual(treeKillerKill.mock.calls, [["SIGKILL"]]);
 	assert.deepEqual(childKill.mock.calls, [["SIGKILL"]]);
 });
+
+function promptDirectories(): string[] {
+	const prefix = `pi-subagents-prompt-${process.pid}-`;
+	return readdirSync(os.tmpdir())
+		.filter((entry) => entry.startsWith(prefix))
+		.sort();
+}
 
 function childRequest(overrides: Partial<ChildRequest> = {}): ChildRequest {
 	return {

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -69,20 +69,20 @@ test("registers five fixed main-agent tools with stable schemas and explicit lim
 		["subagent_spawn", "subagent_inspect", "subagent_cancel", "subagent_wait", "subagent_reply"],
 	);
 	assert.equal(tools[0]?.parameters.properties?.task?.maxLength, 50 * 1024);
-	assert.equal(tools[0]?.parameters.properties?.agent?.maxLength, 64);
-	assert.match(tools[0]?.parameters.properties?.agent?.description ?? "", /empty.*omitted/i);
+	assert.equal(tools[0]?.parameters.properties?.role?.maxLength, 64);
+	assert.match(tools[0]?.parameters.properties?.role?.description ?? "", /empty.*omitted/i);
+	assert.equal(tools[0]?.parameters.properties?.agent, undefined);
+	assert.equal(Check(tools[0]?.parameters, { task: "Review", role: "reviewer" }), true);
+	assert.equal(Check(tools[0]?.parameters, { task: "Review", agent: "reviewer" }), false);
 	assert.equal(tools[0]?.parameters.properties?.tools?.maxItems, 64);
-	assert.match(
-		tools[0]?.parameters.properties?.tools?.description ?? "",
-		/selected agent profile/i,
-	);
+	assert.match(tools[0]?.parameters.properties?.tools?.description ?? "", /selected role profile/i);
 	assert.match(
 		tools[0]?.parameters.properties?.thinkingLevel?.description ?? "",
-		/selected agent profile/i,
+		/selected role profile/i,
 	);
 	assert.match(
 		tools[0]?.parameters.properties?.timeout?.description ?? "",
-		/selected agent profile/i,
+		/selected role profile/i,
 	);
 	assert.deepEqual(
 		(tools[0]?.parameters.properties?.tools as { items?: { enum?: string[] } })?.items?.enum,
@@ -251,7 +251,7 @@ test("spawns jobs with default and explicit tools and thinking levels", async ()
 	]);
 });
 
-test("applies selected agent defaults and explicit spawn overrides without caching", async () => {
+test("applies selected role defaults and explicit spawn overrides without caching", async () => {
 	const agentDirectory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-agents-"));
 	const previousAgentDirectory = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = agentDirectory;
@@ -278,7 +278,7 @@ test("applies selected agent defaults and explicit spawn overrides without cachi
 		);
 		const profileSpawn = await tool(mock, "subagent_spawn").execute(
 			"profile",
-			{ agent: "reviewer", task: "Review one thing" },
+			{ role: "reviewer", task: "Review one thing" },
 			undefined,
 			undefined,
 			context.ctx,
@@ -300,7 +300,7 @@ test("applies selected agent defaults and explicit spawn overrides without cachi
 		const overrideSpawn = await tool(mock, "subagent_spawn").execute(
 			"override",
 			{
-				agent: "reviewer",
+				role: "reviewer",
 				task: "Review another thing",
 				tools: ["read", "edit"],
 				timeout: 5,
@@ -315,7 +315,7 @@ test("applies selected agent defaults and explicit spawn overrides without cachi
 		writeFileSync(agentsPath, "{", "utf8");
 		const unprofiledSpawn = await tool(mock, "subagent_spawn").execute(
 			"unprofiled",
-			{ agent: "", task: "Work directly" },
+			{ role: "", task: "Work directly" },
 			undefined,
 			undefined,
 			context.ctx,
@@ -323,9 +323,9 @@ test("applies selected agent defaults and explicit spawn overrides without cachi
 		await waitFor(mock, context, String(unprofiledSpawn.details.jobId));
 
 		assert.deepEqual(
-			requests.map(({ task, agentPrompt, tools, timeout, thinkingLevel }) => ({
+			requests.map(({ task, rolePrompt, tools, timeout, thinkingLevel }) => ({
 				task,
-				agentPrompt,
+				rolePrompt,
 				tools,
 				timeout,
 				thinkingLevel,
@@ -333,21 +333,21 @@ test("applies selected agent defaults and explicit spawn overrides without cachi
 			[
 				{
 					task: "Review one thing",
-					agentPrompt: "Review independently.",
+					rolePrompt: "Review independently.",
 					tools: ["read", "grep"],
 					timeout: 120,
 					thinkingLevel: "high",
 				},
 				{
 					task: "Review another thing",
-					agentPrompt: "Use the updated reviewer prompt.",
+					rolePrompt: "Use the updated reviewer prompt.",
 					tools: ["read", "edit"],
 					timeout: 5,
 					thinkingLevel: "low",
 				},
 				{
 					task: "Work directly",
-					agentPrompt: undefined,
+					rolePrompt: undefined,
 					tools: ["read", "grep", "find", "ls"],
 					timeout: undefined,
 					thinkingLevel: "off",
@@ -361,7 +361,7 @@ test("applies selected agent defaults and explicit spawn overrides without cachi
 	}
 });
 
-test("rejects unavailable selected agents before a child is queued", async () => {
+test("rejects unavailable selected roles before a child is queued", async () => {
 	const agentDirectory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-missing-agent-"));
 	const previousAgentDirectory = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = agentDirectory;
@@ -376,8 +376,8 @@ test("rejects unavailable selected agents before a child is queued", async () =>
 		await assert.rejects(
 			() =>
 				tool(mock, "subagent_spawn").execute(
-					"missing-agent",
-					{ agent: "reviewer", task: "Review" },
+					"missing-role",
+					{ role: "reviewer", task: "Review" },
 					undefined,
 					undefined,
 					context.ctx,

--- a/packages/pi-subagents/test/subagents.test.ts
+++ b/packages/pi-subagents/test/subagents.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { Component } from "@earendil-works/pi-tui";
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -66,7 +69,21 @@ test("registers five fixed main-agent tools with stable schemas and explicit lim
 		["subagent_spawn", "subagent_inspect", "subagent_cancel", "subagent_wait", "subagent_reply"],
 	);
 	assert.equal(tools[0]?.parameters.properties?.task?.maxLength, 50 * 1024);
+	assert.equal(tools[0]?.parameters.properties?.agent?.maxLength, 64);
+	assert.match(tools[0]?.parameters.properties?.agent?.description ?? "", /empty.*omitted/i);
 	assert.equal(tools[0]?.parameters.properties?.tools?.maxItems, 64);
+	assert.match(
+		tools[0]?.parameters.properties?.tools?.description ?? "",
+		/selected agent profile/i,
+	);
+	assert.match(
+		tools[0]?.parameters.properties?.thinkingLevel?.description ?? "",
+		/selected agent profile/i,
+	);
+	assert.match(
+		tools[0]?.parameters.properties?.timeout?.description ?? "",
+		/selected agent profile/i,
+	);
 	assert.deepEqual(
 		(tools[0]?.parameters.properties?.tools as { items?: { enum?: string[] } })?.items?.enum,
 		["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"],
@@ -98,7 +115,7 @@ test("registers five fixed main-agent tools with stable schemas and explicit lim
 		assert.deepEqual(preparedMalformed, malformedAlias);
 		assert.equal(Check(candidate?.parameters, preparedMalformed), false);
 	}
-	assert.match(tools[0]?.description ?? "", /task defines.*selected tools define/is);
+	assert.match(tools[0]?.description ?? "", /task defines.*effective tools define/is);
 	for (const candidate of tools) {
 		assert.doesNotMatch(
 			JSON.stringify({
@@ -109,7 +126,7 @@ test("registers five fixed main-agent tools with stable schemas and explicit lim
 			/\b(?:background|bounded)\b/i,
 		);
 	}
-	assert.deepEqual([...mock.commands.keys()], []);
+	assert.deepEqual([...mock.commands.keys()], ["subagents"]);
 	const definitions = JSON.stringify(
 		tools.map(({ name, description, parameters }) => ({ name, description, parameters })),
 	);
@@ -234,6 +251,147 @@ test("spawns jobs with default and explicit tools and thinking levels", async ()
 	]);
 });
 
+test("applies selected agent defaults and explicit spawn overrides without caching", async () => {
+	const agentDirectory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tool-agents-"));
+	const previousAgentDirectory = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDirectory;
+	try {
+		const requests: ChildRequest[] = [];
+		const { mock, context } = await setup({
+			runChild: async (request) => {
+				requests.push(request);
+				return completed("done");
+			},
+		});
+		const agentsPath = path.join(agentDirectory, "pi-subagents.json");
+		writeFileSync(
+			agentsPath,
+			JSON.stringify({
+				reviewer: {
+					task: "Review independently.",
+					tools: ["read", "grep"],
+					timeout: 120,
+					thinkingLevel: "high",
+				},
+			}),
+			"utf8",
+		);
+		const profileSpawn = await tool(mock, "subagent_spawn").execute(
+			"profile",
+			{ agent: "reviewer", task: "Review one thing" },
+			undefined,
+			undefined,
+			context.ctx,
+		);
+		await waitFor(mock, context, String(profileSpawn.details.jobId));
+
+		writeFileSync(
+			agentsPath,
+			JSON.stringify({
+				reviewer: {
+					task: "Use the updated reviewer prompt.",
+					tools: [],
+					timeout: 30,
+					thinkingLevel: "medium",
+				},
+			}),
+			"utf8",
+		);
+		const overrideSpawn = await tool(mock, "subagent_spawn").execute(
+			"override",
+			{
+				agent: "reviewer",
+				task: "Review another thing",
+				tools: ["read", "edit"],
+				timeout: 5,
+				thinkingLevel: "low",
+			},
+			undefined,
+			undefined,
+			context.ctx,
+		);
+		await waitFor(mock, context, String(overrideSpawn.details.jobId));
+
+		writeFileSync(agentsPath, "{", "utf8");
+		const unprofiledSpawn = await tool(mock, "subagent_spawn").execute(
+			"unprofiled",
+			{ agent: "", task: "Work directly" },
+			undefined,
+			undefined,
+			context.ctx,
+		);
+		await waitFor(mock, context, String(unprofiledSpawn.details.jobId));
+
+		assert.deepEqual(
+			requests.map(({ task, agentPrompt, tools, timeout, thinkingLevel }) => ({
+				task,
+				agentPrompt,
+				tools,
+				timeout,
+				thinkingLevel,
+			})),
+			[
+				{
+					task: "Review one thing",
+					agentPrompt: "Review independently.",
+					tools: ["read", "grep"],
+					timeout: 120,
+					thinkingLevel: "high",
+				},
+				{
+					task: "Review another thing",
+					agentPrompt: "Use the updated reviewer prompt.",
+					tools: ["read", "edit"],
+					timeout: 5,
+					thinkingLevel: "low",
+				},
+				{
+					task: "Work directly",
+					agentPrompt: undefined,
+					tools: ["read", "grep", "find", "ls"],
+					timeout: undefined,
+					thinkingLevel: "off",
+				},
+			],
+		);
+	} finally {
+		if (previousAgentDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDirectory;
+		rmSync(agentDirectory, { recursive: true, force: true });
+	}
+});
+
+test("rejects unavailable selected agents before a child is queued", async () => {
+	const agentDirectory = mkdtempSync(path.join(os.tmpdir(), "pi-subagents-missing-agent-"));
+	const previousAgentDirectory = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDirectory;
+	try {
+		let launches = 0;
+		const { mock, context } = await setup({
+			runChild: async () => {
+				launches++;
+				return completed("unexpected");
+			},
+		});
+		await assert.rejects(
+			() =>
+				tool(mock, "subagent_spawn").execute(
+					"missing-agent",
+					{ agent: "reviewer", task: "Review" },
+					undefined,
+					undefined,
+					context.ctx,
+				),
+			/does not exist/i,
+		);
+		assert.equal(launches, 0);
+	} finally {
+		if (previousAgentDirectory === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDirectory;
+		rmSync(agentDirectory, { recursive: true, force: true });
+	}
+});
+
 test("shows active job timing, timeout, and selected tools above the editor", async () => {
 	let refreshWidget: (() => void) | undefined;
 	const fakeTimer = { unref() {} } as NodeJS.Timeout;
@@ -302,6 +460,28 @@ test("shows active job timing, timeout, and selected tools above the editor", as
 test("does not install the component widget outside TUI mode", async () => {
 	const { context } = await setup({}, {}, { mode: "rpc", hasUI: true });
 	assert.equal(context.widgets.has(SUBAGENT_WIDGET_KEY), false);
+});
+
+test("subagents command rejects arguments and unsupported modes observably", async () => {
+	const rpc = await setup({}, {}, { mode: "rpc", hasUI: true });
+	const command = rpc.mock.commands.get("subagents");
+	assert.ok(command);
+	await command.handler("unexpected", rpc.context.ctx);
+	await command.handler("", rpc.context.ctx);
+	assert.deepEqual(
+		rpc.context.notifications.map(({ message, level }) => ({ message, level })),
+		[
+			{ message: "/subagents does not accept arguments.", level: "warning" },
+			{ message: "/subagents requires Pi TUI mode.", level: "warning" },
+		],
+	);
+
+	const print = await setup({}, {}, { mode: "print", hasUI: false });
+	const printCommand = print.mock.commands.get("subagents");
+	assert.ok(printCommand);
+	await assert.rejects(async () => {
+		await printCommand.handler("", print.context.ctx);
+	}, /requires Pi TUI mode/i);
 });
 
 test("falls back to the Pi thinking level when context has none", async () => {


### PR DESCRIPTION
## Summary

- add optional named agent profiles from Pi's user `pi-subagents.json`
- add an argument-free `/subagents` TUI manager for profile CRUD
- apply profile prompts and execution defaults while preserving explicit spawn overrides
- validate and atomically publish profile settings without overwriting invalid documents
- document the profile format, lifecycle, security model, and delegation guidance

## Verification

- `npx vitest run packages/pi-subagents/test` (69 tests)
- `npm --workspace @narumitw/pi-subagents run check`
- `npm run check`
- `npm test` (3,140 tests)
- generated Jiti loader test exercises the lazy TUI Kit boundary
- package pack and Pi extension load smokes

## Notes

- no bundled agent profiles or project-level profile overrides are added
- separate Pi processes intentionally use atomic last-writer-wins settings publication without a cross-process merge lock
- manual interactive TUI keypress and live-provider profiled-child smokes remain unverified; deterministic lifecycle and menu tests cover these paths
