### PR TITLE
feat(usage): show Codex reset countdowns

### DIFF
--- a/.changeset/compact-codex-statusline.md
+++ b/.changeset/compact-codex-statusline.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Shorten Codex statusline reset countdowns.

--- a/.changeset/compact-codex-statusline.md
+++ b/.changeset/compact-codex-statusline.md
@@ -1,5 +1,5 @@
 ---
-"@narumitw/pi-usage": patch
+"@narumitw/pi-usage": minor
 ---
 
-Shorten Codex statusline reset countdowns.
+Show compact Codex reset countdowns in the statusline by default, with a setting to restore the legacy window labels.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -116,6 +116,18 @@ Unsupported models and custom or proxy origins are left unchanged.
 A toggle affects provider requests whose payload hook starts after the save; a request already sent is unchanged.
 Repair or remove an invalid file, then run `/reload` before trying the toggle again.
 
+### Codex statusline reset countdown
+
+The `codexStatusResetCountdown` preference defaults to `true`. It replaces the window labels with the time remaining until each returned limit resets.
+
+Set it to `false` in `pi-usage.json`, then run `/reload`, to restore the legacy `5h` and `wk` labels:
+
+```json
+{
+  "codexStatusResetCountdown": false
+}
+```
+
 ### xAI usage
 
 The `xaiUsage` preference defaults to `true` when the settings file or field is absent.
@@ -141,7 +153,7 @@ Turning it Off clears xAI cache state and prevents stale in-flight results from 
 - Source: the Codex usage and earned-reset endpoints using Pi's resolved runtime authorization
 - Displayed data: returned duration-based windows, resets, credits, earned usage-limit resets, and additional model buckets
 - Reset mutation: `POST /wham/rate-limit-reset-credits/consume` with a unique redemption request ID and, when available, the selected opaque credit ID
-- Statusline examples: `codex 59% 5h 61% wk`, `codex fast 59% 5h`, or `codex spark 100% 5h`
+- Statusline examples: `codex 59% (resets in 2h 30m) 61% (resets in 2d 15m)`, `codex fast 59% (resets in 2h 30m)`, or `codex spark 100% (resets in 2h 30m)`. Set `codexStatusResetCountdown` to `false` for the legacy `5h` and `wk` labels.
 
 The statusline selects a returned bucket that matches the current Codex model when one is available.
 Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -89,10 +89,10 @@ Successful, already-completed, not-needed, and no-credit outcomes are reported s
 
 ## ⚙️ Settings
 
-Choose **Settings** in `/usage` to edit Codex Fast mode and xAI usage through Pi's settings-list interaction in TUI mode.
+Choose **Settings** in `/usage` to edit Codex Fast mode, the Codex reset countdown, and xAI usage through Pi's settings-list interaction in TUI mode.
 RPC mode reports the active manual settings path instead of opening terminal UI.
 
-Both preferences live in `pi-usage.json` under Pi's user agent directory, normally `~/.pi/agent/pi-usage.json`.
+These preferences live in `pi-usage.json` under Pi's user agent directory, normally `~/.pi/agent/pi-usage.json`.
 The extension reloads this file at every session start and does not create it until the first successful save.
 Within one Pi process, changes save immediately in invocation order.
 Saves preserve unknown JSON fields and publish through a private temporary file plus rename.
@@ -120,7 +120,7 @@ Repair or remove an invalid file, then run `/reload` before trying the toggle ag
 
 The `codexStatusResetCountdown` preference defaults to `true`. It replaces the window labels with the time remaining until each returned limit resets.
 
-Set it to `false` in `pi-usage.json`, then run `/reload`, to restore the legacy `5h` and `wk` labels:
+Turn **Codex reset countdown** Off in the TUI Settings screen, or set it to `false` in `pi-usage.json` and run `/reload`, to restore the legacy `5h` and `wk` labels:
 
 ```json
 {

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -153,7 +153,7 @@ Turning it Off clears xAI cache state and prevents stale in-flight results from 
 - Source: the Codex usage and earned-reset endpoints using Pi's resolved runtime authorization
 - Displayed data: returned duration-based windows, resets, credits, earned usage-limit resets, and additional model buckets
 - Reset mutation: `POST /wham/rate-limit-reset-credits/consume` with a unique redemption request ID and, when available, the selected opaque credit ID
-- Statusline examples: `codex 59% (resets in 2h 30m) 61% (resets in 2d 15m)`, `codex fast 59% (resets in 2h 30m)`, or `codex spark 100% (resets in 2h 30m)`. Set `codexStatusResetCountdown` to `false` for the legacy `5h` and `wk` labels.
+- Statusline examples: `codex 59% ↻ 2h30m 61% ↻ 2d15m`, `codex fast 59% ↻ 2h30m`, or `codex spark 100% ↻ 2h30m`. Set `codexStatusResetCountdown` to `false` for the legacy `5h` and `wk` labels.
 
 The statusline selects a returned bucket that matches the current Codex model when one is available.
 Unlike `pi-codex-usage`, this successor intentionally has no Codex CLI fallback because the CLI may be logged into a different account than Pi's active runtime account.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -109,7 +109,7 @@ The `codexFastMode` preference defaults to Off.
 
 Fast currently applies only to official `openai-codex-responses` requests for `gpt-5.4`, `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` at `https://chatgpt.com`.
 It sends `service_tier: "priority"` while enabled and explicit `service_tier: "default"` otherwise.
