### PR TITLE
feat(usage): remove xAI usage setting

### DIFF
--- a/.changeset/always-xai-usage.md
+++ b/.changeset/always-xai-usage.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Remove the xAI usage setting and always offer xAI OAuth subscription reporting through explicit `/usage` actions without background or statusline requests.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -5,7 +5,7 @@
 Inspect usage and DeepSeek API balance for Pi's active provider account, query other configured providers, and toggle Fast mode for supported OpenAI Codex models.
 
 The extension keeps each provider's native quota, allowance, and spending semantics instead of treating unlike values as equivalent.
-xAI OAuth subscription reporting defaults to On and follows the reviewed Grok Build contract.
+xAI OAuth subscription reporting follows the reviewed Grok Build contract and runs only after an explicit `/usage` action.
 
 ## ✨ Features
 
@@ -15,7 +15,7 @@ xAI OAuth subscription reporting defaults to On and follows the reviewed Grok Bu
 - Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
-- Reports xAI OAuth subscription allowances and credits when enabled.
+- Reports xAI OAuth subscription allowances and credits.
 - Toggles persistent Codex Fast routing through `/fast` or the usage menu.
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
 - Refreshes one or all configured providers with bounded concurrency while preserving partial results.
@@ -89,7 +89,7 @@ Successful, already-completed, not-needed, and no-credit outcomes are reported s
 
 ## ⚙️ Settings
 
-Choose **Settings** in `/usage` to edit Codex Fast mode, the Codex reset countdown, and xAI usage through Pi's settings-list interaction in TUI mode.
+Choose **Settings** in `/usage` to edit Codex Fast mode and the Codex reset countdown through Pi's settings-list interaction in TUI mode.
 RPC mode reports the active manual settings path instead of opening terminal UI.
 
 These preferences live in `pi-usage.json` under Pi's user agent directory, normally `~/.pi/agent/pi-usage.json`.
@@ -127,22 +127,6 @@ Turn **Codex reset countdown** Off in the TUI Settings screen, or set it to `fal
   "codexStatusResetCountdown": false
 }
 ```
-
-### xAI usage
-
-The `xaiUsage` preference defaults to `true` when the settings file or field is absent.
-Turn it Off in the TUI Settings screen or edit the active user file manually, then run `/reload`:
-
-```json
-{
-  "xaiUsage": false
-}
-```
-
-While enabled, xAI is available only through explicit `/usage` current, configured-provider, or all-provider actions.
-It does not schedule xAI requests or publish xAI data to the statusline.
-The disabled, malformed, and invalid-settings states perform no xAI usage auth resolution or consumer requests.
-Turning it Off clears xAI cache state and prevents stale in-flight results from being published.
 
 ## 📋 Provider semantics
 
@@ -255,7 +239,7 @@ Other origins fail before the credential is sent.
 - Identity route: `GET https://cli-chat-proxy.grok.com/v1/user?include=subscription`
 - Billing route: `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
 - Displayed data: included allowance or legacy monetary limit, period and reset, on-demand spend and cap, prepaid balance, and a sanitized optional plan tier
-- Statusline: not published; xAI is queried only through an explicit `/usage` action while xAI usage is enabled
+- Statusline: not published; xAI is queried only through an explicit `/usage` action
 
 The adapter accepts only the official Pi inference origin `https://api.x.ai` and a freshly resolved bearer that exactly matches one complete Pi OAuth credential.
 Pi's reviewed OAuth scope is `openid profile email offline_access grok-cli:access api:access`.
@@ -283,7 +267,7 @@ The implementation also sends the non-secret client headers present on both rout
 The sanitized identity shape contained a string `userId` and nullable `subscriptionTier`.
 The billing shape contained a `config` object with period and distinct on-demand and prepaid wrappers, without retaining field values.
 
-Disable `xaiUsage` to stop all xAI consumer usage traffic while preserving other provider behavior.
+xAI identity and billing requests occur only after an explicit current, configured-provider, or all-provider `/usage` action.
 
 ### Z.AI (GLM Coding Plan)
 

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -245,15 +245,14 @@ export const XAI_ADAPTER: UsageProviderAdapter = {
 	},
 };
 
