### PR TITLE
feat(plan-mode): allow conservative system diagnostics

### DIFF
--- a/.changeset/allow-local-plan-diagnostics.md
+++ b/.changeset/allow-local-plan-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Allow narrowly validated local `hostname`, `tasklist`, `Get-Process`, and `Get-Service` inspections in Plan mode by default.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -130,6 +130,7 @@ After they become visible, the Plan-only helpers remain visible in Normal mode, 
 
 Limited `bash` uses a fail-closed Bash policy, including when an extension overrides the canonical `bash` tool name.
 It accepts common inspection commands, read-only Git and npm queries, pipelines and command lists composed entirely of accepted commands, plus selected checks such as `npm test`, `npm run typecheck`, and `cargo test`.
+It also accepts `hostname` without arguments and local Windows `tasklist` queries using reviewed display, filter, module, and service flags.
 Reviewed Git inspections may place `--no-pager` before the accepted subcommand.
 They may also place one or more complete `-C <path>` pairs before the accepted subcommand only when every path is `.` or the exact current Pi working directory.
 Other targets are rejected so `git -C` cannot introduce executable configuration, hooks, filters, signing programs, or lazy-fetch remotes from another repository.
@@ -137,6 +138,7 @@ It rejects output/input redirects, shell expansion, substitutions, subshells, ba
 
 Limited `powershell` uses a separate fail-closed PowerShell policy, including when an extension overrides the canonical `powershell` tool name.
 It accepts canonical inspection cmdlets such as `Get-ChildItem`, `Get-Content`, `Get-Item`, `Get-Location`, `Resolve-Path`, `Select-String`, `Test-Path`, `Measure-Object`, `Sort-Object`, `Format-List`, `Format-Table`, `Out-String`, and `Write-Output`.
+It accepts local `Get-Process` and `Get-Service` queries with reviewed static selectors while rejecting remote and object-input parameters.
 It also accepts the same reviewed `git` and configured `gh` queries as limited Bash, including pipelines and semicolon-delimited command lists composed entirely of accepted commands.
 It rejects redirects, variables, substitutions, script blocks, call operators, type or method expressions, stop-parsing tokens, multiline input, non-ASCII quotation delimiters, aliases, mutating cmdlets, and unknown commands.
 Use canonical cmdlet names because PowerShell aliases are intentionally outside the reviewed policy.

