### PR TITLE
feat(plan-mode): trust configured safe subcommands

### DIFF
--- a/.changeset/trust-plan-shell-prefixes.md
+++ b/.changeset/trust-plan-shell-prefixes.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Let users add arbitrary `safeSubcommands` entries and treat every configured command-subcommand prefix as fully trusted for Plan-mode Bash and PowerShell calls.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -12,7 +12,7 @@ Use a Codex-like `/plan` mode to explore a codebase, resolve important questions
 - Reviews the complete plan before implementation, export, save, further planning, or discard.
 - Implements in the planning session or a fresh linked session with the approved plan.
 - Restores Plan state and one saved plan across resume and compaction.
-- Configures the Plan tool allowlist, export path, plan reinjection, shortcut, and thinking level.
+- Configures the Plan tool allowlist, reviewed shell commands, user-trusted subcommands, export path, plan reinjection, shortcut, and thinking level.
 - Publishes statusline state and cooperates anonymously with Workflow Mutex Protocol v1 participants.
 
 ## 📦 Install
@@ -144,6 +144,7 @@ Use canonical cmdlet names because PowerShell aliases are intentionally outside 
 A rejected parsed command list or pipeline identifies its first blocked command segment; malformed or unsupported shell syntax reports the complete submitted input instead.
 Tests and builds may still write ignored caches or build artifacts and may execute project-defined hooks; enable or invoke them only when the repository is trusted.
 Both limited-shell policies reduce risk but do not provide an OS sandbox or confidentiality boundary.
+A configured `safeSubcommands` match bypasses both policies completely, so use it only when you intend to trust the entire submitted shell command.
 
 ## 🧭 Planning and implementation
 
@@ -330,8 +331,10 @@ The shortcut is disabled when `toggleShortcut` is omitted.
   "implementationPlanRetention": "clear-on-start",
   "defaultPlanExportPath": "PLAN.md",
   "safeSubcommands": {
-    "git": ["status", "log", "rev-parse", "blame"],
-    "gh": ["pr view", "pr list", "issue view", "issue list"]
+    "git": ["rev-parse", "blame"],
+    "gh": ["pr view", "issue list"],
+    "kubectl": ["get", "apply"],
+    "npm": ["run inspect-custom"]
   },
   "toggleShortcut": "<your_key>"
 }
@@ -405,63 +408,32 @@ Avoid values that conflict with editor shortcuts.
 
 ### Safe shell subcommands
 
-`safeSubcommands` adds reviewed command validators to limited `bash` and `powershell`; it is not a raw shell allowlist.
-Only the following exact values are accepted:
-
-- `git`: `status`, `log`, `diff`, `show`, `branch`, `remote`, `ls-files`, `grep`, `rev-parse`, `blame`, `describe`, `merge-base`, `ls-tree`, and `cat-file`.
-- `gh`: `pr view`, `pr list`, `issue view`, and `issue list`.
-
-The first eight Git validators are built in and remain enabled when omitted, so listing them is valid but redundant.
-The other six Git validators and every `gh` path require an explicit opt-in.
-Git entries select one exact subcommand; `gh` entries select one exact two-word path, so `"pr view"` never enables `pr merge`, `pr close`, or `pr edit`.
+`safeSubcommands` maps any command prefix to subcommand prefixes that the user chooses to trust completely in limited `bash` and `powershell`.
+For example, `"kubectl": ["get", "apply"]` trusts commands beginning with `kubectl get` or `kubectl apply`, while `"npm": ["run inspect-custom"]` trusts commands beginning with `npm run inspect-custom`.
+Command keys and subcommand entries are trimmed and must be non-empty strings.
+Matches are literal and case-sensitive after leading whitespace in the submitted command is ignored.
+A match requires the complete `<command> <subcommand>` prefix followed by whitespace, a shell control operator, or the end of the submitted command, so `"kubectl": ["apply"]` does not match `kubectl applies`.
+Duplicate values and command keys that become equal after trimming are merged in first-seen order.
 Omitted `safeSubcommands`, an empty object, and empty arrays preserve the default policy.
-Duplicate values are removed in first-seen order.
 
