### PR TITLE
docs: refine package readmes

### DIFF
--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -2,41 +2,34 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-accounts)](https://www.npmjs.com/package/@narumitw/pi-accounts) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Save and switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts without replacing Pi's built-in provider integrations.
-
-Each selection overrides only the chosen provider, and selecting `default` restores Pi's normal authentication without deleting saved accounts.
-
-## ✨ Features
-
-- Manages named OpenAI Codex, Anthropic Claude Pro/Max, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts through `/accounts`.
-- Keeps an independent selected account—or Pi's default login—for each provider.
-- Applies provider-specific credentials, endpoints, headers, and model availability through Pi's built-in providers.
-- Refreshes rotating credentials safely and verifies effective runtime authentication before reporting success.
-- Makes only the verified active OAuth credential available process-locally to compatible current-account consumers.
-- Stores credentials atomically in a private local file and fails closed for the affected provider on activation errors.
-- Migrates legacy `pi-codex-accounts.json` data while preserving its rollback source.
-
-## 🔌 Supported providers
-
-| Provider | Provider ID | Account-specific behavior |
-| --- | --- | --- |
-| OpenAI Codex | `openai-codex` | ChatGPT Plus/Pro OAuth, OAuth-only native-provider bridge, and Codex WebSocket invalidation |
-| Anthropic | `anthropic` | Claude Pro/Max OAuth without interfering with Anthropic API-key auth after returning to `default` |
-| GitHub Copilot | `github-copilot` | Individual or Enterprise login, credential-derived API endpoint, and account-specific available models |
-| Kimi For Coding | `kimi-coding` | Kimi Code subscription OAuth with provider-owned Bearer-header authentication |
-| OpenRouter | `openrouter` | OpenRouter OAuth that mints a persistent account API key without managing manually entered API-key profiles |
-| Radius | `radius` | Gateway-bound OAuth with credential-specific dynamic model-catalog refresh and selected-model rebinding |
-| xAI | `xai` | SuperGrok or X Premium OAuth with the native xAI provider and model catalog |
+Save and switch named OAuth accounts for Pi's built-in providers.
+Each provider keeps its own selection, and choosing `default` restores Pi's normal authentication without deleting saved accounts.
 
 > [!WARNING]
 > Anthropic currently treats Claude Pro/Max use through third-party harnesses as **extra usage billed per token**, rather than consumption of the normal plan allowance.
 > Review your Anthropic billing and extra-usage settings before using a named Anthropic account.
 
+## ✨ Features
+
+- Manages named OpenAI Codex, Anthropic Claude Pro/Max, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts through `/accounts`.
+- Selects an account—or Pi's default login—independently for each provider.
+- Applies provider-specific credentials, endpoints, headers, and model availability through Pi's built-in providers.
+- Refreshes rotating credentials and verifies the effective authentication before reporting success.
+- Offers only the verified active OAuth credential to compatible in-process consumers.
+- Writes credentials atomically to a private local file and fails closed for only the affected provider when activation fails.
+- Imports legacy `pi-codex-accounts.json` data while retaining the source file for rollback.
+
 ## 📦 Install
 
-`pi-codex-accounts` is deprecated and its source is archived under `deprecated/`.
-Do not load both packages together; they can manage and refresh the same rotating Codex credential independently.
-To migrate one Pi installation:
+Install persistently:
+
+```bash
+pi install npm:@narumitw/pi-accounts
+```
+
+`pi-codex-accounts` is deprecated and archived under `deprecated/`.
+Do not load both packages because each can refresh the same rotating Codex credential.
+Migrate an existing installation with:
 
 ```bash
 pi uninstall npm:@narumitw/pi-codex-accounts
@@ -60,8 +53,20 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must be built
 
 ## 🚀 Quick start
 
-Run `/accounts` in TUI or RPC mode, then choose a provider action from the account manager.
-Use the manager to log in, switch accounts, restore Pi's default login, or remove a saved account.
+Run `/accounts` in TUI or RPC mode.
+Use the manager to log in, switch accounts, restore a provider's default Pi login, or remove an account.
+
+## 🔌 Supported providers
+
+| Provider | Provider ID | Account-specific behavior |
+| --- | --- | --- |
+| OpenAI Codex | `openai-codex` | ChatGPT Plus/Pro OAuth, OAuth-only native-provider bridge, and Codex WebSocket invalidation |
+| Anthropic | `anthropic` | Claude Pro/Max OAuth without interfering with Anthropic API-key auth after returning to `default` |
+| GitHub Copilot | `github-copilot` | Individual or Enterprise login, credential-derived API endpoint, and account-specific available models |
+| Kimi For Coding | `kimi-coding` | Kimi Code subscription OAuth with provider-owned Bearer-header authentication |
+| OpenRouter | `openrouter` | OpenRouter OAuth that mints a persistent account API key without managing manually entered API-key profiles |
+| Radius | `radius` | Gateway-bound OAuth with credential-specific dynamic model-catalog refresh and selected-model rebinding |
+| xAI | `xai` | SuperGrok or X Premium OAuth with the native xAI provider and model catalog |
 
 ## 💬 Commands
 
@@ -71,10 +76,11 @@ Open the interactive account manager:
 /accounts
 ```
 
-The standard manager runs in TUI or RPC mode; Back returns through provider/account screens and Escape closes the root.
-Print and JSON modes reject it observably.
-Any extra text after `/accounts` is ignored so the entry point stays singular.
-Provider-owned OAuth challenges, account-name text input, and exact replacement/removal confirmations remain specialized dialogs because they carry credential and destructive-action policy rather than ordinary navigation.
+The manager supports TUI and RPC mode.
+Back returns through provider and account screens, and Escape closes the root.
+Print and JSON modes do not provide account-manager output.
+Extra text after `/accounts` is ignored.
+OAuth challenges, account names, and replacement or removal confirmations use dedicated dialogs.
 
 When no accounts are saved yet, the menu starts with login:
 
@@ -111,24 +117,29 @@ What do you want to do?
   Switch another provider’s account
 ```
 
-Login reuses Pi's native `/login` dialog in TUI mode: choose a provider, enter a named account, then complete the provider's OAuth flow in the same bordered screen with native links, device codes, progress, prompts, and Escape cancellation.
-Provider-owned choices temporarily use Pi's native selector before returning to the login dialog.
-RPC mode uses Pi's standard extension UI requests for the same OAuth contract.
+### Login
+
+In TUI mode, login uses Pi's native `/login` dialog with links, device codes, progress, prompts, and Escape cancellation.
+Provider-owned choices temporarily open Pi's native selector, then return to the login dialog.
+RPC mode uses Pi's standard extension UI requests for the same OAuth flow.
 `default` is reserved for Pi's built-in login.
-Reusing an existing provider/account name asks before replacing the stored credential.
+Reusing a provider and account name requires confirmation before replacement.
 
-Switching the current model provider is the primary flow.
-Switching a different provider is explicit: choose **Switch another provider’s account**, choose the provider, then choose the account.
+### Switch or remove an account
+
+The primary switch action targets the current model's provider.
+To switch another provider, choose **Switch another provider’s account**, then choose the provider and account.
 Choosing `default` restores Pi's built-in login for that provider.
-`/accounts` manages account identity only; it does not switch models except when login succeeds while the current model is still `unknown`, where it selects that provider's default model as onboarding help.
+`/accounts` changes account identity, not the model.
+As onboarding help, a successful login selects the provider's default model only when the current model is `unknown`.
 
-Removing an account lists named accounts as `Provider · account`, asks for confirmation, then removes the credential.
-Removing an active account automatically restores that provider to Pi's built-in login.
+Removal lists accounts as `Provider · account` and requires confirmation.
+Removing the active account restores that provider to Pi's built-in login.
 
 ## 🔒 Security and privacy
 
-Each selected account is refreshed through the provider's own OAuth `refresh()` implementation and converted through `toAuth()`.
-The extension then applies the returned API key, headers, and endpoint, verifies the effective runtime state, and reports success.
+The extension refreshes each selected account through the provider's OAuth `refresh()` implementation and converts it through `toAuth()`.
+It applies the returned API key, headers, and endpoint, then verifies the effective runtime state before reporting success.
 
 If refresh, conversion, provider overlay, or verification fails, the extension installs a non-secret failing runtime credential and aborts turns for that provider.
 It does not silently fall back to Pi's built-in login, an environment API key, or another named account.
@@ -137,17 +148,16 @@ Other providers remain independent and usable.
 Selecting `default` removes the package-owned runtime override and restores the exact provider registration that existed before activation.
 Pi's built-in credentials are never deleted.
 
-The extension implements the versioned `oauth:credential-source:v1` protocol for compatible current-account consumers such as usage reporters.
-It offers a fresh in-memory clone only after the named OAuth credential has produced and verified the active runtime authentication for the exact Pi session.
+The extension implements `oauth:credential-source:v1` for compatible in-process consumers such as usage reporters.
+It offers a fresh clone only after the named credential has produced and verified authentication for the current Pi session.
 Pending, default, stale, failed, replaced, reloaded, and shut-down states offer nothing.
-The offer contains no account name or extension identity and is never persisted or logged by the protocol.
-A consumer must still match the offered access token and provider-specific metadata against freshly resolved runtime auth before using it.
-Installing `pi-accounts` without a compatible consumer does not change account activation behavior.
-An older or absent consumer simply does not request the credential.
+The protocol does not persist or log the offer, which contains neither the account name nor extension identity.
+Consumers must match its access token and provider metadata against freshly resolved runtime authentication.
+Without a compatible consumer, account activation works unchanged and no credential is requested.
 
-Pi extensions run with the user's process privileges, and the shared event bus is not a security boundary between installed extensions.
-Install only trusted extensions because any installed extension may already read user files and process memory.
-The protocol reduces accidental credential coupling; it does not sandbox malicious code.
+Pi extensions run with the user's process privileges, and the shared event bus does not isolate installed extensions.
+Install only trusted extensions because any extension can read user files and process memory.
+The protocol reduces accidental credential coupling; it is not a sandbox.
 
 GitHub Copilot's `availableModelIds` are projected into the active provider model list.
 Switching Copilot accounts rebuilds the projection from the complete pre-overlay model catalog.
@@ -177,7 +187,8 @@ The canonical file is:
 When `PI_CODING_AGENT_DIR` is set, the file is stored at `$PI_CODING_AGENT_DIR/pi-accounts.json` instead.
 Its versioned structure keeps account maps and active names under separate provider IDs.
 Credential values are private and must not be committed.
-When neither canonical nor legacy storage exists, reads use an empty in-memory store without creating an agent directory or file; the first account mutation creates the private canonical file.
+When neither canonical nor legacy storage exists, reads return an empty store without creating a directory or file.
+The first account change creates the private canonical file.
 
 On first load, if `pi-accounts.json` does not exist and released `pi-codex-accounts.json` does, the extension:
 
@@ -187,10 +198,10 @@ On first load, if `pi-accounts.json` does not exist and released `pi-codex-accou
 4. Atomically installs private `pi-accounts.json`.
 5. Retains the private legacy file for rollback.
 
-If both files exist, `pi-accounts.json` is canonical and the legacy file is not imported again.
+If both files exist, `pi-accounts.json` takes precedence and the legacy file is not imported again.
 The retained legacy refresh token may become stale after `pi-accounts` rotates it, so rollback can require a new Codex login.
-Older `pi-accounts` releases that predate these providers reject files containing their provider sections.
-Back up the file and remove the `kimi-coding`, `openrouter`, `radius`, and `xai` sections only after stopping Pi before downgrading.
+Older releases reject files that contain provider sections added later.
+Before downgrading, stop Pi, back up the file, and remove the `kimi-coding`, `openrouter`, `radius`, and `xai` sections.
 
 ### Rollback
 

--- a/packages/pi-analytics/README.md
+++ b/packages/pi-analytics/README.md
@@ -6,16 +6,16 @@
 > This extension is experimental.
 > Its metrics, storage format, and dashboard may change between releases.
 
-See local model, skill, tool, and provider reliability metrics without storing conversation or tool content or sending analytics elsewhere.
+Measure local model, skill, tool, and provider reliability activity without storing conversation or tool content or sending analytics elsewhere.
 
 ## ✨ Features
 
 - Collects content-free metrics automatically after installation.
-- Counts settled response cycles, logical LLM calls, skill activations, tool activity, and observed provider errors.
-- Breaks down tool failures, duration, model attribution, and response-level call distributions.
-- Distinguishes recovered provider errors from terminal failures.
+- Counts settled response cycles, logical LLM calls, skill activations, tool calls, and observed provider errors.
+- Reports tool failures and duration, model attribution, and per-response call distributions.
+- Separates recovered provider errors from terminal failures.
 - Provides Today, rolling 7-day, rolling 30-day, and all-time views through `/analytics`.
-- Stores private versioned JSONL locally, isolates concurrent writers, and never starts an analytics server.
+- Stores private, versioned JSONL locally, isolates concurrent writers, and does not start an analytics server.
 
 ## 📦 Install
 
@@ -40,7 +40,8 @@ pi -e ./packages/pi-analytics
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-The storage implementation uses Node's built-in filesystem APIs and has no native database dependency.
+The extension uses Node's built-in filesystem APIs and has no native database dependency.
+Pi extensions run with the Pi process's user permissions, so install only trusted packages.
 
 ## 🚀 Quick start
 
@@ -65,41 +66,41 @@ Provider errors                     4
 Recovered errors                    3
 ```
 
-Use the menu to change the time range or browse Skills, Tools, Provider reliability, Response cycles, and Data & privacy.
-Only fully settled cycles are included; active work is omitted.
+Use the menu to change the range or inspect Skills, Tools, Provider reliability, Response cycles, and Data & privacy.
+The dashboard includes finalized cycles and omits active work.
 
 ## 📐 Metric definitions
 
 ### Response cycles and LLM calls
 
-A **response cycle** starts when Pi begins agent work and ends at `agent_settled`.
-Automatic retries, overflow-compaction recovery, tool follow-ups, and queued continuations before settlement stay in that cycle.
+A **response cycle** starts when Pi begins agent work and normally ends at `agent_settled`.
+Retries, overflow-compaction recovery, tool follow-ups, and queued continuations before settlement remain in that cycle.
 
 An **LLM call** is one logical provider generation.
-A provider may make several HTTP attempts inside it, so `429 → 429 → 200` is one LLM call, three observed HTTP responses, two provider errors, and a recovered generation.
+A provider can make several HTTP attempts within it, so `429 → 429 → 200` counts as one LLM call, three observed HTTP responses, two provider errors, and one recovered generation.
 
 ### Skills
 
-An activation is **User initiated** when an observed interactive or RPC `/skill:<name>` input is associated with an active or subsequently started response cycle.
+An activation is **User initiated** when an observed interactive or RPC `/skill:<name>` input belongs to an active or subsequently started response cycle.
 This includes skill commands queued while Pi is streaming.
-It is **Model initiated** when the built-in `read` tool successfully loads the exact canonical `SKILL.md` path Pi discovered.
-A skill is counted at most once per response cycle, and explicit user use takes precedence.
+It is **Model initiated** when Pi's built-in `read` tool successfully loads the exact canonical `SKILL.md` path Pi discovered.
+Each skill counts at most once per response cycle, with explicit user use taking precedence.
 
-Pi does not expose a first-class skill-invocation event or a post-chain acceptance event for input observers.
-Non-standard loading such as `bash` plus `cat SKILL.md`, unsuccessful reads, and provider behavior invisible to Pi are not counted.
+Pi does not expose a first-class skill-invocation event or post-chain acceptance event to input observers.
+The extension does not count unsuccessful reads, provider behavior hidden from Pi, or non-standard loading such as `bash` plus `cat SKILL.md`.
 
 ### Tools
 
 A tool call starts at Pi's `tool_execution_start` event and finishes at `tool_execution_end`.
 The extension stores the tool name, model attribution, timing, completion state, and final error flag.
-It cannot reliably distinguish another extension blocking a call from every other tool error, so both appear as errors.
+Pi does not expose enough information to distinguish a call blocked by another extension from other tool errors, so both count as errors.
 
 ### Provider reliability
 
-Pi exposes HTTP responses and final assistant failures, not every provider-SDK transport retry.
-The dashboard therefore labels these values as **observed provider errors**.
-It reports HTTP 429 and 5xx counts; conservative DNS, timeout, connection, TLS, network, and provider categories; recovered errors; and terminal failures.
-Error messages are classified in memory and discarded.
+Pi exposes HTTP responses and final assistant failures, but not every provider-SDK transport retry.
+The dashboard therefore calls these values **observed provider errors**.
+It reports HTTP 429 and 5xx counts, conservative error categories, recovered errors, and terminal failures.
+Raw error messages are classified in memory and discarded.
 
 ## 💬 Commands
 
@@ -108,14 +109,13 @@ Error messages are classified in memory and discarded.
 ```
 
 The command accepts no arguments.
-TUI mode uses the full dashboard; RPC mode adapts the same standard screens to dialogs.
-Print and JSON modes reject the interactive command observably instead of writing ad hoc protocol output.
+TUI mode shows the full dashboard, and RPC mode adapts the same screens to dialogs.
+Print and JSON modes reject the command before reading analytics data.
 
 The root menu contains Change time range, Skills, Tools, Provider reliability, Response cycles, Data & privacy, and Close.
-Skills and Tools are searchable browse views with details and model breakdowns.
-Escape goes Back from nested screens and closes the root.
-Ctrl+C closes the menu.
-Data deletion uses Pi TUI Kit's standalone confirmation: Back keeps the dashboard open, Ctrl+C closes it in TUI mode, and cancellation never clears data.
+Skills and Tools provide searchable details and model breakdowns.
+Escape goes back from nested screens and closes the root, while Ctrl+C closes the menu.
+Deleting data requires confirmation; Back keeps the dashboard open, Ctrl+C closes it in TUI mode, and cancellation leaves data unchanged.
 
 ## 🔒 Security and privacy
 
@@ -138,23 +138,26 @@ Provider-supplied tool-call IDs are replaced with local ordinals before publicat
 
 The extension does **not** store prompts, responses, thinking content, tool arguments or results, raw error messages, HTTP headers, cwd/project/file paths, session names or IDs, or credentials.
 
-Each settled response is one versioned, newline-terminated frame.
+Each finalized response cycle is one versioned, newline-terminated frame.
 Frames larger than 1 MiB are dropped.
-Local writes receive a 500 ms cancellation deadline; Node filesystem cancellation is best-effort, so an operating-system request that has already begun may still finish.
+Local writes receive a 5-second cancellation deadline.
+Node filesystem cancellation is best-effort, so an operating-system request that has begun may still finish.
 The extension reports the first failed or timed-out write and a later recovery without exposing filesystem errors.
 
 `/analytics` streams and validates the active generation, checks cancellation between files and records, and periodically yields to the event loop.
-A crash-truncated final frame is ignored; completed malformed frames and unsupported format versions fail closed without replacing existing files.
+It ignores a crash-truncated final frame.
+Completed malformed frames and unsupported format versions fail closed without replacing existing files.
 
 ### Clear analytics data
 
-Choose **Data & privacy → Clear analytics data…** to atomically publish a fresh active generation.
-Other Pi processes observe that generation before their next write.
-Records racing with Clear may land immediately before or after the generation switch.
+Choose **Data & privacy → Clear analytics data…** to publish a fresh active generation atomically.
+Other Pi processes observe it before their next write.
+A record racing with Clear can land immediately before or after the switch.
 
-The extension then removes the previous generation.
-If another process still has an obsolete file in use, Clear remains logically complete and reports that physical cleanup is incomplete; stop other Pi processes and clear again.
-Clearing files is not a secure-erasure guarantee for underlying storage media.
+The extension then removes obsolete generations.
+If another process still uses an obsolete file, Clear reports incomplete physical cleanup but the logical clear remains complete.
+Stop other Pi processes and clear again to retry cleanup.
+File deletion does not guarantee secure erasure from the storage medium.
 
 ## 🧭 Legacy SQLite data
 
@@ -165,7 +168,7 @@ Versions that used Turso/SQLite stored data in:
 <pi-agent-directory>/pi-analytics.db-wal
 ```
 
-The JSONL version deliberately does not open, import, migrate, delete, or rewrite those files, so startup cannot re-enter the old native database path.
+The JSONL version does not open, import, migrate, delete, or rewrite these files.
 New analytics start empty.
 
 If legacy history matters, stop every old Pi process first and preserve both files together.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -2,18 +2,17 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-btw)](https://www.npmjs.com/package/@narumitw/pi-btw) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Ask temporary questions in a separate side thread while the main Pi conversation and coding task stay focused.
-
-Bring back only the answer or context you explicitly choose.
+Ask questions in a temporary side thread without adding them to the main Pi conversation.
+Only context you explicitly bring back is loaded into the main editor.
 
 ## ✨ Features
 
-- Starts a fresh side thread immediately with `/btw <question>` or opens the manager with `/btw`.
-- Uses any persisted main-session branch as context without switching that branch.
-- Supports scrollable answers, follow-up questions, queued steering, and resumable in-memory threads.
+- Starts a side thread immediately with `/btw <question>` or opens the manager with `/btw`.
+- Uses any persisted main-session branch as context without switching branches.
+- Supports scrollable answers, transcript search, follow-up questions, queued steering, and in-memory resume.
 - Keeps side questions and answers out of the main conversation by default.
-- Brings back only the latest answer, a selected range, a question suffix, or the complete side thread when requested.
-- Uses Pi's current model and thinking level or independent saved choices.
+- Brings back the latest answer, a question suffix, an exact range, or the complete thread only when requested.
+- Uses Pi's current model and thinking level or saved pi-btw choices.
 
 ## 📦 Install
 
@@ -35,15 +34,17 @@ pi -e ./packages/pi-btw
 ```
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+Pi extensions run with the Pi process's user permissions, so install only trusted packages.
 
 ## 🚀 Quick start
 
-Run `/btw <question>` to start a side thread immediately, or run `/btw` to choose context and settings first.
-Side-thread questions and answers remain separate from the main conversation unless you explicitly bring selected context back.
+In TUI mode, run `/btw <question>` to start immediately or `/btw` to choose context and settings first.
+The side thread stays separate until you explicitly bring context to the main editor.
 
 ## 💬 Commands
 
-Open the pi-btw menu or provide the first question immediately:
+`/btw` is TUI-only.
+Open the manager or provide the first question immediately:
 
 ```text
 /btw
@@ -59,72 +60,91 @@ Examples:
 /btw is this API name idiomatic?
 ```
 
-Running `/btw` alone opens a menu with **Start side thread** selected first.
-**Start from main thread tree…** opens Pi's native session tree and uses the root-to-selected-entry path, including the selected entry, as the new side thread's context.
-Selecting context does not navigate, fork, append to, or switch the main conversation, and it preserves the main editor draft.
-The selector is a snapshot of entries persisted when it opens, while the resulting side thread keeps an immutable context snapshot even if the main conversation later changes.
-Press `Escape` to return to the `/btw` menu or `Ctrl+C` to close the flow.
-The native tree controls remain available: copying reports success or failure, and an explicit `Shift+L` label edit persists through Pi as the only main-session mutation available from this selector.
-When the current Pi session has non-empty side threads in memory, **Resume side thread** opens a bounded searchable choice list.
-Search matches the displayed first question and question count while returning the thread's raw in-memory ID.
-**Settings** changes the starting thinking level and whether shortcut changes for fixed levels are remembered.
-Each Resume row keeps the first question as its fixed title, shows its question count, and the list is ordered by the newest recorded answer or visible error.
-Opening and closing a thread without a new result does not reorder it.
-`/btw <question>` bypasses this menu and always starts a fresh side thread.
-Its answer opens above the side-thread editor.
-The side thread uses a dedicated full-screen terminal view.
-The main agent continues running in the background, but its screen rendering stays suspended until `/btw` closes, so new main-thread output cannot move a mouse selection inside the side thread.
-Drag the primary mouse button across side-thread text to request a copy through Pi's host clipboard helper.
-The view reports `Copied!` when Pi accepts the copy and `Copy failed` when Pi reports failure; actual clipboard availability still depends on operating-system and terminal support.
-Returning from `/btw` redraws the main view with everything produced while it was hidden.
-A compact `btw · side thread` header stays fixed above the content so the ephemeral workspace remains recognizable while scrolling.
-Messages use Pi's normal user and assistant presentation without numbered turns or role labels.
-Type each question and press `Enter`; no follow-up shortcut is required.
-Press `Ctrl+Shift+F` to search completed or answering transcript content.
-Press `Enter` or `Ctrl+G` for the next match, `Shift+Enter` or `Ctrl+Shift+G` for the previous match, and `Escape` to close search.
-Search uses Pi's active theme, keeps the composer available after closing the search overlay, and does not include fixed header or footer chrome.
-Previous side questions and answers remain available to the model and visible for that invocation.
-The side-thread header shows its current thinking level.
-Press Pi's configured `app.thinking.cycle` shortcut (`Shift+Tab` by default) in the composer to cycle the levels supported by the side-thread model; every later question uses the displayed level until it is changed again.
-When a fixed thinking level is selected, each shortcut change is also written to `pi-btw.json` for the next invocation by default.
-Turn **Remember thinking level changes** off in Settings to keep fixed-level changes local to the current side thread.
-When **Same as main thread** is selected, shortcut changes are always local to the current side thread.
-Neither path changes the main session's thinking level.
-While a response is running, the transcript and composer remain visible above an `Answering…` status.
-Type another question and press `Enter` to queue it as `Steering`; queued questions are shown in submission order and answered one at a time after the active response completes.
-A queued question uses the side thread's thinking level when its turn begins.
-A failed active response is shown in the transcript and does not discard later steering questions.
-Use the mouse wheel or trackpad to scroll transcript history like Pi's main thread.
-Keyboard `PgUp`/`PgDn` history navigation remains available and appears in the footer only when the transcript can scroll.
-Press `Ctrl+C` to cancel the active response and discard the ephemeral side-thread draft and steering queue.
-Completed questions, answers, and visible errors remain available through Resume until the current extension instance ends.
-Steering remains entirely inside pi-btw and never appends to the main conversation or editor.
+### Choose context or resume a thread
 
-After at least one successful answer, press `Ctrl+R` to bring selected context to the main editor.
-The scope menu shows the size of the latest question and answer and the entire side thread before you choose.
-Bring the latest question and answer, everything from a chosen question onward, an exact text range, or the entire side thread.
-Question-suffix, exact-range, and entire-thread choices preview the exact editable context block before the side thread closes.
-Pressing `Escape` returns, while `Ctrl+C` closes without bringing anything to main.
+Running `/btw` opens a manager with **Start side thread** selected first.
+**Start from main thread tree…** opens Pi's session tree and uses the root-to-selected-entry path, including the selected entry, as context.
+This choice preserves the main editor draft and does not navigate, fork, append to, or switch the main conversation.
+The tree is a snapshot of persisted entries, and the side thread keeps immutable context even if the main conversation later changes.
+Escape returns to the manager, and Ctrl+C closes the flow.
+Native tree copying reports success or failure.
+An explicit `Shift+L` label edit is the only main-session mutation available from this selector and persists through Pi.
 
-The text-range selector supports both fast line selection and editor-style character selection.
-It reports whether anything is selected plus the selected line, message, and approximate token counts.
-Press `Space` to select the current raw source line, then use `Up`/`Down` to extend by whole lines; press `Space` again to clear it.
-Alternatively, use the arrow keys to move the cursor and `Shift`+arrow keys to extend a character-level selection.
-Starting a Shift selection replaces any active line selection.
-Selected lines include a visible `●` marker in addition to highlighting.
-Pi's configured keys control vertical navigation, bringing, and going back (`Up`/`Down`, `Enter`, and `Escape` by default), and the selector displays the active keys.
-Selection follows raw source text rather than terminal-wrapped visual rows.
+When non-empty threads exist in memory, **Resume side thread** opens a bounded searchable list.
+Search matches the first question and question count while retaining each raw thread ID.
+Each row uses the first question as its fixed title and shows the question count.
+Rows are ordered by the newest recorded answer or visible error; opening and closing without a new result does not reorder them.
+**Settings** controls the starting thinking level and whether fixed-level shortcut changes are remembered.
+`/btw <question>` bypasses the manager and always starts a new thread.
 
-Bringing context to main closes the side thread and loads a deterministic, editable context block into Pi's main editor.
-It never sends the draft automatically.
-If the main editor already has a draft, append is the recommended default.
-Replace is labeled as destructive and requires a second confirmation; Cancel returns to the side thread without changing either draft.
-Concurrent editor updates made while these menus are open are preserved.
-A success message reports whether context was loaded, appended, or replaced and its approximate size.
-Without an explicit bring-to-main action, closing `/btw` never adds the side thread to the main conversation.
-Non-empty threads remain only in memory for Resume within the current Pi session.
-`/new`, Pi `/resume`, `/reload`, extension replacement, and process restart discard every retained thread.
-Unsent drafts, steering queues, interrupted answers, and model credentials are never retained.
+### Use the side-thread workspace
+
+The side thread uses a dedicated full-screen terminal view with answers above the editor.
+The main agent can continue running, but main-screen rendering stays suspended until `/btw` closes so new output cannot move a mouse selection.
+Returning to Pi redraws everything produced while the main view was hidden.
+
+A fixed `btw · side thread` header identifies the workspace while scrolling.
+Messages use Pi's normal user and assistant presentation without turn numbers or role labels.
+Type a question and press Enter for each turn.
+Previous successful questions and answers remain visible and available to the side model.
+
+Drag the primary mouse button across transcript text to request a copy through Pi's host clipboard helper.
+The view reports `Copied!` when Pi accepts the request and `Copy failed` when Pi rejects it.
+Actual clipboard access still depends on the operating system and terminal.
+
+Press `Ctrl+Shift+F` to search completed or in-progress transcript content.
+Press Enter or `Ctrl+G` for the next match, `Shift+Enter` or `Ctrl+Shift+G` for the previous match, and Escape to close search.
+Search uses Pi's active theme, excludes fixed header and footer text, and returns focus to the composer when closed.
+
+### Change thinking level or queue steering
+
+The header shows the side thread's current thinking level.
+In the composer, use Pi's configured `app.thinking.cycle` shortcut (`Shift+Tab` by default) to cycle levels supported by the side model.
+Later questions use the displayed level until it changes again.
+For a fixed starting level, shortcut changes are saved to `pi-btw.json` by default.
+Turn **Remember thinking level changes** off to keep them local to the thread.
+With **Same as main thread**, shortcut changes are always local.
+Neither setting changes the main session's thinking level.
+
+During a response, the transcript and composer remain visible above `Answering…`.
+Submit another question to queue it as `Steering`.
+Queued questions appear in submission order and run one at a time after the active response.
+Each queued question uses the side thread's thinking level when its turn starts.
+A failed response remains visible and does not discard later queued questions.
+Steering never appends to the main conversation or editor.
+
+Use the mouse wheel, trackpad, or `PgUp`/`PgDn` to scroll transcript history.
+The footer shows history keys only when scrolling is available.
+Ctrl+C cancels the active response and discards the current draft and steering queue.
+Completed questions, answers, and visible errors remain available through Resume until the extension instance ends.
+
+### Bring context to the main editor
+
+After a successful answer, press `Ctrl+R` to choose context for the main editor.
+The scope menu shows the size of the latest question and answer and the full thread.
+Choose the latest question and answer, everything from one question onward, an exact range, or the full thread.
+Question-suffix, exact-range, and full-thread choices preview the editable context block before the side thread closes.
+Escape returns, while Ctrl+C closes without bringing context back.
+
+The exact-range selector supports whole-line and editor-style character selection.
+It reports selected line, message, and approximate token counts.
+Press Space to select the current raw source line, use Up or Down to extend by lines, and press Space again to clear.
+Alternatively, move with arrow keys and extend a character selection with Shift plus an arrow key.
+Starting a Shift selection replaces an active line selection.
+Selected lines show a `●` marker as well as highlighting.
+Pi's configured keys control vertical navigation, bringing, and going back, with Up, Down, Enter, and Escape as defaults.
+Selection follows raw source text rather than terminal-wrapped rows.
+
+Bringing context closes the side thread and loads a deterministic, editable block into Pi's main editor without sending it.
+If a draft already exists, append is the recommended default.
+Replace is marked destructive and requires a second confirmation.
+Cancel returns to the side thread without changing either draft, and concurrent editor updates are preserved.
+A success message reports whether context was loaded, appended, or replaced and gives its approximate size.
+
+Without an explicit bring action, closing `/btw` never changes the main conversation.
+Non-empty threads remain in memory only for Resume during the current extension instance.
+`/new`, Pi `/resume`, `/reload`, extension replacement, and process restart discard retained threads.
+Unsent drafts, steering queues, interrupted answers, and model credentials are not retained.
 
 ## ⚙️ Settings
 
@@ -149,7 +169,7 @@ The normal location is `~/.pi/agent/pi-btw.json`.
 The `model` value uses `provider/model-id` format.
 Only the first `/` is the separator, so model IDs may contain additional slashes, such as `openrouter/anthropic/claude-sonnet`.
 The configured model must exist in Pi's model registry and have usable credentials.
-If it cannot be found or authenticated, pi-btw warns and falls back to the current session model.
+If it is missing or unauthenticated, pi-btw warns and falls back to the current session model.
 If neither model is available, `/btw` reports an error and stops.
 This selection affects only `/btw`; it does not change the main session model.
 
@@ -170,17 +190,21 @@ When **Same as main thread** is selected, shortcut changes stay local even when 
 If a shortcut write fails, the local change remains active and pi-btw warns that it was not remembered.
 A failed Settings-screen save instead restores the previous displayed value.
 
-A missing settings file is a side-effect-free read: pi-btw creates it only after a Settings change or a remembered shortcut change.
-Saves are ordered within the Pi process and published atomically with a same-directory temporary file and rename.
-They preserve `model` and unknown fields; malformed or invalid files block saves and remain unchanged.
-Settings must be valid UTF-8 and no larger than 64 KiB, so unexpectedly large or invalidly encoded files are rejected without being rewritten.
-Separate Pi processes and external editors are outside this in-process ordering boundary.
-The file is read for each `/btw` invocation, so edits apply without `/reload`.
+Reading a missing settings file has no side effects.
+Pi-btw creates it only after a Settings change or a remembered shortcut change.
+Within one Pi process, saves run in order and publish atomically through a same-directory temporary file and rename.
+Saves preserve `model` and unknown fields.
+Malformed or invalid files block saves and remain unchanged.
+Files must be valid UTF-8 and no larger than 64 KiB.
+Separate Pi processes and external editors are outside the in-process ordering boundary.
+The file is read for every `/btw` invocation, so edits apply without `/reload`.
 
-## 🧠 Why use pi-btw?
+## 🚧 Limitations
 
-Normal assistant messages become part of the main Pi conversation and can distract the coding agent from the task.
-`pi-btw` creates a lightweight side channel for context-aware questions, making it useful for pair programming, debugging, code review, and repository exploration.
+- `/btw` supports TUI mode only.
+- Resume state is memory-only and lasts only for the current extension instance.
+- A side thread retains the latest 40,000 characters of main-conversation context and adds a truncation notice when earlier content is omitted.
+- Clipboard access depends on Pi's host helper, the operating system, and the terminal.
 
 ## 🗂️ Package layout
 
@@ -193,12 +217,14 @@ packages/pi-btw/
 │   ├── index.ts
 │   ├── btw.ts
 │   ├── bring-to-main.ts
+│   ├── fullscreen-ui.ts
 │   ├── main-tree-picker.ts
 │   ├── menu.ts
 │   ├── settings.ts
 │   ├── side-thread.ts
 │   ├── text.ts
 │   └── transcript-pager.ts
+├── test/
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json

--- a/packages/pi-caffeinate/README.md
+++ b/packages/pi-caffeinate/README.md
@@ -2,15 +2,15 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-caffeinate)](https://www.npmjs.com/package/@narumitw/pi-caffeinate) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Prevent system or display sleep while Pi is processing a prompt, then release the inhibitor as soon as the run ends.
+Prevent system or display sleep while Pi is running an agent task, then release the inhibitor when the run ends.
 
 ## ✨ Features
 
 - Starts an OS sleep inhibitor when a Pi run begins and releases it when the run or session ends.
-- Supports macOS, Windows, WSL, and Linux with a display-awake default.
-- Provides `/caffeinate` controls for the keep-awake mode, current status, and quiet mode.
+- Supports macOS, Windows, WSL, and Linux, with display-awake as the default.
+- Provides `/caffeinate` controls for keep-awake mode and status.
 - Persists preferences locally and accepts an optional custom inhibitor command.
-- Shows activity only while the inhibitor is active and fails safely when no supported mechanism is available.
+- Falls back when possible, warns on partial activation, and reports when no inhibitor is available.
 
 ## 📦 Install
 
@@ -32,19 +32,18 @@ pi -e ./packages/pi-caffeinate
 ```
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must be built before Pi loads the package directory.
+Pi extensions run with the Pi process's user permissions, so install only trusted packages.
 
 ## 🚀 Quick start
 
 Load the extension and use Pi normally.
-During an agent run, pi-caffeinate uses the saved keep-awake mode and defaults to keeping both the system and display awake.
-Run `/caffeinate` to open the controls or `/caffeinate status` to inspect the current state.
+During each agent run, pi-caffeinate uses the saved mode and defaults to keeping the system and display awake.
+Run `/caffeinate` for controls or `/caffeinate status` for the current state.
 
 ## 🖥️ Supported platforms
 
-The default mode is `display` on every supported OS.
-That means pi-caffeinate prevents system sleep, suspend, or hibernate and keeps the screen/display awake.
-
-Use `/caffeinate sleep` if you want to prevent system sleep while allowing normal display idle behavior such as screen blanking or monitor power-off.
+The default `display` mode prevents system sleep, suspend, or hibernate and keeps the display awake.
+Use `/caffeinate sleep` to prevent system sleep while allowing normal screen blanking or monitor power-off.
 
 | Platform | `sleep` mode | `display` mode, default |
 | --- | --- | --- |
@@ -54,13 +53,13 @@ Use `/caffeinate sleep` if you want to prevent system sleep while allowing norma
 | Linux with systemd | `systemd-inhibit --what=sleep ... sleep infinity` | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `systemd-inhibit --what=idle:sleep ... sleep infinity` |
 | Linux without systemd | `caffeinate -ims` when available | D-Bus `org.freedesktop.ScreenSaver.Inhibit` + `caffeinate -dimsu` when available; D-Bus only otherwise |
 
-On Linux, `display` mode requests idle inhibition through the standard `org.freedesktop.ScreenSaver` D-Bus service, trying both `/org/freedesktop/ScreenSaver` and `/ScreenSaver` for desktop compatibility.
-The session-bus connection stays open for the whole agent turn.
-The inhibition ends when `UnInhibit` is called or the connection closes.
-`systemd-inhibit --what=idle:sleep` runs alongside it to preserve logind idle and sleep inhibition.
-If no ScreenSaver service is available, pi-caffeinate keeps the systemd blocker or `caffeinate` fallback and reports a partial-activation warning.
-If only D-Bus is available, pi-caffeinate reports partial activation because desktop idle is inhibited but direct system suspend may remain possible.
-D-Bus method calls use short deadlines, and stop or shutdown aborts an in-flight acquisition before closing its session-bus connection.
+On Linux, `display` mode requests idle inhibition from `org.freedesktop.ScreenSaver` over D-Bus.
+It tries `/org/freedesktop/ScreenSaver` and `/ScreenSaver` for desktop compatibility and keeps the session-bus connection open for the agent turn.
+Calling `UnInhibit` or closing the connection releases the request.
+`systemd-inhibit --what=idle:sleep` runs alongside D-Bus to preserve logind idle and sleep inhibition.
+If the ScreenSaver service is unavailable, pi-caffeinate keeps the systemd or `caffeinate` blocker and warns that activation is partial.
+If only D-Bus is available, it warns that direct system suspend may remain possible.
+D-Bus calls have 2-second deadlines, and stop or shutdown aborts an in-progress acquisition before closing the connection.
 
 If no supported inhibitor is available, the extension stays loaded and reports that caffeinate is unavailable.
 
@@ -70,8 +69,9 @@ If no supported inhibitor is available, the extension stays loaded and reports t
 /caffeinate
 ```
 
-Opens standard keep-awake controls in TUI or RPC mode.
-Print and JSON modes reject the interactive menu observably; use the direct `status`, `sleep`, `display`, `stop`, or `help` routes instead.
+Opens keep-awake controls in TUI or RPC mode.
+Print and JSON modes reject the interactive menu.
+Direct routes avoid interactive UI, but Pi's print and JSON modes do not display their notification feedback.
 
 ```text
 /caffeinate display
@@ -91,21 +91,29 @@ If an inhibitor is currently active, it is restarted so the new mode applies imm
 /caffeinate status
 ```
 
-Shows whether an inhibitor is active, unavailable, disabled, or idle.
-The status includes the current mode, quiet mode, and settings file path.
+Shows whether the inhibitor is active, unavailable, disabled, or idle.
+The result includes the mode, quiet-mode state, and settings path.
 
 ```text
 /caffeinate mode
 ```
 
-Opens the standard keep-awake mode selector in TUI or RPC mode.
-Escape closes the selector.
+Opens the keep-awake mode selector in TUI or RPC mode.
+Escape closes it.
 
 ```text
 /caffeinate stop
 ```
 
-Releases any active inhibitor until Pi starts another agent run.
+Releases the active inhibitor until Pi starts another agent run.
+
+```text
+/caffeinate help
+```
+
+Shows the canonical command routes.
+In TUI and RPC mode, unknown commands and trailing text show a rejection with the command guide.
+Compatibility aliases are `screen` for `display`, `system` for `sleep`, `off` for `stop`, and `config` or `settings` for `mode`.
 
 ## ⚙️ Settings
 
@@ -127,21 +135,23 @@ Example:
 }
 ```
 
-Set `"quiet": true` to hide the routine `Keeping computer awake (...)` and `Released pi-caffeinate (agent finished)` lifecycle notifications and keep the `caffeinate` status item clear while active or unavailable.
-Quiet mode does not hide warnings or explicit feedback from `/caffeinate` commands such as `status`, mode changes, help, and manual stop.
+Set `"quiet": true` to hide routine start and release notifications and clear the `caffeinate` status item while active or unavailable.
+Quiet mode does not hide warnings or explicit command feedback.
 It defaults to `false` when omitted.
-The file is read at startup and on `/reload`; run `/reload` after editing it in a running Pi session before using mode commands.
+The file is read at startup and on `/reload`.
+After editing it in a running session, run `/reload` before using mode commands.
 
-Missing, invalid, or deleted settings default back to `display` mode with quiet mode disabled on every supported OS.
+Missing, invalid, or deleted settings use `display` mode with quiet mode off.
 A missing file stays absent until the first successful mode change.
 Within one Pi process, mode saves run in invocation order, reread the latest valid document, and preserve unknown fields.
-Malformed JSON or an invalid recognized field blocks mode saves until repaired instead of being overwritten.
-A failed save keeps the prior runtime mode; if restarting an active inhibitor fails after publication, the extension restores the prior saved mode and inhibitor behavior or reports an explicit rollback failure.
+Malformed JSON or an invalid recognized field blocks saves until repaired.
+A failed save keeps the previous runtime mode.
+If applying a published mode fails while an inhibitor is active, the extension restores the previous saved mode and inhibitor or reports a rollback failure.
 
-Compatibility: older versions used `pi-caffeinate-settings.json`.
-A legacy-only file remains readable with a warning and is never modified automatically; rename it to `pi-caffeinate.json`.
-The first subsequent settings save writes the canonical file.
-If both files exist, `pi-caffeinate.json` wins and the legacy file is ignored.
+Older versions used `pi-caffeinate-settings.json`.
+A legacy-only file remains readable with a warning and is not modified automatically; rename it to `pi-caffeinate.json`.
+The next settings save writes the canonical file.
+If both files exist, `pi-caffeinate.json` takes precedence.
 The legacy filename is deprecated and will be removed in a future major release.
 
 ### Environment variables
@@ -158,8 +168,8 @@ Use a custom inhibitor command:
 PI_CAFFEINATE_COMMAND='systemd-inhibit --what=idle:sleep --why="pi running" --mode=block sleep infinity' pi
 ```
 