-The statusline adds `fast` only while the preference is effective, for example `codex fast 59% 5h`.
+The statusline adds `fast` only while the preference is effective, for example `codex fast 59% ↻ 2h30m` with the default reset countdown.
 Unsupported models and custom or proxy origins are left unchanged.
 
 `/fast` supports TUI and RPC mode, accepts no arguments, and rejects print or JSON mode before mutation.

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -362,13 +362,14 @@ function formatCodexStatusline(
 	for (const bucket of buckets) {
 		if (bucket.remaining === undefined) continue;
 		const percent = `${clampPercent(bucket.remaining).toFixed(0)}%`;
+		const fallback = bucket.id.endsWith(":secondary") ? "weekly" : "5h";
+		const window = formatWindowLabel(bucket.windowMinutes, fallback, true);
 		if (!showResetCountdown) {
-			const fallback = bucket.id.endsWith(":secondary") ? "weekly" : "5h";
-			parts.push(`${percent} ${formatWindowLabel(bucket.windowMinutes, fallback, true)}`);
+			parts.push(`${percent} ${window}`);
 			continue;
 		}
 		const reset = formatResetCountdown(bucket.resetsAt, now);
-		parts.push(`${percent}${reset ? ` ↻ ${reset}` : ""}`);
+		parts.push(`${percent} ${reset ? `↻ ${reset}` : window}`);
 	}
 	return parts.length > 1 ? parts.join(" ") : formatCodexCreditsStatus(report);
 }

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -34,8 +34,15 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 	return lines.join("\n").trimEnd();
 }
 
-export function formatUsageStatusline(report: UsageReport, model?: UsageModel): string | undefined {
-	if (report.providerId === "openai-codex") return formatCodexStatusline(report, model);
+export function formatUsageStatusline(
+	report: UsageReport,
+	model?: UsageModel,
+	now = Date.now(),
+	showCodexResetCountdown = true,
+): string | undefined {
+	if (report.providerId === "openai-codex") {
+		return formatCodexStatusline(report, model, now, showCodexResetCountdown);
+	}
 	if (report.providerId === "deepseek") return formatDeepSeekStatusline(report);
 	if (report.providerId === "github-copilot") return formatGitHubCopilotStatusline(report);
 	if (report.providerId === "openrouter") {
@@ -339,7 +346,12 @@ function formatGenericReport(lines: string[], report: UsageReport): void {
 	}
 }
 
-function formatCodexStatusline(report: UsageReport, model?: UsageModel): string | undefined {
+function formatCodexStatusline(
+	report: UsageReport,
+	model?: UsageModel,
+	now = Date.now(),
+	showResetCountdown = true,
+): string | undefined {
 	const group = selectCodexGroup(report, model);
 	if (!group) return formatCodexCreditsStatus(report);
 	const buckets = report.buckets.filter((bucket) => (bucket.groupId ?? bucket.id) === group);
@@ -349,10 +361,14 @@ function formatCodexStatusline(report: UsageReport, model?: UsageModel): string 
 	];
 	for (const bucket of buckets) {
 		if (bucket.remaining === undefined) continue;
-		const fallback = bucket.id.endsWith(":secondary") ? "weekly" : "5h";
-		parts.push(
-			`${clampPercent(bucket.remaining).toFixed(0)}% ${formatWindowLabel(bucket.windowMinutes, fallback, true)}`,
-		);
+		const percent = `${clampPercent(bucket.remaining).toFixed(0)}%`;
+		if (!showResetCountdown) {
+			const fallback = bucket.id.endsWith(":secondary") ? "weekly" : "5h";
+			parts.push(`${percent} ${formatWindowLabel(bucket.windowMinutes, fallback, true)}`);
+			continue;
+		}
+		const reset = formatResetCountdown(bucket.resetsAt, now);
+		parts.push(`${percent}${reset ? ` (resets in ${reset})` : ""}`);
 	}
 	return parts.length > 1 ? parts.join(" ") : formatCodexCreditsStatus(report);
 }
@@ -453,6 +469,28 @@ function formatWindowLabel(
 	if (minutes % 1_440 === 0) return `${minutes / 1_440}d`;
 	if (minutes % 60 === 0) return `${minutes / 60}h`;
 	return `${minutes}m`;
+}
+
+function formatResetCountdown(resetsAt: number | undefined, now: number): string | undefined {
+	if (resetsAt === undefined || !Number.isFinite(resetsAt) || !Number.isFinite(now))
+		return undefined;
+	const totalMinutes = Math.max(0, Math.ceil((resetsAt * 1_000 - now) / 60_000));
+	const days = Math.floor(totalMinutes / 1_440);
+	const hours = Math.floor((totalMinutes % 1_440) / 60);
+	const minutes = totalMinutes % 60;
+	if (days > 0) {
+		return [
+			`${String(days)}d`,
+			hours > 0 ? `${String(hours)}h` : minutes > 0 ? `${String(minutes)}m` : "",
+		]
+			.filter(Boolean)
+			.join(" ");
+	}
+	if (hours > 0)
+		return [`${String(hours)}h`, minutes > 0 ? `${String(minutes)}m` : ""]
+			.filter(Boolean)
+			.join(" ");
+	return `${String(minutes)}m`;
 }
 
 function formatMetricValue(value: number | string, unit: UsageBucket["unit"] | undefined): string {

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -368,7 +368,7 @@ function formatCodexStatusline(
 			continue;
 		}
 		const reset = formatResetCountdown(bucket.resetsAt, now);
-		parts.push(`${percent}${reset ? ` (resets in ${reset})` : ""}`);
+		parts.push(`${percent}${reset ? ` ↻ ${reset}` : ""}`);
 	}
 	return parts.length > 1 ? parts.join(" ") : formatCodexCreditsStatus(report);
 }
@@ -484,12 +484,10 @@ function formatResetCountdown(resetsAt: number | undefined, now: number): string
 			hours > 0 ? `${String(hours)}h` : minutes > 0 ? `${String(minutes)}m` : "",
 		]
 			.filter(Boolean)