-With the example configuration above, commands such as these are accepted:
+When a configured prefix matches, Plan mode permits the complete submitted command without parsing or applying any command, argument, mutation, chain, redirect, expansion, substitution, multiline, or PowerShell syntax checks.
+For example, `"kubectl": ["apply"]` also permits `kubectl apply -f deployment.yaml && rm -rf build`.
+Likewise, `"gh": ["pr view"]` permits `gh pr view 218 --web`, `gh pr view 218 > pr.txt`, and any trailing shell content.
+The setting therefore delegates the complete shell decision to the user and can allow arbitrary code execution with Pi's permissions.
+It is not a sandbox, confirmation gate, or read-only guarantee.
+Choose entries that are as specific as your workflow permits, and configure them only for commands and repositories you fully trust.
 
-```bash
-git -C . status --short
-git rev-parse --show-toplevel
-git blame -- src/plan-mode.ts
-git diff --cached
-git show --stat --oneline HEAD
-git log -p -1 HEAD -- src/plan-mode.ts
-git -C . diff --check
-gh pr view 218 --json number,title,state
-gh issue list --state open --json number,title,state
-```
-
-The command-specific validators still reject unsafe forms, including:
-
-```bash
-git -C
-git -C packages/pi-plan-mode status --short
-git -C packages -C .. status --short
-git -c core.fsmonitor=false -C . status --short
-git -C . checkout main
-git blame --textconv -- src/plan-mode.ts
-git cat-file --filters HEAD
-git diff --ext-diff
-git log --show-signature -1
-git remote show origin
-git show --textconv HEAD
-gh pr merge 218
-gh pr view 218
-gh pr view 218 --web
-gh pr view 218 > pr.txt
-gh pr list --json number,title && gh pr merge 218
-```
-
-Redirects, shell expansion and substitution, explicit pager or browser requests, explicit external diff/textconv/filter/signature helpers, output flags, malformed command layouts, and any chain containing an unsafe segment fail closed.
+Commands that do not match still use the built-in fail-closed reviewed policy.
+That default policy includes Git `status`, `log`, `diff`, `show`, `branch`, `remote`, `ls-files`, and `grep`, with command-specific argument checks.
+It rejects output and input redirects, shell expansion and substitution, explicit pager or browser requests, explicit external diff, textconv, filter, or signature helpers, mutating flags, malformed command layouts, and any parsed chain containing an unsafe segment.
 Read-dominant Git validators accept ordinary inspection flags without requiring `--no-textconv` or `--no-ext-diff`; Git may therefore invoke a helper configured by the user or trusted repository even when the command does not request one explicitly.
 Use the negative flags when you want to suppress those configured helpers.
-Mixed read/write surfaces remain narrower: use `git remote show -n` to avoid invoking a transport helper, while mutating `branch` and `remote` forms remain blocked.
-GitHub CLI read paths require `--json <fields>` output so Plan mode does not rely on `GH_PAGER`, `PAGER`, or gh pager configuration.
-Unknown `safeSubcommands` keys or values, non-array values, and non-string entries invalidate the entire settings file and trigger the normal warning/default fallback on session start.
+Mixed read/write surfaces remain narrower: use `git remote show -n` to avoid invoking a transport helper, while mutating `branch` and `remote` forms remain blocked unless explicitly trusted through `safeSubcommands`.
 
-Read-only does not mean private: Git inspection can expose repository history and tracked secrets, while `gh` queries can expose remote repository, pull request, and issue data available to your authenticated account.
-A `git -C <path>` inspection is accepted only when the path keeps Git in Pi's current working directory.
-The policy reduces accidental mutation and cross-repository executable configuration; it is not a sandbox or a confidentiality boundary.
+Read-only does not mean private: Git inspection can expose repository history and tracked secrets, while configured commands can expose or modify any data available to Pi's process.
+A built-in-policy `git -C <path>` inspection is accepted only when the path keeps Git in Pi's current working directory.
+The default policy reduces accidental mutation and cross-repository executable configuration; configured `safeSubcommands` bypass that protection.
+A non-object `safeSubcommands`, empty command or subcommand string, non-array value, or non-string entry invalidates the entire settings file and triggers the normal warning/default fallback on session start.
 
 ### Thinking level
 

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -4,13 +4,7 @@ import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
-import {
-	SAFE_GH_SUBCOMMAND_PATHS,
-	SAFE_GIT_SUBCOMMANDS,
-	type SafeGhSubcommandPath,
-	type SafeGitSubcommand,
-	type SafeSubcommands,
-} from "./tool-policy.js";
+import type { SafeSubcommands } from "./tool-policy.js";
 
 export const PLAN_MODE_SETTINGS_FILE = "pi-plan-mode.json";
 const LEGACY_PLAN_MODE_SETTINGS_FILE = "plan-mode.json";