-The custom command is parsed with shell-like quoting and is run directly without a shell.
-`PI_CAFFEINATE_COMMAND` takes precedence over the saved mode; `/caffeinate status` reports when a custom command is active.
+The custom command uses shell-like argument parsing but runs directly without a shell.
+`PI_CAFFEINATE_COMMAND` overrides the saved mode, and `/caffeinate status` reports the override.
 
 Deprecated: `PI_CAFFEINATE_ICON` still works for now.
 If you use `@narumitw/pi-statusline`, move the icon to `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-statusline.json`:
@@ -173,19 +183,13 @@ If you use `@narumitw/pi-statusline`, move the icon to `${PI_CODING_AGENT_DIR:-~
 ```
 
 Without `@narumitw/pi-statusline`, keep using `PI_CAFFEINATE_ICON` during the compatibility window.
-In `pi-statusline.json`, use an empty string to show the caffeinate status without an icon.
+In `pi-statusline.json`, use an empty string to show caffeinate status without an icon.
 
-## 🧠 Why use pi-caffeinate?
-
-AI coding agents often run tool-heavy tasks that take several minutes.
-`pi-caffeinate` keeps your machine awake during active Pi work, helping browser automation, local builds, test runs, code generation, and long prompts finish reliably.
-
-The default display-awake mode prioritizes uninterrupted long-running Pi work across platforms, including Linux desktops that require idle inhibition to prevent automatic suspend.
-Use `/caffeinate sleep` (shown as `system-awake` in status output) when you prefer normal screen power saving and your system does not need idle inhibition to keep Pi running.
+Status output calls `display` mode `display-awake` and `sleep` mode `system-awake`.
 
 ## 📦 Dependencies
 
