### PR TITLE
refactor: remove extension lifecycle metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,12 @@
 - Keep package implementation source under `packages/<package>/src/`.
 - Keep small repository-only Pi extensions and their supporting implementation files under `.pi/extensions/<extension>/`, with `index.ts` as the entrypoint.
 - Each package owns its manifest, README, license, and TypeScript configuration.
-- Set each extension package's `piExtension.lifecycle` to `stable` or `experimental`.
+- Do not classify extension packages with repository-specific lifecycle metadata; treat every active packaged extension uniformly.
 - Treat `.pi/extensions/` as a self-contained project-resource boundary unrelated to extension packages under `packages/`.
 - Keep a project-local extension's implementation, helpers, documentation, and any requested tests inside its own `.pi/extensions/<extension>/` directory.
 - Do not add or modify package manifests, workspaces, Changesets, package tests, root test support, or shared TypeScript configuration for a project-local extension unless the user explicitly asks.
-- Project-local extensions do not require package manifests, lifecycle metadata, Changesets, publication files, or packaged-extension verification gates.
+- Project-local extensions do not require package manifests, Changesets, publication files, or packaged-extension verification gates.
 - Promote a project-local extension into `packages/` only when the user explicitly requests independent installation, reuse, versioning, or publication.
-- Omit `piExtension` from reusable libraries.
 - Keep deprecated reference packages under `deprecated/`, which active checks exclude.
 - Root files such as `package.json`, `package-lock.json`, `biome.json`, `tsconfig.json`, `justfile`, and `.github/workflows/*` own shared tooling.
 - Never edit `node_modules/`.
@@ -75,17 +74,15 @@ Run commands from the repository root unless a command says otherwise.
 - Keep extension implementation in descriptively named source modules.
 - Build and publish reusable libraries as JavaScript with declarations through their own build configuration and without `pi.extensions`.
 - Run `npm run check:boundaries` to verify package boundaries.
-- List every stable extension package's `src/index.ts` repository entrypoint in the root `package.json` under `pi.extensions`.
-- Do not list experimental extension package entrypoints in the root `package.json` under `pi.extensions`.
+- List every active extension package's `src/index.ts` repository entrypoint in the root `package.json` under `pi.extensions`.
 - Do not list `.pi/extensions/` entrypoints in the root `package.json`; Pi discovers them after the project is trusted.
 - Add a root workspace script or recipe only for a workflow users must run from the repository root.
 - Choose the first TUI layer that fully supports the flow: Pi core `ctx.ui` APIs and `@earendil-works/pi-tui` components, then `@narumitw/pi-tui-kit`, and finally an extension-owned custom component.
 - Create a new custom component only when the earlier layers cannot preserve the required state, interaction, or lifecycle behavior.
 - Keep domain state, persistence, confirmations, and specialized UI inside the owning extension.
 - Preserve each README's emoji title; npm, Pi, and license badges; and applicable `✨ Features`, `📦 Install`, `🚀 Quick start`, `⚙️ Settings`, `💬 Commands`, `🗂️ Package layout`, `🔎 Keywords`, and `📄 License` sections.
-- Show a user-facing warning for experimental extensions and features.
-- Keep experimental packages in root checks unless they are private.
-- Gate an experimental feature inside a stable package with explicit configuration that defaults to the existing stable behavior.
+- Show a user-facing warning for experimental features.
+- Gate an experimental feature with explicit configuration that defaults to the existing behavior.
 - Split source files over 1,000 lines by clear responsibilities or document why they must stay intact.
 - Do not mechanically split generated, vendored, migration, snapshot, or mainly declarative files.
 
@@ -157,8 +154,7 @@ Run commands from the repository root unless a command says otherwise.
 - Version every publishable package independently through Changesets.
 - Add a changeset when a pull request changes published package behavior.
 - Repository-only documentation, tests, tooling, and path migrations may omit a changeset.