--- a/packages/pi-plan-mode/src/tool-policy.ts
+++ b/packages/pi-plan-mode/src/tool-policy.ts
@@ -147,19 +147,25 @@ export function findBlockedCommandSegment(
 	command: string,
 	safeSubcommands: SafeSubcommands = {},
 	workingDirectory?: string,
+	platform: NodeJS.Platform = process.platform,
 ): string | undefined {
 	if (matchesConfiguredSafeSubcommand(command, safeSubcommands)) return undefined;
 	const segments = splitShellSegments(command);
 	if (!segments || segments.length === 0) return command.trim() || "(empty command)";
-	return segments.find((segment) => !isSafeSegment(segment, safeSubcommands, workingDirectory));
+	return segments.find(
+		(segment) => !isSafeSegment(segment, safeSubcommands, workingDirectory, platform),
+	);
 }
 
 export function isSafeCommand(
 	command: string,
 	safeSubcommands: SafeSubcommands = {},
 	workingDirectory?: string,
+	platform: NodeJS.Platform = process.platform,
 ) {
-	return findBlockedCommandSegment(command, safeSubcommands, workingDirectory) === undefined;
+	return (
+		findBlockedCommandSegment(command, safeSubcommands, workingDirectory, platform) === undefined
+	);
 }
 
 export function findBlockedPowerShellCommandSegment(
@@ -257,6 +263,8 @@ function isSafePowerShellSegment(
 	if (!command) return false;
 	const args = tokens.slice(1);
 	if (READ_ONLY_POWERSHELL_COMMANDS.has(command)) return true;
+	if (command === "get-process") return isSafeGetProcessArguments(args);
+	if (command === "get-service") return isSafeGetServiceArguments(args);
 	if (command !== "git" && command !== "gh") return false;
 	return isSafeStructuredCommand(command, args, safeSubcommands, workingDirectory);
 }
@@ -359,7 +367,8 @@ function splitShellSegments(command: string): string[] | undefined {
 function isSafeSegment(
 	segment: string,
 	safeSubcommands: SafeSubcommands,
-	workingDirectory?: string,
+	workingDirectory: string | undefined,
+	platform: NodeJS.Platform,
 ) {
 	if (hasShellExpansion(segment) || /(^|\s)[A-Za-z_][A-Za-z0-9_]*=/.test(segment)) {
 		return false;
@@ -370,6 +379,8 @@ function isSafeSegment(
 	if (!command || MUTATING_COMMANDS.has(command)) return false;
 	const args = tokens.slice(1);
 	if (!hasSafeArguments(command, args)) return false;
+	if (command === "hostname") return args.length === 0;
+	if (command === "tasklist") return platform === "win32" && isSafeTasklistArguments(args);
 	if (READ_ONLY_COMMANDS.has(command)) return true;
 	return isSafeStructuredCommand(command, args, safeSubcommands, workingDirectory);
 }
@@ -597,6 +608,72 @@ function isSafeStructuredCommand(
 		);
 	}
 	return false;
+}
+
+function isSafeTasklistArguments(args: string[]) {
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index]?.toLowerCase();
+		if (["/v", "/nh", "/svc"].includes(argument ?? "")) continue;
+		if (argument === "/fo") {
+			const format = args[index + 1]?.toLowerCase();
+			if (!format || !["table", "list", "csv"].includes(format)) return false;
+			index += 1;
+			continue;
+		}
+		if (argument === "/fi") {
+			const filter = args[index + 1];
+			if (!filter || filter.startsWith("/")) return false;
+			index += 1;
+			continue;
+		}
+		if (argument === "/m") {
+			const module = args[index + 1];
+			if (module && !module.startsWith("/")) index += 1;
+			continue;
+		}
+		return false;
+	}
+	return true;
+}
+
+function isSafeGetProcessArguments(args: string[]) {
+	return hasSafePowerShellQueryArguments(
+		args,
+		new Set(["-module", "-fileversioninfo", "-includeusername"]),
+		new Set(["-name", "-id"]),
+	);
+}
+
+function isSafeGetServiceArguments(args: string[]) {
+	return hasSafePowerShellQueryArguments(
+		args,
+		new Set(["-dependentservices", "-requiredservices"]),
+		new Set(["-name", "-displayname", "-include", "-exclude"]),
+	);
+}
+
+function hasSafePowerShellQueryArguments(
+	args: string[],
+	switches: ReadonlySet<string>,
+	valueOptions: ReadonlySet<string>,
+) {
+	let positionalValues = 0;
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+		const normalized = argument?.toLowerCase();
+		if (!argument || !normalized) return false;
+		if (!argument.startsWith("-")) {
+			positionalValues += 1;
+			if (positionalValues > 1) return false;
+			continue;
+		}
+		if (switches.has(normalized)) continue;
+		if (!valueOptions.has(normalized)) return false;
+		const value = args[index + 1];
+		if (!value || value.startsWith("-")) return false;
+		index += 1;
+	}
+	return true;
 }
 
 function isSafeGitCommand(

--- a/packages/pi-plan-mode/test/tool-policy.test.ts
+++ b/packages/pi-plan-mode/test/tool-policy.test.ts
@@ -102,6 +102,33 @@ test("isSafeCommand permits read-only command lists and rejects shell mutation",
 	}
 });
 