-On Linux, `display` mode uses the `dbus-native` package (pure JavaScript, no native build step) to call `org.freedesktop.ScreenSaver` on the session bus.
+On Linux, `display` mode uses the pure-JavaScript `dbus-native` package to call `org.freedesktop.ScreenSaver` on the session bus.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -2,14 +2,14 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-cbmem)](https://www.npmjs.com/package/@narumitw/pi-cbmem) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-pi-cbmem bundles the Codebase Memory extension and its knowledge-graph operating skill.
+Connect Pi to the local Codebase Memory CLI and give the model graph-first operating guidance.
 
 ## ✨ Features
 
-- Registers all 15 Codebase Memory graph, search, indexing, coverage, trace, and architecture tools.
-- Invokes the local `codebase-memory-mcp` CLI with cancellation, failure reporting, and bounded output.
-- Bundles the `codebase-memory` skill for evidence-tier and graph-first workflows.
-- Keeps the extension and skill available through one package declaration.
+- Registers 15 Codebase Memory tools for graph queries, search, indexing, coverage, tracing, and architecture.
+- Runs the local `codebase-memory-mcp` CLI with cancellation, failure reporting, and bounded output.
+- Bundles the `codebase-memory` skill for graph-first, evidence-tier workflows.
+- Loads the extension and skill from one package.
 
 ## 📦 Install
 
@@ -25,7 +25,7 @@ Try from npm without installing permanently:
 pi -e npm:@narumitw/pi-cbmem
 ```
 
-Build and load the package from a repository checkout:
+Build and load a local checkout from the repository root:
 
 ```bash
 npm --workspace @narumitw/pi-cbmem run build
@@ -35,14 +35,12 @@ pi --no-extensions -e ./packages/pi-cbmem
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
 Pi extensions run with your user permissions.
-
-Review the source before loading the package.
+Install only trusted packages, and review the source before loading this extension.
 
 ## 🚀 Quick start
 
-Install `codebase-memory-mcp` at `~/.local/bin/codebase-memory-mcp`, load the package, and ask Pi a structural codebase question.
-
-The bundled skill tells Pi to check the active graph project before exploration and to verify material claims with graph snippets and index-coverage evidence.
+Install `codebase-memory-mcp` at `~/.local/bin/codebase-memory-mcp`, load pi-cbmem, and ask Pi a structural codebase question.
+The bundled skill directs Pi to identify the active graph project before exploration and verify material claims with snippets and index-coverage evidence.
 
 ## 🛠️ Tools
 
@@ -64,37 +62,26 @@ The extension registers these tools:
 - `manage_adr`
 - `ingest_traces`
 
-Each tool sends JSON arguments to `codebase-memory-mcp cli <tool>` over standard input and returns the last JSON response written to standard output.
-
-Validated JSON output over 2,000 lines is truncated with an explicit omission notice.
-
-Standard output over 50 KB fails safely because the complete JSON response cannot be validated within the bounded capture.
-
-Spawn failures, nonzero exits, oversized output, and missing JSON responses are reported as failed tool calls.
+Each tool sends JSON arguments to `codebase-memory-mcp cli <tool>` over standard input and returns the final JSON response from standard output.
+Validated JSON longer than 2,000 lines is truncated with an omission notice.
+Standard output over 50 KB fails because the extension cannot validate a complete JSON response within its capture limit.
+Spawn failures, nonzero exits, oversized output, and missing JSON responses fail the tool call.
 
 ## 🔒 Security and privacy
 
-The Codebase Memory binary runs with the Pi process environment and user permissions.
-
+The Codebase Memory binary inherits the Pi process environment and user permissions.
 Tool calls can read and index repositories, inspect source, persist graph data, manage architecture decisions and traces, or delete indexed projects.
-
-Deleting a project or replacing its Architecture Decision Records requires explicit confirmation in TUI or RPC mode and is rejected in non-interactive modes.
-
+Deleting a project or replacing all Architecture Decision Records requires explicit confirmation in TUI or RPC mode and is rejected in other modes.
 Repository content returned by graph tools can be sent to the selected model provider as tool output.
-
-Terminal controls are removed only from the TUI rendering boundary; the validated raw result remains available to the model.
-
-The extension starts one local CLI child process per tool call in the active session directory and does not start background work during extension factory load.
-
-Cancelling a tool call terminates its child process.
+Terminal controls are removed at the TUI display boundary, while the validated raw result remains available to the model.
+Each tool call starts one local CLI child process in the active session directory; extension loading starts no background work.
+Cancelling the tool call terminates that child process.
 
 ## 🚧 Limitations
 
-The package expects the binary at `~/.local/bin/codebase-memory-mcp` for the current user.
-
-It does not install or update the Codebase Memory binary.
-
-The extension exposes static tool schemas that match the bundled Codebase Memory skill and delegates final argument validation to the installed CLI.
+- The package requires `~/.local/bin/codebase-memory-mcp` for the current user.
+- It does not install or update the Codebase Memory binary.
+- Static tool schemas match the bundled skill, while the installed CLI performs final argument validation.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -7,34 +7,35 @@
 > Its protocol, identity format, networking behavior, and interaction flow may change between releases.
 > It is not an anonymous or reliable messaging service.
 
-Join ephemeral peer-to-peer chat rooms beside your Pi workflow without putting chat messages into prompts, model context, repositories, or agent output.
+Join ephemeral peer-to-peer chat rooms without leaving Pi.
+Chat messages stay out of prompts, model context, repositories, and agent output.
 
-Pi Chat discovers peers with Hyperswarm and HyperDHT and connects them through encrypted Noise streams.
+Pi Chat uses Hyperswarm and HyperDHT for peer discovery and encrypted Noise streams for direct connections.
 
 ## ✨ Features
 
-- Creates private rooms with bearer invites or joins discoverable public rooms by slug.
-- Shows stable public-key fingerprints beside nicknames so peers can verify identities.
-- Keeps chat in a dedicated composer and visible dock beside the normal Pi editor.
-- Preserves drafts and optionally restores a remembered room and the last selected surface.
-- Signs and relays bounded events over authenticated encrypted peer connections.
-- Stores identity settings privately and cleans up all networking and UI resources on leave or shutdown.
+- Creates private rooms with bearer invites and joins discoverable public rooms by slug.
+- Shows stable public-key fingerprints beside nicknames for identity checks.
+- Keeps chat in a dedicated composer and dock beside the normal Pi editor.
+- Preserves drafts and can restore a remembered room and the last selected surface.
+- Signs and relays bounded events over authenticated, encrypted peer connections.
+- Stores identity settings privately and releases networking and UI resources on leave or shutdown.
 
 ## 📦 Install
 
-Install persistently after the package is published:
+Install persistently:
 
 ```bash
 pi install npm:@narumitw/pi-chat
 ```
 
-Try from npm without installing permanently:
+Run once from npm:
 
 ```bash
 pi -e npm:@narumitw/pi-chat
 ```
 
-Try the extension from a local checkout:
+Build and run a local checkout:
 
 ```bash
 npm --workspace @narumitw/pi-chat run build
@@ -43,16 +44,16 @@ pi --no-extensions --no-skills --no-session -e ./packages/pi-chat
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must be built before Pi loads the package directory.
 
-Load the package only once per Pi process.
-Repeating `-e ./packages/pi-chat` creates duplicate extension instances and suffixed commands such as `/chat:1` and `/chat:2`.
+Load the package only once in each Pi process.
+Repeating `-e ./packages/pi-chat` creates duplicate instances and suffixed commands such as `/chat:1` and `/chat:2`.
 
 Pi extensions execute with your user permissions.
 Review source before installing third-party packages.
 
 ## 🚀 Quick start
 
-Run `/chat`, choose a public or private room, set a nickname, and start chatting.
-Press `Escape` or `Ctrl+C` to return to the Pi editor without leaving the room or losing the chat draft.
+Run `/chat`, choose a public or private room, confirm a nickname, and start chatting.
+Press `Escape` or `Ctrl+C` to return to the Pi editor while staying in the room and keeping the draft.
 
 ## 🧭 Rooms and composer
 
@@ -62,15 +63,16 @@ The `/chat` menu offers these entry actions:
 - **Join public room** accepts a lowercase slug such as `pi-dev`, remembers it after the public-room warning is confirmed, and opens the chat composer.
 - **Join with invite** accepts a private-room invite, then offers **Join and remember**, **Join once**, or **Cancel** before networking starts.
 - **Create private room** generates a random `pichat:v2:…` bearer invite and uses the same explicit persistence choice.
-  Existing `pichat:v1` invite text remains accepted as v2 room input.
+  Existing `pichat:v1` invites remain accepted and map to v2 rooms.
 
 The first join asks for a nickname and joined-room display mode, then previews the generated identity fingerprint and display choice before one atomic save.
 Pi Chat does not read your OS username, Git identity, cwd, repository, or Pi session to fill these values.
 Cancelling creates neither identity settings nor network activity.
 
-A successful remembered join stores the room and `chat` surface atomically.
-On the next Pi start, Pi Chat reconnects and reopens the full composer without another command.
-If you intentionally press Escape or Ctrl+C to return to Pi, it remembers the `pi` surface instead: the next start reconnects in the background and leaves the Pi editor focused.
+A remembered join stores the room and `chat` surface atomically.
+On the next Pi start, Pi Chat reconnects and opens the full composer without another command.
+If you press Escape or Ctrl+C to return to Pi, it remembers the `pi` surface instead.
+The next start then reconnects in the background and keeps the Pi editor focused.
 
 While connected, `/chat` opens the state-aware manager.
 **Open chat in <room>** is selected first, followed by participants, private invite, settings, status, help, and **Leave and forget room** last.
@@ -85,7 +87,7 @@ Inside the dedicated chat composer:
 - `Escape` or `Ctrl+C` returns to Pi/LLM without leaving the room or discarding the chat draft.
 
 The composer retains the draft when no authenticated direct neighbor is available or a relay reaches zero neighbors.
-A successful local message reports how many direct neighbors accepted the first relay; it does not claim room-wide delivery.
+A successful local send reports how many direct neighbors accepted the first relay, not room-wide delivery.
 Signed events may arrive over multiple paths, but each client displays and forwards one `originPublicKey:eventId` only once while it remains in the bounded deduplication window.
 Pi Chat never claims exactly-once delivery, delivery receipts, or offline retry.
 
@@ -218,7 +220,7 @@ Hyperswarm's default DHT depends on public bootstrap infrastructure. “P2P” d
 NAT, UDP blocking, enterprise firewalls, bootstrap availability, peer churn, or a partitioned sparse overlay can prevent connectivity or delivery.
 Pi Chat performs bounded refresh and reconnect work but cannot promise a connection or room-wide delivery.
 
-## 🔒 Privacy, security, and recovery
+## 🔒 Security and privacy
 
 - Noise encrypts direct transport, but DHT infrastructure and direct peers may observe IP addresses, timing, and topic participation metadata.
   Pi Chat does not provide anonymity.
@@ -234,6 +236,8 @@ Pi Chat performs bounded refresh and reconnect work but cannot promise a connect
 - Pi Chat never sends cwd, repository data, Git remotes, Pi sessions, prompts, models, files, or agent output unless a user manually types that information into chat.
 - Chat messages never call Pi message APIs and never enter model context or the main transcript.
 - Deleting `pi-chat.json` loses identity continuity and produces a new fingerprint on the next confirmed join.
+
+### Recovery
 
 If an ordinary join fails, Pi Chat tears down partially opened discovery and sockets and preserves the previous valid settings.
 If startup restore fails, the remembered room is kept and `/chat` shows Retry, Join another room, and Forget recovery actions instead of retrying forever.
@@ -257,10 +261,10 @@ The current experimental release intentionally omits:
 - more than 256 tracked remote participants or 8 direct neighbors per client;
 - automatic transfer of chat content into the Pi editor, transcript, or model context.
 
-The joined room uses a persistent read-only widget while the normal Pi view is active.
-Selecting **Reply in <room>** temporarily opens the full custom chat view instead of a small floating window.
+A joined room uses a persistent read-only widget while the normal Pi view is active.
+Selecting **Reply in <room>** opens the full chat view instead of a small floating window.
 Closing it returns to Pi and the dock without leaving the room.
-The dock and composer reduce message rows before hiding room, connectivity, or input-target status.
+On short terminals, the dock and composer reduce message rows before hiding room, connectivity, or input-target status.
 
 Pi's public extension widget API does not provide generic mouse hit-testing, so the dock is not clickable and Pi Chat registers no global shortcut.
 `/chat` remains the menu-first entrypoint.

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -2,56 +2,62 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-chrome-devtools)](https://www.npmjs.com/package/@narumitw/pi-chrome-devtools) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Let Pi inspect browser tabs, navigate pages, evaluate JavaScript, and capture screenshots through native Chrome DevTools Protocol tools.
+Inspect browser tabs, navigate pages, evaluate JavaScript, and capture screenshots from Pi through the Chrome DevTools Protocol.
 
-Use it for web debugging, UI validation, and browser-assisted investigation without running an MCP server.
+Use these native Pi tools for web debugging, UI validation, and browser-assisted investigation without an MCP server.
 
-The design is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), not guaranteed to be compatible with it.
+The design is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), but compatibility is not guaranteed.
 
 ## ✨ Features
 
 - Lists and selects inspectable pages, navigates URLs, evaluates JavaScript, and captures PNG screenshots.
-- Reuses an existing CDP endpoint or lazily launches an isolated Chromium-family browser.
-- Recovers from stale page selections and reports actionable browser startup or endpoint errors.
+- Reuses an existing CDP endpoint or launches an isolated Chromium-family browser on first use.
+- Recovers from stale page selections and explains browser startup or endpoint failures.
 - Loads explicitly approved unpacked extensions only in an extension-owned Chrome for Testing or Chromium process.
-- Uses native deferred browser tools when supported and eager exposure otherwise, with availability, setup, status, and help through `/chrome-devtools`.
+- Uses native deferred browser tools when supported and exposes allowed tools eagerly otherwise.
+- Provides availability controls, setup guidance, status, and help through `/chrome-devtools`.
 - Shows compact expandable results and activity only while browser tools are running.
 - Persists reviewed tool availability while keeping browser connection settings machine-owned.
 - Offers opt-in experimental WebMCP discovery and invocation through two fixed gateway tools without dynamically registering page-provided definitions.
 
 ## 📦 Install
 
+Install persistently:
+
 ```bash
 pi install npm:@narumitw/pi-chrome-devtools
 ```
 
-Try without installing permanently:
+Run once from npm:
 
 ```bash
 pi -e npm:@narumitw/pi-chrome-devtools
 ```
 
-Build and try this package locally from the repository root:
+Build and run a local checkout from the repository root:
 
 ```bash
 npm --workspace @narumitw/pi-chrome-devtools run build
 pi -e ./packages/pi-chrome-devtools
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+The package declares `dist/index.ts`, so build a local checkout before loading its package directory.
+
+Pi extensions run with your user permissions.
+Review third-party extension source before installing it.
 
 ## 🚀 Quick start
 
-Start Pi and ask the agent to load the Chrome DevTools capability needed for the task.
-The extension first tries `http://127.0.0.1:9222` and otherwise launches an isolated local Chromium-family browser by default.
-Run `/chrome-devtools` to review browser status, settings, help, and available tools.
-Experimental WebMCP remains disabled until the user explicitly enables it.
+Start Pi and ask the agent to load the browser capability needed for the task.
+By default, the extension tries `http://127.0.0.1:9222` and launches an isolated local Chromium-family browser if that endpoint is unavailable.
+Run `/chrome-devtools` to review status, settings, help, and available tools.
+WebMCP remains disabled until you explicitly enable it.
 
 ## 🌐 Browser setup
 
 Without unpacked extensions, the extension first tries `browser.endpoint`, defaulting to `http://127.0.0.1:9222`.
 If that endpoint is unavailable and `browser.autoLaunch` is `true`, it lazily launches an extension-owned browser with an isolated temporary profile and retries the CDP request.
-Existing endpoints are reused and never terminated by the extension.
+The extension reuses existing endpoints and never terminates them.
 
 Configure the canonical user file at `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chrome-devtools.json`:
 
@@ -67,7 +73,7 @@ Configure the canonical user file at `${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-chr
 
 `browser.endpoint` must be an HTTP origin with an explicit port and no credentials, path, query, or fragment.
 Omitting it keeps attach-first behavior on `127.0.0.1:9222` and lets a managed launch use Chrome's dynamic DevTools port mode (`--remote-debugging-port=0`).
-Explicitly saving an endpoint pins managed launches to that port.
+Saving an explicit endpoint pins managed launches to that port.
 `browser.autoLaunch` defaults to `true`.
 `browser.executablePath` is optional and must be an absolute path; when absent, normal browser discovery applies.
 
@@ -144,7 +150,7 @@ Enable WebMCP only in the canonical user settings file:
 
 A project `pi-chrome-devtools.json` cannot enable WebMCP or weaken confirmation policy.
 The settings menu labels WebMCP as experimental, persists the user-owned boolean atomically, and aborts active WebMCP work before disablement or browser replacement.
-The two gateway tools remain unavailable while the gate is disabled even if an older `tools` array contains their names.
+The two gateway tools remain unavailable while WebMCP is disabled, even if an older `tools` array contains their names.
 After enabling the gate, choose whether each gateway is available through `/chrome-devtools tools` or the main menu.
 
 WebMCP requires a Chrome build whose `/json/protocol` exposes the experimental `WebMCP` domain.
@@ -199,9 +205,9 @@ It never closes user-started browsers or remote endpoints.
 
 ### Tool exposure
 
-All eight tools are registered: one loader, five stable DevTools capabilities, and two fixed experimental WebMCP gateways.
+The extension registers eight tools: one loader, five stable DevTools capabilities, and two fixed experimental WebMCP gateways.
 
-On a model/provider with native deferred-tool support, only `chrome_devtools_load` starts active for this extension.
+With native deferred-tool support, only `chrome_devtools_load` starts active.
 
 The loader accepts a task-oriented `query`, matches it against the five stable capabilities plus enabled WebMCP gateways, and adds matching available tools without removing any active Pi tool.
 
@@ -220,7 +226,7 @@ After a session enters eager exposure, it stays eager across later model switche
 The capability tools omit active-only prompt snippets so native deferred loading does not rebuild the system-prompt prefix.
 
 The saved `tools` array controls which capabilities the extension may expose.
-The `webmcp.enabled` gate is applied before that catalog, so persisted WebMCP names cannot bypass a disabled gate.
+The `webmcp.enabled` gate takes precedence, so persisted WebMCP names cannot bypass a disabled gate.
 Page-provided tool definitions appear only in list results and never alter Pi's provider-visible tool definitions.
 
 An empty array leaves the loader active but makes every browser capability unavailable.
@@ -258,7 +264,7 @@ If the model cannot inspect the inline image, ask it to read the saved path, for
 ```
 
 Opens a menu that shows the tool catalog size, whether that catalog is saved, the configured endpoint, the observed managed-browser state, and any settings or launch warning before you choose an action.
-The five actions stay on one level:
+The menu keeps five actions on one level:
 
 - **Choose available browser tools…** — stage any combination of the five stable capabilities and, when enabled, the two experimental WebMCP gateways, then review the exact available/unavailable result before selecting **Apply tool changes**.
 - **Make all browser tools available…** or **Make all browser tools unavailable…** — preview the context-appropriate bulk change before applying it.
@@ -298,7 +304,7 @@ Compatibility aliases remain available: `toggle` and `select` mean `tools`, `on`
 - `disable` makes all capability tools unavailable and saves the empty catalog; `off` is a compatibility alias.
   The slash command and `chrome_devtools_load` remain available.
 
-The menu, `settings`, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode so their result is observable.
+The menu, `settings`, `tools`, `help`, `quickstart`, and `status` require TUI or RPC mode.
 TUI uses keyboard navigation and injected Pi keybindings; RPC receives equivalent standard dialogs.
 In print and JSON modes, interactive and informational routes reject explicitly instead of silently opening unavailable UI.
 The immediate `enable`/`disable` routes remain available for deterministic non-interactive use.
@@ -327,6 +333,18 @@ A legacy-only file remains readable with a warning and is never modified automat
 The first subsequent settings save writes the canonical file.
 If both files exist, `pi-chrome-devtools.json` wins and the legacy file is ignored.
 The legacy filename is deprecated and will be removed in a future major release.
+
+## 🔒 Security and privacy
+
+A CDP connection can inspect and change browser content, execute JavaScript, and access the selected browser profile's authenticated pages.
+Connect only to trusted endpoints and profiles.
+
+The extension never closes an external browser.
+It closes only managed browser processes that it started and removes their temporary profiles on a best-effort basis.
+
+Unpacked extensions run privileged browser code and are loaded only into an isolated managed browser after explicit configuration.
+WebMCP page tools use the visible page's authentication and require confirmation before every call.
+Screenshot output is restricted to the current working directory or OS temporary directory as described above.
 
 ## 🧠 Use cases
 

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -2,11 +2,10 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-codex-compact)](https://www.npmjs.com/package/@narumitw/pi-codex-compact) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Use Codex Remote Compaction V2 in Pi instead of generating a local plaintext summary for models that use the `openai-codex-responses` API.
+Use Codex Remote Compaction V2 in Pi for models that use the `openai-codex-responses` API.
+The extension stores an opaque server-generated checkpoint and replays it in later compatible requests instead of generating a local plaintext summary.
 
-The extension requests and stores an opaque server-generated checkpoint, then safely replays it in later Codex Responses requests.
-
-Pi still decides when compaction runs and retains its normal `/compact`, threshold, overflow, and session-publication behavior.
+Pi still decides when compaction runs and keeps its normal `/compact`, threshold, overflow, and session-publication behavior.
 
 ## ✨ Features
 
@@ -16,7 +15,7 @@ Pi still decides when compaction runs and retains its normal `/compact`, thresho
 - Replays the latest checkpoint while preserving newer conversation and extension context.
 - Supports repeated compaction by carrying the previous checkpoint into the next request.
 - Falls back to Pi's native plaintext compaction on non-cancellation failures.
-- Provides `/codex-compact` for route status, settings, and manual compaction.
+- Provides `/codex-compact` for effective-route status, settings, and manual compaction.
 
 ## 📦 Install
 
@@ -39,9 +38,12 @@ npm --workspace @narumitw/pi-codex-compact run build
 pi -e ./packages/pi-codex-compact
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must be built before Pi loads the package directory.
-Loading the package enables Remote V2 with safe defaults.
-Avoid loading a global npm installation and the local workspace at the same time.
+The package declares `dist/index.ts`, so build a local checkout before loading its package directory.
+Loading the package enables Remote V2 with the documented defaults.
+Do not load a global npm installation and the local workspace at the same time.
+
+Pi extensions run with your user permissions.
+Review third-party extension source before installing it.
 
 ## 🚀 Quick start
 
@@ -60,7 +62,7 @@ When the active model uses another API, compaction remains entirely Pi-native.
 /codex-compact
 ```
 
-In TUI mode, the root menu shows whether Remote V2 is enabled, the active model, and whether a manual compact will use **Codex Remote V2** or **Pi native**.
+In TUI mode, the menu shows whether Remote V2 is enabled, the active model, and whether manual compaction will use **Codex Remote V2** or **Pi native**.
 It contains:
 
 ```text
@@ -110,8 +112,8 @@ Settings reload on every `session_start`, including `/reload`, resume, and fork.
 Menu writes apply immediately, preserve unknown JSON fields, serialize within the current Pi process, and use a final conflict check plus same-directory atomic rename.
 On Unix, temporary files use mode `0600`.
 
-Malformed, invalid, oversized, or symlinked settings files are never overwritten.
-Safe defaults stay active, and the menu provides read-only repair guidance until the file is fixed and Pi is reloaded.
+Malformed, invalid, oversized, or symlinked settings files remain unchanged.
+Defaults stay active, and the menu remains read-only until the file is fixed and Pi is reloaded.
 Separate Pi processes do not share a mutation lock; a detected concurrent edit is rejected so the user can reopen Settings and retry.
 
 ### Relationship to Codex configuration
@@ -183,6 +185,40 @@ These hard byte ceilings are intentionally not configurable.
 - Remote failure falls back to Pi's plaintext summary, so a session can contain both remote opaque and native compaction entries over time.
 - Settings concurrency is coordinated only within one Pi process; separate processes rely on the final conflict check.
 
+## 📊 Benchmark
+
+The repository includes a seeded benchmark that compares uncompressed full context, Pi-native plaintext compaction, and this extension's Remote V2 path.
+
+It keeps history length nearly fixed while varying information density across five state categories and ten history epochs.
+
+Benchmark v3 uses repeated artifacts, isolated evaluator probes, seed-level paired statistics, one Pi SDK estimator for dry and live fixtures, and committed protocol manifests for confirmatory candidates.
+
+It never treats nominal Pi 20K and Codex 20K settings as equal information capacity or automatically claims that protocol-conformant evidence was genuinely held out.
+
+Preview its exploratory diagnostic without making a provider request:
+
+```bash
+just benchmark-codex-compact
+```
+
+A live run requires `--live`, review of the request and cost exposure, OpenAI Codex OAuth, and Remote V2 entitlement.
+
+The repository preserves the explicitly labeled v2 matched-tail diagnostic and the v3 calibration evidence, while seeds 301–304 remain consumed and unavailable for future confirmatory protocols.
+
+See the [benchmark guide](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-codex-compact/benchmark) for manifests, repetitions, commands, privacy, cost semantics, and interpretation limits.
+
+## 🧪 Development
+
+From the repository root:
+
+```bash
+npm --workspace @narumitw/pi-codex-compact run check
+npm test
+just pack codex-compact
+```
+
+See [`docs/implementation-notes/codex-compaction-mechanism.md`](../../docs/implementation-notes/codex-compaction-mechanism.md) for the underlying Codex mechanism research and the extension boundary.
+
 ## 🗂️ Package layout
 
 ```text
@@ -200,40 +236,6 @@ scripts/              Runtime builder
 benchmark/            Three-arm compaction benchmark, self-test, and methodology
 test/                 Protocol, checkpoint, lifecycle, remote, settings, menu, and builder coverage
 ```
-
-## 📊 Benchmark
-
-The repository includes a seeded three-arm benchmark for uncompressed full context, Pi-native plaintext compaction, and this extension's Codex Remote Compaction V2 path.
-
-It holds history length nearly fixed while varying information density across five state categories and ten history epochs.
-
-Benchmark v3 uses repeated artifacts, isolated evaluator probes, seed-level paired statistics, one Pi SDK estimator for dry and live fixtures, and committed protocol manifests for confirmatory candidates.
-
-It never treats nominal Pi 20K and Codex 20K settings as equal information capacity or automatically claims that protocol-conformant evidence was genuinely held out.
-
-Preview its exploratory diagnostic without making a provider request:
-
-```bash
-just benchmark-codex-compact
-```
-
-A live run requires an explicit `--live` flag, reviewed request and cost exposure, OpenAI Codex OAuth, and Remote V2 entitlement.
-
-The repository preserves the explicitly labeled v2 matched-tail diagnostic and the v3 calibration evidence, while seeds 301–304 remain consumed and unavailable for future confirmatory protocols.
-
-See the [benchmark guide](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-codex-compact/benchmark) for manifests, repetitions, commands, privacy, cost semantics, and interpretation limits.
-
-## 🧪 Development
-
-From the repository root:
-
-```bash
-npm --workspace @narumitw/pi-codex-compact run check
-npm test
-just pack codex-compact
-```
-
-See [`docs/implementation-notes/codex-compaction-mechanism.md`](../../docs/implementation-notes/codex-compaction-mechanism.md) for the underlying Codex mechanism research and the extension boundary.
 
 ## 🔎 Keywords
 

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -4,16 +4,16 @@
 [![Pi Extension](https://img.shields.io/badge/Pi-extension-blue)](https://github.com/earendil-works/pi)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Browse project files inside Pi, select exact lines or Git changes, and review every snapshot before it is attached to the next prompt.
+Browse project files in Pi, select exact lines or Git changes, and review each snapshot before attaching it to the next prompt.
 
 ## ✨ Features
 
 - Opens from `/file-context` or a configurable shortcut that defaults to `Ctrl+Shift+X`.
-- Browses discovered project folders hierarchically, searches file names or contents globally, and previews bounded text with line numbers.
+- Browses project folders, searches file names or contents globally, and previews bounded text with line numbers.
 - Adds whole-file references, exact line ranges, changed hunks, revisions, or Git diffs without using the clipboard.
 - Opens the current worktree file in Pi's configured external editor from the preview and reloads it after editing.
 - Shows Git state, blame, bounded file history, provenance, and a deterministic token estimate before attachment.
-- Reviews and removes exact queued snapshots before the next prompt.
+- Reviews and removes queued snapshots before the next prompt.
 - Preserves selection order, supports repeated browsing, skips common generated directories, and never follows symlinks during discovery.
 
 ## 📦 Install
@@ -24,26 +24,29 @@ Install persistently from npm:
 pi install npm:@narumitw/pi-file-context
 ```
 
-Try from npm without installing permanently:
+Run once from npm:
 
 ```bash
 pi -e npm:@narumitw/pi-file-context
 ```
 
-Build and try the local working tree from this repository checkout:
+Build and run the local working tree:
 
 ```bash
 npm --workspace @narumitw/pi-file-context run build
 pi -e ./packages/pi-file-context
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+The package declares `dist/index.ts`, so build a local checkout before loading its package directory.
+
+Pi extensions run with your user permissions.
+Review third-party extension source before installing it.
 
 ## 🚀 Quick start
 
 1. Press `Ctrl+Shift+X` or run `/file-context browse`.
-2. Find a file, use the visible preview hints to edit or select exact lines or Git changes, and press `Enter` to attach the snapshot.
-3. Review queued snapshots from `/file-context`, write the request, and submit normally.
+2. Find a file, select exact lines or Git changes, and press `Enter` to queue the snapshot.
+3. Run `/file-context` to review the queue, then write and submit the request normally.
 
 ## 🧭 Browser workflow
 
@@ -93,14 +96,14 @@ Non-Git quotes retain the original `path` and `lines` attributes exactly.
 Git-backed quotes add ordered optional provenance: the repository HEAD at selection time, branch, file status, selected revision or baseline, tracked blob when available, source kind (`worktree`, `revision`, or `git_diff`), and SHA-256 of the exact attached text.
 HEAD alone does not identify uncommitted content; `content_sha256` identifies the actual snapshot.
 
-Token counts are deterministic byte-based estimates (`ceil(UTF-8 bytes / 4)`), not provider billing guarantees.
+Token counts use the deterministic estimate `ceil(UTF-8 bytes / 4)` and do not predict provider billing.
 Diff context is never attached automatically.
 
 ## ⚙️ Settings
 
 File Context reads optional user settings from `~/.pi/agent/pi-file-context.json`, or the equivalent file under Pi's configured agent directory.
 
-The file is not created when defaults are used.
+Using the defaults does not create the file.
 
 Open `/file-context`, choose **Settings**, then choose **Open shortcut** to change or disable it.
 The Settings action is unavailable while context snippets are selected because applying the shortcut reloads Pi and would otherwise discard those in-memory selections.
@@ -112,7 +115,8 @@ A successful menu save reloads Pi automatically so the new shortcut becomes acti
 }
 ```
 
-Set `openShortcut` to any valid Pi key identifier, or set it to `null` to disable the direct browser shortcut and use `/file-context browse`.
+Set `openShortcut` to a valid Pi key identifier.
+Set it to `null` to disable the shortcut and use `/file-context browse`.
 External editing uses Pi's own `app.editor.external` keybinding and `externalEditor` setting rather than a File Context setting.
 Customize those through Pi's `keybindings.json` and `settings.json`; File Context reads the effective values and does not register a competing external-editor shortcut.
 Use an editor wait option such as `code --wait` when the editor command would otherwise return before editing finishes.
@@ -135,11 +139,11 @@ Explicit `F8` and `Ctrl+Alt+F` values remain supported, but the default is now `
 | --- | --- | --- |
 | `/file-context` | TUI only | Open the Add, Review, Settings, Status, and Help menu. |
 | `/file-context browse` | TUI only | Scan and open the file explorer directly. |
-| `/file-context remove` | TUI only | Open selected-context review directly for compatibility. |
+| `/file-context remove` | TUI only | Open selected-context review directly through the compatibility route. |
 
 Unknown and trailing arguments are rejected.
-RPC receives an observable warning.
-JSON and print modes do not enter interactive UI.
+RPC reports that File Context requires the interactive TUI.
+Print and JSON modes reject the command before opening interactive UI.
 
 ## 🔒 Security and privacy
 
@@ -205,6 +209,7 @@ test/file-context-search.test.ts  File-name ranking, typo tolerance, and query-b
 test/file-context-folder-browser.test.ts  Folder hierarchy, navigation, keybinding, and terminal-safety tests
 test/file-context.test.ts       Filesystem, prompt, lifecycle, shortcut, and explorer tests
 test/file-context-selection.test.ts  Add-and-continue, capacity, and progressive-help tests
+test/file-context-lifecycle.test.ts  Session replacement and shutdown disposal tests
 test/file-context-menu.test.ts  Menu, shortcut settings, exact review, removal, and rendering tests
 test/file-context-command-menu.test.ts  Command routes, loading, and direct browser compatibility tests
 test/pending-quotes.test.ts     Exact selected-context removal, cancellation, and stale-flow tests

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-firecrawl)](https://www.npmjs.com/package/@narumitw/pi-firecrawl) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Give Pi on-demand [Firecrawl](https://www.firecrawl.dev/) tools for web search, scraping, crawling, URL discovery, and retrieval-friendly content extraction.
+Add on-demand [Firecrawl](https://www.firecrawl.dev/) tools to Pi for web search, scraping, crawling, URL discovery, and content extraction.
 
 ## ✨ Features
 
@@ -10,35 +10,40 @@ Give Pi on-demand [Firecrawl](https://www.firecrawl.dev/) tools for web search, 
 - Starts crawl jobs, checks their status, and retrieves completed crawl data.
 - Discovers site URLs and searches the web with optional result-page scraping.
 - Loads only the Firecrawl capabilities needed for the task and manages availability through `/firecrawl`.
-- Supports custom Firecrawl endpoints and shows activity only while a tool is running.
+- Supports custom Firecrawl endpoints and shows status only while a tool is running.
 - Bounds model-visible output while preserving oversized responses in private temporary files.
 - Reads the API key from the environment and never logs, displays, or stores it.
 
 ## 📦 Install
 
+Install persistently:
+
 ```bash
 pi install npm:@narumitw/pi-firecrawl
 ```
 
-Try without installing permanently:
+Run once from npm:
 
 ```bash
 FIRECRAWL_API_KEY=fc-... pi -e npm:@narumitw/pi-firecrawl
 ```
 
-Build and try this package locally from the repository root:
+Build and run a local checkout from the repository root:
 
 ```bash
 npm --workspace @narumitw/pi-firecrawl run build
 FIRECRAWL_API_KEY=fc-... pi -e ./packages/pi-firecrawl
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+The package declares `dist/index.ts`, so build a local checkout before loading its package directory.
+
+Pi extensions run with your user permissions.
+Review third-party extension source before installing it.
 
 ## 🚀 Quick start
 
 Set `FIRECRAWL_API_KEY`, start Pi with the extension, and ask the agent to load the Firecrawl capability needed for the task.
-Use `/firecrawl` to review configuration and control which capability tools may be loaded.
+Run `/firecrawl` to review configuration and choose which capabilities the loader may expose.
 
 ## ⚙️ Settings
 
@@ -55,7 +60,28 @@ export FIRECRAWL_API_URL=https://api.firecrawl.dev/v1
 ```
 
 `FIRECRAWL_BASE_URL` is also accepted for compatibility.
-The extension never logs or displays the API key.
+The API key remains in the environment and is sent only as a bearer credential to the configured Firecrawl endpoint.
+
+Available capability names are saved to:
+
+```text
+${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-firecrawl.json
+```
+
+A missing or invalid file leaves the current Firecrawl availability policy unchanged.
+An unsaved catalog remains stable across runtime reloads.
+A valid catalog is restored on startup and `/reload`, with native deferred or eager exposure chosen from model and provider support.
+The first successful availability change creates a missing file.
+Within one Pi process, saves run in invocation order, reread the latest valid document, and preserve unknown fields.
+Malformed JSON or invalid recognized fields block saves without replacing the file.
+A failed save restores the previous availability and loaded capabilities while preserving other extensions' active tools.
+The file stores only tool names and a timestamp, never `FIRECRAWL_API_KEY`, request headers, or other secrets.
+
+Older versions used `pi-firecrawl-settings.json`.
+A legacy-only file remains readable with a warning and is never modified automatically; rename it to `pi-firecrawl.json`.
+The next settings save writes the canonical file.
+If both files exist, `pi-firecrawl.json` wins and the legacy file is ignored.
+The legacy filename is deprecated and will be removed in a future major release.
 
 ## 🛠️ Tools
 
@@ -68,9 +94,9 @@ The extension never logs or displays the API key.
 
 ### Tool exposure
 
-All six tools are registered.
+The extension registers six tools: one loader and five API capabilities.
 
-On a model/provider with native deferred-tool support, only `firecrawl_load` starts active for this extension.
+With native deferred-tool support, only `firecrawl_load` starts active.
 
 The loader accepts a task-oriented `query`, filters to capabilities allowed by settings, and adds up to three matching tools by default without removing any active Pi tool.
 
@@ -78,7 +104,7 @@ Set `limit` from 1 to 5 to change the maximum number loaded by one call.
 
 A general website-crawl query can load both `firecrawl_crawl` and `firecrawl_crawl_status`, while a status-specific query loads the status capability.
 
-Loaded capability tools remain active for the session unless the user makes them unavailable through `/firecrawl`.
+Loaded capability tools remain active for the current session until you make them unavailable through `/firecrawl`.
 
 On reload, resume, or fork, capabilities recorded by `firecrawl_load` on the active branch are restored when the current catalog still allows them.
 
@@ -104,7 +130,6 @@ Every API capability fails with a clear configuration error when `FIRECRAWL_API_
 
 Tool output is limited to 50 KB or 2,000 lines, whichever is reached first.
 When a response is truncated, the result reports the original and displayed sizes and the path to a complete temporary JSON file.
-These files use private permissions, remain available for the current session, and are removed during session shutdown or reload.
 Tool-result metadata contains only size and artifact information rather than a duplicate of the raw Firecrawl response.
 Oversized Firecrawl error bodies are bounded in the same way.
 
@@ -139,9 +164,9 @@ Direct subcommands are also available:
 - `disable` makes all five API capabilities unavailable and unloads affected active definitions.
   The slash command and `firecrawl_load` remain available.
 
-The menu, `tools`, `help`, `config`, `quickstart`, and `status` routes require TUI or RPC mode so their results are observable.
+The menu, `tools`, `help`, `config`, `quickstart`, and `status` routes require TUI or RPC mode.
 
-Print and JSON modes reject those routes and unknown commands explicitly instead of entering unavailable UI or silently notifying a no-op channel.
+Print and JSON modes reject those routes and unknown commands before entering interactive UI.
 
 The deterministic `enable` and `disable` routes remain available in every mode.
 
@@ -149,25 +174,13 @@ Tool-selector toggles save immediately in user action order.
 
 Done, Escape, or cancellation closes the selector without undoing changes that were already saved.
 
-The available capability names are saved to:
+## 🔒 Security and privacy
 
-```text
-${PI_CODING_AGENT_DIR:-~/.pi/agent}/pi-firecrawl.json
-```
+Firecrawl API tools send requested URLs, options, and related data to the configured API endpoint.
+Review the endpoint's privacy policy before sending private or authenticated URLs.
 
-When the file is missing or invalid, the extension preserves Pi's current Firecrawl availability policy instead of replacing it.
-An unsaved catalog remains stable across runtime reloads.
-A valid saved catalog is restored on Pi startup and `/reload`, with capability definitions exposed natively deferred or eagerly according to model/provider support.
-A missing file is created by the first successful availability change.
-Within one Pi process, catalog saves run in invocation order, reread the latest valid document, and preserve unknown fields.
-Malformed JSON or invalid recognized fields block the save without replacement; a failed save restores both the prior availability and loaded capability state while preserving other extensions' active tools.
-The settings file stores only tool names and a timestamp; it never stores `FIRECRAWL_API_KEY`, request headers, or other secrets.
-
-Compatibility: older versions used `pi-firecrawl-settings.json`.
-A legacy-only file remains readable with a warning and is never modified automatically; rename it to `pi-firecrawl.json`.
-The first subsequent settings save writes the canonical file.
-If both files exist, `pi-firecrawl.json` wins and the legacy file is ignored.
-The legacy filename is deprecated and will be removed in a future major release.
+`FIRECRAWL_API_KEY` is sent as a bearer credential but is never logged, displayed, or stored by the extension.
+Truncated response artifacts use private temporary files, remain available only for the current session, and are removed on shutdown or reload.
 
 ## 🧪 Examples
 

--- a/packages/pi-fleet/README.md
+++ b/packages/pi-fleet/README.md
@@ -6,14 +6,15 @@
 > Pi Fleet is experimental.
 > Its local protocol, terminal automation, tool schemas, and agent-request behavior may change between releases.
 
-Start another Pi process in a terminal split without replacing the current session, then optionally connect trusted local Pi sessions for bounded messages and one-turn requests.
+Launch another Pi process in a terminal split without replacing the current session.
+You can also connect trusted local Pi sessions for bounded notifications and one-turn requests.
 
-Pi Fleet automatically detects tmux, Zellij, or Ghostty, and lets you pin a backend when needed.
+Pi Fleet detects tmux, Zellij, or Ghostty automatically, and you can pin a backend when needed.
 
 ## ✨ Features
 
 - Opens a distinct Pi process in tmux, Ghostty, or Zellij while preserving the parent session.
-- Inherits the cwd, model, thinking level, and an optional first task after a reviewed launch flow.
+- Inherits the cwd, model, thinking level, and optional first task after consent and launch review.
 - Waits for the child to authenticate before reporting that the new session is ready.
 - Connects explicitly joined same-user sessions through owner-only local sockets and ephemeral invites.
 - Delivers notifications without a model turn and bounds each allowed request to one turn.
@@ -22,7 +23,7 @@ Pi Fleet automatically detects tmux, Zellij, or Ghostty, and lets you pin a back
 
 ## 📦 Install
 
-Install persistently after the package is published:
+Install persistently:
 
 ```bash
 pi install npm:@narumitw/pi-fleet
@@ -43,21 +44,21 @@ pi --no-extensions --no-skills --no-session -e ./packages/pi-fleet
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
 
-A child started in any supported terminal backend uses normal Pi extension discovery.
-Install Pi Fleet persistently before testing the complete split-and-auto-join flow because a parent's temporary `-e` argument is not copied into the child process.
+A child started in any supported terminal uses normal Pi extension discovery.
+Install Pi Fleet persistently to test split-and-auto-join because the child does not inherit the parent's temporary `-e` argument.
 
 Pi extensions execute with your user permissions.
 Review extension source before installing it.
 
 ## 🚀 Quick start
 
-Run `/fleet`, choose **New Pi session…**, select a split direction, and optionally provide the first task.
-Pi Fleet asks for one-time experimental consent and shows the configured launch confirmation before creating a split.
+Run `/fleet`, choose **New Pi session…**, select a split direction, and optionally enter a first task.
+Before creating a split, Pi Fleet asks for one-time experimental consent and any configured launch confirmation.
 
 ## 🧭 Launch flow
 
-Choose **Settings** first when you want to pin a terminal backend or change final launch confirmation.
-Pi Fleet otherwise resolves the current supported terminal automatically.
+Use **Settings** to pin a terminal backend or change final launch confirmation.
+With the default settings, Pi Fleet detects the current supported terminal.
 
 After consent and any configured launch confirmation, Pi Fleet:
 
@@ -67,7 +68,8 @@ After consent and any configured launch confirmation, Pi Fleet:
 4. Waits for the child to authenticate and report readiness.
 5. Sends the optional first task through a launch-specific one-time kickoff.
 
-If the terminal creates a split but the child does not become ready, Pi Fleet leaves the visible split open and reports a partial launch instead of closing a potentially useful pane.
+If the terminal creates a split but the child does not become ready, Pi Fleet reports a partial launch.
+It leaves the visible split open instead of closing a potentially useful pane.
 
 ## 🛠️ Tools
 
@@ -83,8 +85,8 @@ Creates a separate Pi process in a terminal split.
 | `name` | No | Child session display name. |
 | `cwd` | No | Existing directory; defaults to the current cwd. |
 
-The tool works only in TUI and RPC modes because Pi Fleet requires experimental consent and may require launch confirmation.
-JSON and print modes fail before creating a group, launcher, or split.
+The tool supports only TUI and RPC modes because launch requires experimental consent and may require confirmation.
+In JSON and print modes, it fails before creating a group, launcher, or split.
 Successful details include `terminal`, `terminalId`, and `terminalVersion`.
 Ghostty results also retain `ghosttyVersion` for compatibility.
 
@@ -98,8 +100,7 @@ Lists or messages sessions in the active Pi Fleet group.
 | `send` | `targetSessionId`, `message`, optional `mode` | Sends `notify` by default or a permitted one-turn `request`. |
 | `reply` | `targetSessionId`, `message`, `replyTo` | Correlates a reply without starting another automatic turn. |
 
-An accepted acknowledgement means the recipient extension accepted or deduplicated the message.
-It does not prove that a remote agent completed the requested work.
+An accepted acknowledgement means the recipient extension accepted or deduplicated the message, not that the remote agent completed the work.
 Rejected and busy acknowledgements use stable codes such as `requests_disabled`, `rate_limited`, `target_busy`, and `delivery_failed`.
 Rate-limited responses may include a bounded retry delay.
 Peer-list text and details share a 40 KiB UTF-8 result budget below Pi's tool-output limit.
@@ -129,10 +130,11 @@ It selects the first complete signature in this fixed order:
 2. Zellij when `ZELLIJ` is non-empty and `ZELLIJ_PANE_ID` is numeric.
 3. Ghostty when `TERM_PROGRAM` is exactly `ghostty`.
 
-This order is deterministic when nested terminals leave more than one signature in the environment, and it may select an outer multiplexer instead of the visually innermost pane.
+When nested terminals leave multiple signatures, this fixed order may select an outer multiplexer instead of the visible inner pane.
 Pi Fleet does not inspect the process tree.
 If no signature matches, Pi Fleet fails before creating a group, launcher, socket, or split and asks the user to enter a supported context or pin a backend.
-After resolution, Pi Fleet preflights only the selected adapter and never switches backends after a version, platform, executable, focus, permission, split, child-startup, or kickoff failure.
+After resolution, Pi Fleet preflights only the selected adapter.
+It does not switch backends after a version, platform, executable, focus, permission, split, child-startup, or kickoff failure.
 
 ### tmux
 
@@ -198,16 +200,17 @@ An explicit `session_spawn.terminal` value strictly overrides `defaultTerminal` 
 Disabling launch confirmation does not disable one-time experimental consent.
 Pi Fleet reads standard terminal context variables only for automatic selection and does not treat them as settings overrides.
 Pi Fleet does not read project settings or extension-specific environment-variable overrides.
-A missing file keeps defaults without creating the file, while each Settings change saves immediately.
-Writes preserve unknown fields, serialize within one Pi process, and publish atomically through a private temporary file and rename.
-Malformed or invalid files are reported and never overwritten by the Settings screen.
-Separately running Pi processes do not share a settings lock, so avoid changing this file concurrently from multiple sessions.
+A missing file uses the defaults without creating the file.
+Each Settings change saves immediately.
+Writes preserve unknown fields, run in order within one Pi process, and publish atomically through a private temporary file and rename.
+The Settings screen reports malformed or invalid files and does not overwrite them.
+Separate Pi processes do not share a settings lock, so do not edit this file concurrently from multiple sessions.
 A Settings change applies immediately in the current process; other running Pi processes reload it on their next session start or `/reload`.
 
 Group secrets, request permission, peers, readiness state, and deduplication state stay in memory except for the short-lived private Zellij launch copy described below.
-The `pifleet:v1` prefix versions the bearer-invite encoding independently from the version-2 socket protocol.
+The `pifleet:v1` prefix versions the bearer-invite encoding separately from the version-2 socket protocol.
 Version-2 messages normally expire after two minutes and cannot declare a lifetime longer than five minutes.
-Accepted message ids remain deduplicated for ten minutes, so their retry window outlives their valid delivery window.
+Accepted message ids remain deduplicated for ten minutes, longer than their valid delivery window.
 A copied invite is still a reusable bearer secret, so discard it or start a new group when you need to rotate access.
 A short-lived in-process handoff preserves a group across `/reload` for the same `sessionManager` only.
 Membership does not carry into `/new`, `/resume`, or another logical session without a new invite.
@@ -226,19 +229,22 @@ Enabling them permits trusted invite holders to start paid model turns that may 
 - Discovery ignores symlinks, non-regular files, oversized manifests, wrong owners, malformed records, endpoint filename mismatches, and incompatible versions.
 - Discovery scans at most 512 directory entries, accepts at most 64 valid manifests, probes at most 16 peers concurrently, and finishes under one overall deadline.
 - Invalid manifests do not consume the valid-peer quota, and bounded non-secret diagnostics distinguish saturation, conflicts, protocol failures, deadlines, and unreachable peers.
-- Every manifest, request, and response is authenticated for its group and endpoint instance, while frames also bind the logical target, claimed sender, clock window, nonce, and request id.
+- Every manifest, request, and response is authenticated for its group and endpoint instance.
+  Frames also bind the logical target, claimed sender, clock window, nonce, and request id.
 - The shared group MAC proves possession of the bearer invite, not a separate cryptographic identity for each peer.
 - A trusted invite holder can claim another session id, so session and endpoint labels are collaboration hints rather than a separate authorization boundary.
-- Launch kickoffs additionally require a random capability shared only through the parent-to-child launch envelope; it is not published through peer discovery or persisted with delivered messages.
+- Launch kickoffs also require a random capability shared only through the parent-to-child launch envelope.
+  It is not published through peer discovery or persisted with delivered messages.
 - Two simultaneously live endpoints claiming one session id are omitted from discovery and rejected as an explicit identity conflict.
 - Bearer invites are shown only on the explicit invite screen or direct join input.
 - Pi Fleet does not retain invites as durable settings or group state, but a recipient can copy and reuse one until every holder discards it or moves to a new group.
 - Invites are not placed in tool output, status, notifications, custom renderers, or model context.
 - Tmux receives launch values through per-pane `-e` arguments and Pi Fleet never publishes them to the tmux global environment.
-- Zellij receives only a launcher path, while launch values briefly exist in a private `0700` launcher that unlinks itself before starting Pi so Zellij command metadata cannot retain them.
+- Zellij receives only a launcher path.
+  Launch values briefly exist in a private `0700` launcher that unlinks itself before starting Pi, so Zellij command metadata cannot retain them.
 - Peer names, paths, messages, model ids, and errors are treated as untrusted terminal text and sanitized only at display boundaries.
 - A same-user process or another privileged Pi extension is outside the security boundary and may inspect process arguments, private runtime files, memory, or environment.
-- Pi Fleet provides explicit group separation, not a sandbox against the operating-system user.
+- Pi Fleet separates groups but does not sandbox them from the operating-system user.
 
 ## 🚧 Limitations
 
@@ -256,7 +262,8 @@ Enabling them permits trusted invite holders to start paid model turns that may 
 - One request uses one short-lived socket connection; there is no persistent multiplexed channel or delivery stream.
 - Server connections use an absolute request deadline rather than an activity-reset timeout, and at most eight message deliveries run concurrently.
 - Per-sender and endpoint-wide rate limits are fixed windows, so a busy response can require waiting before retrying.
-- Old orphan temporary files, private launchers, and sockets are removed after a grace period, while empty private group directories may remain to avoid cross-process startup races.
+- Old orphan temporary files, private launchers, and sockets are removed after a grace period.
+  Empty private group directories may remain to avoid cross-process startup races.
 - No tab, window, resize, focus-navigation, or general layout manager.
 - Multiple Pi sessions can still race while editing the same workspace.
 

--- a/packages/pi-github-pr/README.md
+++ b/packages/pi-github-pr/README.md
@@ -2,17 +2,19 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-github-pr)](https://www.npmjs.com/package/@narumitw/pi-github-pr) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-See the current branch's GitHub pull request number, checks, review state, and discussion count directly in Pi's statusline.
+See the current branch's pull request number, checks, review state, and discussion count in Pi's statusline.
 
-The extension reads only PR metadata and remains passive, with no command, model tool, widget, or injected content.
+The extension reads only GitHub pull request metadata.
+It does not register a command or model tool, render a widget, or inject model context.
 
 ## ✨ Features
 
 - Shows compact PR number, checks, review state, and combined comment/review count.
 - Starts the initial refresh in the background without delaying Pi startup.
-- Refreshes once per minute and after agent turns.
+- Refreshes once per minute, after agent turns, and when the Git branch changes.
+- Keeps a recently merged or closed pull request visible for up to 24 hours.
 - Uses GitHub CLI authentication and repository resolution without storing a token.
-- Never reads or displays discussion bodies, review text, or review threads.
+- Never reads or displays discussion bodies, review text, inline comments, or review threads.
 - Runs without commands, model tools, widgets, webhooks, or a separate service.
 
 Example statusline text:
@@ -30,28 +32,7 @@ When rendered by `pi-statusline`, the `github-pr` icon comes from pi-statusline 
 
 ## 📦 Install
 
-```bash
-pi install npm:@narumitw/pi-github-pr
-```
-
-Try without installing permanently:
-
-```bash
-pi -e npm:@narumitw/pi-github-pr
-```
-
-Try this package locally from the repository root:
-
-```bash
-npm --workspace @narumitw/pi-github-pr run build
-pi -e ./packages/pi-github-pr
-```
-
-An unbuilt local checkout must be built before loading the package directory.
-
-## ⚙️ Prerequisites
-
-Install and authenticate GitHub CLI yourself:
+Install and authenticate GitHub CLI first:
 
 ```bash
 brew install gh
@@ -60,34 +41,59 @@ gh auth login
 gh auth login --hostname github.example.com:8443
 ```
 
-The extension shells out to `gh`; GitHub Enterprise hosts and credential storage are delegated to `gh`.
-It uses the PR URL host (including any port) for follow-up API calls, so no manual `GH_HOST` is required.
+The extension delegates authentication, credential storage, and repository resolution to `gh`.
+It uses the pull request URL host, including its port, for follow-up API calls.
+You do not need to set `GH_HOST` manually.
+
+Install the extension persistently:
+
+```bash
+pi install npm:@narumitw/pi-github-pr
+```
+
+Try the published package without installing it:
+
+```bash
+pi -e npm:@narumitw/pi-github-pr
+```
+
+Build and load a local checkout from the repository root:
+
+```bash
+npm --workspace @narumitw/pi-github-pr run build
+pi -e ./packages/pi-github-pr
+```
+
+The package declares `dist/index.ts`, so Pi cannot load an unbuilt local checkout.
+Pi extensions run with your user permissions.
+Review extension source before installing it.
 
 ## 🚀 Quick start
 
-Start Pi inside a Git worktree after authenticating `gh`.
-The extension automatically shows the current branch's pull request status and does not register a command or model tool.
+Authenticate `gh`, then start Pi in a Git worktree whose current branch has a GitHub pull request.
+The pull request status appears automatically.
 
-## 💬 Behavior
+## 🔄 Refresh behavior
 
 The extension runs passively:
 
-- On session start, it begins checking the current branch PR in the background and sets a compact statusline entry when the check completes.
-- On Git branch change, it clears the old PR immediately and refreshes the new current branch.
-- While the session remains open, it refreshes that same current branch PR every 60 seconds and after each agent turn.
-- When an agent turn is aborted, it keeps the last successful PR status instead of treating cancellation as a GitHub failure.
+- On session start, it checks the current branch in the background without delaying Pi startup.
+- On a Git branch change, it clears the old status immediately and refreshes the new branch.
+- While the session is open, it refreshes every 60 seconds and after each agent turn.
+- If an agent turn is aborted, it keeps the last successful status instead of reporting a GitHub failure.
 - On branch change, session replacement, or session shutdown, it cancels the previous refresh timer and applicable in-flight initialization or refresh request.
 - On session shutdown, it clears the statusline entry.
-- If the directory has no GitHub PR, the statusline entry stays empty.
-- If `gh` is missing or unauthenticated, the statusline shows a short hint such as `PR gh missing` or `PR gh auth`.
+- An open pull request stays visible, while a merged or closed pull request stays visible for at most 24 hours after its terminal timestamp.
+- If the current branch has no GitHub pull request, the statusline entry stays empty.
+- If `gh` is missing or unauthenticated, the statusline shows `PR gh missing` or `PR gh auth`.
 
 ## 🚧 Limitations
 
-- Requires `gh`; there is no direct GitHub API, `GITHUB_TOKEN` fallback, or manual `GH_HOST` requirement.
-- Only the current branch PR is shown; there is no command or tool for arbitrary PR lookup.
-- Comment count uses `gh pr view` comments and reviews, not precise unresolved review-thread counts.
-- It does not read PR comment bodies, review bodies, inline diff comments, or unresolved review-thread text.
-- While a session is open, refresh runs every 60 seconds in addition to session start, branch changes, and agent turns; each refresh invokes `gh pr view` and one GraphQL count query.
+- Requires `gh`; there is no direct GitHub API or `GITHUB_TOKEN` fallback.
+- Shows only the current branch's pull request; arbitrary pull request lookup is not supported.
+- Counts pull request comments and reviews, not unresolved review threads.
+- Does not read pull request comment bodies, review bodies, inline diff comments, or unresolved review-thread text.
+- Each refresh invokes `gh pr view` and one GraphQL count query.
 
 ## 🗂️ Package layout
 
@@ -111,4 +117,5 @@ packages/pi-github-pr/
 
 ## 📄 License
 
-MIT
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -2,13 +2,14 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-goal)](https://www.npmjs.com/package/@narumitw/pi-goal) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Give Pi a session-scoped objective and let it continue from each fully settled idle boundary until the work completes, pauses, waits, or reaches a safety limit.
+Give Pi one session-scoped objective and let it continue after Pi becomes fully idle.
+Goal mode stops when work completes, pauses, waits for an external event, or reaches a safety limit.
 
-Goal mode adds explicit completion, blocker, and external-wait tools so managed execution stops for a clear reason instead of looping blindly.
+Explicit completion, blocker, and wait tools give each managed run a clear stopping reason.
 
 ## ✨ Features
 
-- Starts or manages a session goal through one `/goal` command and direct status, pause, resume, edit, or clear routes.
+- Starts and manages one session goal through `/goal` and its status, pause, resume, edit, and clear routes.
 - Continues exactly once from Pi's settled idle boundary after queued work, retries, and compaction have finished.
 - Waits quietly for a follow-up when transient provider retries are exhausted instead of terminally blocking the Goal.
 - Uses explicit `goal_complete`, `goal_blocked`, and `goal_wait` tools with stale-goal guards and evidence requirements.
@@ -18,7 +19,7 @@ Goal mode adds explicit completion, blocker, and external-wait tools so managed 
 - Keeps Goal continuation accounting out of the leading system instructions so post-activation provider request prefixes remain stable.
 - Persists the goal in the current session across reload, resume, compatible forks, and compaction.
 - Rejects stale continuations and tool calls after replacement, pause, completion, limits, or other terminal state changes.
-- Optionally exposes a default-off run protocol for trusted sibling extensions to start, observe, and cancel one Goal lifecycle.
+- Optionally exposes a default-off protocol for trusted extensions to start, observe, and cancel one Goal lifecycle.
 
 ## 📦 Install
 
@@ -41,12 +42,14 @@ npm --workspace @narumitw/pi-goal run build
 pi -e ./packages/pi-goal
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+The package declares `dist/index.ts`, so Pi cannot load an unbuilt local checkout.
+Pi extensions run with your user permissions.
+Goal mode can start repeated paid model turns and edit the current workspace, so review its limits and source before installing it.
 
 ## 🚀 Quick start
 
-Run `/goal <objective>` to start working toward an objective, or run `/goal` to open the state-aware manager.
-Use the manager to review status, pause, resume, edit, or clear the current goal.
+Run `/goal <objective>` to start Goal mode, or run `/goal` to open the state-aware manager.
+Use the manager to review, pause, resume, edit, or clear the current goal.
 
 ## ⚙️ Settings
 
@@ -65,8 +68,9 @@ When `~/.pi/agent/pi-goal.json` is absent, pi-goal uses these built-in defaults 
 }
 ```
 
-Use `/goal` → **Settings…** in the TUI to create or update the file interactively, or create and edit it directly.
-The standard Settings screen keeps all three controls on one level in task order; the two safety limits open standard choice screens:
+Use `/goal` → **Settings…** in the TUI to create or update the file, or edit it directly.
+The Settings screen shows all three controls on one level.
+The two safety limits open separate choice screens:
 
 - **Automatic-work limit** shows the exact response limit or **Unlimited**.
   Choose **Set response limit…** to edit the current finite value (or the built-in default of 25 when switching from Unlimited), or choose **Unlimited…**.
@@ -74,11 +78,12 @@ The standard Settings screen keeps all three controls on one level in task order
 - **No-progress guard** shows **_N_ runs** or **Off**.
   Choose the default threshold, **Off**, or **Set threshold…** and enter a safe whole number greater than zero.
 - **Managed run RPC** controls whether trusted installed extensions may start and cancel managed Goal runs.
-  It defaults to **Off** and is a cooperation setting, not an extension security sandbox.
+  It defaults to **Off** and controls cooperation, not extension permissions.
 
-Custom number inputs reject zero, negative numbers, decimals, text, and unsafe integers without saving; use the explicit **Unlimited** or **Off** choice instead.
-Interactive changes are serialized, written atomically, preserve unknown fields, and apply to the current runtime.
-A successful change updates the visible state immediately.
+Custom number inputs accept only positive safe integers.
+Choose **Unlimited** or **Off** explicitly instead of entering zero, a negative number, a decimal, or text.
+Interactive changes run in order, publish atomically, preserve unknown fields, and apply to the current runtime.
+A successful save updates the visible state immediately.
 A failed save restores the prior value and reports the settings path so it can be retried.
 Escape returns to the previous screen without reverting changes that were already saved.
 
@@ -88,7 +93,8 @@ Pi-goal never widens a restrictive active-tool policy; activation rejects when r
 The retired `toolVisibility` key is ignored and preserved as unknown data when another setting is saved.
 
 `experimental.goals` is a removed legacy setting.
-If it remains `true`, pi-goal accepts the settings file, ignores the old queue feature, and shows an affected-user warning that recommends `/goal edit` when an active objective exists or `/goal <objectives>` when no active goal exists.
+If it remains `true`, pi-goal accepts the settings file and ignores the old queue feature.
+Affected users see a warning that recommends `/goal edit` for an active objective or `/goal <objectives>` when no goal is active.
 Later settings saves preserve unknown legacy fields instead of deleting them.
 
 `rpc.enabled` accepts a boolean and defaults to `false`.
@@ -97,34 +103,46 @@ A Settings-menu change applies immediately after its atomic save.
 Disabling rejects new starts but lets an already accepted run continue publishing its exact state and accept its exact cancellation until terminal, avoiding stranded work.
 Reload, replacement, and shutdown clear that in-memory ownership.
 
-`continuationLimits` controls the runaway guards:
+`continuationLimits` controls the automatic-work safety guards:
 
 - `automaticTurns` accepts a positive safe integer or `null` and defaults to `25`.
   It counts every completed normal `turn_end` owned by automatically started Goal work, including model responses inside tool loops and matching Pi-owned retries.
   The user-triggered kickoff, resume, edit, and ordinary user runs are not charged.
-  At the limit, the goal becomes `paused` with cause `continuation_limit`, pending continuation/recovery is cancelled, and the current operation is aborted before a 26th normal response starts.
+  At the limit, the goal becomes `paused` with cause `continuation_limit` and pending continuation or recovery is cancelled.
+  The current operation is aborted before a 26th normal response starts.
   Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work.
   Set this field explicitly to `null` to opt into Unlimited mode; existing explicit `null` values remain compatible.
 - `noProgressTurns` is a positive safe integer and defaults to `3`.
-  At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercasing, control-character removal, and whitespace collapse.
+  At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercase conversion, control-character removal, and whitespace collapse.
   Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent.
   Consecutive empty or identical tool-free outputs increment the repeat count.
   Different non-empty output starts a new run at one, and any attempted tool call resets it.
   Set this field to `null` to disable only this heuristic.
 
-Settings are reread at Pi startup, session replacement, and `/reload`; direct external file edits are not watched live, while changes made through the Goal menu apply immediately.
+Settings are reread at Pi startup, session replacement, and `/reload`.
+Direct file edits are not watched, while Goal-menu changes apply immediately.
 A missing file remains absent and uses the built-in defaults.
 The first successful settings change creates the file atomically; later saves preserve unknown fields.
 
 Omitted fields use the defaults above.
 Invalid or malformed existing settings are never overwritten; they produce a warning and fall back to all defaults.
-In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and directs the user to fix it and run `/reload`.
-Reload Pi after changing the file.
+In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and tells you to fix it and run `/reload`.
 
 Plan mode or another restrictive policy may hide Goal tools.
-Pi-goal does not fight that policy on restore or on later turns: activation rejects when required terminal tools are unavailable, and an already-active goal pauses without automatic continuation if they disappear.
-A restrictive allowlist created before `goal_wait` existed can still run ordinary Goals with `goal_complete` and `goal_blocked`, but the model cannot enter external waiting until that allowlist also includes `goal_wait`.
-The pause aborts a Goal-owned kickoff, resume, active-edit, or automatic-continuation prompt, but it does not cancel or stale-block an unrelated user or extension turn, including startup follow-ups after a restrictive restore.
+Pi-goal does not override that policy during restore or later turns.
+Activation fails when required terminal tools are unavailable, and an active goal pauses without automatic continuation if they disappear.
+A restrictive allowlist created before `goal_wait` existed can still run ordinary Goals with `goal_complete` and `goal_blocked`.
+The model cannot enter external waiting until that allowlist also includes `goal_wait`.
+The pause aborts a Goal-owned kickoff, resume, active edit, or automatic-continuation prompt.
+It does not cancel or stale-block unrelated user or extension turns, including startup follow-ups after a restrictive restore.
+
+## 🔒 Security and privacy
+
+Goal mode can start repeated paid model turns and use active Pi tools, including tools that modify the workspace.
+The default automatic-work limit and optional token budget reduce runaway work but are not dollar-cost caps.
+Setting `rpc.enabled` to `true` lets trusted installed extensions request and cancel managed runs through Pi's shared event bus.
+The protocol does not authenticate or sandbox installed extensions.
+Workflow mutual exclusion is cooperative and does not prevent unrelated processes or extensions from editing the same workspace.
 
 ## 🤝 Workflow coexistence
 
@@ -133,12 +151,15 @@ On the characterized Pi `0.84.2` runtime, it participates in the anonymous `work
 An active Goal holds the group through ordinary work, external waiting, continuation delivery, compaction recovery, and provider retry.
 Paused, blocked, usage-limited, budget-limited, complete, cleared, and legacy-queue-only states do not hold it.
 
-Direct starts, menu starts, managed-run starts, stopped resumes, and stopped-goal edits use one final synchronous admission after validation and confirmation but before tool, Goal-state, persistence, prompt, queue, or status mutation.
+Direct starts, menu starts, managed-run starts, stopped resumes, and stopped-goal edits use one final synchronous admission.
+Admission occurs after validation and confirmation but before any tool, Goal-state, persistence, prompt, queue, or status mutation.
 Replacing or editing an already active or waiting Goal retains its current owner.
-If admission is busy, TUI and RPC show an anonymous warning, print and JSON direct routes throw before mutation, and managed-run RPC emits one terminal `ACTIVATION_FAILED` event without creating a Goal.
+If admission is busy, TUI and RPC show an anonymous warning, while print and JSON direct routes throw before mutation.
+Managed-run RPC emits one terminal `ACTIVATION_FAILED` event without creating a Goal.
 
 Restored active Goal state acquires before tool restoration, persistence publication, status, wait timers, retry state, or continuation work.
-If restoration is busy, the Goal moves only to its existing paused safe state, does not change active tools or schedule work, and can be resumed explicitly after the other workflow ends.
+If restoration is busy, the Goal moves only to its existing paused safe state.
+It does not change active tools or schedule work, and you can resume it after the other workflow ends.
 Restored stopped Goals and inert legacy queues do not acquire or schedule automatic work.
 
 An active Goal still pauses if a non-participating restrictive policy later removes its required terminal tools.