-			.join(" ");
+			.join("");
 	}
 	if (hours > 0)
-		return [`${String(hours)}h`, minutes > 0 ? `${String(minutes)}m` : ""]
-			.filter(Boolean)
-			.join(" ");
+		return [`${String(hours)}h`, minutes > 0 ? `${String(minutes)}m` : ""].filter(Boolean).join("");
 	return `${String(minutes)}m`;
 }
 

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -9,11 +9,13 @@ export const MAX_USAGE_SETTINGS_BYTES = 64 * 1024;
 
 export interface UsageSettings {
 	codexFastMode: boolean;
+	codexStatusResetCountdown: boolean;
 	xaiUsage: boolean;
 }
 
 export const DEFAULT_USAGE_SETTINGS: Readonly<UsageSettings> = Object.freeze({
 	codexFastMode: false,
+	codexStatusResetCountdown: true,
 	xaiUsage: true,
 });
 
@@ -54,6 +56,12 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 	if (Object.hasOwn(value, "codexFastMode") && typeof value.codexFastMode !== "boolean") {
 		return undefined;
 	}
+	if (
+		Object.hasOwn(value, "codexStatusResetCountdown") &&
+		typeof value.codexStatusResetCountdown !== "boolean"
+	) {
+		return undefined;
+	}
 	if (Object.hasOwn(value, "xaiUsage") && typeof value.xaiUsage !== "boolean") {
 		return undefined;
 	}
@@ -62,6 +70,10 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 			typeof value.codexFastMode === "boolean"
 				? value.codexFastMode
 				: DEFAULT_USAGE_SETTINGS.codexFastMode,
