### PR TITLE
chore(cbmem): make package public

### DIFF
--- a/.changeset/publish-pi-cbmem.md
+++ b/.changeset/publish-pi-cbmem.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-cbmem": patch
+---
+
+Correct the public package metadata and npm installation guidance.

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -1,8 +1,8 @@
 # 🧠 pi-cbmem — Codebase Memory Tools for Pi
 
-[![npm: private](https://img.shields.io/badge/npm-private-lightgrey)](#-install) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-cbmem)](https://www.npmjs.com/package/@narumitw/pi-cbmem) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-pi-cbmem is a private package that bundles the local Codebase Memory extension and its knowledge-graph operating skill.
+pi-cbmem bundles the Codebase Memory extension and its knowledge-graph operating skill.
 
 ## ✨ Features
 
@@ -13,15 +13,19 @@ pi-cbmem is a private package that bundles the local Codebase Memory extension a
 
 ## 📦 Install
 
-This package is private and is not published to npm.
-
-Install it from this repository checkout:
+Install persistently from npm:
 
 ```bash
-pi install ./packages/pi-cbmem
+pi install npm:@narumitw/pi-cbmem
 ```
 
-Build and try it without adding a persistent package setting:
+Try from npm without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-cbmem
+```
+
+Build and load the package from a repository checkout:
 
 ```bash
 npm --workspace @narumitw/pi-cbmem run build
@@ -109,7 +113,7 @@ packages/pi-cbmem/
 ├── test/
 │   ├── build-runtime.test.ts       # Generated-runtime and Jiti loader coverage
 │   └── cbmem.test.ts               # Tool registration coverage
-├── package.json                    # Private Pi extension and skill declarations
+├── package.json                    # Pi extension and skill declarations
 ├── tsconfig.json
 ├── README.md
 └── LICENSE

--- a/packages/pi-cbmem/package.json
+++ b/packages/pi-cbmem/package.json
@@ -4,7 +4,7 @@
 	"description": "Private Pi package for Codebase Memory knowledge graph tools and guidance.",
 	"type": "module",
 	"license": "MIT",
-	"private": true,
+	"private": false,
 	"keywords": [
 		"pi-package",
 		"pi-extension",

--- a/packages/pi-cbmem/package.json
+++ b/packages/pi-cbmem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-cbmem",
 	"version": "0.0.0",
-	"description": "Private Pi package for Codebase Memory knowledge graph tools and guidance.",
+	"description": "Pi extension package for Codebase Memory knowledge graph tools and guidance.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,


### PR DESCRIPTION
## Summary

- mark `@narumitw/pi-cbmem` as publishable
- align the package description and README with its public npm availability
- add a patch Changeset for the corrected public metadata and installation guidance

## Checks

- `npm run check`
- `npm test` — 328 files and 3,192 tests passed
- `just pack cbmem` — 10 expected files
- `npm pack --workspace @narumitw/pi-cbmem --dry-run --json`
- `npx changeset status --output=/tmp/cbmem-changeset-status.json`