@@ -170,14 +191,16 @@ Guaranteed coexistence with Plan mode requires `@narumitw/pi-plan-mode` `0.52.0`
 - In the TUI, `/goal` opens a standard state-aware manager.
   Its first action follows the current state: start when empty, pause when active, review a reached automatic-work limit, resume for other stopped states, or increase an exhausted token budget.
   Active and paused views show **Automatic work: _used_ of _limit_ responses** with the remaining count, or explicitly show **Unlimited**.
-A hard-cap pause opens **Review and continue…**, which states that objective, cumulative usage, and active time are preserved and previews that Continue resets the counter to zero and allows up to one more configured epoch.
-**Change automatic-work limit…** opens that setting while leaving the goal paused; Back and Escape make no change.
-**Start with token budget…** first offers `25k`, a suggested `100k`, `300k`, and **Set a custom budget…**, then collects the objective with the selected budget still visible.
-Custom input accepts examples such as `300000`, `300k`, `2.5k`, and `1.5m`; invalid input retains its draft for correction.
-Status, Settings, Help, invalid-settings guidance, Clear, and Close remain shallow, labeled routes.
-Arrow keys navigate, Enter selects or submits, Escape goes Back, and Ctrl+C closes the full flow.
+  A hard-cap pause opens **Review and continue…** and confirms that the objective, cumulative usage, and active time are preserved.
+  Continuing resets the counter to zero and allows one more configured epoch.
+  **Change automatic-work limit…** opens that setting while leaving the goal paused; Back and Escape make no change.
+  **Start with token budget…** first offers `25k`, a suggested `100k`, `300k`, and **Set a custom budget…**, then collects the objective with the selected budget still visible.
+  Custom input accepts examples such as `300000`, `300k`, `2.5k`, and `1.5m`; invalid input retains its draft for correction.
+  Status, Settings, Help, invalid-settings guidance, Clear, and Close remain shallow, labeled routes.
+  Arrow keys navigate, Enter selects or submits, Escape goes Back, and Ctrl+C closes the full flow.
 - In RPC mode, bare `/goal` and `/goal status` report the current summary through an observable notification without opening terminal UI.
-  Pi exposes no extension-command output channel in print or JSON mode, so those routes reject with an explicit unsupported-mode error instead of misreporting stderr as status output.
+  Pi exposes no extension-command output channel in print or JSON mode.
+  Those routes return an explicit unsupported-mode error instead of treating stderr as status output.
 - Menu-driven Replace and Clear actions preview the exact affected goal and require confirmation.
   Existing direct routes remain immediate for compatibility and automation.
 - `/goal <goal_to_complete>` starts goal mode.
@@ -192,10 +215,13 @@ Arrow keys navigate, Enter selects or submits, Escape goes Back, and Ctrl+C clos
   Failed prompt delivery restores the exact previous Goal, guard id, safety counters, cause, tool-policy snapshot, and active ownership when applicable.
 - `/goal pause` stops prompt injection and auto-continuation, aborts the current turn, and keeps the goal for later resume.
   Only active goals can be paused.
-- `/goal resume` resumes a paused, blocked, usage-limited, or budget-limited goal when its token budget allows it, rotates the stale-turn guard id, resets the automatic-response/repeat safety epoch when the queued resume prompt starts, clears a safety-pause cause, and reports the new finite epoch or explicit Unlimited state.
+- `/goal resume` resumes a paused, blocked, usage-limited, or budget-limited goal when its token budget allows it.
+  When the queued resume prompt starts, pi-goal rotates the stale-turn guard id, resets the automatic-response and repeat safety epoch, and clears a safety-pause cause.
+  The command reports the new finite epoch or explicit Unlimited state.
   Objective, cumulative usage, and elapsed time are preserved.
   If prompt delivery fails, the original stopped state, guard id, counters, fingerprint, and cause are restored.
-- `/goal clear` clears the current goal, status, pending continuation, inert legacy queue state, and legacy persisted state for the current working directory without aborting unrelated in-flight work.
+- `/goal clear` clears the current goal, status, pending continuation, inert legacy queue state, and legacy persisted state for the current working directory.
+  It does not abort unrelated in-flight work.
 
 The experimental ordered-goal queue has been removed.
 Use `/goal edit <objective>` to reprioritize the active objective instead.
@@ -215,14 +241,16 @@ Put longer instructions in a file and reference the file path from `/goal`.
 
 ## 🔁 Session and reload behavior
 
-Goal state is stored as Pi session state, similar to Codex's thread-owned goals.
+Goal state is stored in the current Pi session.
 `/reload` and reopening the same Pi session can restore that session's unfinished goal.
-An active restored goal already at or above its finite automatic-work limit pauses before another provider request and reports that progress is saved; use `/goal` to review and continue.
+An active restored goal at or above its finite automatic-work limit pauses before another provider request and reports that progress is saved.
+Use `/goal` to review and continue.
 A restored waiting Goal remains quiet, excludes offline and waiting wall time from active elapsed time, and restores only its absolute optional deadline timer.
 An active restored goal pauses when workflow admission is busy or either required terminal tool is missing, without changing the active tool set.
 Active elapsed time is checkpointed before shutdown and restarted after reload only when the Goal is not waiting, so offline and stopped wall-clock time is excluded.
 Automatic-response counts, repeat fingerprints, and safety-pause causes persist across reload and compaction.
-A direct non-`/goal` user/RPC input resets the safety epoch only while the goal is active and reclassifies the in-flight run as manual; extension input and messages sent while stopped do not reset it.
+A direct non-`/goal` user or RPC input resets the safety epoch only while the goal is active and reclassifies the in-flight run as manual.
+Extension input and messages sent while stopped do not reset it.
 Starting a new Pi session in the same working directory does not inherit the old goal.
 
 The legacy `{ goal }` shape remains valid, and missing safety fields normalize to zero/defaults.
@@ -253,10 +281,11 @@ This version no longer reads that global file, and `/goal clear` removes any leg
 
 ## 💰 Token budgets and elapsed time
 
-The TUI budget chooser describes token budgets as cumulative Goal usage, warns that the final model call may exceed the chosen value, and keeps the independent automatic-work response limit visible.
-It is not a dollar-cost cap.
+The TUI budget chooser treats a token budget as cumulative Goal usage and keeps the independent automatic-work response limit visible.
+The final model call may exceed the selected token budget, so it is not a dollar-cost cap.
 Choosing a preset or entering a custom value remains provisional until the objective is submitted; cancelling the chooser, custom input, or objective editor creates no Goal.
-**Increase budget and resume…** shows the exact current budget and usage, requires a new total above current usage, previews the new total plus automatic-work epoch, and resumes only after confirmation.
+**Increase budget and resume…** shows the current budget and usage and requires a new total above current usage.
+It previews the new total and automatic-work epoch, then resumes only after confirmation.
 If the goal or its usage changes while that dialog is open, no change is applied.
 
 For each persisted assistant message, `pi-goal` uses finite, non-negative `usage.totalTokens` when available.
@@ -265,12 +294,14 @@ It does not add `reasoning` because reasoning is already part of output, or `cac
 Goal usage is the current branch's cumulative assistant total minus the baseline captured when the goal started, clamped at zero after branch rewinds.
 
 Provider usage becomes authoritative only when an assistant message finishes, so a budget can overshoot by one model call.
-When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`, cancels continuation, recovery, waits, and stale Goal-owned work, aborts the current turn, and releases workflow ownership.
+When completed tool activity first exposes exhaustion, the goal transitions once to `budget_limited`.
+It cancels continuation, recovery, waits, and stale Goal-owned work, aborts the current turn, and releases workflow ownership.
 It does not queue a summary or another model turn after budget exhaustion.
 Stale Goal tool calls remain blocked until an unrelated user or extension turn begins or the Goal is explicitly reactivated.
 A budget-limited Goal cannot call `goal_complete`; raise its budget above current usage and resume or edit it first.
 
-The default 25-response automatic-work limit is a response-count boundary, not a fixed cost ceiling: context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained.
+The default 25-response automatic-work limit is a response-count boundary, not a fixed cost ceiling.
+Context size, cache pricing, output length, and provider rates vary, and the final capped response is still retained.
 Pi derives displayed cost estimates from provider-reported token usage and local model pricing; pi-goal does not query a billing balance or enforce a dollar cap.
 For tighter token control, choose a smaller `automaticTurns` value and/or use `/goal --tokens`; choosing Unlimited removes only the response-count boundary.
 
@@ -281,8 +312,10 @@ Legacy session entries are migrated by preserving their accumulated seconds and 
 ## ✅ How completion works
 
 While a goal is active, Goal-owned messages carry persistence rules and a `<goal_id>` stale-turn guard, and pi-goal exposes `goal_complete`.
-Kickoff, resume, edited-objective, wait-resume, and automatic-continuation prompts all place a trust boundary before the escaped objective, identifying it as user-provided task data; they preserve its full scope across turns and require the agent to derive concrete requirements from the objective and referenced artifacts.
-They treat the current worktree, command output, tests, runtime behavior, PR state, rendered artifacts, and external state as authoritative; previous conversation and plans are context rather than proof.
+Kickoff, resume, edited-objective, wait-resume, and automatic-continuation prompts place a trust boundary before the escaped objective and identify it as user-provided task data.
+They preserve its full scope across turns and require the agent to derive concrete requirements from the objective and referenced artifacts.
+The prompts treat the current worktree, command output, tests, runtime behavior, pull request state, rendered artifacts, and external state as authoritative.
+Previous conversation and plans are context, not proof.
 
 Goal helper names, definitions, and active prompt metadata remain stable across Goal activation, continuation, token accounting, wait resume, completion, and clearing.
 Mode-only positive instructions live in the append-only active Goal contract instead of globally active tool prompt metadata.
@@ -290,12 +323,15 @@ Current token-budget usage is carried by the newly appended Goal prompt instead 
 The first accepted handoff for each Goal identity persists one deterministic hidden Goal contract at the same agent-start boundary, after previously retained conversation history.
 The contract explicitly supersedes earlier Goal contracts, excludes mutable token, iteration, and elapsed-time counters, and stays at its appended history position.
 Editing, replacing, and stopped-state resume append a new superseding active contract without deleting earlier provider input; failed handoff delivery appends no contract.
-Completion, clearing, and stopped transitions append one inactive superseding contract, while compaction and session restore append a missing current-state contract without waking a waiting Goal.
+Completion, clearing, and stopped transitions append one inactive superseding contract.
+Compaction and session restore append a missing current-state contract without waking a waiting Goal.
 These structural guarantees make provider prefix reuse possible, but the provider still decides cache eligibility, cache hits, pricing, and billing.
 
-Before completion, the shared audit tells the agent to treat completion as unproven, inspect requirement-by-requirement evidence for every named artifact, command, test, gate, invariant, and deliverable, and match each check's scope to the requirement it supports.
+Before completion, the shared audit tells the agent to treat completion as unproven.
+The agent must inspect evidence for every named artifact, command, test, gate, invariant, and deliverable and match each check to the requirement it supports.
 Weak, indirect, missing, or merely consistent evidence means work must continue.
-This prompt wording is a behavioral guardrail, not proof by itself: `pi-goal` can enforce the current goal id and reject empty or plainly contradictory summaries, but it cannot independently prove that external work is complete.
+This prompt wording is a behavioral guardrail, not proof.
+Pi-goal can enforce the current goal id and reject empty or plainly contradictory summaries, but it cannot prove that external work is complete.
 
 To finish, the agent must call `goal_complete` with the exact current `goal_id` and a `summary` of completion evidence.
 Missing or stale `goal_id` values are rejected before summary validation.
@@ -303,13 +339,16 @@ Paused, blocked, usage-limited, and budget-limited goals cannot be completed unt
 The summary is completion evidence, not the stale-turn safety token.
 
 If a turn ends before completion, `pi-goal` records usage and creates one continuation intent unless a circuit breaker pauses it first.
-It dispatches that continuation only from Pi's `agent_settled` lifecycle after retries, automatic compaction, steering, and follow-up work have drained, `ctx.isIdle()` is true, and no messages are pending.
+It dispatches that continuation only from Pi's `agent_settled` lifecycle.
+Retries, automatic compaction, steering, and follow-up work must be drained, `ctx.isIdle()` must be true, and no messages may be pending.
 Repeated settled events cannot dispatch the same intent twice.
-Goal-owned kickoff, resume, active-edit, and automatic-continuation deliveries are bound to the goal instance that created them; a delayed prompt from a replaced goal is aborted without rolling back, injecting, or stopping the newer goal.
+Goal-owned kickoff, resume, active-edit, and automatic-continuation deliveries are bound to the goal instance that created them.
+A delayed prompt from a replaced goal is aborted without rolling back, injecting, or stopping the newer goal.
 Plain assistant text never marks a goal complete—even an exact-reply objective pauses safely when the model repeatedly omits `goal_complete`.
 
-Manual compaction does not emit `agent_settled`, so its completion hook uses the same single-flight dispatcher as a narrow idle-only fallback.
-Pi extensions cannot reserve an idle turn atomically like Codex core; another extension can still win the race after the idle check, and its newer turn supersedes the old continuation intent.
+Manual compaction does not emit `agent_settled`, so its completion hook uses the same single-flight dispatcher only when Pi is idle.
+Pi extensions cannot reserve an idle turn atomically like Codex core.
+Another extension can win the race after the idle check, and its newer turn supersedes the old continuation intent.
 
 ## ⏳ External waiting
 
