### PR TITLE
feat(usage): add DeepSeek API balance

### DIFF
--- a/.changeset/report-deepseek-balance.md
+++ b/.changeset/report-deepseek-balance.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add exact DeepSeek API balance reporting for official runtime API keys.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -1,8 +1,8 @@
-# 📊 pi-usage — Check Provider Usage and Codex Fast Mode
+# 📊 pi-usage — Check Provider Usage, API Balance, and Codex Fast Mode
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Inspect usage for Pi's active provider account, query other configured providers, and toggle Fast mode for supported OpenAI Codex models.
+Inspect usage and DeepSeek API balance for Pi's active provider account, query other configured providers, and toggle Fast mode for supported OpenAI Codex models.
 
 The extension keeps each provider's native quota, allowance, and spending semantics instead of treating unlike values as equivalent.
 xAI OAuth subscription reporting defaults to On and follows the reviewed Grok Build contract.
@@ -13,6 +13,7 @@ xAI OAuth subscription reporting defaults to On and follows the reviewed Grok Bu
 - Reports OpenAI Codex subscription windows, credits, resets, and model-specific buckets.
 - Reports Kimi For Coding plan windows, resets, and separately labeled booster-wallet currency.
 - Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
+- Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
 - Reports xAI OAuth subscription allowances and credits when enabled.
 - Toggles persistent Codex Fast routing through `/fast` or the usage menu.