-- Release experimental packages through the same Changesets workflow as stable packages.
-- Preserve experimental warnings in documentation and runtime behavior.
+- Preserve experimental feature warnings in documentation and runtime behavior.
 - Use `just npm-public <package>` only to change the visibility of an existing package.
 - Use `npm publish --workspace <package> --access public` only for the explicitly approved first publication of a new scoped package that still returns 404.
 - Except for that initial-publication exception, let `publish.yml` manage the version pull request, package tags, publications, and GitHub releases.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Install the repository as one Pi package:
 pi install git:github.com/narumiruna/pi-extensions
 ```
 
-The repository root Pi manifest explicitly lists every stable extension under `packages/`, so this enables all of them. Packages marked with the experimental lifecycle are intentionally excluded from the root Git package.
+The repository root Pi manifest explicitly lists every extension under `packages/`, so this enables all of them.
 
 To load only selected extensions, replace the installed package entry in `~/.pi/agent/settings.json` with a resource filter:
 
@@ -200,8 +200,7 @@ independently.
 npm publish --workspace @narumitw/pi-new-extension --access public
 ```
 
-After the initial publication, Changesets handles stable extensions, experimental extensions, and
-libraries through independent package versions.
+After the initial publication, Changesets handles extensions and libraries through independent package versions.
 
 </details>
 
@@ -229,7 +228,7 @@ consumer together.
 ## 🗂️ Repository structure
 
 ```text
-packages/                Stable extensions, experimental extensions, and reusable libraries
+packages/                Extension packages and reusable libraries
 deprecated/              Reference packages excluded from active workspace scripts
 docs/                    Repository conventions and plans
 scripts/                 Shared checks, tests, versioning, and release helpers
@@ -237,7 +236,7 @@ test/                    Root integration and repository tests
 ```
 
 Each active package contains its own `package.json`, `README.md`, `LICENSE`, `tsconfig.json`, and TypeScript source under `src/`.
-Every extension keeps a thin `src/index.ts` source forwarder and declares a stable or experimental lifecycle.
+Every extension keeps a thin `src/index.ts` source forwarder and declares one package entrypoint.
 An extension package may load that source entrypoint directly or publish a build-backed `dist/index.ts` bundle for Pi's Jiti runtime.
 Reusable libraries publish built ESM and declarations from `dist/`.
 

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -177,14 +177,14 @@ interactive work should expose cancellation.
 ### Package layout and boundaries
 
 - **MUST:** Keep every active extension and reusable publishable library under `packages/<package>/`, and deprecated references under `deprecated/<package>/`.
-  Give each extension explicit `piExtension.lifecycle` metadata with value `stable` or `experimental`; omit that metadata from libraries.
-  The private root Pi manifest must list every stable extension's `src/index.ts` repository entrypoint and no experimental entrypoint so direct Git installation preserves the lifecycle boundary without requiring generated package output.
-  **Verification:** `Validator` via `npm run check:boundaries` plus `Review` of lifecycle moves.
+  Treat a package that declares `pi.extensions` as an active extension and do not add a repository-specific lifecycle classification.
+  The private root Pi manifest must list every active extension's `src/index.ts` repository entrypoint so direct Git installation includes the complete extension set without requiring generated package output.
+  **Verification:** `Validator` via `npm run check:boundaries` plus `Review` of package additions and removals.
 - **MUST:** Give every active extension a thin `src/index.ts` default-export forwarder and keep authoritative implementation under `src/` in descriptive modules.
   Declare exactly one package entrypoint: `"pi": { "extensions": ["./src/index.ts"] }` for direct source loading or `"pi": { "extensions": ["./dist/index.ts"] }` for a build-backed TypeScript bundle loaded by Pi's Jiti runtime.
   A `dist/index.ts` entrypoint must be produced by the package build, must not forward back into `src/`, and must keep Pi-bundled peer dependencies external rather than embedding duplicate runtime copies.
   A package that declares `dist/index.ts` must publish `dist`, run its build before packing, and document that an unbuilt local checkout must be built before loading the package directory.
-  Reusable libraries must not declare `pi.extensions` or `piExtension` and must publish built JavaScript plus declarations.
+  Reusable libraries must not declare `pi.extensions` and must publish built JavaScript plus declarations.
   **Verification:** `Validator` via `npm run check:boundaries`, `Review` of the bundle boundary, and clean-build package and Pi load smokes.
 - **MUST:** Keep extension packages free of extension-to-extension dependencies. Extensions may
   depend on publishable helper libraries under `packages/`.