@@ -325,11 +364,13 @@ goal_wait({
 
 `goal_id` must match the current active Goal, `reason` must contain 1–1,000 characters, and the optional `resume_after_ms` must be a whole number from 1 through 2,147,483,647.
 The deadline is a safety wake-up rather than a polling interval.
-Requests below 10,000 milliseconds are accepted for compatibility but clamped to an effective 10,000-millisecond deadline; the tool result reports both the requested and effective values.
+Requests below 10,000 milliseconds are accepted for compatibility but clamped to an effective 10,000-millisecond deadline.
+The tool result reports both the requested and effective values.
 Prefer deadlines measured in minutes instead of repeated short wakes.
 Omitting `resume_after_ms` intentionally permits an indefinite quiet wait.
 
-An accepted call keeps the canonical Goal status active, checkpoints active elapsed time, cancels pending continuation work, persists the reason and absolute optional deadline, and terminates the normal single-tool run.
+An accepted call keeps the canonical Goal status active, checkpoints active elapsed time, and cancels pending continuation work.
+It persists the reason and optional absolute deadline and terminates the normal single-tool run.
 Call `goal_wait` alone because Pi only guarantees early termination when every finalized result in a parallel tool batch terminates.
 
 When Pi exhausts retries for a transient provider error such as HTTP 429, pi-goal enters the same active waiting state without a deadline instead of marking the Goal blocked.
@@ -358,7 +399,12 @@ Editing or replacing a waiting Goal clears the previous wait so the updated obje
 ## 🚧 Blocked goals
 
 `goal_blocked` is intentionally narrower than completion or ordinary clarification.
-Every goal-mode prompt repeats the blocked audit: the model must provide the exact current `goal_id`, a specific reason describing the user or external action required (up to 1,000 characters), concrete evidence from the failed resolution attempts (up to 4,000 characters), and `repeated_turns` showing the same blocker recurred for at least three consecutive goal turns.
+Every goal-mode prompt requires these fields for the blocked audit:
+
+- the exact current `goal_id`;
+- a specific reason, up to 1,000 characters, describing the required user or external action;
+- concrete evidence from failed resolution attempts, up to 4,000 characters;
+- `repeated_turns` showing that the same blocker recurred for at least three consecutive goal turns.
 A resumed goal starts a fresh blocker audit.
 Empty or oversized reasons/evidence, stale ids, non-whole turn counts, stopped goals, and fewer than three turns are rejected.
 Accepted blocker reports set `blocked`, stop automatic continuation, and terminate the tool batch when Pi can do so safely.
@@ -369,9 +415,11 @@ The user can resolve the external condition and run `/goal resume` to rotate the
 ## 🛑 Interruption and queued-input behavior
 
 A user pause or aborted turn produces `paused`; a terminal provider/account quota error produces `usage_limited`; another non-retryable agent error produces `blocked`.
-Each stopped transition cancels pending continuation intent or delivery, aborts stale work when applicable, and blocks stale tool calls until the next non-goal user prompt, successful reactivation/replacement, or `/goal clear`.
+Each stopped transition cancels pending continuation intent or delivery and aborts stale work when applicable.
+Stale tool calls remain blocked until the next non-goal user prompt, successful reactivation or replacement, or `/goal clear`.
 On `/goal clear`, the extension clears goal state, continuation markers, and any stale tool-call block without aborting an unrelated in-flight turn.
-Retryable provider interruptions and overflow compaction retries stay `active` while Pi retries; no extra continuation is queued, and automatic ownership remains charged through retry `agent_start` events.
+Retryable provider interruptions and overflow compaction retries stay `active` while Pi retries.
+No extra continuation is queued, and automatic ownership remains charged through retry `agent_start` events.
 If matching provider recovery still exists at `agent_settled`, retries are exhausted and the Goal enters a deadline-free active wait before any continuation dispatches.
 A later non-Goal input wakes the same Goal without rotating its stale-turn guard, so the model can continue, complete, or enter another wait with the current `goal_id`.
 If matching compaction recovery still exists at `agent_settled`, the Goal becomes `blocked` because recovery did not produce usable context.
@@ -382,7 +430,8 @@ User and extension work that starts before settlement supersedes the older conti
 
 With `rpc.enabled: true`, pi-goal exposes a session-local, dependency-free protocol over Pi's shared `pi.events` bus.
 It is intended for trusted sibling extensions that need to start, observe, and cancel one Goal lifecycle without driving the `/goal` command.
-Installed Pi extensions remain fully privileged: this setting controls only whether pi-goal cooperates with these channels and is not authentication or sandboxing.
+Installed Pi extensions remain fully privileged.
+This setting controls only whether pi-goal cooperates with these channels; it does not provide authentication or sandboxing.
 
 The public channels are:
 
@@ -418,13 +467,14 @@ A successful start produces canonical state on `pi-goal:event:${runId}`:
 }
 ```
 
-Subsequent state events use `active`, `complete`, `blocked`, `paused`, `usage_limited`, `budget_limited`, or `cleared`.
-`complete` is the only successful terminal outcome.
+Later state events use `active`, `complete`, `blocked`, `paused`, `usage_limited`, `budget_limited`, or `cleared`.
+Only `complete` is a successful terminal outcome.
 A matching completion may include `summary`; other terminal outcomes may include `reason`.
 Events come only from canonical Goal persistence and only for the matching managed run.
 Manual and restored Goals are not adopted or broadcast, unchanged persistence does not duplicate a status, and each run emits at most one terminal event.
 
-Terminal events are dispatched after the underlying Goal transition settles, so a listener can start the next managed run directly after `complete` without re-entering completion cleanup.
+Terminal events are dispatched after the underlying Goal transition settles.
+A listener can start the next managed run directly after `complete` without re-entering completion cleanup.
 Other terminal statuses leave a stopped Goal that must be resolved or cleared first.
 If a manual edit, replacement, or edit transition rotates the Goal id, the prior managed run ends as `cleared` with a superseded reason; the replacement remains outside that run.
 
@@ -498,6 +548,7 @@ packages/pi-goal/
 │   ├── markers.ts    # Bounded Goal prompt marker parsing and formatting
 │   ├── run-protocol.ts # Default-off managed-run protocol and session ownership
 │   └── *.ts          # Package-local parsing, settings, prompts, accounting, and persistence
+├── test/
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json

--- a/packages/pi-langfuse/README.md
+++ b/packages/pi-langfuse/README.md
@@ -2,12 +2,12 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-langfuse)](https://www.npmjs.com/package/@narumitw/pi-langfuse) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Trace Pi agent runs, model generations, retries, tools, compaction, usage, and timing in [Langfuse](https://langfuse.com/) through OpenTelemetry.
+Export Pi agent runs, model generations, retries, tools, compaction, usage, and timing to [Langfuse](https://langfuse.com/) through OpenTelemetry.
 
 ## ✨ Features
 
 - Groups each settled agent run into one trace with indexed attempt spans for retries and queued continuations.
-- Records bounded provider requests, final assistant output, identity, TTFT, usage, known costs, and safe response diagnostics.
+- Records bounded provider requests, final assistant output, model identity, time to first content, usage, known costs, and safe response diagnostics.
 - Captures final tool inputs and outputs, progress timing, duration, failures, and structural compaction events.
 - Adds session, context, Git branch, commit, and aggregate counters as searchable metadata.
 - Supports metadata-only tracing when content capture is disabled.
@@ -26,24 +26,26 @@ Try the published package without installing it:
 pi -e npm:@narumitw/pi-langfuse
 ```
 
-Try a local checkout:
+Build and load a local checkout from the repository root:
 
 ```bash
 npm --workspace @narumitw/pi-langfuse run build
 pi -e ./packages/pi-langfuse
 ```
 
-An unbuilt local checkout must be built before loading the package directory.
-The Langfuse v4 SDK requires Node.js 20 or newer.
+The package declares `dist/index.ts`, so Pi cannot load an unbuilt local checkout.
+The installed Langfuse SDK dependencies require Node.js 20 or newer.
+Pi extensions run with your user permissions.
+Review this extension and its data-export behavior before installing it.
 
 ## 🚀 Quick start
 
-Run `/langfuse`, choose the setup action, enter the Langfuse credentials, and restart Pi.
-Subsequent agent runs are traced according to the saved content-capture and metadata settings.
+Run `/langfuse`, choose **Set up Langfuse for this Pi agent directory**, enter your credentials, and restart Pi.
+New agent runs are then traced with the saved content-capture and metadata settings.
 
 ## ⚙️ Settings
 
-Run the interactive manager, then choose **Set up Langfuse for this Pi agent directory** or **Update Langfuse for this Pi agent directory**:
+Run the interactive manager and choose **Set up Langfuse for this Pi agent directory** or **Update Langfuse for this Pi agent directory**:
 
 ```text
 /langfuse
@@ -54,11 +56,12 @@ Leave either key blank to preserve its existing value when updating a valid conf
 Leave the base URL blank to use `https://us.cloud.langfuse.com`.
 The first successful setup creates the file.
 Within one Pi process, updates run in invocation order, reread the latest valid private document, preserve unknown fields, and save atomically with mode `0600`.
-Malformed JSON or invalid recognized fields block setup and update writes until repaired; errors redact entered and stored credentials.
-A failed save leaves the current session and prior file unchanged.
+Malformed JSON or invalid recognized fields block writes until you repair the file.
+Errors redact entered and stored credentials.
+A failed save leaves the current session and previous file unchanged.
 
-Configuration belongs to the displayed Pi agent directory, not just the current conversation.
-Restart each running Pi process after saving; the new connection applies to subsequent sessions in that process.
+Configuration applies to the displayed Pi agent directory, not only the current conversation.
+Restart every running Pi process after saving so later sessions use the new connection.
 `/reload` is not sufficient because the isolated Langfuse runtime is initialized once per process.
 In print or JSON mode, edit the file manually because the interactive manager is unavailable.
 
@@ -84,7 +87,8 @@ Prefer HTTPS because HTTP sends Langfuse credentials and trace content without t
 `environment`, `release`, and `userId` are optional Langfuse trace attributes.
 An environment must match Langfuse's contract: at most 40 lowercase letters, numbers, hyphens, or underscores, and it cannot start with `langfuse`.
 `userId` populates the Langfuse user dimension, which is what the Sessions and Traces views group by; Langfuse accepts at most 200 characters, and leaving it unset reports no user.
-Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata without sending prompts, provider-request snapshots, responses, or tool content.
+Set `captureContent` to `false` to trace timing, model, usage, cost, status, and bounded diagnostic metadata.
+In that mode, pi-langfuse does not export prompts, provider-request snapshots, responses, or tool content.
 
 The extension automatically restricts an existing config file to mode `0600` and refuses to load credentials if that protection cannot be enforced.
 You can also set it explicitly:
@@ -93,9 +97,10 @@ You can also set it explicitly:
 chmod 600 ~/.pi/agent/pi-langfuse.json
 ```
 
-Restart Pi after changing credentials, endpoint, environment, release, or `captureContent`.
+Changes to credentials, endpoint, environment, release, or `captureContent` require a Pi process restart.
 Changes to `userId` apply to new sessions without restarting Pi.
-The isolated OpenTelemetry tracer provider is initialized once per Pi process and selected only for Langfuse; it does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
+The isolated OpenTelemetry tracer provider is initialized once per Pi process and used only for Langfuse.
+It does not replace Pi's process-global provider or send Langfuse observations to another extension's exporter.
 
 ## 🔭 What is traced
 
@@ -148,7 +153,8 @@ Each `pi.llm` generation records:
 - additive input, output, cache-read, cache-write, and total token usage plus known positive input, output, cache-read, cache-write, and total cost buckets;
 - non-additive `pi.usage.reasoning_tokens` and `pi.usage.cache_write_1h_tokens` in metadata so subsets are not double-counted.
 
-The request snapshot is the payload visible at this handler, not a guaranteed final wire payload: later extensions can still replace it.
+The request snapshot is the payload visible to this handler, not a guaranteed final wire payload.
+A later extension can still replace it.
 Final assistant content is reconciled from `turn_end` and `agent_end` after message transformation.
 A recovered sequence such as `429 -> 200` remains queryable in HTTP metadata but is not an error; the final assistant outcome decides generation severity.
 
@@ -162,7 +168,8 @@ Existing `pi.tool.call_id` and `pi.tool.name` correlation fields remain.
 `tool_execution_update` partial-result bodies are never captured.
 Duplicate, parallel, failed, no-progress, and interrupted tools are closed independently.
 
-An active `pi.compaction` records `pi.compaction.reason`, `pi.compaction.will_retry`, `pi.compaction.from_extension`, `pi.compaction.tokens_before`, `pi.compaction.messages_to_summarize`, `pi.compaction.turn_prefix_messages`, `pi.compaction.branch_entries`, and `pi.compaction.is_split_turn`.
+An active `pi.compaction` records its reason, retry state, source, token count, message counts, branch-entry count, and split-turn state.
+The exported field names are `pi.compaction.reason`, `pi.compaction.will_retry`, `pi.compaction.from_extension`, `pi.compaction.tokens_before`, `pi.compaction.messages_to_summarize`, `pi.compaction.turn_prefix_messages`, `pi.compaction.branch_entries`, and `pi.compaction.is_split_turn`.
 It adds `pi.compaction.read_file_count`, `pi.compaction.modified_file_count`, and `pi.compaction.usage.*` / `pi.compaction.cost.*` when Pi reports them.
 It never records the summary, custom instructions, or message bodies.
 Manual compaction outside an active agent trace is ignored; incomplete compaction closes as a warning at settlement or shutdown.
@@ -208,17 +215,19 @@ Available actions depend on that state:
 - **Show setup and privacy help** explains the agent-directory scope, manual configuration path, and content-capture risk.
 
 Connection actions state their agent-directory scope and per-process restart requirement before selection.
-Command arguments are intentionally ignored so remembered subcommands cannot silently bypass the menu.
+For compatibility, command arguments are ignored and cannot select or bypass a menu action.
 Print and JSON modes reject the interactive command with an observable error that includes current tracing state and the manual configuration path.
 
 ## 🔒 Security and privacy
 
 With content capture enabled, traces can contain user prompts, model responses, tool arguments, and tool results.
 These may include source code, file contents, shell output, or other sensitive project data.
-Review your Langfuse retention and access controls before enabling this extension.
+Review Langfuse retention and access controls before enabling the extension.
 
-Git branch names, commit ids, working directory, session/leaf ids, the configured `userId`, model identity, usage/cost, aggregate counts, and allowlisted response-header values are metadata.
-They remain exported when `captureContent` is `false`; branch names and diagnostic header values can themselves contain operational details, and a `userId` may itself be personally identifying if you set it to an email address or a real name.
+Metadata includes Git branch names, commit ids, working directory, session and leaf ids, the configured `userId`, model identity, usage, cost, aggregate counts, and allowlisted response-header values.
+This metadata remains exported when `captureContent` is `false`.
+Branch names and diagnostic header values can contain operational details.
+A `userId` can identify you if you set it to an email address or real name.
 Choose a pseudonymous value when that matters, or leave `userId` unset to export no user at all.
 
 The built-in mask specifically protects Langfuse credentials; it is not a general secret scanner.

--- a/packages/pi-lsp/README.md
+++ b/packages/pi-lsp/README.md
@@ -2,9 +2,8 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-lsp)](https://www.npmjs.com/package/@narumitw/pi-lsp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Give Pi targeted Language Server Protocol diagnostics and source fixes without running a full-project check for every intermediate edit.
-
-Configure any language server by command and file extension instead of using hard-coded language families.
+Give Pi targeted Language Server Protocol diagnostics and source fixes during an edit.
+Configure language servers by command and file extension instead of relying on hard-coded language families.
 
 ## ✨ Features
 
@@ -13,37 +12,6 @@ Configure any language server by command and file extension instead of using har
 - Exposes `lsp_diagnostics` for exact ranges and `lsp_fix` for supported source actions.
 - Supports workspace roots, bounded discovery, per-call server overrides, and preview-or-write edits.
 - Starts servers only for tool calls, shuts them down afterward, and shows activity only while they run.
-
-## 🎯 When to use pi-lsp
-
-Use pi-lsp when an LSP can answer a targeted question about the files being edited faster than the project's authoritative validation commands.
-It is most useful when:
-
-- a full-project lint or typecheck is slow, but only a few files need intermediate feedback;
-- structured diagnostics with exact ranges and severity are easier to act on than CLI output;
-- a language server provides a useful source action such as `source.fixAll` or `source.organizeImports`;
-- a multi-language repository benefits from one configurable interface for targeted diagnostics.
-
-For most repositories, first document the authoritative format, lint, typecheck, build, and test commands in `AGENTS.md`, then enforce them with pre-commit hooks or CI where appropriate.
-If those commands are already fast and reliable, pi-lsp may add little value.
-
-A practical workflow is:
-
-1. Use `lsp_diagnostics` during an edit only when targeted feedback is useful.
-2. Optionally use `lsp_fix` for a supported server-provided source action.
-3. Before considering the task complete, run the repository's authoritative validation commands.
-4. Treat pre-commit hooks and CI as the final enforcement layer.
-
-### Current limitations
-
-- Diagnostics are not continuously injected into the conversation; the agent must call `lsp_diagnostics`.
-- Language servers start and stop for each tool call, so pi-lsp does not retain an editor-like incremental session.
-- The current tools expose diagnostics and source code actions, not symbol navigation, references, or semantic rename.
-- A clean LSP result does not replace the project's formatter, linter, type checker, build, or tests.
-- This project has not yet demonstrated through benchmarks that LSP improves agent task success, latency, or tool usage.
-
-This outcome-first framing is informed by [Eric Traut's comment on LSP integration for coding agents](https://github.com/openai/codex/issues/8745#issuecomment-3713058579).
-The comment explains that the protocol was not designed specifically for coding agents and that repository-native checks may already provide much of the desired verification value.
 
 ## 📦 Install
 
@@ -64,20 +32,44 @@ npm --workspace @narumitw/pi-lsp run build
 pi -e ./packages/pi-lsp
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+The package declares `dist/index.ts`, so Pi cannot load an unbuilt local checkout.
+Pi extensions run with your user permissions.
+Review extension source before installing it.
 
 ## 🚀 Quick start
 
-Install at least one supported language server on `PATH`, then run `/lsp` to inspect command availability.
+Install at least one language server from the built-in catalog on `PATH`, then run `/lsp` to check command availability.
 The agent can call `lsp_diagnostics` for targeted diagnostics and `lsp_fix` for supported source actions.
+
+## 🎯 When to use pi-lsp
+
+Use pi-lsp when a language server can answer a targeted question about the files being edited faster than the project's authoritative checks.
+It is most useful when:
+
+- a full-project lint or typecheck is slow, but only a few files need intermediate feedback;
+- exact diagnostic ranges and severity are easier to act on than CLI output;
+- a server provides a useful source action such as `source.fixAll` or `source.organizeImports`;
+- a multi-language repository benefits from one configurable diagnostics interface.
+
+First document the repository's authoritative format, lint, typecheck, build, and test commands in `AGENTS.md`.
+Use pi-lsp for intermediate feedback, then run those authoritative commands before declaring the task complete.
+If the repository checks are already fast and reliable, pi-lsp may add little value.
+
+A practical workflow is:
+
+1. Call `lsp_diagnostics` when targeted feedback is useful.
+2. Optionally call `lsp_fix` for a server-supported source action.
+3. Run the repository's authoritative validation commands before completion.
+4. Use pre-commit hooks and CI as the final enforcement layer.
 
 ## ⚙️ Settings
 
-If no config is provided, pi-lsp ships a broad catalog of direct-command defaults.
-Servers are started only when matching files are requested. pi-lsp does not download language servers, so install the commands you need and make them available on `PATH`.
-During no-config diagnostics, unavailable default commands are filtered before workspace discovery.
-If none can run, diagnostics completes successfully and reports the skipped servers.
-Explicitly selected or custom-configured missing commands still report an error.
+Without a config file, pi-lsp uses the built-in direct-command catalog below.
+pi-lsp does not download language servers, so install the commands you need and put them on `PATH`.
+A server starts only when a tool call requests a matching file.
+With the built-in catalog, diagnostics skips unavailable default commands before workspace discovery.
+If no default command can run, diagnostics succeeds and reports the skipped servers.
+An explicitly selected or custom-configured missing command still reports an error.
 
 | Language or format | Default server | Startup command | Extensions |
 | --- | --- | --- | --- |
@@ -119,18 +111,20 @@ go install golang.org/x/tools/gopls@latest
 
 Ensure the Go install directory (`$GOBIN` or `$(go env GOPATH)/bin`) is also on `PATH`.
 
-Custom config is resolved in this order:
+pi-lsp resolves configuration in this order:
 
 1. `<workspace>/.pi/pi-lsp.json`, only when Pi trusts the current project
 2. `~/.pi/agent/pi-lsp.json`
 3. the built-in server catalog
 
-An untrusted project's canonical and legacy files are ignored.
-A `root` passed to an LSP tool selects files and the server working directory; it does not grant that directory authority to provide project settings.
+pi-lsp ignores both project files when Pi does not trust the project.
+A tool's `root` selects files and the server working directory; it does not authorize that directory's project settings.
 Project settings always come from the trusted Pi session workspace.
 
-Compatibility: user-scoped `lsp.json` and trusted project-scoped `.pi/lsp.json` remain readable with a warning and are never modified automatically; rename them to their canonical `pi-lsp.json` names.
-New paths take precedence when both names exist.
+For compatibility, pi-lsp still reads user-scoped `lsp.json` and trusted project-scoped `.pi/lsp.json` with a warning.
+It never modifies legacy files automatically.
+Rename them to their canonical `pi-lsp.json` names.
+Canonical paths take precedence when both names exist.
 
 pi-lsp-specific environment settings have been removed.
 Move their values into canonical JSON:
@@ -141,9 +135,9 @@ Move their values into canonical JSON:
 | `PI_LSP_CONFIG=/path/to/file.json` | Move or copy that configuration to one of the canonical paths above |
 | `PI_<SERVER>_LSP_COMMAND` | Set the server's `command` to an argv array, with one string per executable or argument |
 
-`servers[].env` remains supported because it configures the launched LSP child process rather than pi-lsp itself.
+`servers[].env` remains supported because it configures the launched language-server process, not pi-lsp.
 
-Providing custom config replaces the default server map.
+Any custom config replaces the entire built-in server map.
 The following `pi-lsp.json` example intentionally keeps five selected servers:
 
 ```json
@@ -292,7 +286,26 @@ Parameters:
 /lsp
 ```
 
-Shows configured LSP commands and whether each command is available on `PATH`.
+In TUI and RPC modes, it shows each configured LSP command and whether it is available on `PATH`.
+For compatibility, `/lsp` ignores command arguments.
+
+## 🔒 Security and privacy
+
+pi-lsp starts configured language-server commands with your user permissions.
+User config is trusted input, and project config is used only when Pi trusts the current project.
+Review every configured command, argument, environment value, and initialization option before using it.
+A server process inherits Pi's environment and receives any `servers[].env` overrides.
+
+## 🚧 Limitations
+
+- Diagnostics are not injected continuously; the agent must call `lsp_diagnostics`.
+- Language servers start and stop for each tool call, so pi-lsp does not keep an editor-like incremental session.
+- The tools provide diagnostics and source code actions, not symbol navigation, references, or semantic rename.
+- A clean LSP result does not replace the repository's formatter, linter, type checker, build, or tests.
+- This project has not demonstrated through benchmarks that LSP improves agent task success, latency, or tool use.
+
+This guidance is informed by [Eric Traut's comment on LSP integration for coding agents](https://github.com/openai/codex/issues/8745#issuecomment-3713058579).
+The comment notes that repository-native checks may already provide much of the useful verification.
 
 ## 🗂️ Package layout
 
@@ -312,6 +325,7 @@ packages/pi-lsp/
 │   ├── runner.ts
 │   ├── text-edits.ts
 │   └── types.ts
+├── test/
 ├── README.md
 ├── LICENSE
 ├── tsconfig.json

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -2,20 +2,18 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-plan-mode)](https://www.npmjs.com/package/@narumitw/pi-plan-mode) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Explore a codebase, resolve important questions, and produce an implementation-ready plan before Pi is allowed to edit files.
-
-This independently installable extension adds a Codex-like `/plan` collaboration mode that Pi core does not provide.
+Use a Codex-like `/plan` mode to explore a codebase, resolve important questions, and approve an implementation-ready plan before Pi edits files.
 
 ## ✨ Features
 
 - Starts and manages Plan mode through `/plan`, `/plan start`, or `/plan <prompt>`.
-- Keeps Plan helper schemas stable from startup while runtime policy blocks inactive helpers, mutations, and unsafe shell forms.
-- Requires structured questions for important ambiguity and explicit completion for a decision-ready plan.
-- Reviews the complete plan before implementation, export, save, continued planning, or discard.
-- Starts implementation in the planning session or a fresh linked session with the exact approved plan.
-- Persists Plan state and one saved plan across resume and compaction.
-- Exposes statusline state and a configurable Plan tool allowlist, including reviewed native PowerShell inspection on Windows, plus export destination, plan reinjection, shortcut, and thinking level.
-- Cooperates anonymously with Workflow Mutex Protocol v1 participants so only one agent workflow starts in a session.
+- Blocks mutations, inactive helpers, and unsafe shell forms while keeping helper schemas stable.
+- Uses structured questions for important ambiguity and explicit completion for a decision-ready plan.
+- Reviews the complete plan before implementation, export, save, further planning, or discard.
+- Implements in the planning session or a fresh linked session with the approved plan.
+- Restores Plan state and one saved plan across resume and compaction.
+- Configures the Plan tool allowlist, export path, plan reinjection, shortcut, and thinking level.
+- Publishes statusline state and cooperates anonymously with Workflow Mutex Protocol v1 participants.
 
 ## 📦 Install
 
@@ -39,36 +37,13 @@ npm --workspace @narumitw/pi-plan-mode run build
 pi -e ./packages/pi-plan-mode
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
+The package declares `dist/index.ts`, so build an unbuilt local checkout before Pi loads the package directory.
+Install only from sources you trust because Pi extensions run with Pi's permissions.
 
 ## 🚀 Quick start
 
 Run `/plan` to open the state-aware menu, then start Plan mode and ask the agent to inspect and design the change.
 Run `/plan <prompt>` when the first planning request is already known.
-
-## 🧱 Cache-stable mode transitions
-
-Plan and Normal requests share one append-only conversation.
-The extension appends one hidden, model-visible, versioned Plan contract before the first Plan prompt and one Normal contract before the first post-Plan Normal or implementation prompt.
-Ordinary linear turns do not rewrite or duplicate these contracts.
-**Implement here** therefore retains the Plan dialogue, structured questions, assistant tool calls, completion evidence, and `Implement the plan.` kickoff in order.
-**Start fresh and implement** remains the explicit isolation path and transfers only the approved plan plus the Normal mode contract to a linked session.
-
-The `context` hook filters legacy repeated `plan-mode-context` artifacts but preserves current transition messages.
-When compaction removes the effective physical transition, the hook inserts one canonical fallback at a deterministic retained-history boundary.
-Repeated transforms leave that fallback in place instead of moving it to the newest turn.
-An inactive legacy state entry alone does not inject a Normal contract, so sessions that never entered Plan mode keep their ordinary context after resume or reload.
-Manual `/tree` navigation restores branch-owned Plan state and chooses the matching effective contract without navigating automatically or adding a branch summary.
-Pi currently lists hidden custom transition messages in `/tree`; Plan mode rejects those internal targets, so select an adjacent conversation entry instead.
-
-Plan mode registers `plan_mode_question` and `plan_mode_complete` once and keeps their names and definitions stable across Normal, Plan, ready, implementation, and restored workflows.
-Visible helpers do not mean `/plan` is active, and their global descriptions explicitly exclude ordinary planning, the `writing-plans` skill, roadmaps, checklists, and plan-file work.
-Positive helper instructions live only in the latest effective active Plan contract, while inactive or stale calls fail without accepting a plan or opening question UI.
-Plan mode never widens a restrictive active-tool policy; start or restore fails when a required helper is unavailable.
-Stable schemas preserve a cache-eligible prefix but cannot guarantee a hit because provider serialization, cache lifetime, minimum cacheable prefix, implementation details, and session affinity remain external.
-
-The default `thinkingLevel: "inherit"` path also avoids a Plan-specific reasoning-parameter change.
-Choosing a fixed Plan thinking level remains supported, but switching reasoning parameters can prevent provider-side state reuse even when system instructions and tool schemas are stable.
 
 ## 💬 Commands
 
@@ -95,12 +70,12 @@ Use `/plan <prompt>` to enter Plan mode and immediately submit `<prompt>` as the
 The exact argument `start` is reserved for direct activation; longer text such as `/plan start a migration` remains an inline planning prompt.
 The extension does not register a startup flag; run `/plan start` after launch for direct activation.
 
-Use **Choose tools, then start…** or the `/plan tools` compatibility shortcut to choose a session-specific Plan policy override before Planning starts.
+Use **Choose tools, then start…** or the `/plan tools` compatibility shortcut to choose a session-specific Plan policy before planning starts.
 Both routes use the same draft selector: **Done — start with this policy** stores the allowlist and starts the workflow, while cancellation leaves Plan mode off and changes nothing.
 The bounded multi-select shows 10 rows at a time, supports viewport paging, descriptions, and explicit unavailable rows for blocked, currently inactive, or configured but not-yet-registered tools.
 Configured or previously selected names without current metadata appear as pending registration and remain selected for first-request resolution.
 Reopen the picker to refresh tools registered while it was closed because Pi exposes no live tool-registration event.
-In TUI mode, type to fuzzy-search tool names, descriptions, policy, and source metadata; RPC keeps the complete unfiltered list.
+In TUI mode, type to fuzzy-search tool names, descriptions, policy, and source metadata; RPC shows the complete unfiltered list.
 Once Plan mode is active, tools are locked: `/plan` no longer offers tool or Settings actions, and `/plan tools` rejects the request.
 Exit and start a new workflow if a different tool set is required.
 The `plan_mode_question` tool keeps a dedicated model-requested questionnaire instead of using command-menu navigation.
@@ -135,10 +110,11 @@ A failed TUI export retains the draft for correction; RPC reopens its input dial
 Escape returns to the owning menu without writing a file.
 A successful ready-plan export closes the menu and ends Plan mode; saved and active implementation menus close without changing their stored state.
 
-When Plan mode is active, ask the agent to design the change.
-The agent may inspect files and run read-only commands, but it should not edit files or execute the implementation.
-It should explore first, then use structured questions when your preference or a tradeoff materially changes the plan.
-Configure persistent defaults or a one-workflow tool override before activation; Planning and ready menus deliberately keep those controls locked.
+## 🔒 Security and privacy
+
+While Plan mode is active, the policy blocks built-in editing tools and instructs the agent not to edit files or implement the change.
+It should explore first and ask structured questions when a preference or tradeoff materially changes the plan.
+Configure persistent defaults or a one-workflow tool override before activation; active and ready workflows lock those controls.
 
 Plan mode registers `plan_mode_question` and `plan_mode_complete` during extension load and never changes their active status itself.
 Another active-tool policy may hide them, in which case Plan start or restore fails without widening that policy.
@@ -167,7 +143,9 @@ Use canonical cmdlet names because PowerShell aliases are intentionally outside 
 
 A rejected parsed command list or pipeline identifies its first blocked command segment; malformed or unsupported shell syntax reports the complete submitted input instead.
 Tests and builds may still write ignored caches or build artifacts and may execute project-defined hooks; enable or invoke them only when the repository is trusted.
-Both limited-shell policies are extension-level risk reduction, not an OS sandbox or confidentiality boundary.
+Both limited-shell policies reduce risk but do not provide an OS sandbox or confidentiality boundary.
+
+## 🧭 Planning and implementation
 
 `plan_mode_question` follows Codex's `request_user_input` pattern: the agent can ask 1-3 concise questions, each with meaningful options and a free-form Other path.
 In TUI mode, a single question shows its header as plain muted text, submits as soon as its preset or custom answer is confirmed, and does not show tabs, Review, or question-navigation controls.
@@ -280,6 +258,30 @@ During a guaranteed-plan implementation, it removes both the original implementa
 /plan exit
 ```
 
+## 🧱 Cache-stable mode transitions
+
+Plan and Normal requests share one append-only conversation.
+The extension appends one hidden, model-visible, versioned Plan contract before the first Plan prompt and one Normal contract before the first post-Plan Normal or implementation prompt.
+Ordinary linear turns do not rewrite or duplicate these contracts.
+**Implement here** retains the Plan dialogue, structured questions, tool calls, completion evidence, and `Implement the plan.` kickoff in order.
+**Start fresh and implement** is the isolation path and transfers only the approved plan plus the Normal contract to a linked session.
+
+The `context` hook filters repeated legacy `plan-mode-context` artifacts but preserves current transition messages.
+If compaction removes the effective transition, the hook inserts one canonical fallback at a deterministic retained-history boundary.
+Repeated transforms leave that fallback in place instead of moving it to the newest turn.
+An inactive legacy state entry does not inject a Normal contract, so sessions that never entered Plan mode keep their ordinary context after resume or reload.
+Manual `/tree` navigation restores branch-owned Plan state and chooses the matching contract without navigating or adding a branch summary.
+Pi lists hidden transition messages in `/tree`; Plan mode rejects those internal targets, so select an adjacent conversation entry.
+
+Plan mode registers `plan_mode_question` and `plan_mode_complete` once and keeps their names and definitions stable across Normal, Plan, ready, implementation, and restored workflows.
+Visible helpers do not mean `/plan` is active, and their descriptions exclude ordinary planning, the `writing-plans` skill, roadmaps, checklists, and plan-file work.
+Only the latest active Plan contract authorizes the helpers; inactive or stale calls fail without accepting a plan or opening question UI.
+Plan mode does not widen a restrictive active-tool policy; start or restore fails when a required helper is unavailable.
+Stable schemas preserve a cache-eligible prefix but cannot guarantee a hit because provider serialization, cache lifetime, minimum prefix size, implementation details, and session affinity remain external.
+
+The default `thinkingLevel: "inherit"` avoids a Plan-specific reasoning-parameter change.
+A fixed Plan thinking level remains supported, but changing reasoning parameters can prevent provider-side state reuse even when prompts and tool schemas stay stable.
+
 ## 🤝 Workflow coexistence
 
 Plan mode is independently installable and keeps its standalone behavior when no other protocol participant is present.
@@ -316,12 +318,11 @@ Guaranteed coexistence with Goal requires `@narumitw/pi-goal` `0.53.0` or newer 
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit one flat group of five workflow choices: **Plan thinking**, **Plan policy tools**, **Plan reinjection**, **Export destination**, and **Plan mode shortcut**.
+Open **Settings** from an inactive `/plan` menu to edit **Plan thinking**, **Plan policy tools**, **Plan reinjection**, **Export destination**, and **Plan mode shortcut**.
 You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
-`safeSubcommands` remains JSON-only.
-You can change the Plan-mode shortcut with `toggleShortcut` as long as the file remains JSON-only and uses a valid key string.
-The file is optional, is read at session start and reloaded automatically when changed, and is created only after an explicit Settings save or manual edit.
-When omitted, the shortcut is disabled by default.
+`safeSubcommands` is JSON-only.
+The optional file is read at session start, watched for changes, and created only by an explicit Settings save or manual edit.
+The shortcut is disabled when `toggleShortcut` is omitted.
 ```json
 {
   "thinkingLevel": "inherit",
@@ -485,16 +486,12 @@ If both files exist, the canonical filename takes precedence.
 
 This extension maps Codex's `ModeKind::Plan` behavior onto Pi's extension API:
 
-- Plan mode is a conversational collaboration mode, not TODO/progress tracking.
-- `/plan <prompt>` follows Codex behavior by switching to Plan mode before submitting the inline prompt.
-- The agent should use `plan_mode_question` for important non-discoverable preferences or tradeoffs before finalizing.
-- The agent completes with a standalone `plan_mode_complete` tool call instead of relying on semantic prose detection.
-- `update_plan` checklist use is blocked while Plan mode is active.
-- The implementation boundary is explicit: Plan mode appends the Normal contract and lifts its runtime allowlist before saving or starting implementation, while revealed helpers remain active.
-- The default `clear-on-start` policy follows Codex by using ordinary conversation history only; `clear-after-first-run` and `keep` add explicit exact-plan guarantees.
-- Pi extension safety is approximated with tool classification and separate fail-closed filtering for every effective tool named `bash` or `powershell`; other non-built-in tools remain user-selected at user risk because Pi does not expose standardized tool mutability metadata.
-- Plan and Normal instructions are append-only conversation contracts, while helper schemas stay stable from startup and visible helpers remain inactive without the latest effective Plan contract.
-- Unlike native Codex, this extension uses a terminating Pi tool plus an `agent_settled` ready flow; Pi cannot provide sandbox-level enforcement.
+- Plan mode is conversational collaboration, not TODO or progress tracking.
+- `/plan <prompt>` enters Plan mode before submitting the prompt.
+- The agent uses `plan_mode_question` for material preferences and completes with a standalone `plan_mode_complete` call instead of prose detection.
+- `update_plan` is blocked until the explicit implementation boundary restores Normal mode.
+- The default `clear-on-start` policy uses conversation history; `clear-after-first-run` and `keep` add exact-plan guarantees.
+- Append-only Plan and Normal contracts keep helper schemas stable, but Pi's tool policy is risk reduction rather than Codex sandbox enforcement.
 
 ## 🗂️ Package layout
 
@@ -504,7 +501,7 @@ packages/pi-plan-mode/
 ├── scripts/
 │   └── build-runtime.mjs  # Deterministic runtime builder and boundary validator
 ├── src/
-│   ├── index.ts      # Pi package entrypoint
+│   ├── index.ts           # Thin Pi package entrypoint
 │   ├── plan-mode.ts      # Extension registration, mode state, and UI loading boundary
 │   ├── interactive-ui.ts # Lazily loaded interactive menu surface
 │   └── *.ts              # Package-local prompt, policy, question, and message modules

--- a/packages/pi-recall/README.md
+++ b/packages/pi-recall/README.md
@@ -6,9 +6,8 @@
 > Pi Recall is experimental.
 > Its storage format and interaction flow may change between releases.
 
-Save selected user or assistant messages, find them in another Pi session, and quote only the text you choose into a new draft.
-
-Saved content stays local until you explicitly submit a recalled quote.
+Save selected user or assistant messages, find them in another Pi session, and quote them into a new draft.
+Saved content stays local until you submit that draft.
 
 ## ✨ Features
 
@@ -16,9 +15,9 @@ Saved content stays local until you explicitly submit a recalled quote.
 - Recalls by current cwd, current session, or all saved messages.
 - Filters by role and fuzzy-searches message text, role, and session name.
 - Previews the full message before inserting an XML-marked quote at the editor cursor.
-- Never submits recalled text automatically and confirms deletion before changing storage.
-- Stores private versioned JSONL with cross-process locking and atomic replacement.
-- Fails closed for malformed, unsupported, oversized, symlinked, or non-file storage.
+- Inserts recalled text without submitting it and confirms every deletion.
+- Stores private, versioned JSONL with cross-process locking and atomic replacement.
+- Makes malformed, unsupported, oversized, symlinked, or non-file storage read-only.
 
 ## 📦 Install
 
@@ -41,7 +40,8 @@ npm --workspace @narumitw/pi-recall run build
 pi -e ./packages/pi-recall
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must be built before Pi loads the package directory.
+The package declares `dist/index.ts`, so build an unbuilt local checkout before Pi loads the package directory.
+Install only from sources you trust because Pi extensions run with Pi's permissions.
 
 ## 🚀 Quick start
 
@@ -52,11 +52,10 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must be built
 ## 🧭 Recall workflow
 
 1. Type to fuzzy-search saved messages.
-2. Press `Tab` or `Shift+Tab` to change scope, or use the configured `/tree` filter-cycle keys to change the message view.
-3. The default view keys are `Ctrl+O` and `Ctrl+Shift+O`, and the picker shows the active bindings in its help text.
-4. Press `Enter` to open the selected message, or press `Ctrl+D` to review and confirm its deletion directly from the TUI picker.
-5. Preview the message or choose **Quote into draft**.
-6. Add your question or instruction, then submit the draft normally.
+2. Press `Tab` or `Shift+Tab` to change scope.
+3. Use the configured `/tree` filter-cycle keys to change the message view; the defaults are `Ctrl+O` and `Ctrl+Shift+O`.
+4. Press `Enter` to open the selected message, or press `Ctrl+D` to review and confirm deletion from the picker.
+5. Preview or quote the message, then add your instruction and submit the draft normally.
 
 A quoted draft uses this form:
 
@@ -74,7 +73,7 @@ The quote sent to the editor omits cwd, session IDs, entry IDs, session files, a
 
 | Command | Modes | Description |
 | --- | --- | --- |
-| `/recall` | TUI, RPC | Open the Pi Recall manager. Arguments are rejected. |
+| `/recall` | TUI, RPC | Open the Pi Recall manager; arguments are rejected. |
 
 Print and JSON modes reject `/recall` before opening an interactive flow.
 TUI and RPC expose the same save, preview, quote, delete, status, and help capabilities; RPC uses explicit dialogs instead of terminal shortcuts.
@@ -100,13 +99,12 @@ The saved-message TUI has three flat display views:
 - **Assistant only** — only saved assistant messages in the active scope.
 
 The view uses Pi's injected `app.tree.filter.cycleForward` and `app.tree.filter.cycleBackward` bindings, which default to `Ctrl+O` and `Ctrl+Shift+O`.
-Pi Recall does not reuse `/tree`'s direct filter bindings because `Ctrl+D` remains the Recall delete action.
-The active view, filtered count, cursor position, and configured cycle keys remain visible in the picker.
+Pi Recall reserves `Ctrl+D` for deletion instead of reusing `/tree`'s direct filter bindings.
+The picker shows the active view, filtered count, cursor position, and configured cycle keys.
 
-Picker scope, view, and query survive record opening plus cancelled, successful, and failed direct deletion during one `/recall` flow.
-Selection is retained when possible and moves to a neighboring visible record after successful deletion.
-A new `/recall` starts with **Current cwd**, **All messages**, and an empty query.
-RPC continues to ask for scope explicitly and shows the complete scoped list without simulating TUI-only view or search shortcuts.
+Scope, view, query, and selection survive record opening and deletion attempts within one `/recall` flow.
+After successful deletion, selection moves to a neighboring visible record.
+RPC asks for scope explicitly and shows the complete scoped list without TUI-only view or search shortcuts.
 
 ## 🔍 TUI fuzzy search
 
@@ -116,10 +114,9 @@ Search matches complete saved message text, the `user` or `assistant` role, and 
 Matching is case-insensitive and requires every whitespace- or slash-separated token as an ordered subsequence.
 It ranks closer matches first but does not perform typo-edit-distance correction.
 
-The scope, view, query, and current selection survive selected-message navigation during one `/recall` interaction.
-Scope and view changes retain the selected record when it remains visible; otherwise the picker chooses the first ranked or newest visible result.
-A new `/recall` starts with an empty query, **Current cwd**, and **All messages**.
-Queries are limited to 256 UTF-16 code units; an overlong query shows an error and runs no matching.
+Scope and view changes retain the selected record when it remains visible; otherwise the picker chooses the first ranked result, or the newest result for an empty query.
+Each new `/recall` starts with **Current cwd**, **All messages**, and an empty query.
+Queries are limited to 256 UTF-16 code units; an overlong query shows an error and does not run.
 Terminal controls are replaced before matching or display, while ordinary spaces remain available for multi-token queries.
 
 `Ctrl+D`—or the configured `app.session.delete` binding—opens a confirmation identifying the selected record and showing a bounded preview.
@@ -132,7 +129,7 @@ The existing `Enter` → **Delete…** route remains available when a complete s
 RPC continues to show the complete scoped list through explicit dialogs and does not simulate a hidden fuzzy query or terminal shortcut.
 Message timestamps, cwd, session IDs, entry IDs, and local paths are not searchable.
 
-## 🔒 Storage, privacy, and recovery
+## 🔒 Security and privacy
 
 The canonical user file is:
 
@@ -145,15 +142,16 @@ Each line is one active versioned `recall_message` record.
 Records contain the text, role, saved time, original message time, source cwd, source session ID, source entry ID, and optional session name.
 This provenance is shown locally but is excluded from generated quote payloads except for role and original message time.
 
-Pi Recall does not create settings, session custom entries, tools, background processes, watchers, or automatic model context.
-It reads storage only when `/recall` needs it.
+Pi Recall creates no settings, session custom entries, tools, background work, or automatic model context.
+It reads storage only while `/recall` needs it.
 
 Save and delete operations acquire one cross-process lock, reread canonical storage under that lock, and publish a complete JSONL replacement through a unique same-directory `0600` temporary file.
 Lock waiting is abort-aware.
 The canonical file is required to be a regular non-symlink file and is kept at `0600`.
 
 Malformed JSON, duplicate IDs, unknown record types or versions, invalid records, symlinks, and limit violations make storage read-only.
-Fix or move the reported file, then reopen `/recall`; Pi Recall never overwrites invalid storage.
+Fix or move the reported file, then reopen `/recall`.
+Pi Recall never overwrites invalid storage.
 Unknown fields on otherwise valid version-1 records survive later rewrites.
 
 Deleting a message removes it from canonical `pi-recall.jsonl`.
@@ -164,8 +162,7 @@ It is not secure erasure of filesystem blocks, backups, snapshots, temporary cop
 - Eligible sources are `message` entries with role `user` or `assistant` on the active branch.
 - User strings and text blocks are kept; multiple text blocks are joined in source order with newlines.
 - Thinking, tool calls, tool results, images/base64, custom messages, image-only messages, empty text, and abandoned branches are not saved.
-- Markdown, indentation, Unicode, and original line breaks are preserved.
-  Oversized messages are excluded rather than truncated.
+- Markdown, indentation, Unicode, and original line breaks are preserved; oversized messages are excluded rather than truncated.
 - A source message can be saved only once for the same source session ID and entry ID.
 - At most 200 messages may be saved.
 - One message text may contain at most 50,000 UTF-8 bytes.
@@ -181,8 +178,7 @@ The raw stored text is not modified merely for display.
 - No tags, saved-query persistence, message editing, reordering, batch deletion, import/export, automatic expiry, or automatic context injection.
 - No cross-session transcript browser: only previously saved records can be recalled across sessions.
 - Text only; images and tool payloads are deliberately omitted.
-- The custom TUI picker is keyboard-operated.
-  RPC uses sequential dialogs.
+- The custom TUI picker is keyboard-operated; RPC uses sequential dialogs.
 - Scope, view, and search preferences are not persisted; every new `/recall` interaction starts at **Current cwd**, **All messages**, and an empty query.
 
 ## 🗂️ Package layout

--- a/packages/pi-stamp/README.md
+++ b/packages/pi-stamp/README.md
@@ -2,13 +2,12 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-stamp)](https://www.npmjs.com/package/@narumitw/pi-stamp) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Add a quiet right-aligned timestamp after each user and assistant message in Pi's interactive transcript.
-
-Optional details can show response timing, assistant provenance and usage, or tool duration and outcome.
+Add a quiet, right-aligned timestamp after each user and assistant message in Pi's interactive transcript.
+Optionally show response timing, assistant provenance and usage, or tool duration and outcome.
 
 ## ✨ Features
 
-- Shows each message's recorded creation time on a dim right-aligned row.
+- Shows each message's recorded creation time on a dim, right-aligned row.
 - Supports 12/24-hour clocks, seconds, automatic date context, locales, and time zones.
 - Optionally shows response latency, model and provider identity, stop reason, tokens, and estimated cost.
 - Optionally records tool duration and success or error after each complete tool block.
@@ -37,7 +36,8 @@ npm --workspace @narumitw/pi-stamp run build
 pi -e ./packages/pi-stamp
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must be built before Pi loads the package directory.
+The package declares `dist/index.ts`, so build an unbuilt local checkout before Pi loads the package directory.
+Install only from sources you trust because Pi extensions run with Pi's permissions.
 
 ## 🚀 Quick start
 
@@ -65,12 +65,12 @@ Close
 ```
 
 Settings save immediately.
-Mounted compatible stamps reformat on the next render, and future stamps use the same effective values.
+Existing compatible stamps reformat on the next render, and new stamps use the same settings.
 
 ## 💬 Commands
 
-Run `/stamp` in TUI or RPC mode to open the presentation, status, and help menu.
-The command accepts no arguments and rejects print and JSON modes without changing settings.
+Run `/stamp` in TUI or RPC mode to open Settings, Status, and Help.
+The command rejects arguments, print mode, and JSON mode without changing settings.
 
 ## ⚙️ Settings
 
@@ -127,11 +127,9 @@ A fresh process uses defaults while the file is invalid, and a running process r
 Reads and writes are serialized within one Pi process.
 Separate Pi processes do not share a lock, so concurrent saves are last-writer-wins even though each process rereads immediately before atomic publication.
 
-`/stamp` supports TUI and RPC dialog modes.
-Print and JSON command invocations reject without writing ad hoc protocol output.
-Transcript stamps themselves are appended only in TUI mode.
+Transcript stamps are appended only in TUI mode; RPC provides configuration dialogs without adding transcript entries.
 
-## 🕰️ Timestamp and response-timing semantics
+## 🕰️ Timestamp and response timing
 
 - A **user** stamp is the timestamp recorded when Pi creates the submitted user message.
 - An **assistant** clock is the timestamp recorded when Pi creates the response stream/message.
@@ -148,8 +146,9 @@ Transcript stamps themselves are appended only in TUI mode.
   14:32:08 · first 0.8s · total 3.2s
   ```
 
-First content is the first non-empty text, thinking, or tool-call update—not a provider-server timestamp or guaranteed time-to-first-token.
-`first n/a` means Pi finalized the response without such an update; completion time is never substituted.
+First content is the first non-empty text, thinking, or tool-call update observed by Pi.
+It is not a provider-server timestamp or guaranteed time to first token.
+`first n/a` means Pi finalized the response without such an update; completion time is not substituted.
 - If an assistant message invokes tools, response timing ends at the assistant's `message_end` and excludes tool execution even though the assistant stamp appears after the complete tool block.
 - Error and aborted assistant messages use the same local completion boundary.
   Invalid or backwards clock observations degrade to timestamp-only data rather than showing a negative or clamped value.
@@ -163,7 +162,7 @@ Relative labels such as `3m ago` remain unavailable because they would require p
 
 ## 🧾 Assistant provenance and usage
 
-Assistant metadata is captured only when `assistantMetadata` is `"compact"` or `"expanded"` as the assistant stamp is finalized.
+Assistant metadata is captured when the stamp is finalized and only when `assistantMetadata` is `"compact"` or `"expanded"`.
 A compact stamp can look like:
 
 ```text
@@ -180,7 +179,7 @@ requested-alias → provider-response-model · 842 tok
 Expanded mode adds labeled rows for API, provider, requested model, provider-reported response model, stop reason, and each individually reported input/output/reasoning/cache-read/cache-write/total token or estimated-cost field.
 Missing values stay absent; `pi-stamp` never derives a token total, response model, cost, or diagnostic message.
 
-Pi's transcript expansion action (`app.tools.expand`, `Ctrl+O` by default) is the explicit debug view.
+Use Pi's transcript expansion action (`app.tools.expand`, `Ctrl+O` by default) to open the debug view.
 With assistant metadata enabled, it may additionally show the sanitized response ID and at most five diagnostic summaries.
 A summary contains only diagnostic type, error name, and error code.
 Stamp data never copies diagnostic messages, stacks, details, raw payloads, message content, tool arguments, or `textSignature`, `thinkingSignature`, and `thoughtSignature` fields.
@@ -209,11 +208,12 @@ Duplicate, unmatched, malformed, backwards, or excess observations are ignored.
 Pending state is cleared on a new turn, agent cancellation/end, session replacement, reload, and shutdown.
 Tools that were not observed while tool stamps were enabled are not backfilled.
 
-## 🔒 Context and persistence
+## 🔒 Security and privacy
 
-Stamps use Pi custom session entries.
-Pi renders those entries in the interactive transcript but excludes them from model context.
-The extension does not modify user, assistant, or tool-result message content.
+Stamps are Pi custom session entries that appear in the interactive transcript but stay outside model context.
+The extension does not modify user, assistant, or tool-result content.
+
+## 💾 Persistence and compatibility
 
 Message entry compatibility is cumulative:
 
@@ -227,13 +227,14 @@ Message entry compatibility is cumulative:
 Existing versions remain readable.
 Changing settings never rewrites session history.
 Once recorded, a stamp survives `/reload` and session resume while the extension remains loaded.
-Messages and tools created before `pi-stamp` recorded them are not backfilled because Pi's current public API cannot insert a new custom entry into an older position in the session tree.
+Messages and tools created before `pi-stamp` observed them are not backfilled because Pi cannot insert a new custom entry at an older session-tree position.
 
 ## 🚧 Limitations
 
 - Pi does not currently expose a public decorator for built-in message or tool rows, so stamps appear as separate transcript rows rather than inside the original bubble/block.
 - Another extension can append transcript entries at the same lifecycle boundary, so strict visual adjacency between independently loaded extensions is not guaranteed.
-- There are no arbitrary format strings, relative labels, provider-server latency, token/cost estimation beyond Pi's message fields, aggregates, raw diagnostics, or analytics dashboard.
+- There are no arbitrary format strings, relative labels, provider-server latency, aggregates, raw diagnostics, or analytics dashboard.
+- Token and cost values come only from Pi's message fields.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -2,9 +2,8 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-starship)](https://www.npmjs.com/package/@narumitw/pi-starship) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Build a deeply customizable Pi footer with Starship-style TOML, native Pi modules, conditional formats, palettes, and responsive multiline layout.
-
-No `starship` executable or shell prompt is required because this extension parses and renders the footer itself.
+Build a customizable Pi footer with Starship-style TOML, native Pi modules, conditional formats, palettes, and responsive multiline layout.
+The extension parses and renders the footer itself, so it does not need the `starship` executable or a shell prompt.
 
 > **Different package:** The unscoped npm package `pi-starship` delegates to the Starship binary.
 > This package is `@narumitw/pi-starship` and renders Pi-specific modules natively.
@@ -38,14 +37,34 @@ npm --workspace @narumitw/pi-starship run build
 pi -e ./packages/pi-starship
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
-
-Do not enable this together with `@narumitw/pi-statusline`: both own Pi's footer, and Pi does not arbitrate that conflict.
+The package declares `dist/index.ts`, so build an unbuilt local checkout before Pi loads the package directory.
+Install only from sources you trust because Pi extensions run with Pi's permissions.
+Do not enable this with `@narumitw/pi-statusline`: both own Pi's footer, and Pi does not arbitrate that conflict.
 
 ## 🚀 Quick start
 
 Start Pi with the extension to use the built-in footer without creating a settings file.
 Run `/starship` to inspect the footer, choose a preset, or customize the configuration.
+
+## 💬 Commands
+
+| Command | Purpose |
+| --- | --- |
+| `/starship` | Open the current-state menu in TUI mode; show help in RPC |
+| `/starship settings` | Edit, preview, and confirm TOML in TUI; show the file path in RPC |
+| `/starship status` | Show the configuration source, path, and diagnostics in TUI or RPC |
+| `/starship help` | Show command and configuration help in TUI or RPC |
+
+The main menu keeps seven actions on one level: **Customize footer**, **Presets**, **Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**.
+It shows the current source and configuration health.
+Presets, Explain, Modules, and Configuration are menu-only; they do not add textual subcommands.
+Restore is unavailable when there is no document to replace.
+
+The TOML editor, live footer previews, Explain view, module inspector, and configuration reviews use specialized TUI screens.
+Their content and key hints adapt to terminal width and Pi's configured keybindings.
+Escape returns to the previous screen, while Ctrl+C closes the workflow.
+Direct routes reject trailing arguments.
+Print and JSON modes produce no ad hoc output, and footer lifecycle work runs only in TUI mode.
 
 ## ⚙️ Settings
 
@@ -55,7 +74,7 @@ The only configuration source is:
 <getAgentDir()>/pi-starship.toml
 ```
 
-When this file is absent, the extension uses its readable palette-free default without creating the file or parent directory.
+When this file is absent, the extension uses its palette-free default without creating the file or its parent directory.
 The built-in root is the explicit sequence `$brand$model$thinking$directory` `$git_branch$git_status$activity$context$time`; it does not start the opt-in GitHub PR query.
 The first successful settings save creates the file atomically.
 Existing malformed documents are never overwritten.
@@ -69,24 +88,23 @@ Open the interactive menu in TUI mode:
 ```
 
 Choose **Customize footer** to edit the TOML.
-Closing the editor validates the draft and opens an adaptive, scrollable preview whose **Apply changes…**, **Continue editing**, and **Discard draft** actions remain reachable in short or narrow terminals.
-Saving happens only after a separate confirmation.
-Confirmed changes are atomically saved and applied immediately.
-Manual TOML edits load on the next `session_start`, including `/reload` and session replacement.
-Editor cancellation, preview cancellation, component disposal, invalid drafts, write failures, and runtime application failures preserve the previous file and effective footer.
+Closing the editor validates the draft and opens a scrollable preview with **Apply changes…**, **Continue editing**, and **Discard draft**.
+Saving requires separate confirmation, then atomically updates the file and active footer.
+Manual TOML edits load at the next `session_start`, including `/reload` and session replacement.
+Cancellation, disposal, invalid drafts, write failures, and runtime application failures preserve the previous file and footer.
 
 The shallow main menu also exposes **Presets**, **Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**.
 Explain footer uses the current immutable runtime snapshot to list each currently showing non-empty module once with its rendered value and description; it starts no new collection work.
 Modules opens a bounded searchable inspector for every registered module.
 Its textual states distinguish **Showing**, **Empty**, **Disabled**, **Not in format**, and **Unavailable** only when the current footer cannot provide an inspection snapshot.
 Module detail shows the current preview when available, description, root reference and reachability, format variables, style fields, display rules, and the known reason for absent output.
-Both views are read-only and never create or update the settings document.
+Both views are read-only and do not create or update the settings document.
 
 Configuration contains **Overview**, **Effective configuration**, **Settings document**, and **Reload from disk** on one nested level.
 Overview combines state, source, path, health, and bounded diagnostics.
 Effective configuration shows deterministic catalog-ordered public TOML from the normalized state currently in use; comments, unknown fields, parser ASTs, and private runtime selectors are excluded.
 Settings document shows the exact loaded UTF-8 text through a terminal-safe, cell-aware read-only review without changing the raw payload.
-A healthy missing file is shown as **Built-in defaults**, an exact bundled document is shown as its named preset, and **Built-in fallback** is reserved for read or parse errors.
+A missing file is **Built-in defaults**, an exact bundled document uses its preset name, and read or parse errors are **Built-in fallback**.
 Reload from disk reads only after the explicit action, validates and previews the current external state from the existing runtime snapshot, and asks for separate confirmation before changing the active session.
 A deleted document is a valid previewable transition to built-in defaults and creates no file.
 An unchanged document is a no-op, while read or parse failure, cancellation, disposal, external changes after preview, session replacement, shutdown, or runtime apply failure preserves the prior effective footer and every file byte.
@@ -116,16 +134,15 @@ Colors, separators, typography, and layout follow the named Starship preset; mod
 | **Pure Preset** | Clean two-line workspace and session context | Standard Unicode |
 | **Tokyo Night** | Connected cool blue Tokyo Night blocks | Nerd Font |
 
-The preset cursor is a live footer preview.
-Opening the picker and moving with Up/Down, Page Up/Down, Home, or End temporarily renders the selected preset in the actual footer without writing settings or starting new collectors.
-Press Enter to start the named preset's replacement confirmation, or press `e` to customize the selected complete TOML document before its normal editor preview and confirmation.
-Escape returns to the main menu, while Ctrl+C closes the complete workflow; both restore the previously effective footer.
+Moving through the preset picker temporarily renders the selected preset in the footer without writing settings or starting collectors.
+Press Enter to confirm replacement, or press `e` to edit the selected complete TOML document before preview and confirmation.
+Escape returns to the main menu, while Ctrl+C closes the workflow; both restore the active footer.
 
 Presets are complete documents, not overlays.
-Applying one replaces `pi-starship.toml`, including custom settings, unknown fields, and comments, only after a separate confirmation; no post-success backup is kept.
-Cursor movement, confirmation cancellation, disposal, validation failure, write failure, and runtime-apply failure retain the previous valid document and effective footer.
-Exact unedited matches are shown as **Currently applied** and cannot be redundantly selected; editing any byte makes the document custom again.
-**Restore built-in…** remains the deterministic recovery path.
+After confirmation, applying one replaces all of `pi-starship.toml`, including custom settings, unknown fields, and comments; no backup is kept.
+Cancellation, disposal, validation failure, write failure, and runtime-apply failure preserve the previous document and footer.
+An exact match is **Currently applied** and cannot be selected again; editing any byte makes it custom.
+Use **Restore built-in…** for deterministic recovery.
 
 The bundled presets use only pi-starship's local Pi and Git snapshot modules.
 They do not enable the GitHub PR query, cloud/deployment readers, or optional command-backed workspace collectors.
@@ -210,8 +227,9 @@ Icon matching uses the exact key, the longest `:*` wildcard, a leading status em
 An empty configured icon suppresses only the icon.
 `foo:*` matches `foo:server` but not `foo`, `foobar`, or `foo/server`.
 
-Pi does not expose which package owns a status, so exact raw keys are the reliable third-party contract. pi-starship does not inspect installed packages, infer package aliases, assign icons to known extensions, or bridge compatibility keys.
-Extension authors may adopt `<extension-id>` or `<extension-id>:<stable-slot>` for interoperability, but pi-starship does not require that convention.
+Pi does not expose status ownership, so exact raw keys are the reliable third-party contract.
+pi-starship does not inspect installed packages, infer aliases, assign known-extension icons, or bridge compatibility keys.
+Extension authors may use `<extension-id>` or `<extension-id>:<stable-slot>` for interoperability, but pi-starship does not require it.
 
 **Icon migration:** configurations that relied on package-ID aliases, built-in known-extension icons, or compatibility mappings must use an exact raw status key, an explicit namespace wildcard, a leading emoji in the status value, or `fallback`.
 
@@ -263,7 +281,7 @@ Invalid literal style expressions warn and render unstyled.
 An invalid root format falls back to the built-in root format; an invalid module format or catalog-owned style field falls back only at that field's module scope.
 `/starship status` reports warnings.
 
-The background-free direct defaults are: `brand = "bold white"`, `provider`/`model` = `"bold blue"`, `thinking`/`git_branch`/`turn` = `"bold purple"`, `directory`/`git_worktree` = `"cyan bold"`, `github_pr = "bold blue"`, `git_commit = "green bold"`, `git_state`/`activity`/`time` = `"bold yellow"`, `git_status = "red bold"`, `tokens = "bold cyan"`, `cache = "bold green"`, `extension_status = "dimmed white"`, `direnv = "bold bright-yellow"`, and `fill = "bold black"`.
+The background-free defaults are: `brand = "bold white"`, `provider`/`model` = `"bold blue"`, `thinking`/`git_branch`/`turn` = `"bold purple"`, `directory`/`git_worktree` = `"cyan bold"`, `github_pr = "bold blue"`, `git_commit = "green bold"`, `git_state`/`activity`/`time` = `"bold yellow"`, `git_status = "red bold"`, `tokens = "bold cyan"`, `cache = "bold green"`, `extension_status = "dimmed white"`, `direnv = "bold bright-yellow"`, and `fill = "bold black"`.
 Context, cost, Git metrics, and username use the state/multi-style defaults below.
 
 ### Thinking level styles
@@ -390,7 +408,6 @@ There is no hidden compatibility overlay or automatic migration.
   The module name remains `context`, not `context_usage`.
 - Subscription-backed OAuth models and `kimi-coding` set cost `$subscription` to `(sub)`.
   The dollar value is usage cost, not proof of an amount billed under a subscription.
-- Pi's public extension API does not expose the current auto-compaction toggle, so pi-starship cannot reliably provide the native `(auto)` marker.
 
 ### Directory, Git, and environment contraction
 
@@ -454,7 +471,7 @@ An exact alias is selected before the built-in Claude/GPT shortening rules, then
 `truncation_length` counts model grapheme clusters retained before the symbol; `0` disables truncation and is the default.
 The direction names the removed portion: `start` retains the suffix, `end` retains the prefix and is the default, and `middle` retains both ends.
 When no alias matches, truncation runs after the built-in Claude/GPT shortening rules.
-It always changes display only—the provider model ID is untouched.
+Truncation changes display only; the provider model ID is untouched.
 Terminal control sequences in model IDs and truncation symbols are removed at render time.
 An empty symbol truncates without a marker.
 
@@ -478,6 +495,8 @@ In a linked worktree it defaults to the top-level directory name; use `$path` wh
 `git_commit`, `git_state`, and `git_metrics` are intentionally not present in the built-in root format.
 Add their variables to `format` to opt in; also set `[git_metrics].disabled = false`, matching Starship's opt-in metrics default.
 `$tag` resolves only an exact tag on HEAD and is queried only when the configured `git_commit` format references it.
+
+## 🔒 Security and privacy
 
 ### 🔎 Native GitHub pull requests
 
@@ -559,7 +578,7 @@ Branch changes clear the old PR before querying the new branch.
 Closed and merged PRs remain visible for 24 hours, then expire without waiting for the next refresh.
 Missing `gh`, missing authentication, no current PR, timeout, malformed or oversized output, and network failures all render an empty module without exposing raw errors or credentials.
 
-The query sends the repository/current-branch context through authenticated `gh` to the GitHub host configured by the repository.
+The query sends the repository and current branch through authenticated `gh` to the repository's configured GitHub host.
 It requests only the fields above—never comments, review bodies, inline comments, or review threads.
 Footer rendering and previews read only the immutable cached snapshot and perform no network or subprocess work.
 
@@ -604,8 +623,8 @@ Names and paths are control-sanitized and bounded before publication.
 ### 🚢 Deployment and cloud context
 
 These modules read inert local metadata only.
-They do **not** contact Docker, a Kubernetes cluster, a Terraform/OpenTofu backend, a cloud API, an OAuth flow, a credential helper, or a metadata service.
-The deployment/cloud safety review retained opt-in root behavior: context labels may be sensitive and there is no usage evidence justifying more default footer density.
+They do **not** contact Docker, Kubernetes, Terraform/OpenTofu backends, cloud APIs, OAuth flows, credential helpers, or metadata services.
+They remain opt-in because context labels may be sensitive.
 
 - `docker_context`: `DOCKER_CONTEXT`, then `DOCKER_CONFIG/config.json` or `~/.docker/config.json`.
   The `default` context is suppressed.
@@ -640,6 +659,8 @@ Negated username detection names are rejected.
 Ordinary local hostname/username sessions stay empty.
 All identity labels are bounded and stripped of C0/C1 controls, ANSI, newlines, and OSC control bytes.
 
+## 📐 Layout and lifecycle
+
 ### ↔️ Fill layout
 
 Add `${fill}` between left and right root content (braces disambiguate adjacent text):
@@ -673,48 +694,23 @@ Bounded local filesystem operations may finish, but stale generations cannot pub
 Execution identity is retained rather than re-read by the periodic fallback.
 Render and live preview consume snapshots synchronously and perform zero reads or commands.
 
-Missing, unreadable, malformed, oversized, timed-out, or unavailable sources fail to empty values.
-Workspace/Git readers cap direct files at 64 KiB, use one bounded current-directory listing, never recurse, and make no network calls.
+Missing, unreadable, malformed, oversized, timed-out, or unavailable sources produce empty values.
+Workspace and Git readers cap direct files at 64 KiB, use one bounded current-directory listing, never recurse, and make no network calls.
 The native GitHub PR query is the documented network exception.
-Package's explicitly documented Cargo lookup is the only ancestor walk and is capped at eight parents.
+The Cargo package lookup is the only ancestor walk and stops after eight parents.
 
-## 💬 Commands
+## 🚧 Limitations
 
-| Command | Purpose |
-| --- | --- |
-| `/starship` | Open the current-state menu in TUI mode; retain help behavior outside TUI |
-| `/starship settings` | Open the compatible direct edit → preview → confirm flow (TUI only) |
-| `/starship status` | Show config source/path and diagnostics |
-| `/starship help` | Show command and configuration help |
-
-The standard main menu keeps seven goals on one level: **Customize footer**, **Presets**, **Explain footer**, **Modules**, **Configuration**, **Help**, and **Restore built-in…**.
-It shows whether the footer uses built-in defaults, a saved built-in document, a named preset, a custom document, or an error-driven fallback, together with the current health.
-Presets, Explain, Modules, and the nested Configuration capabilities are menu-only paths; they do not add textual subcommands or change RPC, print, or JSON protocols.
-Restore remains last and unavailable when there is no document to replace.
-
-The TOML editor, adaptive live footer previews, Explain view, searchable module inspector, and Configuration document reviews remain specialized extension UI.
-Their hints follow Pi's injected keybindings; list, detail, and exact-document content stay bounded across terminal resize.
-Escape returns from detail or to the main menu, while Ctrl+C closes the whole workflow.
-
-The direct routes accept no trailing arguments.
-Status and help remain safe in TUI, RPC, JSON, and print modes.
-RPC receives notifications but never opens custom terminal UI; print and JSON modes produce no ad hoc output.
-Footer/timer/Git lifecycle work starts only in TUI mode.
-
-## 📐 Scope
-
-The formatter, style concepts, and selected contextual modules are Starship-inspired, while Pi owns the lifecycle, snapshots, privacy boundary, and footer layout.
-This extension does not load `starship.toml`, claim complete module/config compatibility, invoke the Starship binary, run custom shell modules, or expose unrestricted `env_var` behavior.
-JVM/.NET, other long-tail languages, alternative VCS, system-monitor, and additional DevOps modules remain demand-gated; the first-wave review found no issue/discussion evidence for a coherent follow-up batch, so no second wave is added.
-
-Pi-native model, context, cache, cost, Git metrics, and activity remain owned by the existing modules.
-The lifecycle design rejects provider-specific duplicates and ambiguous `turn_duration`/`last_result` modules until separately approved semantics exist.
+- The formatter and modules are Starship-inspired, not fully compatible with Starship.
+- The extension does not load `starship.toml`, invoke the Starship binary, run custom shell modules, or provide unrestricted `env_var` behavior.
+- JVM/.NET, other long-tail languages, alternative version-control systems, system monitoring, and additional DevOps modules are not implemented.
+- Pi does not expose the auto-compaction toggle, so the footer cannot reliably show Pi's native `(auto)` marker.
 
 ## ➕ Adding a module
 
 Create `src/modules/<name>.ts` with its format variables, defaults, and runtime value resolver, then register it in display order in `src/modules/catalog.ts`.
 Configuration names, validation variables, defaults, and `$all` ordering are derived from that catalog.
-Add the module to the built-in root format when it should be visible by default, then document and test its user-facing values.
+Add the module to the built-in root format only when it should be visible by default, then document and test its user-facing values.
 
 Keep `extension_status` last in the catalog so arbitrary third-party statuses follow native module output.
 

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-statusline)](https://www.npmjs.com/package/@narumitw/pi-statusline) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Add an opinionated Powerline-style footer that works without setup and keeps the most useful Pi, workspace, Git, usage, and time context visible as the terminal narrows.
+Add a Powerline-style footer that works without setup and keeps important Pi, workspace, Git, usage, and time context visible as the terminal narrows.
 
 A representative uncolored layout:
 
@@ -20,13 +20,9 @@ A representative uncolored layout:
 - Loads a generated split runtime to reduce Pi package startup work.
 
 > **Need more customization?**
-> See
-> [`pi-starship`](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-starship) ([npm](https://www.npmjs.com/package/@narumitw/pi-starship)).
-> It uses a
-> [Starship-inspired](https://starship.rs/) TOML format and style syntax for deeper control over layout, modules, and colors.
+> See [`pi-starship`](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-starship) ([npm](https://www.npmjs.com/package/@narumitw/pi-starship)).
+> It uses [Starship-inspired](https://starship.rs/) TOML and style syntax for deeper control over layout, modules, and colors.
 > Choose `pi-statusline` for practical defaults and quick setup.
->
-> Do not enable both extensions at the same time because both own Pi's footer.
 
 ## 📦 Install
 
@@ -47,9 +43,8 @@ npm --workspace @narumitw/pi-statusline run build
 pi -e ./packages/pi-statusline
 ```
 
-The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
-
-For the best result, use a terminal font that includes Powerline glyphs and emoji.
+The package declares `dist/index.ts`, so build an unbuilt local checkout before Pi loads the package directory.
+Install only from sources you trust because Pi extensions run with Pi's permissions.
 
 ## 🚀 Quick start
 
@@ -69,15 +64,14 @@ Help
 | Menu item | What it does |
 | --- | --- |
 | **Appearance** | Preview palettes with Up/Down; Enter applies and Escape cancels |
-| **Information** | Preview and apply a curated set of segments |
+| **Information** | Preview and apply a curated segment set |
 | **Advanced** | Open Custom layout or Edit settings JSON |
 | **Status** | Show the effective source, path, appearance, layout, and diagnostics |
 | **Help** | Show command and schema guidance |
 
 ### Information levels
 
-Selecting a level replaces only the `segments` array.
-Unknown and unrelated JSON fields are preserved.
+Selecting a level replaces only `segments` and preserves unrelated JSON fields.
 
 | Level | Included segments |
 | --- | --- |
@@ -99,10 +93,10 @@ The `tools` segment takes no space while idle.
 | `/statusline help` | Show command and schema guidance |
 
 The direct `settings`, `status`, and `help` routes remain for compatibility.
-The root standard menu is TUI-only; Escape returns from Advanced or closes Main.
-RPC receives observable notifications instead of TUI-only controls.
+The main menu is TUI-only; Escape returns from Advanced or closes the menu.
+RPC receives notifications instead of TUI-only controls.
 Unknown subcommands and trailing arguments are rejected.
-The standard palette picker owns navigation and cleanup while pi-statusline still owns footer previews, settings, and rollback.
+The standard palette picker owns navigation and cleanup; pi-statusline owns footer previews, settings, and rollback.
 The width-aware layout editor and JSON editor remain specialized UI.
 
 ## 📐 Runtime behavior
@@ -155,7 +149,7 @@ The extension uses one user-level file:
 ```
 
 There are no project or environment overrides.
-When the file is absent, pi-statusline uses its built-in defaults without creating the file or parent directory.
+When the file is absent, pi-statusline uses built-in defaults without creating the file or its parent directory.
 The first successful settings save creates a complete editable document atomically.
 Malformed or unreadable settings are never overwritten.
 Settings reload on startup, `/reload`, and session replacement.
@@ -177,8 +171,8 @@ If both files exist, `pi-statusline.json` wins.
 
 All fields are optional in an existing document.
 Missing fields use defaults.
-Unknown fields produce a warning but are preserved by menu saves.
-Invalid recognized values block saving, leaving the previous file and live footer unchanged.
+Menu saves warn about and preserve unknown fields.
+Invalid recognized values block saving and leave the file and live footer unchanged.
 
 A compact customization example:
 
@@ -260,7 +254,8 @@ The direction names the removed portion:
 Truncation runs after the built-in Claude/GPT shortening rules but before the configured model prefix and suffix.
 It changes display only—the provider model ID is untouched.
 Terminal control sequences in model IDs are removed at render time, and unsafe configured symbols are rejected.
-An empty `truncationSymbol` truncates without a marker. pi-statusline treats model IDs as opaque strings and does not parse paths, repositories, GGUF suffixes, or quantization names.
+An empty `truncationSymbol` truncates without a marker.
+pi-statusline treats model IDs as opaque strings and does not parse paths, repositories, GGUF suffixes, or quantization names.
 At very narrow widths, the existing responsive priorities may still omit the model rather than overflow the terminal.
 
 ## 🧩 Advanced layout
@@ -280,7 +275,8 @@ Open **Advanced → Custom layout** when the curated levels are not enough.
 | Ctrl+C | Close the screen immediately, including from Move mode |
 
 The layout displays the effective Back key and keeps Ctrl+C available when Back is remapped.
-Every successful change saves and applies immediately; closing the screen does not roll it back.
+Every successful change saves and applies immediately.
+Closing the screen does not roll it back.
 
 Available data segments:
 
@@ -301,12 +297,11 @@ Manually authored leading/trailing breaks represent empty rows.
 ```
 
 An empty `segments` array hides the main powerline while extension statuses can still render.
-The extension intentionally has no variable or format language; use `pi-starship` when you need one.
 
 ## 🔌 Extension statuses and icons
 
 Other extension statuses appear below the main powerline, wrap to terminal width, and are limited to five items.
-Icons resolve in this order:
+Icons use this order:
 
 1. Exact configured raw key, such as `goal` or `foo:server`.
 2. Longest configured colon wildcard, such as `foo:*` or `foo:server:*`.
@@ -327,11 +322,17 @@ For interoperable extensions, prefer one aggregated key or a stable coexistence 
 <extension-id>:<stable-slot>
 ```
 
-Put transient activity in the value and always clear the same complete key.
+Put transient activity in the value, and clear the exact key that was set.
+
+## 🚧 Limitations
+
+- The footer needs Powerline glyphs and emoji for its intended appearance.
+- Pi does not arbitrate footer ownership, so another footer extension can replace pi-statusline.
+- Custom layouts support ordered segments and line breaks, not a variable or format language.
 
 ## 🛠️ Troubleshooting
 
-- **Powerline symbols look wrong:** use a font with Powerline glyphs; emoji support is also recommended.
+- **Powerline symbols look wrong:** use a font with Powerline glyphs and emoji support.
 - **The footer reports settings warnings:** run `/statusline status`, then `/statusline settings` to fix invalid recognized fields.
 - **The footer appears to be replaced:** disable `pi-starship` or another extension that also calls Pi's `setFooter()`.
 - **A custom segment disappears on a narrow terminal:** check the responsive priority above or add an explicit `line_break`.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -2,29 +2,27 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-subagents)](https://www.npmjs.com/package/@narumitw/pi-subagents) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Pi Subagents starts Pi subagent jobs and lets each child ask the main agent necessary questions through an authenticated loopback broker.
+Pi Subagents runs Pi jobs in separate child processes and lets each child ask the main agent necessary questions through an authenticated loopback broker.
 
-A bundled `using-pi-subagents` skill owns delegation strategy, least-privilege tool selection, parallel-work guidance, timeout selection, question handling, result review, and writer safety.
+The bundled `using-pi-subagents` skill explains when to delegate, how to limit child capabilities, and how to verify results safely.
 
 ## ✨ Features
 
-- Starts one isolated Pi child process per job.
-- Lets each task define the child's specialization and each tool list define its capabilities.
-- Defaults child work tools to `read`, `grep`, `find`, and `ls`.
-- Inherits the main agent's effective model and defaults to its thinking level.
-- Gives every child fixed `subagent_ask` and `subagent_wait` communication tools.
-- Lets the main agent answer a pending child question with `subagent_reply`.
-- Interrupts a parent job wait when a question needs a main-agent response without cancelling the job.
-- Publishes one guarded asynchronous completion and releases child resources at terminal state.
-- Shows each active job's state, elapsed time, timeout, and selected work tools above the editor.
-- Exposes privacy-filtered job metadata without leaking task text, output, prompts, selected tools, or broker credentials.
-- Cancels active session-owned work and closes the loopback broker during replacement, reload, or shutdown.
+- Runs each job in an isolated Pi child process and returns its job ID immediately.
+- Uses the task to define the child's specialization and the tool list to limit its capabilities.
+- Defaults work tools to `read`, `grep`, `find`, and `ls`.
+- Inherits the main agent's effective model and uses its thinking level by default.
+- Gives every child fixed `subagent_ask` and `subagent_wait` tools for necessary questions.
+- Lets the main agent answer with `subagent_reply` without cancelling the job.
+- Publishes one asynchronous terminal completion and shows active-job progress above the editor.
+- Exposes privacy-filtered metadata without task text, output, prompts, selected tools, or broker credentials.
+- Cancels session-owned work and closes the broker during replacement, reload, or shutdown.
 
 ## 📦 Install
 
-The version 3 runtime is not published to npm yet.
+The version 3 runtime documented here is not yet published to npm.
 
-The npm package remains on the legacy 2.x runtime and does not provide the tools documented below.
+The npm package still contains the legacy 2.x runtime and does not provide the tools below.
 
 Install the repository source as one Pi package:
 
@@ -63,23 +61,19 @@ Review the source before installing or invoking the extension.
 
 Ask Pi to use the bundled `using-pi-subagents` skill when deciding whether to delegate, or invoke `/skill:using-pi-subagents` directly.
 
-Start one subagent job with `subagent_spawn`.
+Call `subagent_spawn` with a self-contained task and only the work tools that task needs.
 
-The tool returns a `jobId` immediately.
+The call returns a `jobId` immediately, and the job continues in the background.
 
-The job runs in the background while the main agent continues useful work until a completion arrives or the result is required.
+Continue useful main-agent work until the result is required or a completion arrives.
 
-Completion messages follow Pi's global tool-output expansion state and `app.tools.expand` binding (`Ctrl+O` by default).
+If `subagent_wait` returns `reason: "subagent_message"`, answer the visible question with `subagent_reply` and wait for the job again only when needed.
 
-If `subagent_wait` reports `reason: "subagent_message"`, answer the visible question with `subagent_reply`, then wait for the job again when needed.
+Completion messages follow Pi's global tool-output expansion state and the `app.tools.expand` binding (`Ctrl+O` by default).
 
-In TUI mode, an above-editor widget shows one compact line for each queued or running job.
+In TUI mode, the above-editor widget shows each queued or running job's ID, state, elapsed time, timeout, and selected work tools.
 
-Each line includes the job ID, current state, elapsed execution time, configured timeout or `no timeout`, and selected work tools.
-
-The fixed `subagent_ask` and child `subagent_wait` communication tools are omitted from the widget because every child receives them.
-
-The widget disappears when no jobs remain active and is cleared during session replacement, reload, or shutdown.
+The widget omits the fixed communication tools, disappears when no jobs remain active, and clears when the session ends.
 
 ## 🛠️ Tools
 
@@ -120,9 +114,9 @@ See [`docs/tools.md`](./docs/tools.md) for the concise schema reference.
 
 ## ⚙️ Job configuration
 
-The task defines the child's role, objective, scope, constraints, and expected result.
+The task should state the child's role, objective, scope, constraints, and expected result.
 
-The optional `tools` list defines what the child can do.
+The optional `tools` list limits what the child can do.
 
 Accepted names are `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`.
 
@@ -144,9 +138,9 @@ Omitting `thinkingLevel` captures the main agent's effective level when `subagen
 
 The child inherits the main agent's effective provider and model when `subagent_spawn` executes.
 
-Spawn rejects providers registered by a parent extension because children disable unrelated extensions.
+Spawn rejects providers registered by a parent extension because child processes disable unrelated extensions.
 
-Spawn also rejects process-local runtime API keys such as a parent-only `--api-key` value.
+Spawn also rejects process-local runtime API keys, including a parent-only `--api-key` value.
 
 Use stored or environment credentials that child processes can read.
 
@@ -164,7 +158,9 @@ The child bridge reads and closes that descriptor before model tool execution.
 
 Each child communication tool call uses one request-scoped connection, while a response wait uses an abortable long poll.
 
-The first accepted `subagent_reply` wins, and repeated replies acknowledge the existing answer without replacing it.
+The first accepted `subagent_reply` wins.
+
+Repeated replies acknowledge the existing answer without replacing it.
 
 A child may retry `subagent_wait` after a wait timeout because the underlying request remains active.
 
@@ -180,7 +176,9 @@ Session replacement and shutdown cancel active work, suppress stale completion d
 
 ## 🔀 Migrating from 2.x
 
-Version 3.0 replaces the previous orchestration runtime and does not migrate its settings, persisted jobs, retained conversations, or recovery state.
+Version 3.0 replaces the previous orchestration runtime.
+
+It does not migrate legacy settings, persisted jobs, retained conversations, or recovery state.
 
 Finish or record any required work before upgrading, then start a fresh Pi session so stored calls do not request removed tool names.
 
@@ -202,9 +200,9 @@ Describe the child's specialization in `task` and grant only the required work t
 
 The selected work tools run in the current working directory.
 
-The default list is read-only by capability because it contains no shell or file-mutation tool.
+The default list contains no shell or file-mutation tool.
 
-This default is not a filesystem sandbox because the allowed read tools can inspect files available to the user account.
+It is not a filesystem sandbox because its read tools can inspect files available to the user account.
 
 Selecting `bash`, `powershell`, `edit`, or `write` permits workspace mutation with the Pi process environment and user permissions.
 
@@ -230,7 +228,7 @@ Parallel writers require disjoint ownership or workspace isolation outside this 
 
 ## 🚧 Limitations
 
-The extension does not load arbitrary extension tools or parent-registered model providers into child processes.
+The extension does not load arbitrary extension tools or parent-registered model providers in child processes.
 
 Process-local runtime API keys are not forwarded to children.
 

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -2,19 +2,19 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-sync)](https://www.npmjs.com/package/@narumitw/pi-sync) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Sync selected Pi settings and content across machines through Git, WebDAV, Cloudflare R2, or another S3-compatible store.
+Pi Sync synchronizes selected Pi settings and content across machines through Git, WebDAV, Cloudflare R2, or another S3-compatible store.
 
-Reusable storage connections hold credentials, while named sync setups define the exact remote path, included content, and automatic-sync behavior.
+Reusable storage connections hold credentials, while named sync setups define exactly what to sync, where to store it, and whether to sync automatically.
 
 ## ✨ Features
 
-- Manages Git, WebDAV, Cloudflare R2, and general S3-compatible backends through `/sync`.
-- Separates reusable storage connections from named sync setups and exact reviewed remote paths.
-- Selects Pi roots, safe agent-relative paths, and the privacy-sensitive sessions root through one ordered include list.
+- Manages Git, WebDAV, Cloudflare R2, and general S3-compatible storage through `/sync`.
+- Separates reusable storage connections from named setups with exact reviewed remote paths.
+- Uses one ordered list for Pi roots, safe agent-relative paths, and privacy-sensitive sessions.
 - Protects changes with immutable snapshots, secret scanning, locks, conflict checks, pull backups, transactional apply, and recovery journals.
-- Keeps snapshot selection portable and credential-free across environments.
+- Keeps snapshot selection portable and free of credentials.
 - Writes settings atomically, preserves unknown fields, rejects stale edits, and fails closed on unsafe configuration.
-- Loads a generated split runtime while preserving lazy UI and backend chunks.
+- Loads a generated split runtime with lazy UI and backend chunks.
 
 ## 📦 Install
 
@@ -35,19 +35,23 @@ npm --workspace @narumitw/pi-sync run build
 pi -e ./packages/pi-sync
 ```
 
-The package declares `dist/index.ts`, so the build command must finish before Pi loads the local package directory.
+The package declares `dist/index.ts`, so an unbuilt checkout must run the build before Pi loads the package directory.
 
-An unbuilt checkout still declares `dist/index.ts`, but the generated entrypoint and chunks do not exist until the build completes.
+Extensions run with Pi's permissions, so install only packages from sources you trust.
 
 ## 🚀 Quick start
 
-Run `/sync`, choose **Set up sync**, and review the storage connection, exact remote path, included content, automatic-sync choice, and masked credentials before saving.
+Run `/sync` and choose **Set up sync**.
+
+Before saving, review the storage connection, exact remote path, included content, automatic-sync choice, and masked credentials.
+
 Buckets and remote repositories must already exist.
+
 Git uses existing non-interactive SSH or credential-helper configuration and never stores Git credentials.
 
 ## 🧭 Manager, conflicts, and recovery
 
-The manager shows local state without contacting remote storage:
+The `/sync` manager shows local state without contacting remote storage:
 
 ```text
 Current sync setup: home
@@ -58,33 +62,52 @@ Remote status: Not checked
 ```
 
 Primary actions include **Sync now**, **Switch sync setup**, **Status & changes**, **Settings**, and **More…**.
-When pi-sync has already detected a synced-content-list mismatch, the manager instead shows **Sync status: Review needed**, puts **Review synced content (recommended)** first, and keeps **Sync now** visibly unavailable until the choice is reviewed.
-Opening the manager still performs no new remote request.
-The standard manager also owns setup and connection lists/details plus history and recovery.
-Secondary screens provide **Back**; Escape goes back and Ctrl+C closes the flow.
-Specialized operation and masked-credential prompts show the effective cancellation bindings and retain Ctrl+C as a hard-cancel input when Back is remapped.
-Destructive, credential-bearing, and externally visible operations retain exact specialized previews and confirmations.
+
+After Pi Sync detects an included-content mismatch, the manager shows **Sync status: Review needed** and puts **Review synced content (recommended)** first.
+
+**Sync now** remains unavailable until you review the mismatch.
+
+Opening the manager does not make another remote request.
+
+The manager also provides setup and connection details, history, and recovery.
+
+On secondary screens, **Back** and Escape return to the previous screen, while Ctrl+C closes the flow.
+
+Specialized operation and masked-credential prompts show the effective cancellation bindings and keep Ctrl+C as a hard-cancel input when Back is remapped.
+
+Destructive, credential-bearing, and externally visible operations show exact previews and confirmations.
 
 ### Restore sync access
 
-When an operation is currently running, the manager shows its command and process ID, keeps sync and settings changes unavailable, and puts **Refresh operation status** first.
-When lock metadata is still protected by an active guard, the manager explains that another pi-sync process may be starting or finishing and asks the user to wait before refreshing.
+While an operation is running, the manager shows its command and process ID, disables sync and settings changes, and puts **Refresh operation status** first.
+
+When an active guard still protects lock metadata, the manager asks you to wait because another Pi Sync process may be starting or finishing.
+
 It never offers lock removal while an owner or guard may still be active.
 
-When a previous operation appears to have stopped without releasing its local lock, the manager shows **Sync paused** and puts **Restore sync access… (recommended)** first instead of hiding recovery inside **History & recovery…**.
-Unreadable metadata receives a stronger warning because pi-sync cannot verify who owns it.
-Close every other Pi session that may still be syncing, review the local-lock-only confirmation, then choose **Remove local lock and continue**.
-The guarded recovery path rechecks metadata and ownership before removal, changes no settings, local files, sync state, or remote data, and returns directly to the normal manager when access is restored.
+If a stopped operation leaves its local lock behind, the manager shows **Sync paused** and puts **Restore sync access… (recommended)** first.
+
+Unreadable metadata receives a stronger warning because Pi Sync cannot verify its owner.
+
+Close every other Pi session that may still be syncing, review the local-lock-only confirmation, and choose **Remove local lock and continue**.
+
+Before removal, the guarded recovery path rechecks metadata and ownership.
+
+Successful recovery changes no settings, local files, sync state, or remote data and returns to the normal manager.
+
 Cancellation leaves the lock unchanged.
-If ownership changes or a guard is still expiring, pi-sync refuses removal and keeps actionable status available for refresh or retry.
-The deterministic fallback remains `/sync unlock --stale` after the same no-other-sync verification.
+
+If ownership changes or a guard is still expiring, Pi Sync refuses removal and keeps refresh or retry available.
+
+After the same no-other-sync verification, `/sync unlock --stale` provides a deterministic fallback.
 
 ### Resolve conflicts in the manager
 
-When **Sync now**, **Pull from remote…**, or **Push to remote…** finds changes that require a human direction choice, the manager opens **Resolve sync conflict** instead of ending at a command-only error.
-The flow names the current sync setup and explains whether local content, remote content, or the included-content policy changed.
+When **Sync now**, **Pull from remote…**, or **Push to remote…** requires a direction choice, the manager opens **Resolve sync conflict**.
 
-An explicit remote content-list mismatch now opens **Synced content differs** inside the same manager flow.
+The flow names the current setup and explains whether local content, remote content, or the included-content policy changed.
+
+An explicit remote content-list mismatch opens **Synced content differs** in the same manager flow.
 Nothing changes until you choose an action.
 Choose **Review all paths (recommended)** first to compare exact remote-only paths, device-only paths, and both ordered lists.
 If membership matches but order differs, the review says that only ordering differs.
@@ -119,7 +142,9 @@ It clears after verified resolution, invalidation, session replacement, or shutd
 Interactive TUI `/sync sync`, `/sync pull`, and `/sync push` routes without `--yes` open the same review flow when they detect the mismatch.
 Explicit `--yes` routes remain non-interactive and report exact remote-only, device-only, or order-only guidance while leaving visible attention for later review.
 Shutdown automatic sync never opens a dialog because Pi is exiting.
-RPC startup and direct routes remain read-only and notification-based, while print and JSON modes remain unsupported for `/sync` because their UI output is not observable.
+RPC startup mismatch review remains read-only and notification-based.
+
+Print and JSON modes do not support `/sync` because UI output is not observable there.
 
 ## ⚙️ Settings
 
@@ -130,14 +155,18 @@ The canonical private user file is:
 ```
 
 Pi's configured agent directory replaces `~/.pi/agent` when applicable.
-Missing settings load as unconfigured without creating an agent directory, file, temporary, or lock.
+Missing settings load as unconfigured without creating an agent directory, file, temporary file, or lock.
+
 An explicit setup creates the file atomically.
 On POSIX, pi-sync creates and replaces it with mode `0600`.
 Pi-sync processes coordinate settings access through `pi-sync.json.mutation-lock`; lock-unaware editors are outside that serialization boundary and should not save the file while a pi-sync settings operation is running.
 Credentials stay in this canonical private file and are never shown in menus, reviews, status, notifications, errors, logs, or completion metadata.
 
-An existing private `pi-sync.local.json` containing a valid version 3 document is copied byte-for-byte to `pi-sync.json`; the old file remains as a recovery copy.
-If both paths exist, `pi-sync.json` wins and the other path remains untouched.
+A private `pi-sync.local.json` containing a valid version 3 document is copied byte-for-byte to `pi-sync.json`.
+
+The old file remains as a recovery copy.
+
+If both paths exist, `pi-sync.json` wins and the legacy file remains untouched.
 
 ### Complete version 3 example
 
@@ -273,7 +302,10 @@ Automatic apply protects the currently open session file; restart Pi or resume a
 
 ### Unsupported old settings and recovery
 
-Version 1, version 2, and non-empty unversioned documents are intentionally unsupported by this breaking schema reset. pi-sync does **not** migrate, partially interpret, downgrade, or overwrite them.
+Version 1, version 2, and non-empty unversioned documents are unsupported after the version 3 schema reset.
+
+Pi Sync does **not** migrate, partially interpret, downgrade, or overwrite them.
+
 Automatic sync pauses and reports an actionable version 3 error without displaying secrets.
 
 Recovery:
@@ -310,17 +342,19 @@ The menu is preferred, while deterministic routes remain available:
 ```
 
 - `--setup <name>` addresses a setup without switching it.
-- `--yes` / `-y` skips a direct route's confirmation.
-- `--force` accepts a reviewed content conflict but never disables backend concurrency protection.
-- `--stale` requests guarded stale-lock recovery.
+- `--yes` or `-y` skips confirmation for `push`, `pull`, `sync`, `rollback`, or `migrate-state`.
+- `--force` lets `push`, `pull`, and `sync` accept a reviewed content conflict without disabling backend concurrency protection.
+- `--stale` applies only to guarded stale-lock recovery through `unlock`.
 
 The former version 2 setup-addressing flag is rejected.
 Unknown flags, unknown commands, trailing values, and missing setup/snapshot values are rejected.
 Completion includes known setup names and preserves preceding command tokens.
 
-TUI mode uses standard manager, settings, resource, and included-content screens plus specialized secret, wizard, confirmation, and commit-aware loader components.
-RPC uses Pi's supported dialog/notification protocol and does not gain settings mutation.
-Print and JSON modes never enter TUI-only screens; unsupported interactive routes reject or remain protocol-safe rather than relying on no-op output.
+TUI mode provides manager, settings, resource, included-content, secret, wizard, confirmation, and operation-review screens.
+
+In RPC mode, the **Settings** and **Included Content** interfaces provide read-only summaries through Pi's dialog and notification protocol.
+
+Print and JSON modes reject `/sync` before entering interactive screens.
 
 ## 🔄 Backend and recovery model
 
@@ -365,12 +399,15 @@ Preserve both roots before manual recovery; with every Pi process closed and no 
   Publication/apply commit boundaries finish with bounded signals and report ambiguous outcomes explicitly.
 - Terminal-bound names, paths, metadata, and errors are control-character sanitized.
 
-## ♿ Conditional terminal accessibility smoke
+## ♿ Terminal accessibility
 
-Pi exposes terminal components rather than a semantic/ARIA tree.
-Release validation checks textual state, keyboard operation, Escape/Back, control escaping, and narrow rendering.
-Critical meaning appears in text such as `(current)`, `Review needed`, `Later`, `Warning`, `Invalid`, `Saved`, `Cancelled`, and `Applied`; color is supplementary.
-The attention widget is informational and does not pretend to be a clickable control.
+Pi exposes terminal components rather than a semantic or ARIA tree.
+
+Release checks cover textual state, keyboard operation, Escape and Back behavior, control escaping, and narrow rendering.
+
+Critical meaning appears in text such as `(current)`, `Review needed`, `Later`, `Warning`, `Invalid`, `Saved`, `Cancelled`, and `Applied`.
+
+Color is supplementary, and the attention widget is informational rather than interactive.
 
 ## 🗂️ Package layout
 
@@ -420,4 +457,4 @@ Pi extension, Pi coding agent, settings sync, Git, WebDAV, Nextcloud, Cloudflare
 
 ## 📄 License
 
-MIT
+[MIT](./LICENSE)

--- a/packages/pi-ticker/README.md
+++ b/packages/pi-ticker/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-ticker)](https://www.npmjs.com/package/@narumitw/pi-ticker) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Show configurable Yahoo Finance market quotes in a width-aware widget above Pi's editor.
+Pi Ticker shows configurable Yahoo Finance quotes in a width-aware widget above Pi's editor.
 
 ## ✨ Features
 
@@ -11,7 +11,7 @@ Show configurable Yahoo Finance market quotes in a width-aware widget above Pi's
 - Packs complete ticker entries into rows that fit the current terminal width.
 - Provides searchable TUI and RPC menus for adding, removing, and reordering symbols.
 - Persists widget visibility and the ordered symbol list in user settings.
-- Refreshes every 30 seconds while enabled and marks the last successful quote stale after a partial failure.
+- Refreshes every 30 seconds while enabled, keeps successful results, and marks failed symbols' previous quotes stale.
 - Cancels polling, in-flight requests, and active menus during reload, session replacement, and shutdown.
 
 ## 📦 Install
@@ -43,7 +43,7 @@ Extensions run with Pi's permissions, so install only trusted packages.
 
 ## 🚀 Quick start
 
-Run Pi in TUI mode and open the ticker manager:
+Open the ticker manager in TUI mode:
 
 ```text
 /ticker
@@ -57,26 +57,28 @@ The widget appears after the settings save and the first quote request completes
 
 `/ticker` opens **Manage tickers** in TUI and RPC modes.
 
-TUI mode keeps search, symbol removal, direct add, widget visibility, and refresh actions on one screen.
+In TUI mode, one screen provides search, symbol removal, direct add, widget visibility, and refresh actions.
 
 The configured confirm binding or Space activates the focused row.
 
-An unmatched valid search changes the add row to **Add SYMBOL** so the symbol can be added directly.
+When a valid search has no match, the add row changes to **Add SYMBOL** for direct addition.
 
 `Shift+Up` and `Shift+Down` reorder the focused ticker when the search field is empty and those keys do not conflict with configured standard bindings.
 
 RPC mode exposes portable dialogs for choosing and moving a ticker.
 
-Every accepted change saves immediately, and a failed save restores the previous displayed and effective value.
+Each accepted change saves immediately.
 
-Removing the final ticker hides the widget and stops polling.
+If a save fails, the manager restores the previous displayed and effective value.
+
+Removing the final symbol hides the widget and stops polling.
 
 Escape closes transient TUI flows, and `Ctrl+C` remains a hard-close path.
 
 ## 💬 Commands
 
 - `/ticker` opens the ticker manager.
-- `/ticker <SYMBOL ...>` replaces the ordered symbol list and refreshes quotes.
+- `/ticker <SYMBOL ...>` replaces the complete ordered symbol list and refreshes quotes.
 - `/ticker refresh` refreshes quotes immediately when the widget is enabled.
 - `/ticker help` shows direct-command usage.
 - `/ticker reset` reports that no default symbol list exists and leaves settings unchanged.
@@ -105,7 +107,7 @@ The extension does not read project settings or extension-specific environment-v
 
 A missing file uses an empty symbol list, keeps the widget enabled, and does not create the file, its parent directory, or a polling task.
 
-The file must contain a JSON object with these optional fields:
+The settings file must contain a JSON object with these optional fields:
 
 | Field | Accepted values | Default | Behavior |
 | --- | --- | --- | --- |
@@ -127,7 +129,9 @@ Example:
 
 Unknown JSON fields are preserved during saves.
 
-Malformed or invalid settings are reported, ignored at runtime, and never overwritten by the extension.
+Malformed or invalid settings use runtime defaults and leave the file unchanged.
+
+Pi shows a warning when UI is available.
 
 Writes are ordered within one Pi process and published through a temporary file plus atomic rename.
 
@@ -139,13 +143,13 @@ Settings reload on startup and `/reload`.
 
 ## 🔒 Security and privacy
 
-The extension requests public chart metadata from Yahoo Finance over HTTPS without an API key.
+The extension requests public quote metadata from Yahoo Finance over HTTPS without an API key.
 
 Requested ticker symbols and the host network address are visible to Yahoo Finance.
 
 The user settings file contains only ticker symbols and widget visibility; it stores no credential or secret.
 
-Ticker symbols and quote data are shown locally and are not added to model context by this extension.
+The extension displays ticker symbols and quote data locally without adding them to model context.
 
 ## 🚧 Limitations
 
@@ -155,7 +159,7 @@ Quotes may be delayed and are not suitable for trading decisions.
 
 Each request times out after 10 seconds, and one symbol failure does not discard successful symbols.
 
-The polling queue is owned by one Pi session and is not shared across Pi processes.
+Each Pi session owns its polling queue, and separate Pi processes do not share one.
 
 ## 🗂️ Package layout
 
@@ -185,5 +189,4 @@ Pi extension, market quotes, stock ticker, Yahoo Finance, editor widget, termina
 
 ## 📄 License
 
-MIT.
-See [`LICENSE`](./LICENSE).
+[MIT](./LICENSE)

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -4,13 +4,13 @@
 [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Give coding agents a focused todo list for tracking multi-step work above Pi's editor.
+Pi Todo gives the model a focused list for tracking multi-step work above Pi's editor.
 
-The list follows the active session branch and disappears cleanly when no tracked work remains or the session ends.
+The list follows the active session branch and disappears when no tracked work remains or the session ends.
 
 ## ✨ Features
 
-- Registers one `update_todo_list` tool with clear guidance for meaningful multi-step work.
+- Registers one `update_todo_list` tool for meaningful multi-step work.
 - Keeps task text concise and action-oriented, with at most one task in progress.
 - Shows a compact themed task list and completion count above the editor in TUI mode.
 - Restores the latest valid list when Pi starts a session or navigates between branches.
@@ -47,17 +47,17 @@ Pi extensions run with the user's permissions, so install only trusted code.
 
 Ask Pi to perform work with multiple meaningful steps.
 
-The agent can create a concise list through `update_todo_list`, mark one task `in_progress`, and revise the list when the plan changes.
+The model can use `update_todo_list` to create a concise list, mark one task `in_progress`, and revise the plan as work changes.
 
-Stable tool guidance tells the agent to update the list immediately after task status changes and to reconcile it before progress reports or the final response.
+Each update replaces the complete list, and an empty list clears it.
 
-The agent sends the complete current list with every update and sends an empty list when no tracked work remains.
+Tool guidance tells the model to update changed statuses promptly and reconcile the list before progress reports or the final response.
 
 ## 🛠️ Tools
 
 ### `update_todo_list`
 
-Replace the complete current todo list for the active session.
+Replaces the complete todo list for the active session.
 
 Each item has this shape:
 
@@ -72,23 +72,33 @@ Accepted statuses are `pending`, `in_progress`, and `completed`.
 
 A list may contain up to 50 items, each item may contain up to 300 characters, and at most one item may be `in_progress`.
 
-The tool result stores a versioned snapshot in the session branch so branch navigation can reconstruct the latest valid list.
+### Session and compaction behavior
 
-Branch reconstruction also accepts valid results stored under the previous `todo_widget` name, but the extension only registers `update_todo_list` for new calls.
+Each successful tool result stores a versioned snapshot on the active session branch.
 
-During ordinary turns, the model reads the complete list from the persisted `update_todo_list` assistant tool call, while its successful result confirms the active state and preserves append-only prompt history.
+Session startup and branch navigation reconstruct the latest valid list from those results.
 
-If leading compaction or branch summaries remove that matching call/result pair, the extension inserts one hidden, non-persistent state-only fallback immediately after those summaries.
+Reconstruction also accepts valid results stored under the former `todo_widget` name, but new calls use only `update_todo_list`.
 
-That restored message remains fixed for the current leading-summary epoch, including after a later valid todo update or clear.
-The extension stores branch-local boundary metadata in the session so reload and branch navigation retain the established prefix without making the hidden fallback itself persistent model context.
-The later tool call and result supersede the restored state at the conversation tail without rewriting the earlier provider prefix.
-An ordinary context without a leading summary does not synthesize a fallback, and a new summary epoch restores only the then-current list when needed.
+During ordinary turns, the persisted assistant tool call and successful result keep the complete current list visible to the model without rewriting prompt history.
 
-In TUI mode, updates appear immediately in a widget above the editor.
+If leading compaction or branch summaries remove that matching pair, the extension inserts one hidden, non-persistent state message immediately after the summaries.
 
-The widget header shows completed and total task counts, followed by themed completed, in-progress, and pending rows.
-Long task text wraps to the available terminal width with continuation lines aligned beneath the text.
+The restored message stays fixed for that leading-summary epoch, even after a later valid update or clear.
+
+Branch-local boundary metadata preserves the established prefix across reload and branch navigation without persisting the hidden message as model context.
+
+A later tool call and result supersede the restored state at the conversation tail without rewriting the earlier provider prefix.
+
+An ordinary context without a leading summary receives no fallback.
+
+A new summary epoch restores only the list that is current when restoration becomes necessary.
+
+In TUI mode, updates appear immediately above the editor.
+
+The widget shows completed and total task counts, followed by themed completed, in-progress, and pending rows.
+
+Long task text wraps to the terminal width, with continuation lines aligned beneath the text.
 
 In RPC, print, and JSON modes, the tool still returns structured details but does not create a visual widget.
 
@@ -96,13 +106,13 @@ In RPC, print, and JSON modes, the tool still returns structured details but doe
 
 The extension does not read or write files, start processes, access credentials, or make network requests.
 
-Task text is stored in Pi's normal session tool results and therefore follows the user's existing session persistence choices.
+Pi stores task text in normal session tool results, so it follows the user's session persistence choices.
 
 Terminal escape sequences, control characters, and bidirectional display controls are removed at the rendering boundary without changing the stored tool payload.
 
 ## 🚧 Limitations
 
-- The visual widget uses a fixed position above the editor and is available only in TUI mode.
+- The visual widget appears above the editor only in TUI mode.
 - The extension provides a model tool rather than a slash command or manual task editor.
 - The extension reminds the model to update statuses but cannot infer task completion or force a tool call.
 - Branch reconstruction uses only valid versioned `update_todo_list` or legacy `todo_widget` tool results on the active branch.
@@ -117,7 +127,7 @@ packages/pi-todo/
 ├── scripts/
 │   └── build-runtime.mjs     # Deterministic runtime builder and validator
 ├── src/
-│   ├── index.ts              # Thin authoritative extension forwarder
+│   ├── index.ts              # Thin extension entrypoint
 │   └── todo-widget.ts        # Tool, lifecycle, state reconstruction, and rendering
 ├── test/
 │   ├── build-runtime.test.ts       # Build, boundary, and Jiti loader coverage
@@ -145,6 +155,4 @@ Pi extension, coding agent, todo list, task progress, session widget, TypeScript
 
 ## 📄 License
 
-MIT.
-
-See [`LICENSE`](./LICENSE).
+[MIT](./LICENSE)

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-tool)](https://www.npmjs.com/package/@narumitw/pi-tool) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Browse every tool configured in the current Pi session and optionally show the active tool set above the editor.
+Pi Tool lets you browse every tool configured in the current Pi session and optionally show active tool names above the editor.
 
 ## ✨ Features
 
@@ -11,8 +11,7 @@ Browse every tool configured in the current Pi session and optionally show the a
 - Displays the complete JSON parameter schema and prompt guidelines exposed by Pi.
 - Shows the effective system-prompt snippet for each active tool.
 - Refreshes metadata every time the catalog opens.
-- Optionally shows the current active tools above the editor.
-- Keeps the active-tool widget off by default.
+- Optionally shows the current active tools above the editor, with the widget off by default.
 - Persists widget changes in the extension-owned `pi-tool.json` settings file.
 - Never enables, disables, or executes Pi tools.
 
@@ -30,16 +29,16 @@ Try without installing permanently:
 pi -e npm:@narumitw/pi-tool
 ```
 
-Try this package from a local checkout:
+Build and try this package from a local checkout:
 
 ```bash
 npm --workspace @narumitw/pi-tool run build
 pi -e ./packages/pi-tool
 ```
 
-An unbuilt local checkout must be built before loading the package directory.
-Extensions run with the same permissions as Pi.
-Only install packages from sources you trust.
+An unbuilt local checkout must be built before Pi loads the package directory.
+
+Extensions run with the same permissions as Pi, so install only packages from sources you trust.
 
 ## 🚀 Quick start
 
@@ -50,11 +49,14 @@ Run:
 ```
 
 Choose **Browse tools** to search the catalog and inspect a tool.
-Choose **Active tool status** directly from the main menu to turn the widget on or off.
-The widget is off until you enable it.
+
+Choose **Active tool status** to turn the widget on or off.
+
+The widget remains off until you enable it.
 
 The command works in TUI and RPC modes.
-It rejects arguments and rejects print or JSON modes because Pi does not provide an observable interactive command surface there.
+
+It rejects arguments, print mode, and JSON mode before opening an interactive flow.
 
 ## 💬 Commands
 
@@ -62,13 +64,16 @@ It rejects arguments and rejects print or JSON modes because Pi does not provide
 | --- | --- |
 | `/tool` | Browse configured tools and configure the active-tool widget. |
 
-`/tool` intentionally accepts no arguments and does not enable, disable, or execute tools.
-Its menu provides Browse tools, a direct active-tool status toggle, Status, and Help.
+`/tool` accepts no arguments and never enables, disables, or executes tools.
+
+Its menu provides **Browse tools**, **Active tool status**, **Status**, and **Help**.
 
 ## ⚙️ Settings
 
-The active user settings file is `<getAgentDir()>/pi-tool.json`, normally `~/.pi/agent/pi-tool.json`.
-The file is not created when the widget remains at its default.
+The user settings file is `<getAgentDir()>/pi-tool.json`, normally `~/.pi/agent/pi-tool.json`.
+
+The extension does not create the file while the widget remains at its default.
+
 Use this document to enable the widget manually:
 
 ```json
@@ -78,25 +83,46 @@ Use this document to enable the widget manually:
 ```
 
 `activeToolStatus` accepts `true` or `false` and defaults to `false` when absent.
+
 Manual edits apply after `/reload` or the next session start.
-The `/tool` menu toggle applies changes immediately and persists them with an atomic file replacement.
-Settings writes preserve unknown fields so newer configuration is not erased.
-Malformed JSON or an invalid value is ignored with a warning and is never overwritten by the menu.
+
+The `/tool` menu toggle applies changes immediately and persists them through atomic file replacement.
+
+Settings writes preserve unknown fields.
+
+Malformed JSON, invalid values, symbolic links, and non-file settings paths are treated as invalid and remain unchanged.
+
+Pi shows a warning when UI is available.
+
 Writes are ordered within one Pi process, but separate Pi processes do not share a settings lock.
 
 ## ℹ️ Active-tool widget
 
 When enabled, the widget shows every name returned by Pi's public `pi.getActiveTools()` API above the editor.
-It refreshes when relevant lifecycle events fire and polls for changes made by other extensions.
-It clears immediately when disabled and during session replacement, reload, or shutdown.
+
+It refreshes on relevant lifecycle events and polls for changes made by other extensions.
+
+It clears immediately when disabled or when the session is replaced, reloaded, or shut down.
+
 Tool names are sanitized and bounded before terminal rendering.
 
-## ℹ️ Metadata limits
+## 🔒 Security and privacy
 
-The catalog displays the fields returned by Pi's public `pi.getAllTools()` API: name, description, parameter schema, prompt guidelines, and source metadata.
-It combines those fields with the effective snippets returned by `ctx.getSystemPromptOptions()` for the current active tool set.
-An inactive tool's configured snippet is not exposed through the Extension API, so “None in the current system prompt” does not mean its full definition has no snippet.
-Pi does not expose a tool's implementation, runtime secrets, or label through these Extension APIs.
+The catalog reads Pi's public tool metadata and displays it through the `/tool` interface.
+
+It does not execute tools, change the active tool set, make network requests, or add catalog data to model context.
+
+Tool metadata can include local paths and prompt text, so review the screen before sharing terminal output.
+
+## 🚧 Limitations
+
+The catalog shows the name, description, parameter schema, prompt guidelines, and source metadata returned by Pi's public `pi.getAllTools()` API.
+
+It adds effective snippets from `ctx.getSystemPromptOptions()` for the current active tool set.
+
+Pi does not expose an inactive tool's configured snippet, implementation, runtime secrets, or label through these APIs.
+
+Therefore, **None in the current system prompt** does not prove that an inactive tool's full definition has no snippet.
 
 ## 🗂️ Package layout
 
@@ -123,5 +149,4 @@ Pi extension, Pi coding agent, tool browser, active tools, tool status, tool cat
 
 ## 📄 License
 
-MIT.
-See [`LICENSE`](./LICENSE).
+[MIT](./LICENSE)

--- a/packages/pi-tui-kit-showcase/README.md
+++ b/packages/pi-tui-kit-showcase/README.md
@@ -6,30 +6,31 @@
 > Pi TUI Kit Showcase is experimental and private.
 > It is a local maintainer demo, not a published extension.
 
-Preview the public `@narumitw/pi-tui-kit` screens and standalone interactions in one local interactive demo.
+This local maintainer demo previews the public `@narumitw/pi-tui-kit` screens and standalone interactions in one menu.
 
-The showcase uses only in-memory state and stores no settings.
+All demo state stays in memory, and the showcase writes no settings.
 
 ## ✨ Features
 
-- Demonstrates action, detail, browse, choice, settings, input, review, and multi-select screens.
-- Demonstrates standalone questionnaire, task, confirmation, and live-choice interactions from the same menu.
-- Covers disabled rows, busy labels, search, exact documents, adaptive review, bulk actions, and row descriptions.
-- Shows the shared top and bottom horizontal rules across every standard screen at normal terminal heights.
-- Keeps all effects in memory inside the demo process.
+- Includes action, detail, browse, choice, settings, input, review, and multi-select screens.
+- Includes standalone questionnaire, task, confirmation, and live-choice interactions.
+- Demonstrates disabled rows, busy labels, search, exact documents, adaptive review, bulk actions, and row descriptions.
+- Shows the shared top and bottom rules on every standard screen at normal terminal heights.
+- Keeps every demo effect in memory.
 - Loads the Kit runtime only after `/tui-kit-showcase` runs.
 
 ## 📦 Install
 
 This package is private and is not meant for npm publication.
 
-Load it from a local checkout:
+Build Kit, then load only this extension from a local checkout:
 
 ```bash
+npm run build --workspace @narumitw/pi-tui-kit
 pi --no-extensions --no-skills --no-session -e ./packages/pi-tui-kit-showcase
 ```
 
-The repository shortcut builds Kit first and then loads only this showcase extension:
+The repository shortcut runs the same build before opening the showcase:
 
 ```bash
 just showcase-tui-kit
@@ -43,21 +44,21 @@ Run this command in Pi TUI mode:
 /tui-kit-showcase
 ```
 
-Choose any row to inspect a presentation pattern.
+Choose a row to inspect its screen or interaction pattern.
 
-The standalone questionnaire, task, confirmation, and live-choice rows close the menu, show the standalone interaction, then reopen the menu when the interaction finishes.
+Questionnaire, task, confirmation, and live-choice rows temporarily close the menu and reopen it after the interaction finishes.
 
 RPC mode reports that the showcase requires TUI mode.
 
-Print and JSON modes reject the command without writing ad hoc output.
+Print and JSON modes reject the command without ad hoc output.
 
 ## ⚙️ Settings
 
 The showcase has no extension-owned settings file.
 
-The **Settings screen** row edits in-memory demo values only.
+The **Settings screen** row changes only in-memory demo values.
 
-Those values reset when the command starts again or the session owner is replaced.
+Those values reset when the command runs again or Pi replaces the session owner.
 
 ## 💬 Commands
 
@@ -67,7 +68,7 @@ Opens the showcase menu in TUI mode.
 
 The command accepts no arguments.
 
-Unknown arguments are rejected with usage text.
+Any argument is rejected with `Usage: /tui-kit-showcase`.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -3,21 +3,22 @@
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-tui-kit)](https://www.npmjs.com/package/@narumitw/pi-tui-kit)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Build consistent typed menus and interactions for independently installable [Pi](https://pi.dev) extensions without reimplementing navigation, rendering, cancellation, or mode adaptation.
+Pi TUI Kit provides typed menus and interactions for independently installable [Pi](https://pi.dev) extensions.
 
-Pi TUI Kit provides declarative screens, standalone task and confirmation flows, live choices, terminal-text helpers, and lifecycle ownership for specialized components.
+It supplies declarative screens, standalone interactions, terminal-display helpers, and interaction lifecycle ownership.
+Consumers reuse its navigation, rendering, cancellation, and mode adaptation instead of rebuilding them.
 
 ## ✨ Features
 
-- Defines typed action, detail, settings, choice, review, multi-select, and document screens.
-- Adapts shared flows across Pi TUI and RPC modes.
-- Owns standard navigation, cancellation, disposal, lifecycle, consistent horizontal framing, and width-safe rendering.
-- Provides focused task, confirmation, live-choice, custom-interaction, terminal-text, hint, editor-status-widget, horizontal-rule, and testing helpers.
+- Defines typed action, detail, browse, choice, settings, input, review, and multi-select screens.
+- Adapts shared menu and interaction flows across Pi TUI and RPC modes.
+- Handles interaction navigation, cancellation, disposal, horizontal framing, and width-safe rendering.
+- Provides task, confirmation, questionnaire, live-choice, custom-interaction, terminal-text, interaction-hint, editor-status-widget, horizontal-rule, and testing helpers.
 - Publishes built ESM and TypeScript declarations for independently installable extensions.
 
 ## 📦 Install
 
-Add the library as a runtime dependency of the extension package:
+Install the library as a runtime dependency of the consuming extension package:
 
 ```bash
 npm install @narumitw/pi-tui-kit
@@ -26,38 +27,8 @@ npm install @narumitw/pi-tui-kit
 The published package contains built ESM and declarations in `dist/`; consumers do not need a TypeScript loader for dependencies.
 
 The package root remains the supported entrypoint for menus and interaction runners.
-Import lightweight display helpers from `@narumitw/pi-tui-kit/editor-status-widget`, `@narumitw/pi-tui-kit/terminal-text`, or `@narumitw/pi-tui-kit/interaction-hints` when a startup path does not otherwise need the full Kit runtime.
-
-### Compatibility floor
-
-Pi TUI Kit is still a zero-major package, so caret ranges are minor-bounded: for example, `^0.40.0` accepts releases from `0.40.0` up to, but not including, `0.41.0`.
-When an extension adopts an API introduced in a later Kit minor, raise that extension's minimum compatible minor rather than using a broad `<1` range.
-Otherwise an existing npm lock can retain an older Kit that lacks the screen or contract the extension expects.
-
-Compatibility ranges are consumer-owned.
-Review each extension against the APIs it imports and keep its tested minimum; do not automatically synchronize every consumer range with the current Kit version.
-Pi TUI Kit and its consumers version independently through Changesets.
-Publish a new Kit API before raising a consumer's compatibility floor to use it, and declare the dependency in the consuming package so local hoisting cannot hide an incompatible or missing published dependency.
-
-## ⚡ Runtime performance
-
-The Kit's production JavaScript imports Pi TUI at runtime but keeps Pi Coding Agent imports type-only.
-This prevents a source-loaded extension from evaluating a second heavyweight coding-agent runtime when its menu first opens.
-Borders and task loaders compose public Pi TUI primitives with the theme and keybindings supplied by the active UI callback.
-Review syntax coloring synchronously loads the Kit's complete declared highlighter dependency on first use and applies the same callback theme.
-Root imports, ordinary menus, task frames, and Markdown-only reviews do not evaluate that highlighter.
-Mermaid rendering lazy-loads its declared renderer only before the first screen containing an enabled Mermaid fence.
-
-The `editor-status-widget`, `terminal-text`, and `interaction-hints` subpaths expose only their focused ESM and declaration graphs, while the package root keeps every existing export for compatibility.
-
-Repository maintainers can measure cold root and lightweight-subpath imports plus first actions, code-review, Mermaid, and task frames in fresh serial processes:
-
-```bash
-npm run build --workspace @narumitw/pi-tui-kit
-node scripts/benchmark-tui-kit-runtime.mjs --runs 5
-```
-
-The benchmark reports medians, median absolute deviations, resolved package URLs, syntax-color evidence, and graph-presence flags so a fast import cannot hide the same dependency cost in the first interaction.
+When startup does not need the full Kit runtime, import a lightweight display-helper subpath.
+The available subpaths are `editor-status-widget`, `terminal-text`, and `interaction-hints` under `@narumitw/pi-tui-kit`.
 
 ## 🚀 Quick start
 
@@ -84,6 +55,41 @@ export function showMenu(ctx: ExtensionCommandContext) {
   return runMenu(ctx, menu, { getState: () => undefined });
 }
 ```
+
+## 🔗 Compatibility
+
+Pi TUI Kit is a zero-major package, so caret ranges stop at the next minor release.
+For example, `^0.40.0` accepts `0.40.0` and later patch releases but not `0.41.0`.
+When an extension adopts an API from a later Kit minor, raise that extension's minimum compatible minor instead of using a broad `<1` range.
+Otherwise an existing npm lock can retain an older Kit that lacks the required screen or contract.
+
+Each consumer owns its compatibility range.
+Review the APIs each extension imports and keep its tested minimum instead of synchronizing every consumer with the current Kit version.
+Pi TUI Kit and its consumers version independently through Changesets.
+Publish a new Kit API before raising a consumer's compatibility floor.
+Declare Kit in that consumer so local hoisting cannot hide an incompatible or missing published dependency.
+
+## ⚡ Runtime performance
+
+The production JavaScript imports Pi TUI at runtime and keeps Pi Coding Agent imports type-only.
+This avoids evaluating a second coding-agent runtime when a source-loaded extension first opens its menu.
+Borders and task loaders use public Pi TUI primitives with the theme and keybindings from the active UI callback.
+Code review loads the complete declared syntax highlighter synchronously on first use and applies that callback theme.
+Root imports, ordinary menus, task frames, and Markdown-only reviews do not load the highlighter.
+Mermaid rendering loads its declared renderer only before the first screen with an enabled Mermaid fence.
+
+The `editor-status-widget`, `terminal-text`, and `interaction-hints` subpaths expose focused ESM and declaration graphs.
+The package root retains every existing export for compatibility.
+
+Repository maintainers can benchmark cold root and lightweight-subpath imports plus first action, code-review, Mermaid, and task frames in fresh serial processes:
+
+```bash
+npm run build --workspace @narumitw/pi-tui-kit
+node scripts/benchmark-tui-kit-runtime.mjs --runs 5
+```
+
+The benchmark reports medians, median absolute deviations, resolved package URLs, syntax-color evidence, and graph-presence flags.
+These fields reveal dependencies deferred from import time to the first interaction.
 
 ## ➖ Horizontal rules
 
@@ -157,6 +163,7 @@ declare function refreshDomainState(signal: AbortSignal): Promise<void>;
 declare function saveMode(mode: State["mode"], signal: AbortSignal): Promise<void>;
 declare function loadState(signal: AbortSignal): Promise<State>;
 declare function currentGeneration(): number;
+declare function currentSessionSignal(): AbortSignal;
 declare function formatError(error: unknown): string;
 
 const menu = defineMenu<State, Screen, Action>({
@@ -218,7 +225,9 @@ export async function showMenu(ctx: ExtensionCommandContext, generation: number)
 ```
 
 The state loader runs again whenever a screen is entered or refreshed, so screen factories can remain pure projections of current extension state.
-An ordinary terminal result is `{ kind: "closed", reason: "back" | "close" }`: root Back reports `back`; Ctrl+C, a Close hint, a close row, or an accepted action that returns Close reports `close`.
+An ordinary terminal result is `{ kind: "closed", reason: "back" | "close" }`.
+Root Back reports `back`.
+Ctrl+C, a Close hint, a close row, or an accepted Close action reports `close`.
 Nested Back remains inside the menu.
 RPC preserves each adapter's existing transition: a generic cancelled selector applies Back, while input and review cancellation follow their declared hint.
 Owner replacement remains `stale` and takes precedence over any racing Close event.
@@ -264,7 +273,9 @@ if (confirmation.kind === "confirmed") await deleteDomainData();
 else if (confirmation.kind === "closed" && confirmation.reason === "close") return;
 ```
 
-TUI confirmation uses the standard bounded actions presentation: selecting the cancel row or pressing Escape returns `{ kind: "closed", reason: "back" }`, while Ctrl+C returns the same result with reason `"close"`.
+TUI confirmation uses the standard bounded actions presentation.
+Selecting the cancel row or pressing Escape returns `{ kind: "closed", reason: "back" }`.
+Ctrl+C returns the same result with reason `"close"`.
 RPC uses one signal-aware `select()` request with explicit confirm and cancel rows.
 Explicit cancel and protocol cancellation deterministically map to Back because Pi RPC does not expose a separate Ctrl+C dialog outcome.
 Print and JSON return `unsupported`.
@@ -312,7 +323,9 @@ else if (choice?.kind === "shortcut") await customizePreset(choice.itemId);
 
 TUI calls `onSelectionChange` for the initial cursor and later focused rows, including disabled rows.
 A fully `disabled` row blocks both primary confirmation and shortcuts.
-Set `confirmationDisabled` with an optional `confirmationDisabledReason` when only the primary action must be inert while shortcuts remain available, such as allowing Customize for an already-active preset that cannot be applied again.
+Set `confirmationDisabled` when only the primary action must be inert while shortcuts remain available.
+For example, an active preset can still allow Customize even when it cannot be applied again.
+Use `confirmationDisabledReason` to explain the blocked primary action.
 If both states are present, full `disabled` behavior and its reason take precedence.
 Shortcut keys use Pi `KeyId` values; keys that conflict with current standard choice controls are omitted from shortcut hints and dispatch.
 Synchronous previews run immediately.
@@ -321,7 +334,9 @@ Completion, Back, Close, owner cancellation, external disposal, and errors abort
 The callback must honor that signal.
 The caller still owns its preview snapshot, rollback, persistence, confirmation, and final apply policy.
 
-RPC deliberately degrades to a signal-aware ordinary selector: it never runs live previews or custom shortcuts, disabled and confirmation-disabled rows remain explanatory and inert, and cancellation follows the requested Back/Close hint.
+RPC deliberately degrades to a signal-aware ordinary selector.
+It never runs live previews or custom shortcuts.
+Disabled and confirmation-disabled rows remain explanatory and inert, and cancellation follows the requested Back or Close hint.
 Print and JSON return `unsupported`.
 Results distinguish `selected`, `shortcut`, `closed`, `stale`, `unsupported`, and `error`.
 
@@ -355,7 +370,8 @@ if (result.kind === "submitted") {
 ```
 
 TUI preserves Pi selector framing, effective keybindings, Back versus Ctrl+C Close, exact editor input, optional notes, and a plain non-selectable review for multiple questions.
-A single question renders its header as plain muted text, omits Review and question-navigation controls, labels answer confirmation as submission, and returns immediately after a preset or free-form answer is confirmed.
+A single question renders its header as plain muted text and omits Review and question-navigation controls.
+Its answer confirmation is labeled as submission, and the interaction returns as soon as that answer is confirmed.
 Add an optional note before confirming a single preset answer because that confirmation submits the interaction.
 Free-form answers are enabled by default, notes require `allowNotes`, and `maxTextLength` applies to free-form answers and notes.
 RPC preserves the existing sequential `select()` and `editor()` fallback for choices and free-form answers, but does not collect TUI-only notes or show the final review.
@@ -366,7 +382,8 @@ Owner abort, stale state, external disposal, invalid options, and UI failures re
 The caller owns question-count and option-count policy, domain validation, side effects, result persistence, and mapping answer IDs back to domain objects.
 
 `formatInteractionHints()` is available for other specialized components.
-Pass the callback-injected keybindings plus binding-backed or literal-key hint groups; the formatter normalizes arrows, Enter/Escape names, sanitizes controls, applies exclusions, de-duplicates keys, and supports a custom separator.
+Pass the callback-injected keybindings with binding-backed or literal-key hint groups.
+The formatter normalizes arrows and Enter or Escape names, sanitizes controls, applies exclusions, de-duplicates keys, and supports a custom separator.
 
 ```ts
 import { formatInteractionHints } from "@narumitw/pi-tui-kit/interaction-hints";
@@ -379,7 +396,8 @@ const hint = formatInteractionHints(keybindings, [
 ```
 
 For a specialized custom component that does not belong in the declarative screen union, use `runCustomInteraction()`.
-It supplies an interaction-owned signal, classifies owner replacement and external component disposal as stale, disposes exactly once, and drains optional `waitForPending()` work before returning.
+It supplies an interaction-owned signal and classifies owner replacement or external component disposal as stale.
+It disposes exactly once and drains optional `waitForPending()` work before returning.
 The consumer still owns the component, its Back/Close value, and every domain side effect.
 Async factories and pending work must honor the supplied signal; the helper drains them but does not hide uncooperative work behind a timeout.
 
@@ -417,12 +435,12 @@ const result = await runCustomInteraction<{ kind: "back" | "close" }>(ctx, {
 
 - **`actions`** — navigation targets, domain actions, close rows, optional cancellable busy labels, adaptive long-label columns, and disabled explanations.
 - **`detail`** — read-only wrapped text with Back or Close behavior.
-- **`browse`** — a read-only searchable catalog with textual status, adaptive list/detail views, stable selection restoration, legacy prose or exact document details, and paginated RPC details.
-- **`choice`** — one confirmed value from a static list, with separate current and initial items, selected details, disabled explanations, an optional TUI search field, and a bounded viewport.
+- **`browse`** — a searchable read-only catalog with textual status, adaptive list/detail views, restored selection, prose or exact details, and RPC pagination.
+- **`choice`** — one confirmed static value with separate current and initial items, details, disabled explanations, optional TUI search, and a bounded viewport.
 - **`settings`** — Pi-style searchable, aligned settings rows with immediate value changes, serialized saves, and rollback when an action rejects.
 - **`input`** — single-line text entry inside the menu stack with IME focus, serialized submission, rejected-draft retention, and TUI/RPC adaptation.
 - **`review`** — fixed or terminal-adaptive scrollable exact text, code, or diff content with an optional primary confirmation action and paginated RPC fallback.
-- **`multiSelect`** — optimistic toggles with stable cursor restoration, serialized saves, rollback, selected-row descriptions, optional fuzzy search and bulk action rows, and a bounded TUI viewport.
+- **`multiSelect`** — optimistic toggles with restored cursor, serialized saves, rollback, row descriptions, optional fuzzy search and bulk actions, and a bounded viewport.
 
 All standard TUI screens use Pi's injected keybindings, sanitize display text, rebuild themed content after invalidation, and bound rendered output to the supplied terminal width.
 At normal terminal heights, every screen renders a themed full-width horizontal rule above and below its content.
@@ -431,7 +449,8 @@ Escape follows the screen's Back/Close hint; `Ctrl+C` closes the menu.
 
 Disabled action rows stay visible and focusable for context but never navigate, close, or invoke a domain action.
 Set `disabledReason` to explain why.
-TUI prefixes the semantic label with `[-]`, keeps a supplied unavailable reason visible below the selected row at every width, and adapts the primary column to available width; unavoidable action-label truncation uses an ellipsis.
+TUI prefixes the semantic label with `[-]` and keeps an unavailable reason visible below the selected row at every width.
+The primary column adapts to available width, and unavoidable action-label truncation uses an ellipsis.
 When a reason is supplied, RPC adds the unavailable state and reason to its selector label; legacy disabled rows without a reason keep their existing RPC label.
 This contract also applies to action rows under `multiSelect.actions`.
 
@@ -481,7 +500,8 @@ const profileScreen = {
 ```
 
 Set `enableSearch: true` when a choice list needs local filtering, and provide optional `searchText` for safe aliases or metadata that should not be rendered.
-TUI fuzzy-searches sanitized labels, descriptions, and explicit search text while preserving raw stable IDs, query and selection after a rejected action, disabled explanations, and IME focus.
+TUI fuzzy-searches sanitized labels, descriptions, and explicit search text.
+It preserves raw stable IDs, query and selection after a rejected action, disabled explanations, and IME focus.
 Details and raw IDs are not searched implicitly.
 RPC deliberately keeps one deterministic unfiltered selector and ignores interactive search metadata.
 
@@ -542,11 +562,12 @@ const schemasScreen = {
 Use `choice` when confirmation invokes a domain action; use `browse` when selection only reveals information.
 Domain status meaning, catalog construction, and data freshness remain consumer-owned.
 
-TUI settings screens retain the extension title and supporting context above Pi's familiar search field, aligned label/value columns, ten-row viewport, position indicator, selected-row description, and keyboard hint.
+TUI settings screens retain the extension title and supporting context above Pi's familiar search field.
+They use aligned label and value columns, a ten-row viewport, a position indicator, a selected-row description, and a keyboard hint.
 Typing fuzzy-filters labels, arrows navigate, and Enter or Space changes the selected value.
 Changes save immediately, so Back or Close never implies rollback.
 The embedded search input forwards focus for IME positioning.
-The kit owns this adapter because Pi's public `SettingsList` does not currently expose restored-cursor, disabled-row, async rollback, and search focus behavior together.
+The Kit owns this adapter because Pi's public `SettingsList` does not expose restored cursor, disabled rows, asynchronous rollback, and search focus together.
 
 Input screens submit through the existing action `value`.
 Validation, normalization, persistence, and product copy remain extension-owned.
@@ -566,7 +587,7 @@ const inputScreen = {
 Review screens preserve indentation and hard-wrap by terminal cells rather than prose words.
 Their viewport supports Up, Down, Page Up, Page Down, Home, and End.
 RPC sends bounded pages instead of one unbounded dialog title.
-Treat `content` as untrusted display input; the kit strips terminal and bidirectional display controls before formatting it.
+Treat `content` as untrusted display input; the Kit strips terminal and bidirectional display controls before formatting it.
 
 ```ts
 const reviewScreen = {
@@ -603,10 +624,12 @@ Rich Markdown rendering is TUI-only.
 RPC keeps sanitized, bounded source pages, and a host without Pi's public rich-Markdown capability safely displays readable source for unsupported rich elements.
 Omitted `viewportSize` keeps the fixed 14-row TUI viewport, and numeric values remain fixed integers from 1 through 50.
 Set `viewportSize: "adaptive"` to recompute from the live terminal height on every TUI render.
-Adaptive review reserves three terminal rows for Pi-owned UI and keeps the complete frame within `max(1, floor(terminal rows) - 3)` rows; this mode is not capped at the numeric 50-row maximum.
+Adaptive review reserves three terminal rows for Pi-owned UI.
+It keeps the complete frame within `max(1, floor(terminal rows) - 3)` rows and is not capped at the numeric 50-row maximum.
 
 At constrained heights, adaptive review prioritizes one content row, then a compact title, then a compact confirmation/Back-or-Close/navigation hint.
-From four available rows it shows position when content scrolls; additional space restores wrapped title and supporting context, the full keyboard hint, and the separator before enlarging the content viewport.
+With four available rows, adaptive review shows position when content scrolls.
+Additional space restores the wrapped title, supporting context, full keyboard hint, and separator before enlarging the content viewport.
 Fixed and omitted review rendering is unchanged.
 RPC does not read terminal dimensions: adaptive and omitted reviews use deterministic pages of at most eight rows, while numeric values retain the existing eight-row cap.
 A review without `confirm` is read-only.
@@ -630,14 +653,16 @@ Up and Down wrap; Page Up and Page Down move by one viewport and clamp at the fi
 Descriptions for the selected row appear below the viewport.
 
 Set `enableSearch: true` when toggle rows can become difficult to scan.
-TUI typing fuzzy-filters each sanitized label plus optional non-rendered `searchText`; use that field for source, policy, aliases, or other useful metadata without parsing display labels or raw IDs.
+TUI typing fuzzy-filters each sanitized label and optional non-rendered `searchText`.
+Use `searchText` for source, policy, aliases, or other useful metadata without parsing display labels or raw IDs.
 The query is local to the current screen instance.
 Rows in `actions` remain pinned below the matches, including when there are no matching toggle rows, so Save, Discard, and bulk workflows stay reachable.
 Clearing the query restores a valid stable-ID selection.
 The embedded public Pi `Input` forwards focus for IME positioning and sanitizes pasted terminal controls before filtering.
 
 Search and the viewport affect TUI presentation only.
-RPC deliberately keeps one flat, unfiltered list of unique dialog choices, preserving raw identity, disabled rows, toggle semantics, and action rows without introducing a second query protocol.
+RPC deliberately keeps one flat, unfiltered list of unique dialog choices.
+It preserves raw identity, disabled rows, toggle semantics, and action rows without adding a second query protocol.
 
 ```ts
 const tools = {
@@ -662,7 +687,8 @@ const tools = {
 };
 ```
 
-Disabled multi-select rows stay visible and focusable, use a textual `[-]`/`unavailable` marker, show `disabledReason` with the selected description, and never invoke the toggle handler.
+Disabled multi-select rows stay visible and focusable with a textual `[-]` or `unavailable` marker.
+They show `disabledReason` with the selected description and never invoke the toggle handler.
 RPC exposes the same unavailable reason and safely returns to the screen when the row is selected.
 Keep policy and bulk-set validation in the consuming extension and revalidate it again before mutation.
 
@@ -701,20 +727,21 @@ pi.on("agent_settled", async (_event, ctx) => {
 });
 ```
 
-The consumer must own and abort the session signal, check its generation or equivalent identity after every await, and never retain or use an `ExtensionContext` after session replacement, reload, or shutdown.
-The kit does not create lifecycle ownership for the extension.
+The consumer must own and abort the session signal and check its generation or equivalent identity after every await.
+It must not retain or use an `ExtensionContext` after session replacement, reload, or shutdown.
+The Kit does not create lifecycle ownership for the extension.
 `input` uses a signal-aware RPC dialog; a multi-line `editor` screen is intentionally deferred because Pi's current RPC editor contract does not accept an `AbortSignal`.
 
 ## 🧩 Ownership boundary
 
 Reuse Pi primitives and domain components from their package root whenever their public contract fits.
 Use non-exported Pi composites only as interaction references; never deep-import Pi's `dist/*` implementation paths.
-The kit owns a composite only when public controls do not provide the complete cross-mode and lifecycle contract shared by multiple extensions.
+The Kit owns a composite only when public controls do not provide the complete cross-mode and lifecycle contract shared by multiple extensions.
 
 The library owns:
 
 - standalone task-mode adaptation, cancellation, stale checks, error routing, and draining;
-- lifecycle ownership, disposal, and pending-work draining around live-choice and specialized custom interactions;
+- interaction lifecycle ownership, disposal, and pending-work draining for live-choice and specialized custom interactions;
 - width-safe standard rendering and injected keybindings;
 - screen-stack navigation, Back/Close semantics, and per-screen cursor memory;
 - serial settings and multi-select updates, optimistic rollback, and pending-update draining;
@@ -738,7 +765,8 @@ Keep specialized UI local rather than adding package hooks that expose Pi TUI in
 
 The same npm package exposes test-only drivers from `@narumitw/pi-tui-kit/testing`; there is no second package to install.
 Keep production imports on the main entrypoint and import harnesses only from test code.
-The testing entrypoint drives Kit behavior through Pi's public custom-factory and RPC dialog boundaries without returning a raw component or creating a general `ExtensionContext` mock.
+The testing entrypoint drives Kit behavior through Pi's public custom-factory and RPC dialog boundaries.
+It neither returns a raw component nor creates a general `ExtensionContext` mock.
 
 Compose `createTuiHarness()` with the consumer's own context fixture:
 
@@ -765,7 +793,8 @@ const frame = tui.render();
 const result = await running;
 ```
 
-The TUI harness supports semantic Kit bindings, explicit raw input, Ctrl+C/Home/End, focus, invalidation, live width/row changes, render-request observations, pending-action draining, sequential screens, result observation, and external disposal.
+The TUI harness supports semantic Kit bindings, explicit raw input, Ctrl+C, Home, End, focus, and invalidation.
+It also supports live dimension changes, render-request observations, pending-action draining, sequential screens, result observation, and external disposal.
 `done`, disposal, factory failure, and obsolete async openings settle exactly once; input after closure is inert.
 Supply optional callback-compatible theme/keybinding overrides only when a test needs them.
 
@@ -794,7 +823,8 @@ RPC steps match call kind and optional exact title, placeholder, or choices.
 Responses are exact raw strings or `undefined` cancellation; the harness never fuzzy-matches labels.
 A `waitForAbort: true` step supports owner-abort tests without a timer.
 Dialog records are immutable, unexpected or leftover steps fail observably, and any RPC request for custom TUI throws.
-The current Kit runtime uses only signal-aware `input()` and `select()` in RPC, so the testing entrypoint deliberately does not mock confirmations, editors, notifications, sessions, models, settings, filesystems, clocks, or networks.
+The current Kit runtime uses only signal-aware `input()` and `select()` in RPC.
+The testing entrypoint therefore does not mock confirmations, editors, notifications, sessions, models, settings, filesystems, clocks, or networks.
 Consumer fixtures continue to own domain state, persistence, generation checks, and owner signals.
 
 ## 📚 Public API
@@ -803,21 +833,27 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `runMenu()` — runs the definition in the current Pi mode and preserves root Back versus Close.
 - `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
 - `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one standalone confirmation without owning the confirmed side effect.
-- `runLiveChoice()` — adapts a live-preview choice to TUI and ordinary RPC selection while preserving typed selection, confirmation-only gating, shortcuts, Back, Close, Stale, Unsupported, and Error.
-- `runQuestionnaire()` — adapts required choices, free-form answers, optional TUI notes, direct single-question submission, multi-question read-only review, and sequential RPC while preserving typed Submitted, Back, Close, Stale, Unsupported, and Error outcomes.
-- `formatInteractionHints()` — formats sanitized, normalized, de-duplicated injected bindings and literal shortcut keys for specialized interaction hints; the lightweight `@narumitw/pi-tui-kit/interaction-hints` subpath exports it and its public types.
-- `sanitizeTerminalText()` — removes terminal and bidirectional display controls from untrusted single-line presentation text without mutating raw payloads; the lightweight `@narumitw/pi-tui-kit/terminal-text` subpath exports it.
-- `EditorStatusWidget` — frames extension-owned passive editor status rows with the standard muted top rule and a final terminal-width guard; the lightweight `@narumitw/pi-tui-kit/editor-status-widget` subpath exports it and its public options.
+- `runLiveChoice()` — adapts live-preview choice to TUI and RPC while preserving typed selection, gating, shortcuts, and lifecycle outcomes.
+- `runQuestionnaire()` — adapts choices, free-form answers, optional TUI notes, direct single-question submission, multi-question review, and sequential RPC.
+- `formatInteractionHints()` — formats sanitized, normalized, de-duplicated bindings and literal keys; `@narumitw/pi-tui-kit/interaction-hints` also exports it and its types.
+- `sanitizeTerminalText()` — removes terminal and bidirectional controls from untrusted single-line display text without changing raw payloads; `@narumitw/pi-tui-kit/terminal-text` also exports it.
+- `EditorStatusWidget` — frames passive editor status rows with a muted top rule and terminal-width guard; `@narumitw/pi-tui-kit/editor-status-widget` exports it and its options.
 - `HorizontalRule` — renders a full-width or inset horizontal divider with an optional sanitized and aligned label plus render-time style callbacks.
-- `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending work draining, and typed results around one extension-owned custom TUI component.
+- `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending-work draining, and typed results for one custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, `BrowseDetailDocument`, `MenuCloseReason`, and result types.
-- `@narumitw/pi-tui-kit/testing` — separate subpath for `createTuiHarness()`, `createRpcHarness()`, strict scripts, and their public testing types; it is not re-exported from the production root.
+- `@narumitw/pi-tui-kit/testing` — test-only subpath for `createTuiHarness()`, `createRpcHarness()`, strict scripts, and their types; the production root does not re-export it.
 - `PI_EXTENSION_MENU_API_VERSION` — current API version (`14`).
 Version 14 adds the standalone `runQuestionnaire()` interaction while version-13 menu definitions remain valid.
 Version 13 adds opt-in Markdown, LaTeX, and Mermaid document formatting while version-12 menu definitions remain valid.
-Version 12 added optional searchable `choice` fields, version 11 added Live Choice confirmation-only gating, version 10 added exact browse detail documents, version 9 added `runLiveChoice()` and `formatInteractionHints()`, version 8 added disabled action reasons and adaptive action-label columns, version 7 added `runConfirmation()`, and version 6 added the read-only `browse` screen and `runCustomInteraction()`.
+Version 12 added optional searchable `choice` fields.
+Version 11 added Live Choice confirmation-only gating.
+Version 10 added exact browse detail documents.
+Version 9 added `runLiveChoice()` and `formatInteractionHints()`.
+Version 8 added disabled action reasons and adaptive action-label columns.
+Version 7 added `runConfirmation()`.
+Version 6 added the read-only `browse` screen and `runCustomInteraction()`.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -2,28 +2,32 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Check the limits and usage for the provider account Pi is actually using, toggle Fast mode for supported OpenAI Codex models, and report xAI OAuth subscription usage.
+Inspect usage for Pi's active provider account, query other configured providers, and toggle Fast mode for supported OpenAI Codex models.
 
-The extension reports each provider's native semantics instead of presenting unlike quotas as equivalent.
-xAI reporting defaults On and follows the current official Grok Build implementation.
+The extension keeps each provider's native quota, allowance, and spending semantics instead of treating unlike values as equivalent.
+xAI OAuth subscription reporting defaults to On and follows the reviewed Grok Build contract.
 
 ## ✨ Features
 
-- Shows current-account usage and next actions through `/usage`.
-- Supports OpenAI Codex subscription windows, credits, resets, and model-specific buckets.
-- Supports Kimi For Coding plan windows, resets, and separately labeled booster-wallet currency.
-- Supports GitHub Copilot allowances and OpenRouter per-key limits and spend windows.
-- Supports xAI OAuth subscription allowance and credit reporting.
-- Toggles persistent Codex Fast routing through `/fast` or the contextual usage menu.
+- Shows active-account usage and next actions through `/usage`.
+- Reports OpenAI Codex subscription windows, credits, resets, and model-specific buckets.
+- Reports Kimi For Coding plan windows, resets, and separately labeled booster-wallet currency.
+- Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
+- Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
+- Reports xAI OAuth subscription allowances and credits when enabled.
+- Toggles persistent Codex Fast routing through `/fast` or the usage menu.
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
-- Refreshes one or all configured providers with bounded concurrency and partial-result preservation.
-- Keeps statusline and cache data scoped to the current provider and runtime account.
+- Refreshes one or all configured providers with bounded concurrency while preserving partial results.
+- Scopes statusline and cache data to the active provider and runtime account.
 - Resolves credentials through Pi or the process-local OAuth credential-source protocol and validates the effective provider endpoint before sending them.
 
 ## 📦 Install
 
-Requires Pi 0.81.0 or newer so the extension can validate the effective base URL attached to resolved provider auth before sending credentials to an official usage endpoint.
-The v1 credential-source interoperability path is characterized against Pi 0.84.3; other runtimes retain standalone fallback but do not receive the protocol timing guarantee.
+Requires Pi 0.81.0 or newer to validate the effective base URL for resolved provider auth before sending credentials to an official usage endpoint.
+The v1 credential-source path is characterized against Pi 0.84.3; other runtimes keep the standalone fallback without its protocol timing guarantee.
+
+Like every Pi extension, this package runs with Pi's process permissions.
+Review [Security and privacy](#-security-and-privacy) before installation.
 
 ```bash
 pi install npm:@narumitw/pi-usage
@@ -46,18 +50,18 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 
 ## 🚀 Quick start
 
-Run `/usage` in TUI or RPC mode to inspect the current provider, refresh usage, or choose another configured provider.
-Use `/fast` separately to toggle Fast mode for a supported current Codex model.
+Run `/usage` in TUI or RPC mode to inspect the active provider, refresh its usage, or choose another configured provider.
+Run `/fast` to toggle Fast mode for a supported active Codex model.
 
 ## 💬 Commands
 
-Run:
+Open the manager with:
 
 ```text
 /usage
 ```
 
-In TUI or RPC mode, the standard menu first queries the current model provider and presents its state with these actions:
+In TUI or RPC mode, the menu first queries the active model provider and then offers these actions:
 
 ```text
 Refresh current usage
@@ -69,13 +73,14 @@ View all configured providers…
 Close
 ```
 
-There are intentionally no `/usage --refresh`, `/usage <provider>`, or `/usage --all` argument paths.
-Cross-provider traffic requires an explicit interactive choice.
-Escape returns from provider selection and closes the root menu.
-Print and JSON modes reject `/usage` observably because they cannot host the interactive flow.
-The cancellable live-query progress view remains extension-owned because it streams provider work and supports in-flight abort rather than presenting a standard menu screen.
+`/usage` accepts no arguments, including `--refresh`, a provider ID, or `--all`.
+Cross-provider requests require an explicit interactive choice.
+Escape returns from provider selection or closes the root menu.
+Print and JSON modes reject `/usage` because they cannot host the interactive flow.
+The extension owns the cancellable live-query progress view because it streams provider work and supports in-flight abort.
 
-For the current OpenAI Codex provider, **Redeem usage limit reset…** checks fresh earned-reset details, lets you select a reset when details are available, and shows the exact reset before asking for confirmation.
+For the current OpenAI Codex provider, **Redeem usage limit reset…** first checks fresh earned-reset details.
+When details are available, you select a reset and review its exact effect before confirmation.
 **No, go back** is the safe default and cancellation before confirmation sends no mutation.
 After confirmation, the reset operation cannot be cancelled from its progress view; session replacement or shutdown still aborts owned work.
 A transport failure offers **Try again** with the same redemption request ID so the backend can treat an uncertain retry idempotently.
@@ -86,16 +91,17 @@ Successful, already-completed, not-needed, and no-credit outcomes are reported s
 Choose **Settings** in `/usage` to edit Codex Fast mode and xAI usage through Pi's settings-list interaction in TUI mode.
 RPC mode reports the active manual settings path instead of opening terminal UI.
 
-Both preferences live in Pi's user agent directory as `pi-usage.json`, normally `~/.pi/agent/pi-usage.json`.
-The file reloads at every session start and is not created until the first successful save.
-Changes save immediately in input order inside one Pi process.
-Unknown JSON fields are preserved, writes use a private temporary file plus rename, and malformed or invalid files remain untouched.
+Both preferences live in `pi-usage.json` under Pi's user agent directory, normally `~/.pi/agent/pi-usage.json`.
+The extension reloads this file at every session start and does not create it until the first successful save.
+Within one Pi process, changes save immediately in invocation order.
+Saves preserve unknown JSON fields and publish through a private temporary file plus rename.
+Malformed or invalid files remain untouched.
 A failed save restores the prior displayed and effective value, while shutdown waits for queued writes.
 Separate Pi processes are not mutually locked.
 
 ### Codex Fast mode
 
-Run bare `/fast` to toggle Fast for the active supported Codex model, or use **Turn Fast mode on/off** in `/usage`.
+Run `/fast` without arguments to toggle Fast for the active supported Codex model, or use **Turn Fast mode on/off** in `/usage`.
 
 Fast is about 1.5× faster and uses more of your plan allowance.
 The `codexFastMode` preference defaults to Off.
@@ -139,7 +145,8 @@ Turning it Off clears xAI cache state and prevents stale in-flight results from 
 The statusline selects a returned bucket that matches the current Codex model when one is available.
 Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.
 
-Reset redemption is available only when Codex is the current provider and Pi's freshly resolved access token exactly matches an OAuth credential from Pi's stored login or a compatible credential source.
+Reset redemption is available only when Codex is the current provider.
+Pi's freshly resolved access token must exactly match an OAuth credential from Pi's stored login or a compatible credential source.
 `pi-usage` forwards only the bearer authorization and matching `chatgpt-account-id` to the official ChatGPT origin.
 API-key credentials, configured-but-not-current Codex accounts, account changes during the flow, and custom/proxy origins fail before mutation.
 Backend-provided titles and descriptions are sanitized for terminal display.
@@ -150,7 +157,8 @@ Opaque credit and account IDs are never shown or persisted by the extension.
 - Provider ID: `kimi-coding`
 - Semantics: Kimi Coding Plan request windows plus a separate Extra Usage booster wallet
 - Source: `GET https://api.kimi.com/coding/v1/usages` using Pi's freshly resolved runtime Bearer credential
-- Displayed data: the weekly plan summary, returned sub-windows such as five-hour or daily limits, used and remaining request percentages, valid reset times, wallet balance, monthly spend, and monthly charge limit
+- Displayed plan data: the weekly summary, returned sub-windows, used and remaining request percentages, and valid reset times
+- Displayed wallet data: balance, monthly spend, and monthly charge limit
 - Statusline examples: `kimi 99% 5h 96% wk` or `kimi 95% 1d`
 
 Both Pi API-key credentials and Pi OAuth credentials are accepted because current Pi resolves each form as Bearer authorization for the same official Kimi inference origin.
@@ -171,7 +179,8 @@ The pinned Kimi managed-usage source at `cd7c97b377a77f7ae1b9d541cafe314e986ec07
 ### GitHub Copilot
 
 - Provider ID: `github-copilot`
-- Semantics: the allowance reported for the active Copilot plan—AI credits for current usage-based billing, premium requests for legacy annual billing, or chat requests for Copilot Free's limited response shape
+- Semantics: the allowance reported for the active Copilot plan
+- Allowance labels: AI credits for usage-based billing, premium requests for legacy annual billing, or chat requests for Copilot Free
 - Source: GitHub's undocumented `GET /copilot_internal/user` endpoint
 - Displayed data: entitlement, remaining allowance, percentage, reset time, plan, and any additional usage beyond the included allowance
 - Statusline examples: `copilot credits 1200/1500 80%`, `copilot 245/300 82%`, or `copilot chat 40/50 80%`
@@ -181,7 +190,8 @@ GitHub's quota endpoint requires the original GitHub OAuth token rather than the
 It uses a candidate only when its short-lived access token exactly matches the freshly resolved active runtime credential.
 Duplicate equivalent candidates are harmless, while conflicting matches fail closed without choosing by extension load order.
 API-key credentials, account mismatches, GitHub Enterprise accounts, and proxy/custom provider origins fail closed.
-The detailed report follows the endpoint's `token_based_billing` marker so AI credits are not mislabeled as legacy premium requests, and it reports overage without treating a negative included balance as a malformed response.
+The detailed report follows the endpoint's `token_based_billing` marker so AI credits are not mislabeled as legacy premium requests.
+It reports overage without treating a negative included balance as malformed.
 
 ### OpenRouter
 
@@ -199,10 +209,13 @@ OpenRouter documents the distinction between credit and rate limits in its [API 
 - Provider ID: `opencode-go`
 - Semantics: OpenCode Zen plan usage windows—rolling, weekly, and monthly
 - Source: `GET https://opencode.ai/zen/go/v1/usage` using Pi's resolved inference API key
-- Displayed data: used percentage and reset time for each window; `rate-limited` windows remain visible at their reported usage, while unknown statuses are reported as unavailable notes
+- Displayed data: used percentage and reset time for each window
+- Status handling: `rate-limited` windows remain visible, while unknown statuses become unavailable notes
 - Statusline examples: `zen 0% r 4% w 2% m`
 
-The fixed endpoint is queried only when the candidate OpenCode Go model and the resolved provider-auth base URL, when present, use the official `https://opencode.ai` origin; other origins fail before sending the credential.
+The fixed endpoint is queried only when the OpenCode Go model uses the official `https://opencode.ai` origin.
+When resolved provider auth includes a base URL, that URL must use the same origin.
+Other origins fail before the credential is sent.
 
 ### xAI consumer subscriptions
 
@@ -210,12 +223,13 @@ The fixed endpoint is queried only when the candidate OpenCode Go model and the 
 - Semantics: consumer subscription allowance and credits, not xAI API-team billing
 - Identity route: `GET https://cli-chat-proxy.grok.com/v1/user?include=subscription`
 - Billing route: `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
-- Displayed data: included allowance percentage or legacy monetary limit, weekly or monthly period and reset, on-demand spend and cap, prepaid balance, and a sanitized optional plan tier
+- Displayed data: included allowance or legacy monetary limit, period and reset, on-demand spend and cap, prepaid balance, and a sanitized optional plan tier
 - Statusline: not published; xAI is queried only through an explicit `/usage` action while xAI usage is enabled
 
 The adapter accepts only the official Pi inference origin `https://api.x.ai` and a freshly resolved bearer that exactly matches one complete Pi OAuth credential.
 Pi's reviewed OAuth scope is `openid profile email offline_access grok-cli:access api:access`.
-`XAI_API_KEY`, duplicate or conflicting OAuth candidates, account mismatches, incomplete OAuth records, custom origins, and proxy-resolved origins fail before consumer-proxy access.
+The adapter rejects `XAI_API_KEY`, duplicate or conflicting OAuth candidates, account mismatches, and incomplete OAuth records.
+It also rejects custom or proxy-resolved origins before consumer-proxy access.
 API-key users can review API-team spend through [console.x.ai](https://console.x.ai/) instead.
 The public Management API requires a separate management key and team ID and is intentionally outside this runtime-credential integration.
 
@@ -232,9 +246,11 @@ The implementation contract was verified against these first-party revisions:
 - Grok Build [`UserInfo`](https://github.com/xai-org/grok-build/blob/9684fa3cdbf2995e30ea8b9b637f1db008f144fc/crates/codegen/xai-grok-shell/src/auth/model.rs), [`subscription_check.rs`](https://github.com/xai-org/grok-build/blob/9684fa3cdbf2995e30ea8b9b637f1db008f144fc/crates/codegen/xai-grok-shell/src/agent/subscription_check.rs), [`billing.rs`](https://github.com/xai-org/grok-build/blob/9684fa3cdbf2995e30ea8b9b637f1db008f144fc/crates/codegen/xai-grok-shell/src/extensions/billing.rs), [`auth/config.rs`](https://github.com/xai-org/grok-build/blob/9684fa3cdbf2995e30ea8b9b637f1db008f144fc/crates/codegen/xai-grok-shell/src/auth/config.rs), [`xai-grok-http`](https://github.com/xai-org/grok-build/blob/9684fa3cdbf2995e30ea8b9b637f1db008f144fc/crates/codegen/xai-grok-http/src/lib.rs), and [`xai-grok-version`](https://github.com/xai-org/grok-build/blob/9684fa3cdbf2995e30ea8b9b637f1db008f144fc/crates/codegen/xai-grok-version/Cargo.toml) at `9684fa3`.
 - [xAI Management API team billing boundary at `723dd2a`](https://github.com/xai-org/xai-proto/blob/723dd2aa22d17be35617463837dc47cda008d90e/proto/xai/management_api/v1/billing.proto).
 
-The approved 2026-08-27 disposable-or-maintainer-account protocol smoke used only Pi's OAuth bearer, read no Grok-local files, and received HTTP 200 without redirects from both routes.
+The approved 2026-08-27 protocol smoke used only Pi's OAuth bearer and read no Grok-local files.
+A disposable or maintainer account received HTTP 200 without redirects from both routes.
 The implementation also sends the non-secret client headers present on both routes in current Grok Build source, with `x-userid` added only for billing.
-The sanitized identity shape contained a string `userId` and nullable `subscriptionTier`; the billing shape contained an object `config` with period and distinct on-demand and prepaid wrappers, without retaining field values.
+The sanitized identity shape contained a string `userId` and nullable `subscriptionTier`.
+The billing shape contained a `config` object with period and distinct on-demand and prepaid wrappers, without retaining field values.
 
 Disable `xaiUsage` to stop all xAI consumer usage traffic while preserving other provider behavior.
 
@@ -242,20 +258,23 @@ Disable `xaiUsage` to stop all xAI consumer usage traffic while preserving other
 
 - Provider ID: `zai` and `zai-coding-cn`
 - Semantics: GLM Coding Plan quota windows—the rolling 5-hour and weekly plan-usage windows plus the monthly MCP allowance
-- Source: Z.AI's undocumented `GET {origin}/api/monitor/usage/quota/limit` endpoint, also used by its official coding plugin, with the origin derived from the model base URL (`https://api.z.ai` or `https://open.bigmodel.cn`)
-- Displayed data: explicit used and remaining values, reset times, provider-reported per-tool MCP details, and the reported plan level. Windows that report only a percentage remain percent-based
+- Source: the undocumented `GET {origin}/api/monitor/usage/quota/limit` endpoint also used by Z.AI's official coding plugin
+- Allowed origins: the model base URL must resolve to `https://api.z.ai` or `https://open.bigmodel.cn`
+- Displayed data: explicit used and remaining values, reset times, provider-reported per-tool MCP details, and the reported plan level
+- Percentage-only windows remain percent-based
 - Statusline: publishes remaining plan percentages such as `zai 87% 5h 76% wk`; monthly MCP details remain available through `/usage`
 
 The monitor endpoint is not a published API contract and may return legacy `TOKENS_LIMIT` or newer `CREDIT_LIMIT` window names.
 The extension classifies both forms by the provider's window unit and does not label provider-reported counts as tokens or calls.
-The quota monitor expects the raw API key without a `Bearer` prefix, so the extension strips a `Bearer` prefix from the resolved authorization before sending it to the monitor endpoint.
+The quota monitor expects a raw API key without a `Bearer` prefix.
+The extension removes that prefix from resolved authorization before sending it to the monitor endpoint.
 Fingerprinting and redaction keep using the original resolved credential.
 Only the official `api.z.ai` and `open.bigmodel.cn` origins are queried; other origins fail before sending the credential.
 
 ## 🧭 Current and configured accounts
 
-`Current` means the provider and credential used by Pi's selected model.
-`Configured` means Pi reports runtime auth for another supported provider; it does not mean that provider is active.
+`Current` identifies the provider and credential used by Pi's selected model.
+`Configured` identifies runtime auth for another supported provider, not an active provider.
 
 The extension does not enumerate multiple accounts inside one provider and does not switch accounts.
 Account selection remains owned by Pi or an account-management extension.
@@ -271,7 +290,7 @@ It refreshes every five minutes while the session remains on such a provider and
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
-Manual another-provider and all-provider queries never publish to the statusline.
+Queries for another provider or all providers never publish their results to the statusline.
 `@narumitw/pi-statusline` supplies the default `📊` icon; `pi-usage` publishes text-only values.
 
 ## 🔄 Migrating from pi-codex-usage
@@ -297,10 +316,11 @@ Behavior changes:
 
 Credential candidates are collected synchronously in memory and are not cached, persisted, logged, formatted, or appended to the Pi session.
 The protocol carries no account name or extension identity.
-Only the selected provider's exact runtime match is used, and secrets are sent only to the validated official provider origin.
+Only the selected provider's exact runtime match is used, and secrets are sent only to its validated official origin.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
-Install only trusted extensions because any installed extension may already read user files and process memory.
-Protocol v1 interoperability is characterized for the repository's supported Pi runtime; an absent or incompatible peer preserves standalone fallback and fail-closed mismatch behavior.
+Install only trusted extensions because they can read user files and process memory.
+Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
+An absent or incompatible peer preserves standalone fallback and fail-closed mismatch behavior.
 
 ## 🚧 Limitations
 

--- a/packages/pi-worktree/README.md
+++ b/packages/pi-worktree/README.md
@@ -4,19 +4,22 @@
 
 Create, inspect, switch, remove, and prune Git worktrees through one guarded `/worktree` manager.
 
-Because Pi cannot change its parent process directory with `cd`, the extension switches to a prepared Pi session whose cwd is the selected worktree and preserves the current conversation when possible.
+Because `cd` cannot change Pi's parent process directory, switching prepares a Pi session whose cwd is the selected worktree and carries over the active conversation when possible.
 
 ## ✨ Features
 
-- Lists main, linked, current, detached, locked, and prunable worktrees with searchable status details.
-- Creates a worktree from a new branch or an unoccupied local branch after previewing the exact base commit.
+- Lists main, linked, current, detached, locked, and prunable worktrees with searchable local status details.
+- Creates a worktree from a new branch or an unoccupied local branch after showing the exact base commit.
 - Suggests a configurable path under `~/.worktrees/` and rejects unsafe, occupied, or ambiguous targets.
-- Switches Pi to an existing or newly created worktree while preserving the conversation when possible.
-- Removes only non-current unlocked worktrees after checking tracked, untracked, index, submodule, and detached-commit risk.
-- Previews ignored files and stale metadata before confirmed removal or pruning, then revalidates the plan.
-- Runs Git with argument arrays and never interpolates user input into shell commands.
+- Switches Pi to an existing or newly created worktree while preserving the active conversation when possible.
+- Removes only non-current, unlocked worktrees after checking tracked, untracked, index, submodule, and detached-commit risks.
+- Shows ignored files and stale metadata before confirmed removal or pruning, then revalidates the approved plan.
+- Passes arguments directly to Git without interpolating user input into shell commands.
 
 ## 📦 Install
+
+This extension runs Git and writes settings and Pi sessions with Pi's process permissions.
+Install it only from a source you trust.
 
 ```bash
 pi install npm:@narumitw/pi-worktree
@@ -39,34 +42,36 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must be built
 
 ## 🚀 Quick start
 
-Run `/worktree` in TUI or RPC mode and choose the worktree action you need.
-Every mutation shows package-owned safety checks and an exact confirmation before Git changes the worktree state.
+Run `/worktree` in TUI or RPC mode and choose an action.
+Before each Git mutation, the extension runs its safety checks and shows the exact change for confirmation.
 
 ## 💬 Commands
 
-Run the command without arguments:
+Open the manager without arguments:
 
 ```text
 /worktree
 ```
 
-Choose one action:
+The root menu provides these actions:
 
 - **Worktree status** — browse a local snapshot for every registered worktree without fetching remotes.
 - **Add worktree** — enter a branch, optional start point, and optional path; review exact base provenance, confirm creation, and optionally switch.
 - **Switch worktree** — search for another existing worktree by displayed path, branch, or HEAD and continue this Pi conversation there.
-- **Remove worktree** — search for a linked worktree by displayed path, branch, or HEAD, then remove it without deleting its branch; ignored-only data is listed for explicit confirmation.
+- **Remove worktree** — search for a linked worktree by path, branch, or HEAD, then remove it without deleting its branch.
 - **Prune stale metadata** — inspect Git's dry-run output, then optionally run the matching prune.
 - **Configure worktree root** — set a machine-local default root or submit a blank value to restore `~/.worktrees`.
 
-The standard root menu shows the registered count, current path, effective worktree root, its source, and any settings warning.
-Escape closes it.
-`/worktree` intentionally does not accept text subcommands or expose argument autocomplete.
-Every change is initiated and confirmed through TUI or RPC dialogs; print and JSON modes reject the command observably.
-Operation-specific branch/path inputs, searchable worktree identity selectors, preflight previews, and destructive confirmations remain extension-owned because they carry Git safety and commit-aware revalidation.
+The root menu shows the registered count, current path, effective worktree root, its source, and any settings warning.
+Escape closes the root menu.
+`/worktree` accepts no arguments and provides no argument completions.
+Every operation starts through TUI or RPC dialogs, and destructive Git changes require confirmation.
+Print and JSON modes reject the command before any Git call.
+The extension owns branch and path inputs, searchable worktree selectors, preflight previews, and destructive confirmations.
+These flows enforce Git safety and commit-aware revalidation.
 
-The status browser runs only when selected and has no watcher, timer, persistent cache, or network fetch.
-Each card shows textual current/main/detached state, full snapshot HEAD, aggregate working-tree counts, configured upstream ahead/behind, and the last commit timestamp and subject.
+The status browser runs only when selected and uses no watcher, timer, persistent cache, or network fetch.
+Each card shows current, main, or detached state; the full snapshot HEAD; aggregate working-tree counts; configured upstream divergence; and the last commit timestamp and subject.
 A missing upstream is reported as **not configured**; it is not treated as proof that no commits are unpushed.
 Bare, missing, prunable, or individually failing worktrees remain visible with an unavailable reason.
 The snapshot is informational and can become stale immediately, so Remove still performs its stricter inventory and identity checks.
@@ -77,7 +82,8 @@ For a new branch, the current symbolic branch is the default start point.
 If Pi is running from detached HEAD, the command requires an explicit commit-ish.
 Git must resolve the start point to exactly one commit.
 
-Before mutation, Add identifies whether the branch is new or existing and displays the provenance as the current branch, an explicit commit-ish, or an existing local branch together with its full resolved OID and target path.
+Before mutation, Add identifies whether the branch is new or existing.
+It shows the current branch, explicit commit-ish, or existing local branch used as provenance, plus the full resolved OID and target path.
 New branches are created from that approved OID even if the source ref later moves.
 Existing branches are checked again immediately before mutation and the created worktree HEAD is verified afterward.
 Git has no atomic compare-and-add operation for attaching an existing branch, so a post-add mismatch is retained for inspection rather than rolled back.
@@ -94,7 +100,8 @@ suggested:     /home/user/.worktrees/project/feat-login
 
 On Windows, the equivalent default is such as `C:\Users\Alice\.worktrees`.
 Branch `/` characters become `-`.
-The extension does not add hashes or collision suffixes: if two normalized paths collide or the target already exists, Add stops before Git mutation.
+The extension does not add hashes or collision suffixes.
+If normalized paths collide or the target already exists, Add stops before mutating Git state.
 
 Leave the path input blank to accept the suggestion.
 A custom absolute path is used directly; a custom relative path is resolved from the current Pi cwd.
@@ -125,9 +132,11 @@ It does not expand `$VAR`, `%VAR%`, or other shell syntax.
 Empty, relative, NUL-containing, non-string, and invalid paths are rejected.
 There is no project override or extension-specific environment variable.
 
-A missing `worktreeRoot` uses `~/.worktrees`; the settings file is created only by a successful interactive change.
+A missing `worktreeRoot` uses `~/.worktrees`.
+A successful interactive change is the only operation that creates the settings file.
 Submitting a blank value in the interactive action removes the override.
-Within one Pi process, queued saves run in invocation order, reread the latest valid document immediately before merging `worktreeRoot`, and preserve concurrent unknown-field edits.
+Within one Pi process, queued saves run in invocation order.
+Each save rereads the latest valid document before merging `worktreeRoot` and preserves concurrent edits to unknown fields.
 Settings reload on every `session_start`, including `/reload` and workspace replacement; a successful interactive save applies immediately to the next Add flow.
 
 Malformed or invalid settings are warned about but never overwritten, including an invalid edit made while a settings action is open.
@@ -137,41 +146,47 @@ Failed publication leaves the prior file and effective runtime root unchanged, a
 
 ## 🔀 Pi workspace switching
 
-Switching uses Pi's public `SessionManager` and `ctx.switchSession()` APIs:
+Switching uses Pi's public `SessionManager` and `ctx.switchSession()` APIs in this order:
 
 1. The command waits for Pi to become fully idle so the current assistant/tool results are persisted.
 2. A linear persisted session is forked into the target worktree.
-   If `/tree` currently points at an older branch, the documented session entries for that active branch are written to the target instead, so switching cannot jump to a newer serialized leaf.
+   If `/tree` points at an older branch, only that active branch's documented session entries are written to the target.
+   Switching therefore cannot jump to a newer serialized leaf.
 3. Pi tears down the old cwd-bound runtime and creates the target runtime.
 4. The extension reports success only through the fresh replacement-session context.
 
 If the current session is completely empty, the extension creates a valid empty Pi session for the target.
-If the current session is ephemeral (`--no-session`), the extension copies its active conversation branch into a persisted target session so the workspace switch does not lose context.
+For an ephemeral session created with `--no-session`, the extension copies the active conversation branch into a persisted target session.
+This preserves context across the workspace switch.
 
-A successfully created Git worktree is never rolled back merely because Pi session switching fails.
-Re-run `/worktree` and choose **Switch worktree** after resolving the reported Pi/session issue.
+If switching fails after Add, the extension retains the successfully created Git worktree.
+If Pi prepared a target session before the failure, it retains that session too.
+Resolve the reported Pi or session issue, then run `/worktree` and choose **Switch worktree**.
 
 ## 🛡️ Safety boundaries
 
 - The main worktree and current worktree cannot be removed.
 - Locked or stale worktrees cannot be removed through this extension.
 - Dirty, untracked, initialized-submodule, and intentional `assume-unchanged`/`skip-worktree` index state causes removal to fail closed.
-  Sparse-checkout-managed `skip-worktree` entries outside the active sparsity rules are allowed when Git's rule checker can confirm them; clear other intentional index flags before removing the worktree.
+  Sparse-checkout-managed `skip-worktree` entries outside the active sparsity rules are allowed when Git's rule checker confirms them.
+  Clear other intentional index flags before removing the worktree.
 - Ignored-only files and directories do not block removal.
   The confirmation lists them, and the extension rechecks the exact ignored inventory before Git deletes the worktree.
 - A detached HEAD must be reachable from a local branch, tag, or remote ref before removal or prune.
 - Removal and prune inspect reflogs, pseudorefs, per-worktree refs, and `FETCH_HEAD`.
-  Historical commits reachable only through this administrative recovery state are listed by full OID in the destructive confirmation; approval removes those recovery pointers, so Git may later garbage-collect the commits.
+  Historical commits reachable only through this administrative recovery state are listed by full OID in the destructive confirmation.
+  Approval removes those recovery pointers, so Git may later garbage-collect the commits.
   Create a branch or tag instead when any listed commit should survive.
 - Staged-only administrative index state, a missing attached branch ref, or an unreachable current detached HEAD still blocks prune without an override.
 - Removal never deletes a branch and never uses `--force`.
 - Remove invokes only argv-based `git worktree remove <path>`; production runtime never invokes a shell, `rm`, `rm -rf`, or a Node filesystem directory-deletion API for worktrees.
-- Prune always runs `git worktree prune --dry-run --verbose` before confirmation, inspects candidates omitted from porcelain, rechecks the exact preview and recovery-risk set after confirmation, and uses Git's default expiry.
+- Prune runs `git worktree prune --dry-run --verbose`, inspects candidates omitted from porcelain, and shows the result before confirmation.
+  After confirmation, it rechecks the exact preview and recovery-risk set before pruning with Git's default expiry.
   Remove likewise rechecks worktree identity, inventory, administrative path, and the approved recovery-risk set before mutation.
 - The status browser uses only local Git state and never fetches a remote; its cards never authorize Remove or Prune.
 - The extension does not commit, push, fetch, rebase, repair, move, lock, or unlock worktrees.
 
-Use Git directly when you intentionally need force removal, branch deletion, custom prune expiry, detach/orphan creation, move, repair, lock, unlock, or remote refresh behavior.
+Use Git directly for force removal, branch deletion, custom prune expiry, detach or orphan creation, move, repair, lock, unlock, and remote refresh operations.
 
 ## 🚧 Limitations
 


### PR DESCRIPTION
## Summary

- refine all 29 package READMEs for clearer, more concise introductions and guidance
- standardize section ordering and labels while preserving package-specific behavior, safety, compatibility, and lifecycle details
- correct documentation claims against package source and tests

## Verification

- `npm run check`
- `npm test` — 3,192 tests across 328 files
- fenced-code-aware README heading, order, badge, warning, and link audits
- `git diff --check`

## Notes

- no Changeset is required for documentation-only changes
- package packs and runtime smokes were not run because metadata and runtime loading did not change