@@ -204,6 +205,24 @@ It reports overage without treating a negative included balance as malformed.
 The extension does not call OpenRouter's account-level `/credits` endpoint because that operation requires a separate management key.
 OpenRouter documents the distinction between credit and rate limits in its [API limits guide](https://openrouter.ai/docs/api_reference/limits).
 
+### DeepSeek API balance
+
+- Provider ID: `deepseek`
+- Semantics: current API account balance, not historical usage or quota
+- Source: documented `GET https://api.deepseek.com/user/balance` using Pi's freshly resolved runtime API key
+- Displayed data: whether API calls are available plus separate total, granted, and topped-up balances for each returned CNY or USD currency
+- Statusline examples: `deepseek CNY 110.00` or `deepseek CNY 110.00 · USD 20.00`
+
+The extension queries the fixed balance endpoint only when the selected model origin is `https://api.deepseek.com` and any resolved-auth origin override, when present, has the same official origin.
+Pi's built-in DeepSeek API-key resolver does not attach a redundant auth origin, so the validated model origin remains authoritative when no override exists.
+Custom and proxy origins fail before network access, redirects are rejected, and only the resolved Bearer credential is forwarded from Pi's runtime auth.
+Monetary decimal strings remain exact from the response through display.
+CNY and USD stay separate and are never converted or added together.
+The balance endpoint does not provide historical spend, request windows, reset times, or aggregate token usage, so `pi-usage` does not claim those DeepSeek capabilities.
+
+The contract was verified on 2026-08-28 against [DeepSeek's Get User Balance documentation](https://api-docs.deepseek.com/api/get-user-balance) and Pi's [`deepseek.ts`](https://github.com/earendil-works/pi/blob/c49906ec77788625aacbdc53ebca6fbe65bd20f5/packages/ai/src/providers/deepseek.ts) at `c49906ec77788625aacbdc53ebca6fbe65bd20f5`.
+DeepSeek Harness `cd5ef8148158c3a752a658978873241fdf8e2bbc` reports only per-request model token usage and does not provide account balance data.
+
 ### OpenCode Go (Zen)
 
 - Provider ID: `opencode-go`
@@ -287,6 +306,7 @@ After the active runtime credential changes, the next command, turn, or schedule
 
 The `usage` status item is active only for selected providers that publish statusline usage.
 It refreshes every five minutes while the session remains on such a provider and is cleared when the model changes to an unsupported or menu-only provider.
+DeepSeek publishes each returned currency as a separate exact balance segment and reports when the API is unavailable.
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
@@ -317,6 +337,7 @@ Behavior changes:
 Credential candidates are collected synchronously in memory and are not cached, persisted, logged, formatted, or appended to the Pi session.
 The protocol carries no account name or extension identity.
 Only the selected provider's exact runtime match is used, and secrets are sent only to its validated official origin.
+DeepSeek balance requests require Bearer authentication, send only that resolved credential from Pi's runtime auth to `https://api.deepseek.com/user/balance`, and refuse redirects.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
 Install only trusted extensions because they can read user files and process memory.
 Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
@@ -330,6 +351,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - xAI usage supports only a uniquely matched Pi OAuth subscription credential; xAI API keys and Management API credentials are unsupported.
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
+- DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.
@@ -372,7 +394,7 @@ The generated runtime is built from the authoritative `src/index.ts` graph and d
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-usage",
 	"version": "0.55.0",
-	"description": "Pi extension that shows current-account usage for Codex, Kimi For Coding, GitHub Copilot, OpenRouter, OpenCode Zen, Z.AI, and xAI OAuth subscriptions.",
+	"description": "Pi extension that shows current-account usage and DeepSeek API balance for supported providers.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,
@@ -11,6 +11,8 @@
 		"pi",
 		"usage",
 		"quota",
+		"balance",
+		"deepseek",
 		"codex",
 		"kimi",
 		"kimi-coding",

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -11,11 +11,14 @@ const VALUE_COLUMN = 29;
 
 export function formatUsageReport(report: UsageReport, displayState: UsageDisplayState): string {
 	const stateLabel = displayState === "current" ? "Current" : "Configured";
-	const lines = [`${report.providerName} Usage · ${stateLabel}`];
+	const title =
+		report.providerId === "deepseek" ? "DeepSeek API Balance" : `${report.providerName} Usage`;
+	const lines = [`${title} · ${stateLabel}`];
 	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
 	lines.push(`Semantics: ${report.semantics.label}`, "");
 
 	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
+	else if (report.providerId === "deepseek") formatDeepSeekReport(lines, report);
 	else if (report.providerId === "github-copilot") formatGitHubCopilotReport(lines, report);
 	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
 	else if (report.providerId === "opencode-go") formatOpenCodeZenReport(lines, report);
@@ -33,6 +36,7 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 
 export function formatUsageStatusline(report: UsageReport, model?: UsageModel): string | undefined {
 	if (report.providerId === "openai-codex") return formatCodexStatusline(report, model);
+	if (report.providerId === "deepseek") return formatDeepSeekStatusline(report);
 	if (report.providerId === "github-copilot") return formatGitHubCopilotStatusline(report);
 	if (report.providerId === "openrouter") {
 		const limit = report.buckets.find((bucket) => bucket.id === "key-limit");
@@ -85,6 +89,33 @@ function formatCodexReport(lines: string[], report: UsageReport): void {
 			);
 		}
 	}
+}
+
+function formatDeepSeekReport(lines: string[], report: UsageReport): void {
+	const availability = report.metrics.find((metric) => metric.id === "api-availability");
+	lines.push(
+		`${"API calls:".padEnd(VALUE_COLUMN)}${availability?.value === "available" ? "Available" : "Unavailable"}`,
+	);
+	for (const currency of ["CNY", "USD"]) {
+		const metrics = report.metrics.filter((metric) => metric.currency === currency);
+		if (metrics.length === 0) continue;
+		lines.push("", `${currency} balance:`);
+		for (const metric of metrics) {
+			lines.push(`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${currency} ${metric.value}`);
+		}
+	}
+}
+
+function formatDeepSeekStatusline(report: UsageReport): string {
+	const availability = report.metrics.find((metric) => metric.id === "api-availability");
+	if (availability?.value !== "available") return "deepseek API unavailable";
+	const totals = ["CNY", "USD"].flatMap((currency) => {
+		const metric = report.metrics.find(
+			(candidate) => candidate.id === `${currency.toLowerCase()}-total`,
+		);
+		return metric ? [`${currency} ${metric.value}`] : [];
+	});
+	return totals.length > 0 ? `deepseek ${totals.join(" · ")}` : "deepseek balance unavailable";
 }
 
 function formatGitHubCopilotReport(lines: string[], report: UsageReport): void {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from "./core.js";
 export { formatProviderStates, formatUsageReport, formatUsageStatusline } from "./format.js";
 export { normalizeCodexBackendPayload } from "./providers/codex.js";
+export { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
 export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 export { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 export { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -62,6 +63,7 @@ export {
 	usageSettingsPath,
 } from "./settings.js";
 export type {
+	DeepSeekBalancePayload,
 	KimiCodingUsagePayload,
 	ProviderUsageState,
 	ResolvedUsageAuth,

--- a/packages/pi-usage/src/providers/deepseek.ts
+++ b/packages/pi-usage/src/providers/deepseek.ts
@@ -1,0 +1,85 @@
+import type { DeepSeekBalancePayload, UsageMetric, UsageReport } from "../types.js";
+
+const CURRENCIES = ["CNY", "USD"] as const;
+type DeepSeekCurrency = (typeof CURRENCIES)[number];
+
+const BALANCE_FIELDS = [
+	["total", "Total balance", "total_balance"],
+	["granted", "Granted balance", "granted_balance"],
+	["topped-up", "Topped-up balance", "topped_up_balance"],
+] as const;
+
+export function normalizeDeepSeekBalancePayload(
+	payload: DeepSeekBalancePayload,
+	capturedAt: number,
+): UsageReport {
+	if (typeof payload.is_available !== "boolean") {
+		throw new Error("DeepSeek API balance response availability was not a boolean.");
+	}
+	if (!Array.isArray(payload.balance_infos) || payload.balance_infos.length === 0) {
+		throw new Error("DeepSeek API balance response returned no balance information.");
+	}
+
+	const balances = new Map<DeepSeekCurrency, Record<string, unknown>>();
+	for (const raw of payload.balance_infos) {
+		const balance = asObject(raw);
+		if (!balance) throw new Error("DeepSeek API balance row was not an object.");
+		const currency = deepSeekCurrency(balance.currency);
+		if (!currency) throw new Error("DeepSeek API balance row returned an unsupported currency.");
+		if (balances.has(currency)) {
+			throw new Error(`DeepSeek API balance response repeated ${currency}.`);
+		}
+		for (const [, label, field] of BALANCE_FIELDS) {
+			if (!decimalAmount(balance[field])) {
+				throw new Error(`DeepSeek API balance ${label.toLowerCase()} was not a valid amount.`);
+			}
+		}
+		balances.set(currency, balance);
+	}
+
+	const metrics: UsageMetric[] = [
+		{
+			id: "api-availability",
+			label: "API calls",
+			value: payload.is_available ? "available" : "unavailable",
+		},
+	];
+	for (const currency of CURRENCIES) {
+		const balance = balances.get(currency);
+		if (!balance) continue;
+		for (const [id, label, field] of BALANCE_FIELDS) {
+			metrics.push({
+				id: `${currency.toLowerCase()}-${id}`,
+				label,
+				value: balance[field] as string,
+				unit: "currency",
+				currency,
+			});
+		}
+	}
+
+	return {
+		providerId: "deepseek",
+		providerName: "DeepSeek",
+		capturedAt,
+		source: "deepseek-balance",
+		semantics: { kind: "api-key", label: "DeepSeek API balance" },
+		buckets: [],
+		metrics,
+	};
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function deepSeekCurrency(value: unknown): DeepSeekCurrency | undefined {
+	return CURRENCIES.find((currency) => currency === value);
+}
+
+function decimalAmount(value: unknown): value is string {
+	return (
+		typeof value === "string" && value.length <= 64 && /^(?:0|[1-9]\d*)(?:\.\d+)?$/u.test(value)
+	);
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -6,6 +6,7 @@ import {
 	type OAuthCredentialCandidateReader,
 } from "./oauth-credential-source.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
+import { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -14,6 +15,7 @@ import { normalizeXaiBillingPayload } from "./providers/xai.js";
 import { normalizeZaiQuotaPayload } from "./providers/zai.js";
 import type {
 	CodexBackendPayload,
+	DeepSeekBalancePayload,
 	GitHubCopilotUsagePayload,
 	KimiCodingUsagePayload,
 	OpenCodeZenPayload,
@@ -28,6 +30,7 @@ import type {
 } from "./types.js";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance";
 const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
@@ -63,6 +66,22 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				"Codex usage endpoint",
 			);
 			return normalizeCodexBackendPayload(payload as CodexBackendPayload, Date.now());
+		},
+	},
+	{
+		id: "deepseek",
+		displayName: "DeepSeek",
+		semantics: { kind: "api-key", label: "DeepSeek API balance" },
+		async query(auth, signal, timeoutMs) {
+			const payload = await fetchProviderJson(
+				DEEPSEEK_BALANCE_URL,
+				auth,
+				signal,
+				timeoutMs,
+				"DeepSeek API balance endpoint",
+				{ redirect: "error" },
+			);
+			return normalizeDeepSeekBalancePayload(payload as DeepSeekBalancePayload, Date.now());
 		},
 	},
 	{
@@ -299,6 +318,26 @@ export async function resolveUsageAuth(
 			: fallbackOAuthCredentialCandidates(adapter.id, credentialReader);
 		if (!offered.ok) throw new Error("xAI OAuth credential discovery failed closed.");
 		return resolveXaiUsageAuth(auth, model, salt, offered.candidates);
+	}
+	if (adapter.id === "deepseek") {
+		const resolvedAuthorization = authorizationFrom(auth);
+		const access = bearerToken(resolvedAuthorization);
+		if (!access) throw new Error("DeepSeek API balance requires Bearer authentication.");
+		const authorization = `Bearer ${access}`;
+		const headers = { Authorization: authorization };
+		return {
+			apiKey: access,
+			headers,
+			fingerprint: fingerprintResolvedAuth({ headers }, salt),
+			secrets: [
+				access,
+				auth.apiKey,
+				headerValue(auth.headers, "Authorization"),
+				resolvedAuthorization,
+				authorization,
+			].filter((value): value is string => Boolean(value)),
+			model,
+		};
 	}
 	const authorization = authorizationFrom(auth);
 	if (!authorization) return undefined;
@@ -683,6 +722,7 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 	try {
 		const url = new URL(value);
 		if (providerId === "openai-codex") return url.origin === "https://chatgpt.com";
+		if (providerId === "deepseek") return url.origin === "https://api.deepseek.com";
 		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
 		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
 		if (providerId === "kimi-coding") return url.origin === "https://api.kimi.com";

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -72,12 +72,17 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 		id: "deepseek",
 		displayName: "DeepSeek",
 		semantics: { kind: "api-key", label: "DeepSeek API balance" },
-		async query(auth, signal, timeoutMs) {
+		async query(auth, signal, timeoutMs, guard) {
+			if (!guard) throw new Error("DeepSeek API balance requires request-boundary revalidation.");
+			const startedAt = Date.now();
+			await guard();
+			const remainingMs = timeoutMs - (Date.now() - startedAt);
+			if (remainingMs <= 0) throw new Error("Timed out while revalidating DeepSeek runtime auth.");
 			const payload = await fetchProviderJson(
 				DEEPSEEK_BALANCE_URL,
 				auth,
 				signal,
-				timeoutMs,
+				remainingMs,
 				"DeepSeek API balance endpoint",
 				{ redirect: "error" },
 			);
@@ -278,11 +283,14 @@ export async function resolveUsageAuth(
 	// SAFETY: Pi exposes the required auth methods at runtime, and checks below narrow them before use.
 	const registry = ctx.modelRegistry as unknown as UsageAuthRegistry;
 	let modelAuth: RequestAuth | undefined;
-	if (ctx.model?.provider === adapter.id && typeof registry.getApiKeyAndHeaders === "function") {
-		const result = await registry.getApiKeyAndHeaders(ctx.model);
+	const currentModel = ctx.model?.provider === adapter.id ? ctx.model : undefined;
+	const resolveCurrentModelAuth = async (): Promise<RequestAuth | undefined> => {
+		if (!currentModel || typeof registry.getApiKeyAndHeaders !== "function") return undefined;
+		const result = await registry.getApiKeyAndHeaders(currentModel);
 		if (!result.ok) throw new Error(redactUsageError(result.error));
-		if (authorizationFrom(result)) modelAuth = result;
-	}
+		return authorizationFrom(result) ? result : undefined;
+	};
+	if (adapter.id !== "deepseek") modelAuth = await resolveCurrentModelAuth();
 	if (typeof registry.getProviderAuth !== "function") {
 		throw new Error("pi-usage requires Pi 0.81.0 or newer to validate resolved provider auth.");
 	}
@@ -295,6 +303,9 @@ export async function resolveUsageAuth(
 			`${adapter.displayName} usage cannot send a proxy-resolved credential to the official usage endpoint.`,
 		);
 	}
+	// DeepSeek reads selected-model auth last so a rotation during provider-origin validation
+	// cannot leave the earlier credential queued for the balance request.
+	if (adapter.id === "deepseek") modelAuth = await resolveCurrentModelAuth();
 	const auth = modelAuth ?? providerResult?.auth;
 	if (!auth) return undefined;
 	if (adapter.id === "github-copilot") {

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -84,6 +84,11 @@ export type ProviderUsageState =
 			message: string;
 	  };
 
+export type DeepSeekBalancePayload = {
+	is_available?: unknown;
+	balance_infos?: unknown;
+};
+
 export type GitHubCopilotUsagePayload = {
 	login?: unknown;
 	copilot_plan?: unknown;

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -210,8 +210,9 @@ export default function usageExtension(
 		displayState: UsageDisplayState,
 		force: boolean,
 		signal: AbortSignal,
+		authRetry = 0,
+		deadlineAt = Date.now() + DEFAULT_TIMEOUT_MS,
 	): Promise<QueryOutcome> => {
-		const startedAt = Date.now();
 		const expectedSessionGeneration = sessionGeneration;
 		const expectedXaiSettingsGeneration = xaiSettingsGeneration;
 		const expectedSessionId = ctx.sessionManager.getSessionId();
@@ -221,7 +222,7 @@ export default function usageExtension(
 			auth = await awaitWithDeadline(
 				resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
 				signal,
-				DEFAULT_TIMEOUT_MS,
+				Math.max(1, deadlineAt - Date.now()),
 				`resolving ${adapter.displayName} runtime auth`,
 			);
 		} catch (error) {
@@ -239,16 +240,14 @@ export default function usageExtension(
 				},
 			};
 		}
-		if (
-			adapter.id === "xai" &&
-			(expectedSessionGeneration !== sessionGeneration ||
-				expectedXaiSettingsGeneration !== xaiSettingsGeneration ||
-				!xaiUsageEnabled() ||
-				ctx.sessionManager.getSessionId() !== expectedSessionId ||
-				modelIdentity(ctx.model) !== expectedModelIdentity)
-		) {
-			throw abortError();
-		}
+		const requiresRequestBoundaryGuard = adapter.id === "deepseek" || adapter.id === "xai";
+		const requestContextChanged = () =>
+			expectedSessionGeneration !== sessionGeneration ||
+			ctx.sessionManager.getSessionId() !== expectedSessionId ||
+			modelIdentity(ctx.model) !== expectedModelIdentity ||
+			(adapter.id === "xai" &&
+				(expectedXaiSettingsGeneration !== xaiSettingsGeneration || !xaiUsageEnabled()));
+		if (requiresRequestBoundaryGuard && requestContextChanged()) throw abortError();
 		if (!auth) {
 			if (displayState === "current") {
 				transitionCurrentIdentity(`${adapter.id}:unavailable`, adapter.id);
@@ -301,40 +300,28 @@ export default function usageExtension(
 		const queryId = querySequence;
 		setBoundedMap(latestQueries, failureKey, queryId, MAX_ACCOUNT_STATES);
 
+		let deepSeekAuthChanged = false;
 		try {
-			const remainingMs = Math.max(1, DEFAULT_TIMEOUT_MS - (Date.now() - startedAt));
-			const guard =
-				adapter.id === "xai"
-					? async () => {
-							if (
-								signal.aborted ||
-								expectedSessionGeneration !== sessionGeneration ||
-								expectedXaiSettingsGeneration !== xaiSettingsGeneration ||
-								!xaiUsageEnabled() ||
-								ctx.sessionManager.getSessionId() !== expectedSessionId ||
-								modelIdentity(ctx.model) !== expectedModelIdentity
-							) {
-								throw abortError();
+			const remainingMs = Math.max(1, deadlineAt - Date.now());
+			const guard = requiresRequestBoundaryGuard
+				? async () => {
+						if (signal.aborted || requestContextChanged()) throw abortError();
+						const revalidated = await awaitWithDeadline(
+							resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
+							signal,
+							Math.max(1, deadlineAt - Date.now()),
+							`revalidating ${adapter.displayName} runtime auth`,
+						);
+						if (signal.aborted || requestContextChanged()) throw abortError();
+						if (revalidated?.fingerprint !== auth.fingerprint) {
+							if (adapter.id === "deepseek") {
+								deepSeekAuthChanged = true;
+								throw new Error("DeepSeek runtime credential changed during the balance query.");
 							}
-							const revalidated = await awaitWithDeadline(
-								resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
-								signal,
-								Math.max(1, DEFAULT_TIMEOUT_MS - (Date.now() - startedAt)),
-								"revalidating xAI runtime auth",
-							);
-							if (
-								signal.aborted ||
-								expectedSessionGeneration !== sessionGeneration ||
-								expectedXaiSettingsGeneration !== xaiSettingsGeneration ||
-								!xaiUsageEnabled() ||
-								ctx.sessionManager.getSessionId() !== expectedSessionId ||
-								modelIdentity(ctx.model) !== expectedModelIdentity ||
-								revalidated?.fingerprint !== auth.fingerprint
-							) {
-								throw abortError();
-							}
+							throw abortError();
 						}
-					: undefined;
+					}
+				: undefined;
 			const report = await queryProviderUsage(adapter, auth, signal, remainingMs, guard);
 			if (guard) await guard();
 			if (latestQueries.get(failureKey) === queryId) {
@@ -353,6 +340,24 @@ export default function usageExtension(
 			};
 		} catch (error) {
 			if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
+			if (
+				deepSeekAuthChanged &&
+				authRetry === 0 &&
+				!signal.aborted &&
+				!requestContextChanged() &&
+				Date.now() < deadlineAt
+			) {
+				if (latestQueries.get(failureKey) === queryId) latestQueries.delete(failureKey);
+				return queryAdapterState(
+					ctx,
+					adapter,
+					displayState,
+					true,
+					signal,
+					authRetry + 1,
+					deadlineAt,
+				);
+			}
 			const message = errorMessage(error);
 			const now = Date.now();
 			for (const [key, failure] of failureBackoff) {

--- a/packages/pi-usage/test/deepseek.test.ts
+++ b/packages/pi-usage/test/deepseek.test.ts
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	type DeepSeekBalancePayload,
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeDeepSeekBalancePayload,
+	queryProviderUsage,
+	type ResolvedUsageAuth,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+} from "../src/index.js";
+
+const DEEPSEEK_MODEL = {
+	id: "deepseek-v4-pro",
+	name: "DeepSeek V4 Pro",
+	provider: "deepseek",
+	baseUrl: "https://api.deepseek.com",
+};
+
+const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === "deepseek");
+assert.ok(adapter);
+
+function balance(
+	currency: "CNY" | "USD",
+	total: string,
+	granted: string,
+	toppedUp: string,
+): Record<string, unknown> {
+	return {
+		currency,
+		total_balance: total,
+		granted_balance: granted,
+		topped_up_balance: toppedUp,
+	};
+}
+
+function availableBalance(): DeepSeekBalancePayload {
+	return {
+		is_available: true,
+		balance_infos: [balance("CNY", "110.00", "10.00", "100.00")],
+	};
+}
+
+function deepSeekAuth(secret = "deepseek-test-secret"): ResolvedUsageAuth {
+	return {
+		apiKey: secret,
+		headers: { Authorization: `Bearer ${secret}` },
+		fingerprint: "fingerprint",
+		secrets: [secret, `Bearer ${secret}`],
+		model: DEEPSEEK_MODEL as never,
+	};
+}
+
+test("DeepSeek API balance preserves exact separate currency amounts and deterministic display", () => {
+	const report = normalizeDeepSeekBalancePayload(
+		{
+			is_available: true,
+			balance_infos: [
+				balance("USD", "0.12345678901234567890", "0", "0.12345678901234567890"),
+				balance("CNY", "110.00", "10.00", "100.00"),
+			],
+		},
+		1_000,
+	);
+
+	assert.equal(report.providerId, "deepseek");
+	assert.equal(report.source, "deepseek-balance");
+	assert.deepEqual(report.semantics, { kind: "api-key", label: "DeepSeek API balance" });
+	assert.deepEqual(
+		report.metrics.map((metric) => [metric.id, metric.value, metric.currency]),
+		[
+			["api-availability", "available", undefined],
+			["cny-total", "110.00", "CNY"],
+			["cny-granted", "10.00", "CNY"],
+			["cny-topped-up", "100.00", "CNY"],
+			["usd-total", "0.12345678901234567890", "USD"],
+			["usd-granted", "0", "USD"],
+			["usd-topped-up", "0.12345678901234567890", "USD"],
+		],
+	);
+	const formatted = formatUsageReport(report, "current");
+	assert.match(formatted, /^DeepSeek API Balance · Current/mu);
+	assert.match(formatted, /Semantics: DeepSeek API balance/u);
+	assert.match(formatted, /API calls:\s+Available/u);
+	assert.ok(formatted.indexOf("CNY balance:") < formatted.indexOf("USD balance:"));
+	assert.match(formatted, /Total balance:\s+CNY 110\.00/u);
+	assert.match(formatted, /Total balance:\s+USD 0\.12345678901234567890/u);
+	assert.equal(formatUsageStatusline(report), "deepseek CNY 110.00 · USD 0.12345678901234567890");
+});
+
+test("DeepSeek API balance reports provider availability without inventing quota semantics", () => {
+	const report = normalizeDeepSeekBalancePayload(
+		{
+			is_available: false,
+			balance_infos: [balance("USD", "0.00", "0.00", "0.00")],
+		},
+		2_000,
+	);
+
+	assert.match(formatUsageReport(report, "configured"), /^DeepSeek API Balance · Configured/mu);
+	assert.match(formatUsageReport(report, "configured"), /API calls:\s+Unavailable/u);
+	assert.equal(formatUsageStatusline(report), "deepseek API unavailable");
+	assert.doesNotMatch(formatUsageReport(report, "configured"), /quota|reset|historical/iu);
+});
+
+test("DeepSeek API balance rejects malformed, ambiguous, or hostile response fields", () => {
+	const invalid: Array<[DeepSeekBalancePayload, RegExp]> = [
+		[{}, /availability/iu],
+		[{ is_available: "yes", balance_infos: [] }, /availability/iu],
+		[{ is_available: true }, /no balance information/iu],
+		[{ is_available: true, balance_infos: [] }, /no balance information/iu],
+		[{ is_available: true, balance_infos: [null] }, /row was not an object/iu],
+		[
+			{
+				is_available: true,
+				balance_infos: [
+					{
+						...balance("CNY", "1.00", "0.00", "1.00"),
+						currency: "EUR",
+					},
+				],
+			},
+			/unsupported currency/iu,
+		],
+		[
+			{
+				is_available: true,
+				balance_infos: [balance("CNY", "1.00", "0.00", "1.00"), balance("CNY", "2", "1", "1")],
+			},
+			/repeated CNY/iu,
+		],
+		[
+			{
+				is_available: true,
+				balance_infos: [{ ...balance("USD", "1", "0", "1"), total_balance: "-1" }],
+			},
+			/total balance/iu,
+		],
+		[
+			{
+				is_available: true,
+				balance_infos: [{ ...balance("USD", "1", "0", "1"), granted_balance: "1e3" }],
+			},
+			/granted balance/iu,
+		],
+		[
+			{
+				is_available: true,
+				balance_infos: [{ ...balance("USD", "1", "0", "1"), topped_up_balance: `1\u001b[31m` }],
+			},
+			/topped-up balance/iu,
+		],
+		[
+			{
+				is_available: true,
+				balance_infos: [balance("USD", "9".repeat(65), "0", "0")],
+			},
+			/total balance/iu,
+		],
+	];
+	for (const [payload, pattern] of invalid) {
+		assert.throws(() => normalizeDeepSeekBalancePayload(payload, 0), pattern);
+	}
+});
+
+test("DeepSeek runtime auth accepts only official model and resolved-auth origins", async () => {
+	const { ctx: officialContext } = createMockContext({
+		model: DEEPSEEK_MODEL,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({
+				ok: true,
+				headers: {
+					Authorization: "Bearer current-deepseek-key",
+					"X-Private": "must-not-send",
+				},
+			}),
+			getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+			getAvailable: () => [DEEPSEEK_MODEL],
+			getAll: () => [DEEPSEEK_MODEL],
+		},
+	});
+	const auth = await resolveUsageAuth(officialContext, adapter);
+	assert.deepEqual(auth?.headers, { Authorization: "Bearer current-deepseek-key" });
+	assert.ok(!auth?.secrets.includes("must-not-send"));
+
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		const { ctx: nonBearerContext } = createMockContext({
+			model: DEEPSEEK_MODEL,
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => ({
+					ok: true,
+					headers: { Authorization: "Basic must-not-send" },
+				}),
+				getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+				getAvailable: () => [DEEPSEEK_MODEL],
+				getAll: () => [DEEPSEEK_MODEL],
+			},
+		});
+		await assert.rejects(() => resolveUsageAuth(nonBearerContext, adapter), /requires Bearer/iu);
+
+		for (const [modelBaseUrl, authBaseUrl, pattern] of [
+			["https://proxy.example.test/v1", undefined, /custom.*official/iu],
+			[DEEPSEEK_MODEL.baseUrl, "https://proxy.example.test/v1", /proxy-resolved.*official/iu],
+		] as const) {
+			const model = { ...DEEPSEEK_MODEL, baseUrl: modelBaseUrl };
+			const { ctx } = createMockContext({
+				model,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-send" }),
+					getProviderAuth: async () => ({
+						auth: {
+							apiKey: "must-not-send",
+							...(authBaseUrl ? { baseUrl: authBaseUrl } : {}),
+						},
+					}),
+					getAvailable: () => [model],
+					getAll: () => [model],
+				},
+			});
+			await assert.rejects(() => resolveUsageAuth(ctx, adapter), pattern);
+		}
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("DeepSeek transport uses only the fixed balance endpoint and rejects redirects", async () => {
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		requests.push({ url: String(input), init });
+		return new Response(JSON.stringify(availableBalance()), { status: 200 });
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const report = await queryProviderUsage(
+			adapter,
+			deepSeekAuth(),
+			new AbortController().signal,
+			1_000,
+		);
+		assert.equal(report.providerId, "deepseek");
+		assert.equal(requests.length, 1);
+		assert.equal(requests[0]?.url, "https://api.deepseek.com/user/balance");
+		assert.equal(requests[0]?.init?.method, "GET");
+		assert.equal(requests[0]?.init?.redirect, "error");
+		assert.deepEqual(requests[0]?.init?.headers, {
+			Authorization: "Bearer deepseek-test-secret",
+			"User-Agent": "pi-usage",
+		});
+		assert.ok(requests[0]?.init?.signal instanceof AbortSignal);
+
+		const redirected = new Response(JSON.stringify(availableBalance()), { status: 200 });
+		Object.defineProperty(redirected, "redirected", { value: true });
+		fetchMock.mockResolvedValueOnce(redirected);
+		await assert.rejects(
+			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
+			/refused a redirected response/iu,
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("DeepSeek transport bounds timeout, cancellation, bodies, JSON, and redacted errors", async () => {
+	const fetchMock = vi.fn(
+		(_input: string | URL | Request, init?: RequestInit) =>
+			new Promise<Response>((_resolve, reject) => {
+				init?.signal?.addEventListener(
+					"abort",
+					() => reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+					{ once: true },
+				);
+			}),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 5),
+			/Timed out/iu,
+		);
+		const controller = new AbortController();
+		const cancelled = queryProviderUsage(adapter, deepSeekAuth(), controller.signal, 1_000);
+		controller.abort();
+		await assert.rejects(
+			() => cancelled,
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+
+		let cancelledBodies = 0;
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				new ReadableStream({
+					cancel() {
+						cancelledBodies += 1;
+					},
+				}),
+				{ status: 200 },
+			),
+		);
+		const bodyController = new AbortController();
+		const stalledBody = queryProviderUsage(adapter, deepSeekAuth(), bodyController.signal, 1_000);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		bodyController.abort();
+		await assert.rejects(
+			() => stalledBody,
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+		assert.equal(cancelledBodies, 1);
+
+		fetchMock.mockResolvedValueOnce(new Response("x".repeat(70_000), { status: 200 }));
+		await assert.rejects(
+			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
+			/exceeded.*bytes/iu,
+		);
+		fetchMock.mockResolvedValueOnce(new Response("{broken", { status: 200 }));
+		await assert.rejects(
+			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
+			/invalid JSON/iu,
+		);
+
+		for (const status of [401, 403]) {
+			fetchMock.mockResolvedValueOnce(
+				new Response("Bearer deepseek-test-secret failed\u001b[31m", {
+					status,
+					statusText: "Denied",
+				}),
+			);
+			await assert.rejects(
+				() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
+				(error: unknown) =>
+					error instanceof Error &&
+					error.message.includes(String(status)) &&
+					!error.message.includes("deepseek-test-secret") &&
+					!error.message.includes("\u001b"),
+			);
+		}
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});

--- a/packages/pi-usage/test/deepseek.test.ts
+++ b/packages/pi-usage/test/deepseek.test.ts
@@ -10,6 +10,7 @@ import {
 	type ResolvedUsageAuth,
 	resolveUsageAuth,
 	SUPPORTED_ADAPTERS,
+	type UsageProviderAdapter,
 } from "../src/index.js";
 
 const DEEPSEEK_MODEL = {
@@ -19,8 +20,13 @@ const DEEPSEEK_MODEL = {
 	baseUrl: "https://api.deepseek.com",
 };
 
-const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === "deepseek");
-assert.ok(adapter);
+function deepSeekAdapter(): UsageProviderAdapter {
+	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === "deepseek");
+	assert.ok(candidate);
+	return candidate;
+}
+
+const adapter = deepSeekAdapter();
 
 function balance(
 	currency: "CNY" | "USD",
@@ -51,6 +57,10 @@ function deepSeekAuth(secret = "deepseek-test-secret"): ResolvedUsageAuth {
 		secrets: [secret, `Bearer ${secret}`],
 		model: DEEPSEEK_MODEL as never,
 	};
+}
+
+function queryDeepSeek(signal = new AbortController().signal, timeoutMs = 1_000) {
+	return queryProviderUsage(adapter, deepSeekAuth(), signal, timeoutMs, async () => undefined);
 }
 
 test("DeepSeek API balance preserves exact separate currency amounts and deterministic display", () => {
@@ -165,6 +175,30 @@ test("DeepSeek API balance rejects malformed, ambiguous, or hostile response fie
 	}
 });
 
+test("DeepSeek reads current model auth after provider validation when the key rotates", async () => {
+	let activeKey = "stale-deepseek-key";
+	const { ctx } = createMockContext({
+		model: DEEPSEEK_MODEL,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => {
+				const resolvedKey = activeKey;
+				await Promise.resolve();
+				return { ok: true, apiKey: resolvedKey };
+			},
+			getProviderAuth: async () => {
+				activeKey = "current-deepseek-key";
+				return { auth: { apiKey: activeKey, baseUrl: DEEPSEEK_MODEL.baseUrl } };
+			},
+			getAvailable: () => [DEEPSEEK_MODEL],
+			getAll: () => [DEEPSEEK_MODEL],
+		},
+	});
+
+	const auth = await resolveUsageAuth(ctx, adapter);
+	assert.deepEqual(auth?.headers, { Authorization: "Bearer current-deepseek-key" });
+	assert.ok(!auth?.secrets.includes("stale-deepseek-key"));
+});
+
 test("DeepSeek runtime auth accepts only official model and resolved-auth origins", async () => {
 	const { ctx: officialContext } = createMockContext({
 		model: DEEPSEEK_MODEL,
@@ -228,6 +262,52 @@ test("DeepSeek runtime auth accepts only official model and resolved-auth origin
 	}
 });
 
+test("DeepSeek transport revalidates before network access", async () => {
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		await assert.rejects(
+			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
+			/request-boundary revalidation/iu,
+		);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					deepSeekAuth(),
+					new AbortController().signal,
+					1_000,
+					async () => {
+						throw Object.assign(new Error("stale auth"), { name: "AbortError" });
+					},
+				),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("DeepSeek transport counts request-boundary revalidation against its deadline", async () => {
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					deepSeekAuth(),
+					new AbortController().signal,
+					5,
+					() => new Promise<void>((resolve) => setTimeout(resolve, 10)),
+				),
+			/timed out.*revalidating/iu,
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
 test("DeepSeek transport uses only the fixed balance endpoint and rejects redirects", async () => {
 	const requests: Array<{ url: string; init?: RequestInit }> = [];
 	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -236,12 +316,7 @@ test("DeepSeek transport uses only the fixed balance endpoint and rejects redire
 	});
 	vi.stubGlobal("fetch", fetchMock);
 	try {
-		const report = await queryProviderUsage(
-			adapter,
-			deepSeekAuth(),
-			new AbortController().signal,
-			1_000,
-		);
+		const report = await queryDeepSeek();
 		assert.equal(report.providerId, "deepseek");
 		assert.equal(requests.length, 1);
 		assert.equal(requests[0]?.url, "https://api.deepseek.com/user/balance");
@@ -256,10 +331,7 @@ test("DeepSeek transport uses only the fixed balance endpoint and rejects redire
 		const redirected = new Response(JSON.stringify(availableBalance()), { status: 200 });
 		Object.defineProperty(redirected, "redirected", { value: true });
 		fetchMock.mockResolvedValueOnce(redirected);
-		await assert.rejects(
-			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
-			/refused a redirected response/iu,
-		);
+		await assert.rejects(() => queryDeepSeek(), /refused a redirected response/iu);
 	} finally {
 		vi.unstubAllGlobals();
 	}
@@ -269,21 +341,17 @@ test("DeepSeek transport bounds timeout, cancellation, bodies, JSON, and redacte
 	const fetchMock = vi.fn(
 		(_input: string | URL | Request, init?: RequestInit) =>
 			new Promise<Response>((_resolve, reject) => {
-				init?.signal?.addEventListener(
-					"abort",
-					() => reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
-					{ once: true },
-				);
+				const rejectAbort = () =>
+					reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+				if (init?.signal?.aborted) rejectAbort();
+				else init?.signal?.addEventListener("abort", rejectAbort, { once: true });
 			}),
 	);
 	vi.stubGlobal("fetch", fetchMock);
 	try {
-		await assert.rejects(
-			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 5),
-			/Timed out/iu,
-		);
+		await assert.rejects(() => queryDeepSeek(undefined, 5), /Timed out/iu);
 		const controller = new AbortController();
-		const cancelled = queryProviderUsage(adapter, deepSeekAuth(), controller.signal, 1_000);
+		const cancelled = queryDeepSeek(controller.signal);
 		controller.abort();
 		await assert.rejects(
 			() => cancelled,
@@ -302,7 +370,7 @@ test("DeepSeek transport bounds timeout, cancellation, bodies, JSON, and redacte
 			),
 		);
 		const bodyController = new AbortController();
-		const stalledBody = queryProviderUsage(adapter, deepSeekAuth(), bodyController.signal, 1_000);
+		const stalledBody = queryDeepSeek(bodyController.signal);
 		await new Promise<void>((resolve) => setImmediate(resolve));
 		bodyController.abort();
 		await assert.rejects(
@@ -312,15 +380,9 @@ test("DeepSeek transport bounds timeout, cancellation, bodies, JSON, and redacte
 		assert.equal(cancelledBodies, 1);
 
 		fetchMock.mockResolvedValueOnce(new Response("x".repeat(70_000), { status: 200 }));
-		await assert.rejects(
-			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
-			/exceeded.*bytes/iu,
-		);
+		await assert.rejects(() => queryDeepSeek(), /exceeded.*bytes/iu);
 		fetchMock.mockResolvedValueOnce(new Response("{broken", { status: 200 }));
-		await assert.rejects(
-			() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
-			/invalid JSON/iu,
-		);
+		await assert.rejects(() => queryDeepSeek(), /invalid JSON/iu);
 
 		for (const status of [401, 403]) {
 			fetchMock.mockResolvedValueOnce(
@@ -330,7 +392,7 @@ test("DeepSeek transport bounds timeout, cancellation, bodies, JSON, and redacte
 				}),
 			);
 			await assert.rejects(
-				() => queryProviderUsage(adapter, deepSeekAuth(), new AbortController().signal, 1_000),
+				() => queryDeepSeek(),
 				(error: unknown) =>
 					error instanceof Error &&
 					error.message.includes(String(status)) &&

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -436,12 +436,13 @@ test("explicit all-provider query retains DeepSeek balance, Kimi, and partial fa
 	t.onTestFinished(() => {
 		globalThis.fetch = originalFetch;
 	});
-	globalThis.fetch = async (input) => {
-		if (
-			String(input).endsWith("/api/v1/key") ||
-			String(input).endsWith("/coding/v1/usages") ||
-			String(input).endsWith("/user/balance")
-		) {
+	const deepSeekFetchedKeys: string[] = [];
+	globalThis.fetch = async (input, init) => {
+		if (String(input).endsWith("/user/balance")) {
+			deepSeekFetchedKeys.push(new Headers(init?.headers).get("authorization") ?? "");
+			return usageFetch(input);
+		}
+		if (String(input).endsWith("/api/v1/key") || String(input).endsWith("/coding/v1/usages")) {
 			return usageFetch(input);
 		}
 		return new Response("backend unavailable", { status: 503, statusText: "Unavailable" });
@@ -450,6 +451,7 @@ test("explicit all-provider query retains DeepSeek balance, Kimi, and partial fa
 	const titles: string[] = [];
 	const choices = ["View all configured providers…", "Close"];
 	const configured = new Set(["openrouter", "openai-codex", "kimi-coding", "deepseek"]);
+	let deepSeekAuthLookups = 0;
 	const mock = createMockPi();
 	usageExtension(mock.pi);
 	const command = mock.commands.get("usage");
@@ -463,12 +465,18 @@ test("explicit all-provider query retains DeepSeek balance, Kimi, and partial fa
 			return choices.shift();
 		},
 		modelRegistry: {
-			getProviderAuth: async (provider: string) => ({
-				auth: {
-					apiKey: `${provider}-key`,
-					...(provider === "kimi-coding" ? { baseUrl: kimiModel.baseUrl } : {}),
-				},
-			}),
+			getProviderAuth: async (provider: string) => {
+				if (provider === "deepseek") deepSeekAuthLookups += 1;
+				return {
+					auth: {
+						apiKey:
+							provider === "deepseek" && deepSeekAuthLookups === 1
+								? "deepseek-account-a"
+								: `${provider}-key`,
+						...(provider === "kimi-coding" ? { baseUrl: kimiModel.baseUrl } : {}),
+					},
+				};
+			},
 			getAvailable: () => [openRouterModel, codexModel, kimiModel, deepSeekModel],
 			getAll: () => [openRouterModel, codexModel, kimiModel, deepSeekModel],
 			getProviderAuthStatus: (provider: string) => ({
@@ -488,6 +496,7 @@ test("explicit all-provider query retains DeepSeek balance, Kimi, and partial fa
 	assert.match(titles[1] ?? "", /1 of 100 used · 99% left/);
 	assert.match(titles[1] ?? "", /DeepSeek API Balance · Configured/);
 	assert.match(titles[1] ?? "", /Total balance:\s+USD 12\.50/u);
+	assert.deepEqual(deepSeekFetchedKeys, ["Bearer deepseek-key"]);
 	assert.match(titles[1] ?? "", /query failed/i);
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 });
@@ -933,6 +942,60 @@ test("current DeepSeek API balance follows account changes and clears status", a
 		ctx,
 	);
 	assert.equal(statuses.get("usage"), undefined);
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("DeepSeek account rotation at the request boundary retries without querying the stale key", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let authLookups = 0;
+	const fetchedKeys: string[] = [];
+	globalThis.fetch = async (_input, init) => {
+		fetchedKeys.push(new Headers(init?.headers).get("authorization") ?? "");
+		return new Response(
+			JSON.stringify({
+				is_available: true,
+				balance_infos: [
+					{
+						currency: "USD",
+						total_balance: "7.25",
+						granted_balance: "2.50",
+						topped_up_balance: "4.75",
+					},
+				],
+			}),
+			{ status: 200 },
+		);
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx, statuses } = createMockContext({
+		model: deepSeekModel,
+		modelRegistry: {
+			getProviderAuth: async () => {
+				authLookups += 1;
+				return {
+					auth: {
+						apiKey: authLookups === 1 ? "deepseek-account-a" : "deepseek-account-b",
+						baseUrl: deepSeekModel.baseUrl,
+					},
+				};
+			},
+			getAvailable: () => [deepSeekModel],
+			getAll: () => [deepSeekModel],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	await settle();
+
+	assert.ok(authLookups >= 5);
+	assert.deepEqual(fetchedKeys, ["Bearer deepseek-account-b"]);
+	assert.equal(statuses.get("usage"), "deepseek USD 7.25");
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 	assert.equal(statuses.get("usage"), undefined);
 });

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -51,6 +51,13 @@ const kimiModel = {
 	baseUrl: "https://api.kimi.com/coding",
 };
 
+const deepSeekModel = {
+	id: "deepseek-v4-pro",
+	name: "DeepSeek V4 Pro",
+	provider: "deepseek",
+	baseUrl: "https://api.deepseek.com",
+};
+
 function codexAccessToken(accountId: string): string {
 	const payload = Buffer.from(
 		JSON.stringify({
@@ -126,6 +133,24 @@ function usageFetch(input: string | URL | Request): Promise<Response> {
 						{
 							window: { duration: "300", timeUnit: "TIME_UNIT_MINUTE" },
 							detail: { used: "1", limit: "100" },
+						},
+					],
+				}),
+				{ status: 200 },
+			),
+		);
+	}
+	if (url.endsWith("/user/balance")) {
+		return Promise.resolve(
+			new Response(
+				JSON.stringify({
+					is_available: true,
+					balance_infos: [
+						{
+							currency: "USD",
+							total_balance: "12.50",
+							granted_balance: "2.50",
+							topped_up_balance: "10.00",
 						},
 					],
 				}),
@@ -406,13 +431,17 @@ test("command arguments are rejected instead of becoming a hidden interface", as
 	assert.match(notifications[0]?.message ?? "", /does not accept arguments/);
 });
 
-test("explicit all-provider query labels current/configured and retains Kimi plus failures", async (t) => {
+test("explicit all-provider query retains DeepSeek balance, Kimi, and partial failures", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.onTestFinished(() => {
 		globalThis.fetch = originalFetch;
 	});
 	globalThis.fetch = async (input) => {
-		if (String(input).endsWith("/api/v1/key") || String(input).endsWith("/coding/v1/usages")) {
+		if (
+			String(input).endsWith("/api/v1/key") ||
+			String(input).endsWith("/coding/v1/usages") ||
+			String(input).endsWith("/user/balance")
+		) {
 			return usageFetch(input);
 		}
 		return new Response("backend unavailable", { status: 503, statusText: "Unavailable" });
@@ -420,7 +449,7 @@ test("explicit all-provider query labels current/configured and retains Kimi plu
 
 	const titles: string[] = [];
 	const choices = ["View all configured providers…", "Close"];
-	const configured = new Set(["openrouter", "openai-codex", "kimi-coding"]);
+	const configured = new Set(["openrouter", "openai-codex", "kimi-coding", "deepseek"]);
 	const mock = createMockPi();
 	usageExtension(mock.pi);
 	const command = mock.commands.get("usage");
@@ -440,8 +469,8 @@ test("explicit all-provider query labels current/configured and retains Kimi plu
 					...(provider === "kimi-coding" ? { baseUrl: kimiModel.baseUrl } : {}),
 				},
 			}),
-			getAvailable: () => [openRouterModel, codexModel, kimiModel],
-			getAll: () => [openRouterModel, codexModel, kimiModel],
+			getAvailable: () => [openRouterModel, codexModel, kimiModel, deepSeekModel],
+			getAll: () => [openRouterModel, codexModel, kimiModel, deepSeekModel],
 			getProviderAuthStatus: (provider: string) => ({
 				configured: configured.has(provider),
 				source: "stored",
@@ -457,6 +486,8 @@ test("explicit all-provider query labels current/configured and retains Kimi plu
 	assert.match(titles[1] ?? "", /OpenAI Codex · Configured/);
 	assert.match(titles[1] ?? "", /Kimi For Coding Usage · Configured/);
 	assert.match(titles[1] ?? "", /1 of 100 used · 99% left/);
+	assert.match(titles[1] ?? "", /DeepSeek API Balance · Configured/);
+	assert.match(titles[1] ?? "", /Total balance:\s+USD 12\.50/u);
 	assert.match(titles[1] ?? "", /query failed/i);
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 });
@@ -824,6 +855,144 @@ test("current Kimi usage follows account changes and clears status on model repl
 		ctx,
 	);
 	assert.equal(statuses.get("usage"), undefined);
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("current DeepSeek API balance follows account changes and clears status", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activeKey = "deepseek-account-a";
+	const fetchedKeys: string[] = [];
+	globalThis.fetch = async (_input, init) => {
+		const authorization = new Headers(init?.headers).get("authorization") ?? "";
+		fetchedKeys.push(authorization);
+		const total = activeKey === "deepseek-account-a" ? "12.50" : "7.25";
+		return new Response(
+			JSON.stringify({
+				is_available: true,
+				balance_infos: [
+					{
+						currency: "USD",
+						total_balance: total,
+						granted_balance: "2.50",
+						topped_up_balance: activeKey === "deepseek-account-a" ? "10.00" : "4.75",
+					},
+				],
+			}),
+			{ status: 200 },
+		);
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const titles: string[] = [];
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: deepSeekModel,
+		select: async (title: string) => {
+			titles.push(title);
+			return "Close";
+		},
+		modelRegistry: {
+			getProviderAuth: async () => ({
+				auth: { apiKey: activeKey, baseUrl: deepSeekModel.baseUrl },
+			}),
+			getAvailable: () => [deepSeekModel],
+			getAll: () => [deepSeekModel],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "deepseek USD 12.50");
+	await command.handler("", ctx);
+	assert.match(titles[0] ?? "", /DeepSeek API Balance · Current/u);
+	assert.match(titles[0] ?? "", /Total balance:\s+USD 12\.50/u);
+
+	activeKey = "deepseek-account-b";
+	mock.events.get("turn_start")?.[0]?.({}, ctx);
+	await settle();
+	assert.equal(statuses.get("usage"), "deepseek USD 7.25");
+	assert.ok(fetchedKeys.includes("Bearer deepseek-account-a"));
+	assert.ok(fetchedKeys.includes("Bearer deepseek-account-b"));
+
+	mock.events.get("model_select")?.[0]?.(
+		{
+			model: {
+				id: "other",
+				name: "Other",
+				provider: "unsupported",
+				baseUrl: "https://example.test",
+			},
+		},
+		ctx,
+	);
+	assert.equal(statuses.get("usage"), undefined);
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("DeepSeek session replacement aborts a stale balance request before publication", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activeKey = "deepseek-account-a";
+	let requests = 0;
+	let firstRequestSignal: AbortSignal | undefined;
+	let firstRequestStarted: () => void = () => undefined;
+	const firstRequestReady = new Promise<void>((resolve) => {
+		firstRequestStarted = resolve;
+	});
+	globalThis.fetch = async (_input, init) => {
+		requests += 1;
+		if (requests === 1) {
+			firstRequestSignal = init?.signal ?? undefined;
+			firstRequestStarted();
+			return new Response(new ReadableStream({ start() {} }), { status: 200 });
+		}
+		return new Response(
+			JSON.stringify({
+				is_available: true,
+				balance_infos: [
+					{
+						currency: "USD",
+						total_balance: "7.25",
+						granted_balance: "2.50",
+						topped_up_balance: "4.75",
+					},
+				],
+			}),
+			{ status: 200 },
+		);
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx, statuses } = createMockContext({
+		model: deepSeekModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({
+				auth: { apiKey: activeKey, baseUrl: deepSeekModel.baseUrl },
+			}),
+			getAvailable: () => [deepSeekModel],
+			getAll: () => [deepSeekModel],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await firstRequestReady;
+	activeKey = "deepseek-account-b";
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+
+	assert.equal(requests, 2);
+	assert.equal(firstRequestSignal?.aborted, true);
+	assert.equal(statuses.get("usage"), "deepseek USD 7.25");
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 	assert.equal(statuses.get("usage"), undefined);
 });


### PR DESCRIPTION
## Summary

- add source-backed DeepSeek API balance reporting through the documented `GET /user/balance` endpoint
- preserve exact CNY and USD decimal strings, availability, detailed balance fields, and separate statusline segments
- fail closed for custom or proxy origins, non-Bearer auth, redirects, malformed responses, stale sessions, and cancelled work
- document the precise balance-only semantics and add a minor `@narumitw/pi-usage` Changeset

## Verification

- `npm --workspace @narumitw/pi-usage run build`
- `npm exec vitest run -- packages/pi-usage/test/deepseek.test.ts packages/pi-usage/test/adapters.test.ts packages/pi-usage/test/usage.test.ts packages/pi-usage/test/generated-entry.test.ts` — 57 tests passed
- `npm run check`
- `npm test` — 329 files and 3,200 tests passed
- fenced-code-aware README heading audit — all active packages passed
- `npm exec changeset status` — reports the intended minor `@narumitw/pi-usage` bump; existing Kit-floor notices remain unchanged
- `just pack usage` — 26 declared files inspected
- isolated `pi --no-extensions --no-skills -e ./packages/pi-usage --list-models` loader smoke

## Risks and unverified paths

- DeepSeek's external balance response remains provider-owned and can change.
- No live balance request was sent because use of a real or disposable DeepSeek API key was not explicitly approved.
- No package was published and no release workflow was dispatched.