-export function usageAdapters(xaiUsage = true): readonly UsageProviderAdapter[] {
-	return xaiUsage ? [...SUPPORTED_ADAPTERS, XAI_ADAPTER] : SUPPORTED_ADAPTERS;
+export function usageAdapters(): readonly UsageProviderAdapter[] {
+	return [...SUPPORTED_ADAPTERS, XAI_ADAPTER];
 }
 
 export function adapterForProvider(
 	providerId: string | undefined,
-	xaiUsage = true,
 ): UsageProviderAdapter | undefined {
-	return usageAdapters(xaiUsage).find((adapter) => adapter.id === providerId);
+	return usageAdapters().find((adapter) => adapter.id === providerId);
 }
 
 export function isStaleExtensionContextError(error: unknown): boolean {

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -10,13 +10,11 @@ export const MAX_USAGE_SETTINGS_BYTES = 64 * 1024;
 export interface UsageSettings {
 	codexFastMode: boolean;
 	codexStatusResetCountdown: boolean;
-	xaiUsage: boolean;
 }
 
 export const DEFAULT_USAGE_SETTINGS: Readonly<UsageSettings> = Object.freeze({
 	codexFastMode: false,
 	codexStatusResetCountdown: true,
-	xaiUsage: true,
 });
 
 export interface UsageSettingsState {
@@ -62,9 +60,6 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 	) {
 		return undefined;
 	}
-	if (Object.hasOwn(value, "xaiUsage") && typeof value.xaiUsage !== "boolean") {
-		return undefined;
-	}
 	return {
 		codexFastMode:
 			typeof value.codexFastMode === "boolean"
@@ -74,8 +69,6 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 			typeof value.codexStatusResetCountdown === "boolean"
 				? value.codexStatusResetCountdown
 				: DEFAULT_USAGE_SETTINGS.codexStatusResetCountdown,
-		xaiUsage:
-			typeof value.xaiUsage === "boolean" ? value.xaiUsage : DEFAULT_USAGE_SETTINGS.xaiUsage,
 	};
 }
 

--- a/packages/pi-usage/src/usage-helpers.ts
+++ b/packages/pi-usage/src/usage-helpers.ts
@@ -3,8 +3,8 @@ import { sanitizeDisplayText } from "./core.js";
 import { providerIsConfigured, usageAdapters } from "./query.js";
 import type { PiModel, UsageProviderAdapter } from "./types.js";
 
-export function configuredAdapters(ctx: ExtensionContext, xaiUsage = true): UsageProviderAdapter[] {
-	return usageAdapters(xaiUsage).filter(
+export function configuredAdapters(ctx: ExtensionContext): UsageProviderAdapter[] {
+	return usageAdapters().filter(
 		(adapter) => adapter.id === ctx.model?.provider || providerIsConfigured(ctx, adapter.id),
 	);
 }

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -23,7 +23,7 @@ export async function showUsageSettings(
 	settingsRuntime: UsageSettingsRuntime,
 	parentSignal: AbortSignal,
 	isCurrent: () => boolean,
-	onApplied: (id: UsageSettingId, previous: boolean, next: boolean) => void,
+	onApplied: (id: UsageSettingId) => void,
 ): Promise<boolean> {
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${settingsRuntime.get().path}`, "info");
@@ -53,13 +53,6 @@ export async function showUsageSettings(
 				currentValue: state.settings.codexStatusResetCountdown ? ON : OFF,
 				values: [OFF, ON],
 			},
-			{
-				id: "xaiUsage",
-				label: "xAI usage",
-				description: "Report OAuth subscription allowance and credits.",
-				currentValue: state.kind !== "invalid" && state.settings.xaiUsage ? ON : OFF,
-				values: [OFF, ON],
-			},
 		];
 		const container = new Container();
 		container.addChild(new Text(theme.fg("accent", theme.bold("pi-usage Settings")), 1, 1));
@@ -82,8 +75,7 @@ export async function showUsageSettings(
 				saveQueue = saveQueue.then(async () => {
 					const previous = settingsRuntime.get().settings[settingId];
 					if (settingsRuntime.get().kind === "invalid") {
-						const effectivePrevious = settingId === "xaiUsage" ? false : previous;
-						settingsList.updateValue(id, displayValue(settingId, effectivePrevious));
+						settingsList.updateValue(id, displayValue(previous));
 						if (!signal.aborted && isCurrent()) {
 							ctx.ui.notify("Repair pi-usage.json and reload before changing settings.", "error");
 							tui.requestRender();
@@ -94,17 +86,17 @@ export async function showUsageSettings(
 						await settingsRuntime.update({ [settingId]: requested }, signal);
 					} catch (error) {
 						if (signal.aborted || !isCurrent()) return;
-						settingsList.updateValue(id, displayValue(settingId, previous));
+						settingsList.updateValue(id, displayValue(previous));
 						ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
 						tui.requestRender();
 						return;
 					}
 					if (previous !== requested) {
 						changed = true;
-						onApplied(settingId, previous, requested);
+						onApplied(settingId);
 					}
 					if (signal.aborted || !isCurrent()) return;
-					settingsList.updateValue(id, displayValue(settingId, requested));
+					settingsList.updateValue(id, displayValue(requested));
 					tui.requestRender();
 				});
 			},
@@ -130,6 +122,6 @@ export async function showUsageSettings(
 	});
 }
 
-function displayValue(_id: UsageSettingId, enabled: boolean): string {
+function displayValue(enabled: boolean): string {
 	return enabled ? ON : OFF;
 }

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -104,18 +104,10 @@ export default function usageExtension(
 	let sessionActive = false;
 	let statusGeneration = 0;
 	let sessionGeneration = 0;
-	let xaiSettingsGeneration = 0;
 	let statusRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 	let statusCountdownTimer: ReturnType<typeof setTimeout> | undefined;
 	let statusController: AbortController | undefined;
 	let fastRuntime: ReturnType<typeof registerCodexFastMode>;
-
-	const xaiUsageEnabled = () => {
-		const state = settingsRuntime.get();
-		return state.kind !== "invalid" && state.settings.xaiUsage;
-	};
-	const activeAdapterForProvider = (providerId: string | undefined) =>
-		adapterForProvider(providerId, xaiUsageEnabled());
 
 	const clearStatusRefreshTimer = () => {
 		if (statusRefreshTimer) clearTimeout(statusRefreshTimer);
@@ -168,7 +160,7 @@ export default function usageExtension(
 		shouldSchedule: boolean,
 	) => {
 		clearStatusCountdownTimer();
-		if (activeAdapterForProvider(model.provider)?.publishesStatusline === false) {
+		if (adapterForProvider(model.provider)?.publishesStatusline === false) {
 			clearStatusRefreshTimer();
 			safeSetStatus(ctx, undefined);
 			return;
@@ -260,7 +252,6 @@ export default function usageExtension(
 		deadlineAt = Date.now() + DEFAULT_TIMEOUT_MS,
 	): Promise<QueryOutcome> => {
 		const expectedSessionGeneration = sessionGeneration;
-		const expectedXaiSettingsGeneration = xaiSettingsGeneration;
 		const expectedSessionId = ctx.sessionManager.getSessionId();
 		const expectedModelIdentity = modelIdentity(ctx.model);
 		let auth: ResolvedUsageAuth | undefined;
@@ -290,9 +281,7 @@ export default function usageExtension(
 		const requestContextChanged = () =>
 			expectedSessionGeneration !== sessionGeneration ||
 			ctx.sessionManager.getSessionId() !== expectedSessionId ||
-			modelIdentity(ctx.model) !== expectedModelIdentity ||
-			(adapter.id === "xai" &&
-				(expectedXaiSettingsGeneration !== xaiSettingsGeneration || !xaiUsageEnabled()));
+			modelIdentity(ctx.model) !== expectedModelIdentity;
 		if (requiresRequestBoundaryGuard && requestContextChanged()) throw abortError();
 		if (!auth) {
 			if (displayState === "current") {
@@ -436,7 +425,7 @@ export default function usageExtension(
 		force: boolean,
 		signal: AbortSignal,
 	): Promise<QueryOutcome> => {
-		const adapter = activeAdapterForProvider(model?.provider);
+		const adapter = adapterForProvider(model?.provider);
 		if (!adapter) {
 			const providerId = model?.provider ?? "none";
 			transitionCurrentIdentity(`unsupported:${providerId}`, providerId);
@@ -446,12 +435,9 @@ export default function usageExtension(
 					providerName: providerDisplayName(ctx, providerId),
 					displayState: "current",
 					status: "unsupported",
-					message:
-						providerId === "xai" && !xaiUsageEnabled()
-							? "xAI usage is disabled. Open Settings to enable it."
-							: model
-								? `Usage reporting is not supported for ${providerDisplayName(ctx, providerId)}.`
-								: "No model is selected.",
+					message: model
+						? `Usage reporting is not supported for ${providerDisplayName(ctx, providerId)}.`
+						: "No model is selected.",
 				},
 			};
 		}
@@ -463,7 +449,7 @@ export default function usageExtension(
 		model: PiModel | undefined,
 		force: boolean,
 	) => {
-		const adapter = activeAdapterForProvider(model?.provider);
+		const adapter = adapterForProvider(model?.provider);
 		if (!adapter || !model) {
 			const providerId = model?.provider ?? "none";
 			transitionCurrentIdentity(`unsupported:${providerId}`, providerId);
@@ -546,7 +532,7 @@ export default function usageExtension(
 		if (generation !== statusGeneration || modelIdentity(ctx.model) !== modelIdentity(model)) {
 			return false;
 		}
-		const adapter = activeAdapterForProvider(model?.provider);
+		const adapter = adapterForProvider(model?.provider);
 		if (outcome.authState === "unavailable") {
 			if (!adapter) return false;
 			try {
@@ -720,7 +706,7 @@ export default function usageExtension(
 					providers: () => ({
 						kind: "actions",
 						title: "Select a configured provider",
-						items: configuredAdapters(ctx, xaiUsageEnabled())
+						items: configuredAdapters(ctx)
 							.filter((adapter) => adapter.id !== ctx.model?.provider)
 							.map((adapter) => ({
 								id: adapter.id,
@@ -794,24 +780,14 @@ export default function usageExtension(
 							settingsRuntime,
 							controller.signal,
 							() => statusGeneration === menuGeneration && !controller.signal.aborted,
-							(id, _previous, next) => {
-								if (id === "codexStatusResetCountdown") {
-									if (
-										stableCurrent &&
-										statusGeneration === menuGeneration &&
-										!controller.signal.aborted
-									) {
-										publishStableCurrent(ctx, stableCurrent);
-									}
-									return;
-								}
-								if (id !== "xaiUsage") return;
-								xaiSettingsGeneration += 1;
-								invalidateProviderState("xai");
-								if (!next) {
-									for (const active of activeControllers) {
-										if (active !== controller) active.abort();
-									}
+							(id) => {
+								if (
+									id === "codexStatusResetCountdown" &&
+									stableCurrent &&
+									statusGeneration === menuGeneration &&
+									!controller.signal.aborted
+								) {
+									publishStableCurrent(ctx, stableCurrent);
 								}
 							},
 						);
@@ -1008,7 +984,7 @@ export default function usageExtension(
 						return { kind: "stay" };
 					},
 					another: async () => {
-						const others = configuredAdapters(ctx, xaiUsageEnabled()).filter(
+						const others = configuredAdapters(ctx).filter(
 							(adapter) => adapter.id !== ctx.model?.provider,
 						);
 						if (others.length === 0) {
@@ -1018,7 +994,7 @@ export default function usageExtension(
 						return { kind: "to", screen: "providers" };
 					},
 					provider: async ({ itemId }) => {
-						const adapter = configuredAdapters(ctx, xaiUsageEnabled()).find(
+						const adapter = configuredAdapters(ctx).find(
 							(candidate) => candidate.id === itemId && candidate.id !== ctx.model?.provider,
 						);
 						if (!adapter) return { kind: "back" };
@@ -1046,7 +1022,7 @@ export default function usageExtension(
 						return { kind: "back" };
 					},
 					all: async () => {
-						const adapters = configuredAdapters(ctx, xaiUsageEnabled());
+						const adapters = configuredAdapters(ctx);
 						const currentProviderId = ctx.model?.provider;
 						const settled = await runMenuOperation(
 							ctx,
@@ -1129,7 +1105,6 @@ export default function usageExtension(
 	});
 	pi.on("session_start", (_event, ctx) => {
 		sessionGeneration += 1;
-		xaiSettingsGeneration += 1;
 		statusGeneration += 1;
 		clearStatusTimers();
 		for (const controller of activeControllers) controller.abort();
@@ -1150,7 +1125,6 @@ export default function usageExtension(
 	pi.on("session_shutdown", (_event, ctx) => {
 		sessionActive = false;
 		sessionGeneration += 1;
-		xaiSettingsGeneration += 1;
 		statusGeneration += 1;
 		clearStatusTimers();
 		for (const controller of activeControllers) controller.abort();

--- a/packages/pi-usage/test/codex-fast-menu.test.ts
+++ b/packages/pi-usage/test/codex-fast-menu.test.ts
@@ -21,7 +21,7 @@ function runtime(kind: UsageSettingsState["kind"] = "loaded") {
 	let state: UsageSettingsState = {
 		kind,
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: false, codexStatusResetCountdown: false, xaiUsage: false },
+		settings: { codexFastMode: false, codexStatusResetCountdown: false },
 		...(kind === "invalid" ? { issue: "bad file" } : { document: {} }),
 	};
 	const patches: unknown[] = [];

--- a/packages/pi-usage/test/codex-fast-runtime.test.ts
+++ b/packages/pi-usage/test/codex-fast-runtime.test.ts
@@ -32,7 +32,6 @@ function memoryRuntime(
 		settings: {
 			codexFastMode: options.enabled ?? false,
 			codexStatusResetCountdown: false,
-			xaiUsage: false,
 		},
 		...(options.kind === "invalid" ? { issue: "bad file" } : { document: {} }),
 	};
@@ -313,7 +312,7 @@ test("session replacement aborts stale loads and accepted writes before UI publi
 	releaseLoad({
 		kind: "loaded",
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: true, codexStatusResetCountdown: false, xaiUsage: false },
+		settings: { codexFastMode: true, codexStatusResetCountdown: false },
 		document: { codexFastMode: true },
 	});
 	await pendingLoad;

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -34,20 +34,15 @@ afterEach(async () => {
 	);
 });
 
-test("normalizes the default-enabled xAI setting and rejects invalid values", () => {
+test("normalizes owned settings and ignores the retired xAI field", () => {
 	assert.deepEqual(normalizeUsageSettings({}), DEFAULT_USAGE_SETTINGS);
 	assert.deepEqual(normalizeUsageSettings({ codexFastMode: true }), {
 		codexFastMode: true,
 		codexStatusResetCountdown: true,
-		xaiUsage: true,
 	});
-	assert.deepEqual(normalizeUsageSettings({ xaiUsage: false }), {
-		codexFastMode: false,
-		codexStatusResetCountdown: true,
-		xaiUsage: false,
-	});
+	assert.deepEqual(normalizeUsageSettings({ xaiUsage: false }), DEFAULT_USAGE_SETTINGS);
+	assert.deepEqual(normalizeUsageSettings({ xaiUsage: "retired" }), DEFAULT_USAGE_SETTINGS);
 	assert.equal(normalizeUsageSettings({ codexFastMode: "true" }), undefined);
-	assert.equal(normalizeUsageSettings({ xaiUsage: "true" }), undefined);
 	assert.equal(normalizeUsageSettings([]), undefined);
 });
 
@@ -57,11 +52,11 @@ test("missing loads are side-effect free and valid loads preserve unknown fields
 	assert.equal(missing.kind, "missing");
 	assert.equal((await readdir(join(path, ".."))).length, 0);
 
-	await writeFile(path, '{"codexFastMode":true,"future":"kept"}\n');
+	await writeFile(path, '{"codexFastMode":true,"xaiUsage":false,"future":"kept"}\n');
 	const loaded = await loadUsageSettings(path);
 	assert.equal(loaded.kind, "loaded");
 	assert.equal(loaded.settings.codexFastMode, true);
-	assert.equal(loaded.settings.xaiUsage, true);
+	assert.equal(loaded.document?.xaiUsage, false);
 	assert.equal(loaded.document?.future, "kept");
 });
 
@@ -79,10 +74,6 @@ test("malformed, invalid, oversized, and symbolic-link settings stay read-only",
 	await writeFile(invalidPath, '{"codexFastMode":"yes"}\n');
 	assert.equal((await loadUsageSettings(invalidPath)).kind, "invalid");
 
-	const invalidXaiPath = await tempSettingsPath();
-	await writeFile(invalidXaiPath, '{"xaiUsage":1}\n');
-	assert.equal((await loadUsageSettings(invalidXaiPath)).kind, "invalid");
-
 	const oversizedPath = await tempSettingsPath();
 	await writeFile(oversizedPath, JSON.stringify({ padding: "x".repeat(70 * 1024) }));
 	assert.match((await loadUsageSettings(oversizedPath)).issue ?? "", /64 KiB/);
@@ -97,16 +88,15 @@ test("malformed, invalid, oversized, and symbolic-link settings stay read-only",
 test("the first explicit save creates a private file and preserves unknown fields", async () => {
 	const path = await tempSettingsPath();
 	const runtime = createUsageSettingsRuntime(path);
-	await runtime.update({ codexFastMode: true, xaiUsage: false });
+	await runtime.update({ codexFastMode: true });
 	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
 		codexFastMode: true,
-		xaiUsage: false,
 	});
 	if (process.platform !== "win32") assert.equal((await stat(path)).mode & 0o777, 0o600);
 
-	await writeFile(path, '{"codexFastMode":true,"future":"kept"}\n');
+	await writeFile(path, '{"codexFastMode":true,"xaiUsage":false,"future":"kept"}\n');
 	if (process.platform !== "win32") await chmod(path, 0o644);
-	await runtime.update({ codexFastMode: false, xaiUsage: false });
+	await runtime.update({ codexFastMode: false });
 	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
 		codexFastMode: false,
 		xaiUsage: false,
@@ -122,13 +112,12 @@ test("serialized updates reread the latest document and leave no temporary files
 	await runtime.reload();
 	await writeFile(path, '{"codexFastMode":false,"external":"newer"}\n');
 	await Promise.all([
-		runtime.update({ codexFastMode: true, xaiUsage: true }),
-		runtime.update({ codexFastMode: false, xaiUsage: false }),
+		runtime.update({ codexFastMode: true }),
+		runtime.update({ codexFastMode: false }),
 	]);
 	await runtime.flush();
 	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
 		codexFastMode: false,
-		xaiUsage: false,
 		external: "newer",
 	});
 	assert.deepEqual(
@@ -137,15 +126,15 @@ test("serialized updates reread the latest document and leave no temporary files
 	);
 });
 
-test("reload waits for queued writes and observes the latest durable xAI value", async () => {
+test("reload waits for queued writes and observes the latest durable Codex value", async () => {
 	const path = await tempSettingsPath();
 	const runtime = createUsageSettingsRuntime(path);
-	const update = runtime.update({ xaiUsage: false });
+	const update = runtime.update({ codexFastMode: true });
 	const reload = runtime.reload();
 	await update;
 	const reloaded = await reload;
-	assert.equal(reloaded.settings.xaiUsage, false);
-	assert.equal(JSON.parse(await readFile(path, "utf8")).xaiUsage, false);
+	assert.equal(reloaded.settings.codexFastMode, true);
+	assert.equal(JSON.parse(await readFile(path, "utf8")).codexFastMode, true);
 });
 
 test("aborted saves retain prior runtime state", async () => {
@@ -154,11 +143,10 @@ test("aborted saves retain prior runtime state", async () => {
 	const controller = new AbortController();
 	controller.abort();
 	await assert.rejects(
-		abortedRuntime.update({ codexFastMode: true, xaiUsage: false }, controller.signal),
+		abortedRuntime.update({ codexFastMode: true }, controller.signal),
 		/aborted/i,
 	);
 	assert.equal(abortedRuntime.get().settings.codexFastMode, false);
-	assert.equal(abortedRuntime.get().settings.xaiUsage, true);
 	assert.equal((await loadUsageSettings(abortedPath)).kind, "missing");
 });
 
@@ -174,9 +162,8 @@ test("failed saves retain prior runtime state, clean up, and do not poison retri
 			},
 		},
 	});
-	await assert.rejects(runtime.update({ codexFastMode: true, xaiUsage: false }), /rename rejected/);
+	await assert.rejects(runtime.update({ codexFastMode: true }), /rename rejected/);
 	assert.equal(runtime.get().settings.codexFastMode, false);
-	assert.equal(runtime.get().settings.xaiUsage, true);
 	assert.equal((await loadUsageSettings(path)).kind, "missing");
 	assert.deepEqual(
 		(await readdir(join(path, ".."))).filter((name) => name.endsWith(".tmp")),
@@ -191,7 +178,6 @@ test("failed saves retain prior runtime state, clean up, and do not poison retri
 test("normalizes the Codex reset countdown status preference", () => {
 	assert.deepEqual(normalizeUsageSettings({ codexStatusResetCountdown: false }), {
 		codexFastMode: false,
-		xaiUsage: true,
 		codexStatusResetCountdown: false,
 	});
 	assert.equal(normalizeUsageSettings({ codexStatusResetCountdown: "false" }), undefined);

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -68,25 +68,31 @@ function codexAccessToken(accountId: string): string {
 }
 
 function memorySettingsRuntime(
-	xaiUsage = true,
-	failUpdates = false,
-	kind: UsageSettingsState["kind"] = "loaded",
-	codexStatusResetCountdown = false,
+	options: {
+		codexStatusResetCountdown?: boolean;
+		document?: Record<string, unknown>;
+		failUpdates?: boolean;
+		kind?: UsageSettingsState["kind"];
+	} = {},
 ): { runtime: UsageSettingsRuntime; state: () => UsageSettingsState } {
+	const kind = options.kind ?? "loaded";
 	let state: UsageSettingsState = {
 		kind,
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: false, codexStatusResetCountdown, xaiUsage },
+		settings: {
+			codexFastMode: false,
+			codexStatusResetCountdown: options.codexStatusResetCountdown ?? false,
+		},
 		...(kind === "invalid"
 			? { issue: "invalid test settings" }
-			: { document: { codexFastMode: false, xaiUsage } }),
+			: { document: { codexFastMode: false, ...options.document } }),
 	};
 	const runtime: UsageSettingsRuntime = {
 		get: () => structuredClone(state),
 		reload: async () => structuredClone(state),
 		update: async (patch, signal) => {
 			signal?.throwIfAborted();
-			if (failUpdates) throw new Error("disk full");
+			if (options.failUpdates) throw new Error("disk full");
 			state = {
 				...state,
 				settings: { ...state.settings, ...patch },
@@ -1317,7 +1323,7 @@ test("Codex reset countdown repaints locally and stops across replacement and sh
 			{ status: 200 },
 		);
 	};
-	const settings = memorySettingsRuntime(false, false, "loaded", true);
+	const settings = memorySettingsRuntime({ codexStatusResetCountdown: true });
 	const mock = createMockPi();
 	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
 	const { ctx, statuses } = createMockContext({
@@ -1508,93 +1514,7 @@ test("statusline follows runtime auth changes and clears for unsupported selecte
 	assert.equal(fetches, 5);
 });
 
-test("disabled xAI reports its state with zero auth and network requests", async (t) => {
-	const originalFetch = globalThis.fetch;
-	t.onTestFinished(() => {
-		globalThis.fetch = originalFetch;
-	});
-	let fetches = 0;
-	let authCalls = 0;
-	globalThis.fetch = async () => {
-		fetches += 1;
-		throw new Error("must not fetch");
-	};
-	const settings = memorySettingsRuntime(false);
-	const mock = createMockPi();
-	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
-	const command = mock.commands.get("usage");
-	assert.ok(command);
-	let title = "";
-	const { ctx, statuses } = createMockContext({
-		hasUI: true,
-		mode: "rpc",
-		model: xaiModel,
-		select: async (value: string) => {
-			title = value;
-			return "Close";
-		},
-		modelRegistry: {
-			getApiKeyAndHeaders: async () => {
-				authCalls += 1;
-				return { ok: true, apiKey: "xai-access" };
-			},
-			getProviderAuth: async () => {
-				authCalls += 1;
-				return { auth: { apiKey: "xai-access" } };
-			},
-			getAvailable: () => [xaiModel],
-			getAll: () => [xaiModel],
-			getProviderDisplayName: () => "xAI",
-		},
-	});
-
-	await command.handler("", ctx);
-
-	assert.match(title, /xAI usage is disabled/);
-	assert.equal(authCalls, 0);
-	assert.equal(fetches, 0);
-	assert.equal(statuses.get("usage"), undefined);
-});
-
-test("invalid settings keep xAI disabled without resolving auth or fetching", async (t) => {
-	const originalFetch = globalThis.fetch;
-	t.onTestFinished(() => {
-		globalThis.fetch = originalFetch;
-	});
-	let fetches = 0;
-	let authCalls = 0;
-	globalThis.fetch = async () => {
-		fetches += 1;
-		throw new Error("must not fetch");
-	};
-	const settings = memorySettingsRuntime(true, false, "invalid");
-	const mock = createMockPi();
-	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
-	const command = mock.commands.get("usage");
-	assert.ok(command);
-	const { ctx } = createMockContext({
-		hasUI: true,
-		mode: "rpc",
-		model: xaiModel,
-		select: async () => "Close",
-		modelRegistry: {
-			getProviderAuth: async () => {
-				authCalls += 1;
-				return { auth: { apiKey: "xai-access" } };
-			},
-			getAvailable: () => [xaiModel],
-			getAll: () => [xaiModel],
-			getProviderDisplayName: () => "xAI",
-		},
-	});
-
-	await command.handler("", ctx);
-
-	assert.equal(authCalls, 0);
-	assert.equal(fetches, 0);
-});
-
-test("enabled xAI queries only through explicit usage and never publishes status", async (t) => {
+test("a retired xAI setting cannot disable explicit usage or publish status", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.onTestFinished(() => {
 		globalThis.fetch = originalFetch;
@@ -1616,7 +1536,7 @@ test("enabled xAI queries only through explicit usage and never publishes status
 					{ status: 200 },
 				);
 	};
-	const settings = memorySettingsRuntime(true);
+	const settings = memorySettingsRuntime({ document: { xaiUsage: false } });
 	const credential = {
 		type: "oauth",
 		access: "xai-access",
@@ -1663,57 +1583,6 @@ test("enabled xAI queries only through explicit usage and never publishes status
 	assert.equal(statuses.get("usage"), undefined);
 });
 
-test("xAI opt-out after identity prevents billing and stale publication", async (t) => {
-	const originalFetch = globalThis.fetch;
-	t.onTestFinished(() => {
-		globalThis.fetch = originalFetch;
-	});
-	const settings = memorySettingsRuntime(true);
-	let fetches = 0;
-	globalThis.fetch = async () => {
-		fetches += 1;
-		await settings.runtime.update({ xaiUsage: false });
-		return new Response(JSON.stringify({ userId: "fixture-user" }), { status: 200 });
-	};
-	const credential = {
-		type: "oauth",
-		access: "xai-access",
-		refresh: "xai-refresh",
-		expires: Date.now() + 60_000,
-	};
-	const mock = createMockPi();
-	usageExtension(mock.pi, {
-		settingsRuntime: settings.runtime,
-		credentialReader: () => credential,
-	});
-	const command = mock.commands.get("usage");
-	assert.ok(command);
-	let menus = 0;
-	const { ctx, statuses } = createMockContext({
-		hasUI: true,
-		mode: "rpc",
-		model: xaiModel,
-		select: async () => {
-			menus += 1;
-			return "Close";
-		},
-		modelRegistry: {
-			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "xai-access" }),
-			getProviderAuth: async () => ({ auth: { apiKey: "xai-access" } }),
-			getAvailable: () => [xaiModel],
-			getAll: () => [xaiModel],
-			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: () => "xAI",
-		},
-	});
-
-	await command.handler("", ctx);
-
-	assert.equal(fetches, 1);
-	assert.equal(menus, 0);
-	assert.equal(statuses.get("usage"), undefined);
-});
-
 test("xAI account changes after identity prevent billing and stale publication", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.onTestFinished(() => {
@@ -1726,7 +1595,7 @@ test("xAI account changes after identity prevent billing and stale publication",
 		activeAccess = "xai-access-b";
 		return new Response(JSON.stringify({ userId: "fixture-user" }), { status: 200 });
 	};
-	const settings = memorySettingsRuntime(true);
+	const settings = memorySettingsRuntime();
 	const mock = createMockPi();
 	usageExtension(mock.pi, {
 		settingsRuntime: settings.runtime,
@@ -1784,7 +1653,7 @@ test("xAI account changes after the final adapter guard prevent configured publi
 			status: 200,
 		});
 	};
-	const settings = memorySettingsRuntime(true);
+	const settings = memorySettingsRuntime();
 	const choices = ["View another configured provider…", "xAI"];
 	const titles: string[] = [];
 	const mock = createMockPi();
@@ -1839,7 +1708,7 @@ test("xAI account changes after the final adapter guard prevent configured publi
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 });
 
-test("enabled xAI appears as a configured provider without changing current status", async (t) => {
+test("xAI appears as a configured provider without changing current status", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.onTestFinished(() => {
 		globalThis.fetch = originalFetch;
@@ -1856,7 +1725,7 @@ test("enabled xAI appears as a configured provider without changing current stat
 			status: 200,
 		});
 	};
-	const settings = memorySettingsRuntime(true);
+	const settings = memorySettingsRuntime();
 	const choices = ["View another configured provider…", "xAI", "Close"];
 	const titles: string[] = [];
 	const mock = createMockPi();
@@ -1933,7 +1802,7 @@ test("the Settings menu action gives RPC mode the active manual settings path", 
 });
 
 test("the TUI SettingsList describes and applies usage preferences immediately", async (t) => {
-	const settings = memorySettingsRuntime(false);
+	const settings = memorySettingsRuntime();
 	const rendered: string[][] = [];
 	const applied = new Set<string>();
 	const controller = new AbortController();
@@ -1976,7 +1845,6 @@ test("the TUI SettingsList describes and applies usage preferences immediately",
 					done,
 				);
 				rendered.push(component.render(100));
-				component.handleInput("j");
 				component.handleInput("x");
 				setImmediate(() => {
 					component.handleInput("j");
@@ -1995,23 +1863,21 @@ test("the TUI SettingsList describes and applies usage preferences immediately",
 	);
 
 	assert.equal(changed, true);
+	assert.equal(settings.state().settings.codexFastMode, true);
 	assert.equal(settings.state().settings.codexStatusResetCountdown, true);
-	assert.equal(settings.state().settings.xaiUsage, true);
-	assert.deepEqual(applied, new Set(["codexStatusResetCountdown", "xaiUsage"]));
+	assert.deepEqual(applied, new Set(["codexFastMode", "codexStatusResetCountdown"]));
 	const renderedSettings = rendered.map((lines) => lines.join("\n"));
 	assert.ok(
 		renderedSettings.some((frame) =>
 			/Show time remaining until each Codex usage limit resets/.test(frame),
 		),
 	);
-	assert.ok(
-		renderedSettings.some((frame) => /OAuth subscription allowance and credits/.test(frame)),
-	);
-	assert.doesNotMatch(renderedSettings.join("\n"), /warning|undocumented|experimental/iu);
+	assert.ok(renderedSettings.some((frame) => /Use faster Codex routing/.test(frame)));
+	assert.doesNotMatch(renderedSettings.join("\n"), /xAI|warning|undocumented|experimental/iu);
 });
 
 test("Ctrl+C hard-cancels Settings before conflicting configurable actions", async (t) => {
-	const settings = memorySettingsRuntime(false);
+	const settings = memorySettingsRuntime();
 	let applied = 0;
 	const previousKeybindings = getKeybindings();
 	const conflictingKeybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
@@ -2069,7 +1935,6 @@ test("Ctrl+C hard-cancels Settings before conflicting configurable actions", asy
 	assert.deepEqual(settings.state().settings, {
 		codexFastMode: false,
 		codexStatusResetCountdown: false,
-		xaiUsage: false,
 	});
 	assert.equal(applied, 0);
 });
@@ -2083,7 +1948,7 @@ test("settings cancellation aborts a stalled save and closes without awaiting it
 	t.onTestFinished(() => setKeybindings(previousKeybindings));
 
 	for (const cancellation of ["ctrl+c", "configured cancel", "parent abort"] as const) {
-		const settings = memorySettingsRuntime(false);
+		const settings = memorySettingsRuntime();
 		let markStarted: () => void = () => undefined;
 		const started = new Promise<void>((resolve) => {
 			markStarted = resolve;
@@ -2160,12 +2025,12 @@ test("settings cancellation aborts a stalled save and closes without awaiting it
 
 		assert.equal(await pending, false, cancellation);
 		await aborted;
-		assert.equal(settings.state().settings.xaiUsage, false, cancellation);
+		assert.equal(settings.state().settings.codexStatusResetCountdown, false, cancellation);
 	}
 });
 
 test("a durable settings save still applies lifecycle cleanup when disposal wins the await", async () => {
-	const settings = memorySettingsRuntime(false);
+	const settings = memorySettingsRuntime();
 	const controller = new AbortController();
 	const update = settings.runtime.update;
 	settings.runtime.update = async (patch, signal) => {
@@ -2205,7 +2070,6 @@ test("a durable settings save still applies lifecycle cleanup when disposal wins
 					done,
 				);
 				component.handleInput("\u001b[B");
-				component.handleInput("\u001b[B");
 				component.handleInput("\r");
 			}),
 	});
@@ -2216,16 +2080,16 @@ test("a durable settings save still applies lifecycle cleanup when disposal wins
 		controller.signal,
 		() => true,
 		(id) => {
-			if (id === "xaiUsage") applied += 1;
+			if (id === "codexStatusResetCountdown") applied += 1;
 		},
 	);
 
-	assert.equal(settings.state().settings.xaiUsage, true);
+	assert.equal(settings.state().settings.codexStatusResetCountdown, true);
 	assert.equal(applied, 1);
 });
 
 test("the TUI SettingsList rolls back its displayed and effective value after save failure", async () => {
-	const settings = memorySettingsRuntime(false, true);
+	const settings = memorySettingsRuntime({ failUpdates: true });
 	let latest: string[] = [];
 	const { ctx, notifications } = createMockContext({
 		hasUI: true,
@@ -2259,7 +2123,6 @@ test("the TUI SettingsList rolls back its displayed and effective value after sa
 					done,
 				);
 				component.handleInput("\u001b[B");
-				component.handleInput("\u001b[B");
 				component.handleInput("\r");
 				setImmediate(() => component.handleInput("\u0003"));
 			}),
@@ -2274,9 +2137,9 @@ test("the TUI SettingsList rolls back its displayed and effective value after sa
 	);
 
 	assert.equal(changed, false);
-	assert.equal(settings.state().settings.xaiUsage, false);
+	assert.equal(settings.state().settings.codexStatusResetCountdown, false);
 	assert.match(notifications[0]?.message ?? "", /disk full/);
-	assert.match(latest.join("\n"), /xAI usage.*Off/su);
+	assert.match(latest.join("\n"), /Codex reset countdown.*Off/su);
 });
 
 test("shutdown cancels an explicit xAI identity body before billing or status publication", async (t) => {
@@ -2294,7 +2157,7 @@ test("shutdown cancels an explicit xAI identity body before billing or status pu
 		identityStarted();
 		return new Response(new ReadableStream({ start() {} }), { status: 200 });
 	};
-	const settings = memorySettingsRuntime(true);
+	const settings = memorySettingsRuntime();
 	const credential = {
 		type: "oauth",
 		access: "xai-access",

--- a/packages/pi-usage/test/xai.test.ts
+++ b/packages/pi-usage/test/xai.test.ts
@@ -66,9 +66,8 @@ function resolvedAuth(): ResolvedUsageAuth {
 	};
 }
 
-test("xAI is discovered by default and can be disabled through settings", () => {
+test("xAI is always registered for explicit usage actions", () => {
 	assert.equal(adapterForProvider("xai"), XAI_ADAPTER);
-	assert.equal(adapterForProvider("xai", false), undefined);
 });
 
 test("normalizes current credits while keeping allowance, on-demand, and prepaid values distinct", async () => {


### PR DESCRIPTION
## Summary

- remove the `xaiUsage` schema field, Settings row, and runtime enablement gates
- keep xAI OAuth subscription reporting available only through explicit `/usage` current, configured-provider, or all-provider actions
- preserve session, model, and account revalidation, cancellation, no-background-query, and no-statusline behavior
- ignore and preserve legacy `xaiUsage` JSON fields as unknown data

## Checks

- `npm exec vitest run -- packages/pi-usage/test/settings.test.ts packages/pi-usage/test/xai.test.ts packages/pi-usage/test/usage.test.ts packages/pi-usage/test/codex-fast-runtime.test.ts packages/pi-usage/test/codex-fast-menu.test.ts` (66 passed)
- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` (330 files, 3,223 tests)
- fenced-code-aware README heading audit
- `npm exec changeset status` (intended minor bump; existing unrelated pi-tui-kit dependency-floor warnings remain)

## Smokes

- `just pack usage` inspected the 26-file dry-run tarball
- isolated `pi --no-extensions --no-skills -e ./packages/pi-usage --list-models` load passed with 68 model lines and no xAI usage action

## Audit

Reviewed against `docs/extension-conventions.md`, `docs/extension-settings.md`, and `docs/readme-conventions.md`.
No deviations or unverified paths remain.