+		codexStatusResetCountdown:
+			typeof value.codexStatusResetCountdown === "boolean"
+				? value.codexStatusResetCountdown
+				: DEFAULT_USAGE_SETTINGS.codexStatusResetCountdown,
 		xaiUsage:
 			typeof value.xaiUsage === "boolean" ? value.xaiUsage : DEFAULT_USAGE_SETTINGS.xaiUsage,
 	};

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -47,6 +47,13 @@ export async function showUsageSettings(
 				values: [OFF, ON],
 			},
 			{
+				id: "codexStatusResetCountdown",
+				label: "Codex reset countdown",
+				description: "Show time remaining until each Codex usage limit resets.",
+				currentValue: state.settings.codexStatusResetCountdown ? ON : OFF,
+				values: [OFF, ON],
+			},
+			{
 				id: "xaiUsage",
 				label: "xAI usage",
 				description: "Report OAuth subscription allowance and credits.",

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -795,6 +795,16 @@ export default function usageExtension(
 							controller.signal,
 							() => statusGeneration === menuGeneration && !controller.signal.aborted,
 							(id, _previous, next) => {
+								if (id === "codexStatusResetCountdown") {
+									if (
+										stableCurrent &&
+										statusGeneration === menuGeneration &&
+										!controller.signal.aborted
+									) {
+										publishStableCurrent(ctx, stableCurrent);
+									}
+									return;
+								}
 								if (id !== "xaiUsage") return;
 								xaiSettingsGeneration += 1;
 								invalidateProviderState("xai");

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -56,6 +56,7 @@ import {
 import { showUsageSettings } from "./usage-settings-ui.js";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const STATUS_COUNTDOWN_REFRESH_MS = 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 15_000;
 const ALL_PROVIDER_CONCURRENCY = 2;
 const FAILURE_BACKOFF_MS = 30_000;
@@ -105,6 +106,7 @@ export default function usageExtension(
 	let sessionGeneration = 0;
 	let xaiSettingsGeneration = 0;
 	let statusRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+	let statusCountdownTimer: ReturnType<typeof setTimeout> | undefined;
 	let statusController: AbortController | undefined;
 	let fastRuntime: ReturnType<typeof registerCodexFastMode>;
 
@@ -115,9 +117,19 @@ export default function usageExtension(
 	const activeAdapterForProvider = (providerId: string | undefined) =>
 		adapterForProvider(providerId, xaiUsageEnabled());
 
-	const clearStatusTimer = () => {
+	const clearStatusRefreshTimer = () => {
 		if (statusRefreshTimer) clearTimeout(statusRefreshTimer);
 		statusRefreshTimer = undefined;
+	};
+
+	const clearStatusCountdownTimer = () => {
+		if (statusCountdownTimer) clearTimeout(statusCountdownTimer);
+		statusCountdownTimer = undefined;
+	};
+
+	const clearStatusTimers = () => {
+		clearStatusRefreshTimer();
+		clearStatusCountdownTimer();
 	};
 
 	const safeSetStatus = (ctx: ExtensionContext, value: string | undefined): boolean => {
@@ -134,12 +146,12 @@ export default function usageExtension(
 		statusGeneration += 1;
 		statusController?.abort();
 		statusController = undefined;
-		clearStatusTimer();
+		clearStatusTimers();
 		safeSetStatus(ctx, undefined);
 	};
 
 	const scheduleStatusRefresh = (ctx: ExtensionContext, model: PiModel) => {
-		clearStatusTimer();
+		clearStatusRefreshTimer();
 		const generation = statusGeneration;
 		statusRefreshTimer = setTimeout(() => {
 			statusRefreshTimer = undefined;
@@ -155,13 +167,14 @@ export default function usageExtension(
 		model: PiModel,
 		shouldSchedule: boolean,
 	) => {
+		clearStatusCountdownTimer();
 		if (activeAdapterForProvider(model.provider)?.publishesStatusline === false) {
-			clearStatusTimer();
+			clearStatusRefreshTimer();
 			safeSetStatus(ctx, undefined);
 			return;
 		}
 		if (outcome.state.status === "unsupported") {
-			clearStatusTimer();
+			clearStatusRefreshTimer();
 			safeSetStatus(ctx, undefined);
 			return;
 		}
@@ -176,15 +189,43 @@ export default function usageExtension(
 			}
 			return;
 		}
+		const showCodexResetCountdown =
+			outcome.state.report.providerId === "openai-codex" &&
+			settingsRuntime.get().settings.codexStatusResetCountdown;
+		const now = Date.now();
 		const rawValue = formatUsageStatusline(
 			outcome.state.report,
 			model,
-			Date.now(),
-			settingsRuntime.get().settings.codexStatusResetCountdown,
+			now,
+			showCodexResetCountdown,
 		);
 		const value = rawValue ? fastRuntime.decorateStatus(model, rawValue) : undefined;
 		if (!safeSetStatus(ctx, value)) return;
 		if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
+		if (
+			sessionActive &&
+			showCodexResetCountdown &&
+			outcome.state.report.buckets.some(
+				(bucket) =>
+					bucket.resetsAt !== undefined &&
+					Number.isFinite(bucket.resetsAt) &&
+					bucket.resetsAt * 1_000 > now,
+			)
+		) {
+			const generation = statusGeneration;
+			statusCountdownTimer = setTimeout(() => {
+				statusCountdownTimer = undefined;
+				if (
+					!sessionActive ||
+					generation !== statusGeneration ||
+					modelIdentity(ctx.model) !== modelIdentity(model)
+				) {
+					return;
+				}
+				publishStatus(ctx, outcome, model, false);
+			}, STATUS_COUNTDOWN_REFRESH_MS);
+			statusCountdownTimer.unref?.();
+		}
 	};
 
 	const invalidateProviderState = (providerId: string) => {
@@ -435,6 +476,7 @@ export default function usageExtension(
 		}
 		statusGeneration += 1;
 		const generation = statusGeneration;
+		clearStatusCountdownTimer();
 		statusController?.abort();
 		const controller = new AbortController();
 		statusController = controller;
@@ -579,7 +621,7 @@ export default function usageExtension(
 		const menuGeneration = statusGeneration;
 		statusController?.abort();
 		statusController = undefined;
-		clearStatusTimer();
+		clearStatusTimers();
 		const controller = new AbortController();
 		activeControllers.add(controller);
 		try {
@@ -1079,7 +1121,7 @@ export default function usageExtension(
 		sessionGeneration += 1;
 		xaiSettingsGeneration += 1;
 		statusGeneration += 1;
-		clearStatusTimer();
+		clearStatusTimers();
 		for (const controller of activeControllers) controller.abort();
 		activeControllers.clear();
 		statusController = undefined;
@@ -1100,7 +1142,7 @@ export default function usageExtension(
 		sessionGeneration += 1;
 		xaiSettingsGeneration += 1;
 		statusGeneration += 1;
-		clearStatusTimer();
+		clearStatusTimers();
 		for (const controller of activeControllers) controller.abort();
 		activeControllers.clear();
 		statusController = undefined;

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -176,7 +176,12 @@ export default function usageExtension(
 			}
 			return;
 		}
-		const rawValue = formatUsageStatusline(outcome.state.report, model);
+		const rawValue = formatUsageStatusline(
+			outcome.state.report,
+			model,
+			Date.now(),
+			settingsRuntime.get().settings.codexStatusResetCountdown,
+		);
 		const value = rawValue ? fastRuntime.decorateStatus(model, rawValue) : undefined;
 		if (!safeSetStatus(ctx, value)) return;
 		if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);

--- a/packages/pi-usage/test/adapters.test.ts
+++ b/packages/pi-usage/test/adapters.test.ts
@@ -348,7 +348,7 @@ test("Codex adapter preserves windows, credits, and model-specific statusline bu
 	const statusNow = 1_000_000;
 	assert.equal(
 		formatUsageStatusline(report, undefined, statusNow),
-		"codex 40% (resets in 2h 30m) 20% (resets in 2d 15m)",
+		"codex 40% ↻ 2h30m 20% ↻ 2d15m",
 	);
 	assert.equal(formatUsageStatusline(report, undefined, statusNow, false), "codex 40% 5h 20% wk");
 	assert.equal(

--- a/packages/pi-usage/test/adapters.test.ts
+++ b/packages/pi-usage/test/adapters.test.ts
@@ -318,8 +318,8 @@ test("Codex adapter preserves windows, credits, and model-specific statusline bu
 		{
 			plan_type: "pro",
 			rate_limit: {
-				primary_window: { used_percent: 60, limit_window_seconds: 18_000, reset_at: 100 },
-				secondary_window: { used_percent: 80, limit_window_seconds: 604_800 },
+				primary_window: { used_percent: 60, limit_window_seconds: 18_000, reset_at: 10_000 },
+				secondary_window: { used_percent: 80, limit_window_seconds: 604_800, reset_at: 174_700 },
 			},
 			credits: { has_credits: true, unlimited: false, balance: "12" },
 			rate_limit_reset_credits: { available_count: 2 },
@@ -345,13 +345,23 @@ test("Codex adapter preserves windows, credits, and model-specific statusline bu
 	assert.equal(report.metrics.find((metric) => metric.id === "reset-credits")?.value, 2);
 	assert.match(formatUsageReport(report, "current"), /5h limit:/);
 	assert.match(formatUsageReport(report, "current"), /Weekly limit:/);
+	const statusNow = 1_000_000;
 	assert.equal(
-		formatUsageStatusline(report, {
-			id: "gpt-5.3-codex-spark",
-			name: "GPT-5.3 Codex Spark",
-			provider: "openai-codex",
-		}),
-		"codex spark 90% 5h",
+		formatUsageStatusline(report, undefined, statusNow),
+		"codex 40% (resets in 2h 30m) 20% (resets in 2d 15m)",
+	);
+	assert.equal(formatUsageStatusline(report, undefined, statusNow, false), "codex 40% 5h 20% wk");
+	assert.equal(
+		formatUsageStatusline(
+			report,
+			{
+				id: "gpt-5.3-codex-spark",
+				name: "GPT-5.3 Codex Spark",
+				provider: "openai-codex",
+			},
+			statusNow,
+		),
+		"codex spark 90%",
 	);
 
 	const sparkBucket = report.buckets.find((bucket) => bucket.groupId === "gpt-5.3-codex-spark");
@@ -363,6 +373,6 @@ test("Codex adapter preserves windows, credits, and model-specific statusline bu
 			name: "-".repeat(100_000),
 			provider: "openai-codex",
 		}),
-		"codex spark 90% 5h",
+		"codex spark 90%",
 	);
 });

--- a/packages/pi-usage/test/adapters.test.ts
+++ b/packages/pi-usage/test/adapters.test.ts
@@ -361,7 +361,7 @@ test("Codex adapter preserves windows, credits, and model-specific statusline bu
 			},
 			statusNow,
 		),
-		"codex spark 90%",
+		"codex spark 90% 5h",
 	);
 
 	const sparkBucket = report.buckets.find((bucket) => bucket.groupId === "gpt-5.3-codex-spark");
@@ -373,6 +373,6 @@ test("Codex adapter preserves windows, credits, and model-specific statusline bu
 			name: "-".repeat(100_000),
 			provider: "openai-codex",
 		}),
-		"codex spark 90%",
+		"codex spark 90% 5h",
 	);
 });

--- a/packages/pi-usage/test/codex-fast-menu.test.ts
+++ b/packages/pi-usage/test/codex-fast-menu.test.ts
@@ -21,7 +21,7 @@ function runtime(kind: UsageSettingsState["kind"] = "loaded") {
 	let state: UsageSettingsState = {
 		kind,
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: false, xaiUsage: false },
+		settings: { codexFastMode: false, codexStatusResetCountdown: false, xaiUsage: false },
 		...(kind === "invalid" ? { issue: "bad file" } : { document: {} }),
 	};
 	const patches: unknown[] = [];

--- a/packages/pi-usage/test/codex-fast-runtime.test.ts
+++ b/packages/pi-usage/test/codex-fast-runtime.test.ts
@@ -31,6 +31,7 @@ function memoryRuntime(
 		path: "/tmp/pi-usage.json",
 		settings: {
 			codexFastMode: options.enabled ?? false,
+			codexStatusResetCountdown: false,
 			xaiUsage: false,
 		},
 		...(options.kind === "invalid" ? { issue: "bad file" } : { document: {} }),
@@ -312,7 +313,7 @@ test("session replacement aborts stale loads and accepted writes before UI publi
 	releaseLoad({
 		kind: "loaded",
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: true, xaiUsage: false },
+		settings: { codexFastMode: true, codexStatusResetCountdown: false, xaiUsage: false },
 		document: { codexFastMode: true },
 	});
 	await pendingLoad;

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -38,10 +38,12 @@ test("normalizes the default-enabled xAI setting and rejects invalid values", ()
 	assert.deepEqual(normalizeUsageSettings({}), DEFAULT_USAGE_SETTINGS);
 	assert.deepEqual(normalizeUsageSettings({ codexFastMode: true }), {
 		codexFastMode: true,
+		codexStatusResetCountdown: true,
 		xaiUsage: true,
 	});
 	assert.deepEqual(normalizeUsageSettings({ xaiUsage: false }), {
 		codexFastMode: false,
+		codexStatusResetCountdown: true,
 		xaiUsage: false,
 	});
 	assert.equal(normalizeUsageSettings({ codexFastMode: "true" }), undefined);
@@ -184,4 +186,13 @@ test("failed saves retain prior runtime state, clean up, and do not poison retri
 	rejectRename = false;
 	await runtime.update({ codexFastMode: true });
 	assert.equal(runtime.get().settings.codexFastMode, true);
+});
+
+test("normalizes the Codex reset countdown status preference", () => {
+	assert.deepEqual(normalizeUsageSettings({ codexStatusResetCountdown: false }), {
+		codexFastMode: false,
+		xaiUsage: true,
+		codexStatusResetCountdown: false,
+	});
+	assert.equal(normalizeUsageSettings({ codexStatusResetCountdown: "false" }), undefined);
 });

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -6,7 +6,7 @@ import {
 	setKeybindings,
 	TUI_KEYBINDINGS,
 } from "@earendil-works/pi-tui";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { OAUTH_CREDENTIAL_SOURCE_CHANNEL } from "../src/oauth-credential-source.js";
 import type { UsageSettingsRuntime, UsageSettingsState } from "../src/settings.js";
@@ -71,11 +71,12 @@ function memorySettingsRuntime(
 	xaiUsage = true,
 	failUpdates = false,
 	kind: UsageSettingsState["kind"] = "loaded",
+	codexStatusResetCountdown = false,
 ): { runtime: UsageSettingsRuntime; state: () => UsageSettingsState } {
 	let state: UsageSettingsState = {
 		kind,
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: false, codexStatusResetCountdown: false, xaiUsage },
+		settings: { codexFastMode: false, codexStatusResetCountdown, xaiUsage },
 		...(kind === "invalid"
 			? { issue: "invalid test settings" }
 			: { document: { codexFastMode: false, xaiUsage } }),
@@ -340,7 +341,7 @@ test("current Codex usage can redeem a selected reset and refresh account state"
 	});
 	assert.equal(new Headers(consume.init?.headers).get("chatgpt-account-id"), "account-123");
 	assert.ok(usageRequests >= 2);
-	assert.equal(statuses.get("usage"), "codex 100%");
+	assert.equal(statuses.get("usage"), "codex 100% 5h");
 	assert.match(titles.at(-1) ?? "", /Usage reset.*0 usage limit resets left/isu);
 });
 
@@ -1291,6 +1292,73 @@ test("session shutdown clears status through the shutdown context", async (t) =>
 	assert.equal(statuses.get("usage"), undefined);
 });
 
+test("Codex reset countdown repaints locally and stops across replacement and shutdown", async (t) => {
+	const originalFetch = globalThis.fetch;
+	vi.useFakeTimers();
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+		vi.useRealTimers();
+	});
+	const now = Date.parse("2026-08-29T00:00:00Z");
+	vi.setSystemTime(now);
+	let fetches = 0;
+	globalThis.fetch = async () => {
+		fetches += 1;
+		return new Response(
+			JSON.stringify({
+				rate_limit: {
+					primary_window: {
+						used_percent: 20,
+						limit_window_seconds: 18_000,
+						reset_at: (now + 150_000) / 1_000,
+					},
+				},
+			}),
+			{ status: 200 },
+		);
+	};
+	const settings = memorySettingsRuntime(false, false, "loaded", true);
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const { ctx, statuses } = createMockContext({
+		model: codexModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: codexToken } }),
+			getAvailable: () => [codexModel],
+			getAll: () => [codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await vi.advanceTimersByTimeAsync(0);
+	assert.equal(statuses.get("usage"), "codex 80% ↻ 3m");
+	assert.equal(fetches, 1);
+
+	await vi.advanceTimersByTimeAsync(60_000);
+	assert.equal(statuses.get("usage"), "codex 80% ↻ 2m");
+	assert.equal(fetches, 1);
+
+	Object.assign(ctx, { model: undefined });
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await vi.advanceTimersByTimeAsync(60_000);
+	assert.equal(statuses.get("usage"), undefined);
+	assert.equal(fetches, 1);
+
+	Object.assign(ctx, { model: codexModel });
+	mock.events.get("model_select")?.[0]?.({ model: codexModel }, ctx);
+	await vi.advanceTimersByTimeAsync(0);
+	assert.equal(statuses.get("usage"), "codex 80% ↻ 1m");
+	assert.equal(fetches, 2);
+
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(statuses.get("usage"), undefined);
+	await vi.advanceTimersByTimeAsync(60_000);
+	assert.equal(statuses.get("usage"), undefined);
+	assert.equal(fetches, 2);
+});
+
 test("a slow command cannot overwrite status after the selected model changes", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.onTestFinished(() => {
@@ -1336,11 +1404,11 @@ test("a slow command cannot overwrite status after the selected model changes", 
 	Object.assign(ctx, { model: codexModel });
 	mock.events.get("model_select")?.[0]?.({ model: codexModel }, ctx);
 	await settle();
-	assert.equal(statuses.get("usage"), "codex 80%");
+	assert.equal(statuses.get("usage"), "codex 80% 5h");
 
 	resolveSlowFetch(await usageFetch("https://openrouter.ai/api/v1/key"));
 	await commandPromise;
-	assert.equal(statuses.get("usage"), "codex 80%");
+	assert.equal(statuses.get("usage"), "codex 80% 5h");
 });
 
 test("statusline follows runtime auth changes and clears for unsupported selected providers", async (t) => {

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -75,7 +75,7 @@ function memorySettingsRuntime(
 	let state: UsageSettingsState = {
 		kind,
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: false, xaiUsage },
+		settings: { codexFastMode: false, codexStatusResetCountdown: false, xaiUsage },
 		...(kind === "invalid"
 			? { issue: "invalid test settings" }
 			: { document: { codexFastMode: false, xaiUsage } }),
@@ -340,7 +340,7 @@ test("current Codex usage can redeem a selected reset and refresh account state"
 	});
 	assert.equal(new Headers(consume.init?.headers).get("chatgpt-account-id"), "account-123");
 	assert.ok(usageRequests >= 2);
-	assert.equal(statuses.get("usage"), "codex 100% 5h");
+	assert.equal(statuses.get("usage"), "codex 100%");
 	assert.match(titles.at(-1) ?? "", /Usage reset.*0 usage limit resets left/isu);
 });
 
@@ -1336,11 +1336,11 @@ test("a slow command cannot overwrite status after the selected model changes", 
 	Object.assign(ctx, { model: codexModel });
 	mock.events.get("model_select")?.[0]?.({ model: codexModel }, ctx);
 	await settle();
-	assert.equal(statuses.get("usage"), "codex 80% 5h");
+	assert.equal(statuses.get("usage"), "codex 80%");
 
 	resolveSlowFetch(await usageFetch("https://openrouter.ai/api/v1/key"));
 	await commandPromise;
-	assert.equal(statuses.get("usage"), "codex 80% 5h");
+	assert.equal(statuses.get("usage"), "codex 80%");
 });
 
 test("statusline follows runtime auth changes and clears for unsupported selected providers", async (t) => {
@@ -1992,6 +1992,7 @@ test("Ctrl+C hard-cancels Settings before conflicting configurable actions", asy
 	assert.equal(changed, false);
 	assert.deepEqual(settings.state().settings, {
 		codexFastMode: false,
+		codexStatusResetCountdown: false,
 		xaiUsage: false,
 	});
 	assert.equal(applied, 0);

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -1932,10 +1932,10 @@ test("the Settings menu action gives RPC mode the active manual settings path", 
 	assert.match(notifications[0]?.message ?? "", /Edit settings manually: \/tmp\/pi-usage\.json/);
 });
 
-test("the TUI SettingsList describes and applies xAI changes immediately", async (t) => {
+test("the TUI SettingsList describes and applies usage preferences immediately", async (t) => {
 	const settings = memorySettingsRuntime(false);
 	const rendered: string[][] = [];
-	let applied = 0;
+	const applied = new Set<string>();
 	const controller = new AbortController();
 	const previousKeybindings = getKeybindings();
 	const remappedKeybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
@@ -1978,7 +1978,11 @@ test("the TUI SettingsList describes and applies xAI changes immediately", async
 				rendered.push(component.render(100));
 				component.handleInput("j");
 				component.handleInput("x");
-				setImmediate(() => component.handleInput("q"));
+				setImmediate(() => {
+					component.handleInput("j");
+					component.handleInput("x");
+					setImmediate(() => component.handleInput("q"));
+				});
 			}),
 	});
 
@@ -1987,15 +1991,19 @@ test("the TUI SettingsList describes and applies xAI changes immediately", async
 		settings.runtime,
 		controller.signal,
 		() => true,
-		(id) => {
-			if (id === "xaiUsage") applied += 1;
-		},
+		(id) => applied.add(id),
 	);
 
 	assert.equal(changed, true);
+	assert.equal(settings.state().settings.codexStatusResetCountdown, true);
 	assert.equal(settings.state().settings.xaiUsage, true);
-	assert.equal(applied, 1);
+	assert.deepEqual(applied, new Set(["codexStatusResetCountdown", "xaiUsage"]));
 	const renderedSettings = rendered.map((lines) => lines.join("\n"));
+	assert.ok(
+		renderedSettings.some((frame) =>
+			/Show time remaining until each Codex usage limit resets/.test(frame),
+		),
+	);
 	assert.ok(
 		renderedSettings.some((frame) => /OAuth subscription allowance and credits/.test(frame)),
 	);
@@ -2197,6 +2205,7 @@ test("a durable settings save still applies lifecycle cleanup when disposal wins
 					done,
 				);
 				component.handleInput("\u001b[B");
+				component.handleInput("\u001b[B");
 				component.handleInput("\r");
 			}),
 	});
@@ -2249,6 +2258,7 @@ test("the TUI SettingsList rolls back its displayed and effective value after sa
 					{ matches: () => false },
 					done,
 				);
+				component.handleInput("\u001b[B");
 				component.handleInput("\u001b[B");
 				component.handleInput("\r");
 				setImmediate(() => component.handleInput("\u0003"));


### PR DESCRIPTION
## Summary
- show actual Codex reset countdowns in the statusline
- format each reset compactly, for example `↻ 21m` and `↻ 6d19h`
- repair pi-usage test settings fixtures for the reset-countdown preference

## Verification
- `npm run check`
- `./node_modules/.bin/vitest run packages/pi-usage/test`

`npm test` is currently blocked by an unrelated existing failure in `packages/pi-github-pr/test/github-pr.test.ts`: `branch changes abort an in-flight periodic refresh` observes an already-aborted signal.