@@ -357,7 +357,7 @@ fragile regular expressions. Until then, label the real verification method hone
 
 ## New extension checklist
 
-- [ ] Place the package under `packages/`, declare the correct extension lifecycle when applicable,
+- [ ] Place the package under `packages/`, include its source entrypoint in the root Pi manifest,
       and keep it independently installable.
 - [ ] Add the thin `src/index.ts` forwarder and declare one supported `pi.extensions` entrypoint: direct `src/index.ts` or build-backed `dist/index.ts`.
 - [ ] Separate factory registration from session-owned startup and idempotent shutdown cleanup.

--- a/docs/readme-conventions.md
+++ b/docs/readme-conventions.md
@@ -18,7 +18,6 @@ Every active package README must present these elements in this order:
 9. `## 🔎 Keywords`.
 10. `## 📄 License`.
 
-Experimental packages must show a user-facing warning near the introduction.
 Reusable libraries omit the Pi extension badge and may make Quick start an import example rather than a Pi command.
 
 ## Standard section labels

--- a/packages/pi-accounts/package.json
+++ b/packages/pi-accounts/package.json
@@ -32,9 +32,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-analytics/package.json
+++ b/packages/pi-analytics/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check --vcs-use-ignore-file=false src test scripts package.json tsconfig.json README.md && npm run typecheck",

--- a/packages/pi-btw/package.json
+++ b/packages/pi-btw/package.json
@@ -23,9 +23,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-caffeinate/package.json
+++ b/packages/pi-caffeinate/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-cbmem/package.json
+++ b/packages/pi-cbmem/package.json
@@ -28,9 +28,6 @@
 			"./skills"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-chat/package.json
+++ b/packages/pi-chat/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-chrome-devtools/package.json
+++ b/packages/pi-chrome-devtools/package.json
@@ -25,9 +25,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-codex-compact/package.json
+++ b/packages/pi-codex-compact/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check --vcs-use-ignore-file=false src test scripts package.json tsconfig.json README.md && npm run typecheck",

--- a/packages/pi-file-context/package.json
+++ b/packages/pi-file-context/package.json
@@ -25,9 +25,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-firecrawl/package.json
+++ b/packages/pi-firecrawl/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-fleet/package.json
+++ b/packages/pi-fleet/package.json
@@ -26,9 +26,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-github-pr/package.json
+++ b/packages/pi-github-pr/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"prepack": "npm run build",

--- a/packages/pi-goal/package.json
+++ b/packages/pi-goal/package.json
@@ -23,9 +23,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-langfuse/package.json
+++ b/packages/pi-langfuse/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"prepack": "npm run build",

--- a/packages/pi-lsp/package.json
+++ b/packages/pi-lsp/package.json
@@ -27,9 +27,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-plan-mode/package.json
+++ b/packages/pi-plan-mode/package.json
@@ -23,9 +23,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-recall/package.json
+++ b/packages/pi-recall/package.json
@@ -25,9 +25,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-stamp/package.json
+++ b/packages/pi-stamp/package.json
@@ -27,9 +27,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check --vcs-use-ignore-file=false src test scripts package.json tsconfig.json README.md && npm run typecheck",

--- a/packages/pi-starship/package.json
+++ b/packages/pi-starship/package.json
@@ -26,9 +26,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check --vcs-use-ignore-file=false src test scripts package.json tsconfig.json README.md NOTICES.md && npm run typecheck",