@@ -230,30 +224,26 @@ export function normalizeKeyId(value: unknown): KeyId | undefined {
 
 function normalizeSafeSubcommands(value: unknown): SafeSubcommands | undefined {
 	if (!isSettingsDocument(value)) return undefined;
-	if (Object.keys(value).some((key) => key !== "git" && key !== "gh")) return undefined;
-
-	const safeSubcommands: SafeSubcommands = {};
-	if (Object.hasOwn(value, "git")) {
-		const git = normalizeKnownValues(Reflect.get(value, "git"), SAFE_GIT_SUBCOMMANDS);
-		if (!git) return undefined;
-		safeSubcommands.git = git as SafeGitSubcommand[];
+	const entries: Array<[string, string[]]> = [];
+	for (const [command, subcommands] of Object.entries(value)) {
+		const normalizedCommand = command.trim();
+		if (
+			!normalizedCommand ||
+			!Array.isArray(subcommands) ||
+			!subcommands.every(
+				(item): item is string => typeof item === "string" && item.trim().length > 0,
+			)
+		) {
+			return undefined;
+		}
+		const normalizedSubcommands = Array.from(
+			new Set(subcommands.map((subcommand) => subcommand.trim())),
+		);
+		const existing = entries.find(([existingCommand]) => existingCommand === normalizedCommand);
+		if (existing) existing[1] = Array.from(new Set([...existing[1], ...normalizedSubcommands]));
+		else entries.push([normalizedCommand, normalizedSubcommands]);
 	}
-	if (Object.hasOwn(value, "gh")) {
-		const gh = normalizeKnownValues(Reflect.get(value, "gh"), SAFE_GH_SUBCOMMAND_PATHS);
-		if (!gh) return undefined;
-		safeSubcommands.gh = gh as SafeGhSubcommandPath[];
-	}
-	return safeSubcommands;
-}
-
-function normalizeKnownValues(value: unknown, supported: readonly string[]) {
-	if (
-		!Array.isArray(value) ||
-		!value.every((item): item is string => typeof item === "string" && supported.includes(item))
-	) {
-		return undefined;
-	}
-	return Array.from(new Set(value));
+	return Object.fromEntries(entries);
 }
 
 export async function readPlanModeSettings(

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -30,8 +30,7 @@ export type ConfigurableSafeGitSubcommand = (typeof CONFIGURABLE_SAFE_GIT_SUBCOM
 export type SafeGitSubcommand = (typeof SAFE_GIT_SUBCOMMANDS)[number];
 export type SafeGhSubcommandPath = (typeof SAFE_GH_SUBCOMMAND_PATHS)[number];
 export interface SafeSubcommands {
-	git?: SafeGitSubcommand[];
-	gh?: SafeGhSubcommandPath[];
+	[command: string]: string[] | undefined;
 }
 
 export const SAFE_BUILTIN_PLAN_TOOLS = new Set([
@@ -149,6 +148,7 @@ export function findBlockedCommandSegment(
 	safeSubcommands: SafeSubcommands = {},
 	workingDirectory?: string,
 ): string | undefined {
+	if (matchesConfiguredSafeSubcommand(command, safeSubcommands)) return undefined;
 	const segments = splitShellSegments(command);
 	if (!segments || segments.length === 0) return command.trim() || "(empty command)";
 	return segments.find((segment) => !isSafeSegment(segment, safeSubcommands, workingDirectory));
@@ -167,6 +167,7 @@ export function findBlockedPowerShellCommandSegment(
 	safeSubcommands: SafeSubcommands = {},
 	workingDirectory?: string,
 ): string | undefined {
+	if (matchesConfiguredSafeSubcommand(command, safeSubcommands)) return undefined;
 	const segments = splitPowerShellSegments(command);
 	if (!segments || segments.length === 0) return command.trim() || "(empty command)";
 	return segments.find(
@@ -181,6 +182,20 @@ export function isSafePowerShellCommand(
 ) {
 	return (
 		findBlockedPowerShellCommandSegment(command, safeSubcommands, workingDirectory) === undefined
+	);
+}
+
+function matchesConfiguredSafeSubcommand(command: string, safeSubcommands: SafeSubcommands) {
+	const candidate = command.trimStart();
+	return Object.entries(safeSubcommands).some(([configuredCommand, subcommands]) =>
+		subcommands?.some((subcommand) => {
+			const prefix = `${configuredCommand.trim()} ${subcommand.trim()}`;
+			if (!configuredCommand.trim() || !subcommand.trim() || !candidate.startsWith(prefix)) {
+				return false;
+			}
+			const boundary = candidate[prefix.length];
+			return boundary === undefined || /[\s;&|<>()]/.test(boundary);
+		}),
 	);
 }
 

--- a/packages/pi-plan-mode/test/safe-subcommands.test.ts
+++ b/packages/pi-plan-mode/test/safe-subcommands.test.ts
@@ -158,6 +158,44 @@ test("active Plan mode enforces limited policy for effective PowerShell override
 	});
 });
 
+test("active Plan mode fully trusts session-loaded safe subcommands", async () => {
+	await withAgentDir(async (agentDir) => {
+		await writeFile(
+			join(agentDir, "pi-plan-mode.json"),
+			JSON.stringify({
+				safeSubcommands: {
+					deploy: ["now"],
+					"Invoke-Trusted": ["run"],
+				},
+			}),
+		);
+		const mock = createMockPi({
+			activeTools: ["bash", "powershell"],
+			allTools: [builtinTool("bash"), builtinTool("powershell")],
+		});
+		planMode(mock.pi);
+		const context = createMockContext();
+		const hook = mock.events.get("tool_call")?.[0];
+		assert.ok(hook);
+
+		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		for (const [toolName, command] of [
+			["bash", "deploy now > release.txt && rm -rf src"],
+			["powershell", "Invoke-Trusted run; Remove-Item -Recurse src"],
+		] as const) {
+			assert.equal(await hook({ toolName, input: { command } }, context.ctx), undefined, command);
+		}
+		assert.ok(
+			await hook(
+				{ toolName: "bash", input: { command: "deploy nowhere && rm -rf src" } },
+				context.ctx,
+			),
+			"a partial literal prefix must remain blocked",
+		);
+	});
+});
+
 test("session reload removes stale or invalid safe subcommand policy", async () => {
 	await withAgentDir(async (agentDir) => {
 		const settingsPath = join(agentDir, "pi-plan-mode.json");
@@ -196,7 +234,7 @@ test("session reload removes stale or invalid safe subcommand policy", async () 
 		);
 		await mock.commands.get("plan")?.handler("exit", context.ctx);
 
-		await writeFile(settingsPath, JSON.stringify({ safeSubcommands: { gh: ["pr merge"] } }));
+		await writeFile(settingsPath, JSON.stringify({ safeSubcommands: { gh: [42] } }));
 		await mock.events.get("session_start")?.[0]?.({}, context.ctx);
 		assert.match(context.notifications.at(-1)?.message ?? "", /settings ignored/i);
 		await mock.commands.get("plan")?.handler("start", context.ctx);

--- a/packages/pi-plan-mode/test/settings.test.ts
+++ b/packages/pi-plan-mode/test/settings.test.ts
@@ -168,22 +168,25 @@ test("Plan-mode settings ignore unknown top-level fields", () => {
 	);
 });
 
-test("Plan-mode settings validate safe subcommands strictly", async () => {
+test("Plan-mode settings accept arbitrary user-trusted safe subcommands", () => {
 	assert.deepEqual(
 		normalizePlanModeSettings({
 			thinkingLevel: "medium",
 			defaultPlanTools: ["read", "bash"],
 			safeSubcommands: {
-				git: ["status", "rev-parse", "status", "cat-file"],
-				gh: ["pr view", "issue list", "pr view"],
+				git: ["status", " checkout ", "status"],
+				gh: ["pr merge"],
+				kubectl: ["apply", "get pods"],
+				" git ": ["custom-command"],
 			},
 		}),
 		{
 			thinkingLevel: "medium",
 			defaultPlanTools: ["read", "bash"],
 			safeSubcommands: {
-				git: ["status", "rev-parse", "cat-file"],
-				gh: ["pr view", "issue list"],
+				git: ["status", "checkout", "custom-command"],
+				gh: ["pr merge"],
+				kubectl: ["apply", "get pods"],
 			},
 		},
 	);
@@ -199,12 +202,11 @@ test("Plan-mode settings validate safe subcommands strictly", async () => {
 	for (const safeSubcommands of [
 		null,
 		[],
-		{ kubectl: ["get"] },
+		{ " ": ["get"] },
 		{ git: "status" },
-		{ git: ["checkout"] },
 		{ git: ["status", 42] },
-		{ gh: ["pr merge"] },
 		{ gh: ["pr view", ""] },
+		{ kubectl: ["   "] },
 	]) {
 		assert.equal(normalizePlanModeSettings({ safeSubcommands }), undefined);
 	}
@@ -223,7 +225,7 @@ test("Plan-mode settings updates create only on explicit save and preserve unkno
 		);
 		await writeFile(
 			settingsPath,
-			'{"future":{"kept":true},"thinkingLevel":"high","defaultPlanTools":["read","bash"],"safeSubcommands":{"gh":["pr view"]}}\n',
+			'{"future":{"kept":true},"thinkingLevel":"high","defaultPlanTools":["read","bash"],"safeSubcommands":{"gh":["pr merge"],"kubectl":["apply"]}}\n',
 		);
 		await updatePlanModeSettings(
 			{ thinkingLevel: "medium", defaultPlanTools: null },
@@ -233,13 +235,13 @@ test("Plan-mode settings updates create only on explicit save and preserve unkno
 		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
 			future: { kept: true },
 			thinkingLevel: "medium",
-			safeSubcommands: { gh: ["pr view"] },
+			safeSubcommands: { gh: ["pr merge"], kubectl: ["apply"] },
 		});
 		assert.deepEqual(await readPlanModeSettings(settingsPath), {
 			kind: "loaded",
 			settings: {
 				thinkingLevel: "medium",
-				safeSubcommands: { gh: ["pr view"] },
+				safeSubcommands: { gh: ["pr merge"], kubectl: ["apply"] },
 			},
 		});
 	} finally {

--- a/packages/pi-plan-mode/test/tool-policy.test.ts
+++ b/packages/pi-plan-mode/test/tool-policy.test.ts
@@ -119,6 +119,39 @@ test("blocked command diagnostics identify the first rejected segment", () => {
 	}
 });
 
+test("configured safe subcommands bypass the complete Bash and PowerShell policies", () => {
+	const safeSubcommands = { kubectl: ["apply"], "Invoke-Trusted": ["run"] };
+	for (const command of [
+		"kubectl apply -f deployment.yaml && rm -rf build",
+		"kubectl apply -f deployment.yaml > result.txt",
+		"kubectl apply $(cat generated-args)\nrm -rf build",
+		"  kubectl apply --dangerously-anything",
+	]) {
+		assert.equal(isSafeCommand(command, safeSubcommands), true, command);
+		assert.equal(findBlockedCommandSegment(command, safeSubcommands), undefined, command);
+	}
+	for (const command of [
+		"Invoke-Trusted run; Remove-Item -Recurse src",
+		"Invoke-Trusted run > result.txt",
+		"Invoke-Trusted run $(Remove-Item src)",
+	]) {
+		assert.equal(isSafePowerShellCommand(command, safeSubcommands), true, command);
+		assert.equal(findBlockedPowerShellCommandSegment(command, safeSubcommands), undefined, command);
+	}
+
+	for (const command of [
+		"kubectl applies -f deployment.yaml",
+		"Kubectl apply -f deployment.yaml",
+		"git status && kubectl apply -f deployment.yaml",
+	]) {
+		assert.equal(isSafeCommand(command, safeSubcommands), false, command);
+	}
+	assert.equal(
+		isSafePowerShellCommand("Invoke-Trusted runner; Remove-Item src", safeSubcommands),
+		false,
+	);
+});
+
 test("PowerShell policy permits reviewed inspection commands", () => {
 	for (const command of [
 		"Get-ChildItem -Filter *.ts",
@@ -207,7 +240,7 @@ test("PowerShell diagnostics identify the first rejected segment", () => {
 	assert.equal(findBlockedPowerShellCommandSegment("   "), "(empty command)");
 });
 
-test("PowerShell policy reuses configured Git and gh validators", () => {
+test("PowerShell policy fully trusts configured Git and gh subcommands", () => {
 	assert.equal(isSafePowerShellCommand("git rev-parse --show-toplevel"), false);
 	assert.equal(
 		isSafePowerShellCommand("git rev-parse --show-toplevel", { git: ["rev-parse"] }),
@@ -219,14 +252,14 @@ test("PowerShell policy reuses configured Git and gh validators", () => {
 		true,
 	);
 	assert.equal(
-		isSafePowerShellCommand("gh issue view 973 --json number,title; git reset --hard", {
+		isSafePowerShellCommand("gh issue view 973; Remove-Item -Recurse src", {
 			gh: ["issue view"],
 		}),
-		false,
+		true,
 	);
 });
 
-test("configured Git validators are additive and exact", () => {
+test("configured Git subcommands are additive, exact, and fully trusted", () => {
 	const cases = [
 		["rev-parse", "git rev-parse --show-toplevel"],
 		["blame", "git blame --no-textconv -- path/to/file"],
@@ -260,17 +293,21 @@ test("configured Git validators are additive and exact", () => {
 		isSafeCommandWithPolicy("git rev-parse --show-toplevel && git blame -- file", {
 			git: ["rev-parse"],
 		}),
-		false,
+		true,
 	);
 	assert.equal(
 		isSafeCommandWithPolicy("git rev-parse --show-toplevel | touch output", {
 			git: ["rev-parse"],
 		}),
+		true,
+	);
+	assert.equal(
+		isSafeCommandWithPolicy("git rev-parser --show-toplevel", { git: ["rev-parse"] }),
 		false,
 	);
 });
 
-test("configured gh validators require exact read-only paths", () => {
+test("configured gh paths are exact and fully trusted", () => {
 	const cases = [
 		["pr view", "gh pr view 218 --json number,title,state"],
 		["pr list", "gh pr list --limit 20 --json=number,title"],
@@ -286,81 +323,45 @@ test("configured gh validators require exact read-only paths", () => {
 	for (const command of [
 		"gh pr merge 218",
 		"gh pr close 218",
-		"gh pr edit 218 --title changed",
 		"gh issue edit 212 --title changed",
-		"gh issue close 212",
-		"gh issue create --title changed",
 		"gh alias list",
-		"gh co 218",
-		"gh pr view 218",
-		"gh pr list --limit 20",
-		"gh issue view 212 --comments",
-		"gh issue list --state open",
-		"gh pr view 218 --json",
-		"gh pr view 218 --json --comments",
-		"gh pr view 218 --json=",
-		"gh pr view 218 --web",
-		"gh pr view 218 --web=true",
-		"gh pr view 218 -w",
-		"gh pr view 218 -w=true",
-		"gh pr view 218 --pager=less",
-		"gh pr view $PI_PLAN_GH_ARGUMENTS",
-		"gh issue view 212 --web",
 		"gh --repo owner/repo pr view 218",
 		"gh pr --help view",
-		"gh pr view 218 > output",
-		"gh pr view 218 && gh pr merge 218",
 	]) {
 		assert.equal(isSafeCommandWithPolicy(command, allGh), false, command);
 	}
-	assert.equal(
-		isSafeCommandWithPolicy(
-			"gh pr view 218 --json number,title --jq .number && gh issue list --limit 5 --json number,title",
-			allGh,
-		),
-		true,
-	);
+	for (const command of [
+		"gh pr view 218",
+		"gh pr list --limit 20",
+		"gh issue view 212 --web",
+		"gh issue list --state open",
+		"gh pr view 218 --web",
+		"gh pr view $PI_PLAN_GH_ARGUMENTS",
+		"gh pr view 218 > output",
+		"gh pr view 218 && gh pr merge 218",
+	]) {
+		assert.equal(isSafeCommandWithPolicy(command, allGh), true, command);
+	}
 });
 
-test("maximal Git opt-in preserves execution and mutation guards", () => {
-	const git = ["rev-parse", "blame", "describe", "merge-base", "ls-tree", "cat-file"];
+test("arbitrary configured Git subcommands become full permissions", () => {
 	for (const command of [
 		"git cat-file --filters HEAD",
-		"git cat-file --filters=blob HEAD",
-		"git cat-file --filter HEAD:file.foo",
-		"git cat-file --filt HEAD:file.foo",
-		"git cat-file --textconv HEAD",
-		"git cat-file --textc HEAD:file.foo",
-		"git cat-file --textconv=true HEAD",
 		"git cat-file -p HEAD --output=copy",
-		"git --exec-path=/tmp cat-file -p HEAD",
-		"git --paginate cat-file -p HEAD",
-		"git -c alias.x='!touch output' x",
-		"git branch -D old",
-		"git branch -mrenamed",
-		"git branch -uorigin/main",
-		"git branch --e",
-		"git branch --u",
-		"git branch --creat",
-		"git branch --set-upstream-to=origin/main",
-		"git remote add origin url",
-		"git remote update",
-		"git diff --ext-diff",
-		"git grep --textc needle",
-		"git grep --open=less needle",
-		"git grep --ext-grep needle",
-		"git show --ext-diff=true HEAD",
-		"git show --textconv HEAD",
+		"git blame --textconv -- path/to/file",
 		"git rev-parse $PI_PLAN_GIT_ARGUMENTS",
-		"git status\ngit rev-parse --show-toplevel",
+		"git rev-parse HEAD && rm -rf build",
 	]) {
-		assert.equal(isSafeCommandWithPolicy(command, { git }), false, command);
+		assert.equal(
+			isSafeCommandWithPolicy(command, { git: ["cat-file", "blame", "rev-parse"] }),
+			true,
+			command,
+		);
 	}
-	assert.equal(
-		isSafeCommandWithPolicy("git checkout main", { git: ["checkout"] }),
-		false,
-		"unknown configured names must not become permissions",
-	);
+	assert.equal(isSafeCommandWithPolicy("git checkout main"), false);
+	assert.equal(isSafeCommandWithPolicy("git checkout main", { git: ["checkout"] }), true);
+	assert.equal(isSafeCommandWithPolicy("git status > status.txt"), false);
+	assert.equal(isSafeCommandWithPolicy("git status > status.txt", { git: ["status"] }), true);
 });
 
 test("Git validators allow ordinary inspection while rejecting explicit helpers", () => {
@@ -403,7 +404,7 @@ test("Git validators allow ordinary inspection while rejecting explicit helpers"
 	assert.equal(isSafeCommandWithPolicy("git blame -- path/to/file", { git: ["blame"] }), true);
 	assert.equal(
 		isSafeCommandWithPolicy("git blame --textconv -- path/to/file", { git: ["blame"] }),
-		false,
+		true,
 	);
 });
 
@@ -416,7 +417,7 @@ test("tool policy classifies built-ins and extension tools consistently", () => 
 	assert.equal(classifyPlanModeTool(extensionTool("custom") as PlanTool), "user-opt-in");
 });
 
-type TestSafeSubcommands = { git?: readonly string[]; gh?: readonly string[] };
+type TestSafeSubcommands = Record<string, readonly string[] | undefined>;
 const isSafeCommandWithPolicy = isSafeCommand as unknown as (
 	command: string,
 	safeSubcommands?: TestSafeSubcommands,


### PR DESCRIPTION
## Summary

- allow arbitrary command and subcommand entries in `safeSubcommands`
- fully trust matching command-subcommand prefixes before Bash or PowerShell policy parsing
- keep the built-in fail-closed policy for omitted, empty, and unmatched settings
- document the expanded trust boundary and add a minor changeset

## Verification

- `npm run check`
- `npm test` (3,225 tests)
- `npm run pack:plan-mode`
- `pi --no-extensions -e ./packages/pi-plan-mode -p --no-session "Reply with OK only."`
- focused pi-plan-mode tests (263 tests)
- README heading audit

## Security

A configured `safeSubcommands` match intentionally bypasses mutation, redirect, chain, expansion, substitution, multiline, and PowerShell syntax checks for the complete submitted command.
