### PR TITLE
refactor(subagents): unbundle example skill

### DIFF
--- a/.changeset/clarify-subagent-delegation.md
+++ b/.changeset/clarify-subagent-delegation.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-subagents": patch
 ---
 
-Require independent work or a concrete context-isolation benefit before the bundled skill delegates to a subagent.
+Update the repository-only example skill to require independent work or a concrete context-isolation benefit before delegating to a subagent.

--- a/.changeset/promote-subagents-v3.md
+++ b/.changeset/promote-subagents-v3.md
@@ -6,6 +6,8 @@ Replace the legacy orchestration runtime with subagent jobs and authenticated ma
 
 Remove `/subagents`, extension settings, persisted and retained agents, the previous blocking orchestration interfaces, custom agent catalogs, advanced orchestration, alternate transports, trust-aware cwd policy, and extension-owned worktrees.
 
-Use the bundled `using-pi-subagents` skill with `subagent_spawn`, `subagent_inspect`, `subagent_cancel`, `subagent_wait`, and `subagent_reply` after upgrading, and start a fresh Pi session so stored calls do not request removed tool names.
+Use `subagent_spawn`, `subagent_inspect`, `subagent_cancel`, `subagent_wait`, and `subagent_reply` directly or through a user-designed skill after upgrading, and start a fresh Pi session so stored calls do not request removed tool names.
+
+The package no longer registers or publishes a delegation skill, while the repository keeps `using-pi-subagents` as an example for designing one.
 
 Completion messages follow Pi's global tool-output expansion state and configured `app.tools.expand` binding.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -4,8 +4,6 @@
 
 Pi Subagents runs Pi jobs in separate child processes and lets each child ask the main agent necessary questions through an authenticated loopback broker.
 
-The bundled `using-pi-subagents` skill explains when to delegate, how to limit child capabilities, and how to verify results safely.
-
 ## ✨ Features
 
 - Runs each job in an isolated Pi child process and returns its job ID immediately.
@@ -42,7 +40,7 @@ npm --workspace @narumitw/pi-subagents run build
 pi install ./packages/pi-subagents
 ```
 
-Build before trying the extension and bundled skill from a local checkout:
+Build before trying the extension from a local checkout:
 
 ```bash
 npm --workspace @narumitw/pi-subagents run build
@@ -59,9 +57,15 @@ Review the source before installing or invoking the extension.
 
 ## 🚀 Quick start
 
-Ask Pi to use the bundled `using-pi-subagents` skill when deciding whether to delegate, or invoke `/skill:using-pi-subagents` directly.
-
 Call `subagent_spawn` with a self-contained task and only the work tools that task needs.
+
+The package intentionally does not register or publish a skill.
+
+Create a project skill under `.pi/skills/<your-skill>/SKILL.md` or a global skill under `~/.pi/agent/skills/<your-skill>/SKILL.md` when you want reusable delegation policy.
+
+Choose a name, trigger description, tool policy, task format, and verification workflow for your own use case.
+
+The repository-only [`using-pi-subagents` example](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-subagents/skills/using-pi-subagents) demonstrates one possible design without imposing it on installed users.
 
 The call returns a `jobId` immediately, and the job continues in the background.
 
@@ -249,10 +253,10 @@ packages/pi-subagents/
 ├── dist/                        # Generated Jiti runtime and child bridge
 ├── docs/                        # Concise tools and design references
 ├── scripts/                     # Deterministic runtime builder
+├── skills/using-pi-subagents/  # Repository-only example delegation skill
 ├── src/                         # Extension, broker, child bridge, and subprocess runtime
-├── skills/using-pi-subagents/  # Delegation and messaging operating manual
 ├── test/                        # Protocol, lifecycle, process, and policy tests
-├── package.json                 # Pi extension and skill declarations
+├── package.json                 # Pi extension declaration
 └── README.md                    # User guide and safety boundaries
 ```
 

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -16,7 +16,6 @@
 	"files": [
 		"src",
 		"dist",
-		"skills",
 		"docs",
 		"README.md",
 		"LICENSE"
@@ -24,9 +23,6 @@
 	"pi": {
 		"extensions": [
 			"./dist/index.ts"
-		],
-		"skills": [
-			"./skills"
 		]
 	},
 	"piExtension": {

--- a/packages/pi-subagents/test/package.test.ts
+++ b/packages/pi-subagents/test/package.test.ts
@@ -6,7 +6,7 @@ import { test } from "vitest";
 
 const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-test("package declares one generated extension and one bundled operating skill", () => {
+test("package declares one generated extension without a bundled skill", () => {
 	const manifest = JSON.parse(
 		readFileSync(path.join(packageDirectory, "package.json"), "utf8"),
 	) as {
@@ -14,7 +14,7 @@ test("package declares one generated extension and one bundled operating skill",
 		description: string;
 		private: boolean;
 		files: string[];
-		pi: { extensions: string[]; skills: string[] };
+		pi: { extensions: string[]; skills?: string[] };
 		piExtension: { lifecycle: string };
 		peerDependencies: Record<string, string>;
 		repository: { directory: string };
@@ -24,17 +24,18 @@ test("package declares one generated extension and one bundled operating skill",
 	assert.equal(manifest.private, true);
 	assert.equal(manifest.repository.directory, "packages/pi-subagents");
 	assert.deepEqual(manifest.pi.extensions, ["./dist/index.ts"]);
-	assert.deepEqual(manifest.pi.skills, ["./skills"]);
+	assert.equal("skills" in manifest.pi, false);
 	assert.equal(manifest.piExtension.lifecycle, "stable");
 	assert.equal(manifest.peerDependencies["@earendil-works/pi-ai"], "*");
 	assert.equal(manifest.peerDependencies["@earendil-works/pi-coding-agent"], "*");
 	assert.ok(manifest.files.includes("src"));
 	assert.ok(manifest.files.includes("dist"));
-	assert.ok(manifest.files.includes("skills"));
+	assert.equal(manifest.files.includes("skills"), false);
+	assert.equal(manifest.files.includes("examples"), false);
 	assert.ok(manifest.files.includes("docs"));
 });
 
-test("bundled skill documents every minimal-runtime operating responsibility", () => {
+test("repository example skill documents every minimal-runtime operating responsibility", () => {
 	const skill = readFileSync(
 		path.join(packageDirectory, "skills", "using-pi-subagents", "SKILL.md"),
 		"utf8",


### PR DESCRIPTION
## Summary

- stop registering and publishing `using-pi-subagents` with the extension package
- preserve the unchanged skill as a repository-only example for user-designed delegation workflows
- update documentation, package tests, and pending release notes to reflect the new boundary

## Verification

- `npm run check`
- `npm test` (330 files, 3223 tests)
- `just pack subagents` (confirmed the tarball excludes `skills/` and `examples/`)

The extension runtime and declared entrypoint are unchanged, so no additional Pi load smoke was required.