--- a/packages/pi-statusline/package.json
+++ b/packages/pi-statusline/package.json
@@ -23,9 +23,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check --vcs-use-ignore-file=false src test scripts package.json tsconfig.json README.md && npm run typecheck",

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -28,7 +28,7 @@ Install the repository source as one Pi package:
 pi install git:github.com/narumiruna/pi-extensions
 ```
 
-This Git installation enables every stable extension listed in the repository root manifest, including Pi Subagents.
+This Git installation enables every extension listed in the repository root manifest, including Pi Subagents.
 
 To install only Pi Subagents, clone the repository, install dependencies, build its generated runtime, and install its package directory:
 

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -25,9 +25,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-subagents/test/package.test.ts
+++ b/packages/pi-subagents/test/package.test.ts
@@ -15,7 +15,6 @@ test("package declares one generated extension without a bundled skill", () => {
 		private: boolean;
 		files: string[];
 		pi: { extensions: string[]; skills?: string[] };
-		piExtension: { lifecycle: string };
 		peerDependencies: Record<string, string>;
 		repository: { directory: string };
 	};
@@ -25,7 +24,6 @@ test("package declares one generated extension without a bundled skill", () => {
 	assert.equal(manifest.repository.directory, "packages/pi-subagents");
 	assert.deepEqual(manifest.pi.extensions, ["./dist/index.ts"]);
 	assert.equal("skills" in manifest.pi, false);
-	assert.equal(manifest.piExtension.lifecycle, "stable");
 	assert.equal(manifest.peerDependencies["@earendil-works/pi-ai"], "*");
 	assert.equal(manifest.peerDependencies["@earendil-works/pi-coding-agent"], "*");
 	assert.ok(manifest.files.includes("src"));

--- a/packages/pi-sync/package.json
+++ b/packages/pi-sync/package.json
@@ -31,9 +31,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-ticker/package.json
+++ b/packages/pi-ticker/package.json
@@ -27,9 +27,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-todo/package.json
+++ b/packages/pi-todo/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check . && npm run typecheck",

--- a/packages/pi-tool/package.json
+++ b/packages/pi-tool/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"prepack": "npm run build",

--- a/packages/pi-tui-kit-showcase/package.json
+++ b/packages/pi-tui-kit-showcase/package.json
@@ -22,9 +22,6 @@
 			"./src/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"check": "biome check . && npm run typecheck",
 		"format": "biome check --write .",

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -36,9 +36,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check --vcs-use-ignore-file=false src test scripts package.json tsconfig.json README.md && npm run typecheck",

--- a/packages/pi-worktree/package.json
+++ b/packages/pi-worktree/package.json
@@ -24,9 +24,6 @@
 			"./dist/index.ts"
 		]
 	},
-	"piExtension": {
-		"lifecycle": "stable"
-	},
 	"scripts": {
 		"build": "node scripts/build-runtime.mjs",
 		"check": "npm run build && biome check --vcs-use-ignore-file=false src test scripts package.json README.md tsconfig.json && npm run typecheck",

--- a/scripts/check-extension-boundaries.mjs
+++ b/scripts/check-extension-boundaries.mjs
@@ -47,9 +47,6 @@ const activePackages = workspacePackages.filter(
 const libraryPackages = workspacePackages.filter(
 	({ packageJson }) => packageJson.pi?.extensions === undefined,
 );
-const experimentalPackageCount = activePackages.filter(
-	({ packageJson }) => packageJson.piExtension?.lifecycle === "experimental",
-).length;
 const libraryPackageNames = new Set(libraryPackages.map(({ name }) => name));
 const failures = [];
 const sourcePaths = activePackages.flatMap((extensionPackage) => {
@@ -67,7 +64,6 @@ try {
 	for (const libraryPackage of libraryPackages) checkLibraryPackage(libraryPackage);
 	for (const extensionPackage of activePackages) {
 		checkPiEntrypoint(extensionPackage);
-		checkExtensionLifecycle(extensionPackage);
 		checkPackageDependencies(extensionPackage);
 		checkSourceImports(extensionPackage);
 	}
@@ -82,7 +78,7 @@ if (failures.length > 0) {
 	process.exitCode = 1;
 } else {
 	console.log(
-		`Extension boundary check passed: ${libraryPackages.length} libraries and ${activePackages.length} active extensions (${experimentalPackageCount} experimental) have valid package boundaries.`,
+		`Extension boundary check passed: ${libraryPackages.length} libraries and ${activePackages.length} active extensions have valid package boundaries.`,
 	);
 }
 
@@ -120,7 +116,6 @@ function findWorkspacePackages(directory) {
 
 function checkRootPiManifest() {
 	const expectedEntries = activePackages
-		.filter(({ packageJson }) => packageJson.piExtension?.lifecycle === "stable")
 		.map(
 			({ directory }) =>
 				`./${relative(path.join(directory, "src", "index.ts"))
@@ -134,17 +129,12 @@ function checkRootPiManifest() {
 		JSON.stringify([...actualEntries].sort()) !== JSON.stringify(expectedEntries)
 	) {
 		failures.push(
-			`package.json pi.extensions must list every stable package entrypoint and no experimental entrypoints: ${JSON.stringify(expectedEntries)}.`,
+			`package.json pi.extensions must list every active package entrypoint: ${JSON.stringify(expectedEntries)}.`,
 		);
 	}
 }
 
 function checkLibraryPackage(libraryPackage) {
-	if (libraryPackage.packageJson.piExtension !== undefined) {
-		failures.push(
-			`${relative(libraryPackage.packagePath)} libraries must not declare piExtension metadata.`,
-		);
-	}
 	if (!libraryPackage.packageJson.scripts?.build) {
 		failures.push(`${relative(libraryPackage.packagePath)} libraries must define a build script.`);
 	}
@@ -218,15 +208,6 @@ function checkPiEntrypoint(extensionPackage) {
 	if (typeof prepack !== "string" || !/(?:^|\s)npm run build(?:\s|$)/u.test(prepack)) {
 		failures.push(
 			`${relative(extensionPackage.packagePath)} dist entrypoint prepack must run the package build.`,
-		);
-	}
-}
-
-function checkExtensionLifecycle(extensionPackage) {
-	const lifecycle = extensionPackage.packageJson.piExtension?.lifecycle;
-	if (lifecycle !== "stable" && lifecycle !== "experimental") {
-		failures.push(
-			`${relative(extensionPackage.packagePath)} piExtension.lifecycle must be "stable" or "experimental".`,
 		);
 	}
 }

--- a/test/extension-boundaries.test.ts
+++ b/test/extension-boundaries.test.ts
@@ -29,6 +29,17 @@ test("extension boundary validator accepts a complete build-backed dist entrypoi
 	}
 });
 
