### PR TITLE
fix(subagents): restore package publishing

### DIFF
--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -4,7 +4,7 @@
 	"description": "Subagent jobs with asynchronous main-agent messaging for Pi.",
 	"type": "module",
 	"license": "MIT",
-	"private": true,
+	"private": false,
 	"keywords": [
 		"pi-package",
 		"pi-extension",

--- a/packages/pi-subagents/test/package.test.ts
+++ b/packages/pi-subagents/test/package.test.ts
@@ -20,7 +20,7 @@ test("package declares one generated extension without a bundled skill", () => {
 	};
 	assert.equal(manifest.name, "@narumitw/pi-subagents");
 	assert.doesNotMatch(manifest.description, /\b(?:background|bounded)\b/i);
-	assert.equal(manifest.private, true);
+	assert.equal(manifest.private, false);
 	assert.equal(manifest.repository.directory, "packages/pi-subagents");
 	assert.deepEqual(manifest.pi.extensions, ["./dist/index.ts"]);
 	assert.equal("skills" in manifest.pi, false);


### PR DESCRIPTION
## Summary

- mark `@narumitw/pi-subagents` as publishable
- update the package manifest test to enforce the public package state

## Checks

- `npm run check`
- `npm test` (3,228 tests)
- `just pack subagents`