+test("Bash policy permits only conservative local system diagnostics", () => {
+	assert.equal(isSafeCommand("hostname"), true);
+	for (const command of ["hostname changed-host", "hostname -F hostname.txt"]) {
+		assert.equal(isSafeCommand(command), false, command);
+	}
+
+	for (const command of [
+		"tasklist",
+		"tasklist /V /FO CSV /NH",
+		'tasklist /FI "STATUS eq running"',
+		"tasklist /M ntdll.dll /SVC",
+	]) {
+		assert.equal(isSafeCommand(command, {}, undefined, "win32"), true, command);
+	}
+	for (const command of [
+		"tasklist /S remote-host",
+		"tasklist /U account",
+		"tasklist /P secret",
+		"tasklist /FO HTML",
+		"tasklist /FI",
+		"tasklist /unknown",
+	]) {
+		assert.equal(isSafeCommand(command, {}, undefined, "win32"), false, command);
+	}
+	assert.equal(isSafeCommand("tasklist", {}, undefined, "linux"), false);
+});
+
 test("blocked command diagnostics identify the first rejected segment", () => {
 	const accepted = "git status --short && git diff --cached | head -20";
 	const singleBlocked = "touch output";
@@ -171,6 +198,38 @@ test("PowerShell policy permits reviewed inspection commands", () => {
 		"git log -1 --oneline",
 	]) {
 		assert.equal(isSafePowerShellCommand(command), true, command);
+	}
+});
+
+test("PowerShell policy permits only conservative local process and service queries", () => {
+	for (const command of [
+		"Get-Process",
+		"Get-Process -Name pwsh",
+		"Get-Process -Id 123 -Module",
+		"Get-Process pwsh -IncludeUserName | Format-Table Name,Id",
+		"Get-Service",
+		"Get-Service -Name sshd -RequiredServices",
+		"Get-Service -DisplayName 'Windows Update'",
+		"Get-Service win* | Sort-Object DisplayName",
+	]) {
+		assert.equal(isSafePowerShellCommand(command), true, command);
+	}
+	for (const command of [
+		"Get-Process -ComputerName remote-host",
+		"Get-Process -CimSession remote-host",
+		"Get-Process -InputObject process",
+		"Get-Process -Name",
+		"Get-Process one two",
+		"Get-Service -ComputerName remote-host",
+		"Get-Service -CimSession remote-host",
+		"Get-Service -InputObject service",
+		"Get-Service -Name",
+		"Get-Process | Stop-Process",
+		"Get-Service | Stop-Service",
+		"gps pwsh",
+		"gsv sshd",
+	]) {
+		assert.equal(isSafePowerShellCommand(command), false, command);
 	}
 });
 


### PR DESCRIPTION
## Summary

- allow zero-argument `hostname` inspections in limited Bash
- allow local Windows `tasklist` queries through a narrow positive argument grammar
- allow canonical local `Get-Process` and `Get-Service` queries with reviewed static selectors
- document the default policy and add a minor Changeset

## Safety boundaries

- gate `tasklist` to Windows and reject remote credentials and hosts, unknown flags, and unsupported output formats
- reject PowerShell remote, session, object-input, alias, unknown-parameter, and mutating pipeline forms
- keep `cd`, `wmic`, environment assignments, shell expansion, globs, redirects, and substitutions fail-closed

## Verification

- `npm exec -- vitest run packages/pi-plan-mode/test/tool-policy.test.ts` (17 tests)
- `npm exec -- tsc --noEmit -p packages/pi-plan-mode/tsconfig.json`
- `npm run check`
- `npm test` (3,227 tests)
- fenced-code-aware README heading audit
- `npx changeset status` identifies the intended minor `@narumitw/pi-plan-mode` bump; it also reports existing internal `pi-tui-kit` dependency-floor notices

The first full test run hit one unrelated flaky `pi-analytics` concurrent-clear test.
That test passed in isolation, and the complete suite passed on retry.
A Windows live smoke was not run; deterministic policy tests cover the Windows platform gate and accepted and rejected argument forms.