+test("extension boundary validator requires every active package in the root manifest", async () => {
+	const fixture = await createFixture({ entrypoint: "./src/index.ts", rootExtensions: [] });
+	try {
+		const result = runBoundaryCheck(fixture);
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /must list every active package entrypoint/u);
+	} finally {
+		await rm(fixture, { force: true, recursive: true });
+	}
+});
+
 test("extension boundary validator rejects unsupported and incomplete dist entrypoints", async () => {
 	const fixtureCases: Array<{ name: string; options: FixtureOptions; expected: RegExp }> = [
 		{
@@ -67,6 +78,7 @@ test("extension boundary validator rejects unsupported and incomplete dist entry
 interface FixtureOptions {
 	entrypoint: string;
 	files?: readonly string[];
+	rootExtensions?: readonly string[];
 	scripts?: Readonly<Record<string, string>>;
 }
 
@@ -79,7 +91,9 @@ async function createFixture(options: FixtureOptions) {
 		`${JSON.stringify({
 			name: "fixture-root",
 			private: true,
-			pi: { extensions: [] },
+			pi: {
+				extensions: options.rootExtensions ?? ["./packages/pi-fixture/src/index.ts"],
+			},
 		})}\n`,
 		"utf8",
 	);
@@ -98,7 +112,6 @@ async function createFixture(options: FixtureOptions) {
 			type: "module",
 			files: options.files ?? ["src", "dist"],
 			pi: { extensions: [options.entrypoint] },
-			piExtension: { lifecycle: "experimental" },
 			scripts: options.scripts ?? {
 				build: "node scripts/build-runtime.mjs",
 				prepack: "npm run build",


### PR DESCRIPTION
## Summary

- remove the repository-specific `piExtension.lifecycle` field from all 28 active extension manifests
- identify active extensions only through `pi.extensions` and require every active extension source entrypoint in the root Pi manifest
- remove stable/experimental package classification guidance while preserving opt-in gates and warnings for experimental features

This follows #1100, which promoted the remaining experimental packages before removing the classification.

## Verification

- `npm run check`
- `npm test` — 3,224 tests passed
- focused boundary and package tests — 6 tests passed
- README heading audit for all 28 active extensions
- dry-run pack inspection for all 29 workspaces
- full-repository search confirms no `piExtension` references remain

No Changeset is included because this removes repository-only metadata and does not change published runtime behavior.
