### PR TITLE
feat: show extension UI prompt waiting state

### DIFF
--- a/.changeset/show-ui-prompt-waits.md
+++ b/.changeset/show-ui-prompt-waits.md
@@ -1,0 +1,8 @@
+---
+"@narumitw/pi-starship": minor
+"@narumitw/pi-statusline": minor
+---
+
+Show when Pi is waiting for blocking extension UI input and restore the underlying activity after the prompt closes.
+
+Expose `waiting`, `$kind`, and `$title` through pi-starship's activity module.

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -360,7 +360,7 @@ There is no hidden compatibility overlay or automatic migration.
 | `git_state` | `$symbol`, `$state`, `$progress_current`, `$progress_total` | Rebase, merge, revert, cherry-pick, bisect, or mail-apply state |
 | `git_metrics` | `$symbol`, `$added`, `$deleted` | Added/deleted line totals from the working tree diff |
 | `git_status` | `$symbol`, `$all_status`, `$ahead_behind`, `$ahead`, `$behind`, `$diverged`, `$up_to_date`, `$conflicted`, `$stashed`, `$deleted`, `$renamed`, `$modified`, `$typechanged`, `$staged`, `$untracked`, and detailed index/worktree counters | Cached porcelain-v2 counters |
-| `activity` | `$symbol`, `$state`, `$tool`, `$count`, `$text` | Active tools, streaming, completion, or idle |
+| `activity` | `$symbol`, `$state`, `$tool`, `$count`, `$kind`, `$title`, `$text` | Extension UI waits, active tools, streaming, completion, or idle |
 | `context` | `$symbol`, `$percentage`, `$tokens`, `$window` | Context-window use |
 | `tokens` | `$symbol`, `$input`, `$output`, `$total` | Token totals |
 | `cache` | `$symbol`, `$rate`, `$read`, `$write` | Prompt-cache reads, writes, and latest hit rate; disabled by default |
@@ -395,6 +395,8 @@ There is no hidden compatibility overlay or automatic migration.
 
 ### Usage semantics
 
+- During a blocking extension UI prompt, `activity` sets `$state` to `waiting`, `$kind` to the prompt kind, and `$title` to the sanitized bounded title or an empty string.
+- Prompt waiting takes precedence without losing the underlying tool, streaming, completed, or idle state, which returns when the prompt closes.
 - `tokens`, `cache`, and `cost` total every usage-bearing session entry, matching Pi's native footer.
   This includes assistant messages, nested-LLM tool results, compactions, and branch summaries, including abandoned branches retained in the session.
 - Cache `$read` and `$write` are cumulative.

--- a/packages/pi-starship/src/modules/activity.ts
+++ b/packages/pi-starship/src/modules/activity.ts
@@ -31,7 +31,7 @@ export const activityModule = defineModule({
 	variables: ["symbol", "state", "tool", "count", "kind", "title", "text"],
 	defaults: {
 		format: "[ $text ]($style)",
-		symbol: "⚙",
+		symbol: "⚙️",
 		style: "bold yellow",
 		disabled: false,
 	},

--- a/packages/pi-starship/src/modules/activity.ts
+++ b/packages/pi-starship/src/modules/activity.ts
@@ -1,8 +1,19 @@
+import { sliceByColumn, visibleWidth } from "@earendil-works/pi-tui";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { defineModule } from "./types.js";
+
+const MAX_UI_PROMPT_TITLE_WIDTH = 40;
+const EMPTY_PROMPT_VALUES = { kind: "", title: "" } as const;
+
+function formatUIPromptTitle(title: string | undefined): string {
+	const safeTitle = title ? sanitizeTerminalText(title).trim() : "";
+	if (visibleWidth(safeTitle) <= MAX_UI_PROMPT_TITLE_WIDTH) return safeTitle;
+	return `${sliceByColumn(safeTitle, 0, MAX_UI_PROMPT_TITLE_WIDTH - 1, true)}…`;
+}
 
 export const activityModule = defineModule({
 	name: "activity",
-	variables: ["symbol", "state", "tool", "count", "text"],
+	variables: ["symbol", "state", "tool", "count", "kind", "title", "text"],
 	defaults: {
 		format: "[ $text ]($style)",
 		symbol: "⚙",
@@ -10,6 +21,19 @@ export const activityModule = defineModule({
 		disabled: false,
 	},
 	values: ({ runtime, symbol }) => {
+		if (runtime.uiPrompt) {
+			const title = formatUIPromptTitle(runtime.uiPrompt.title);
+			const waiting = `waiting for ${runtime.uiPrompt.kind}${title ? ` · ${title}` : ""}`;
+			return {
+				state: "waiting",
+				tool: "",
+				count: "0",
+				kind: runtime.uiPrompt.kind,
+				title,
+				text: `${symbol} ${waiting}`,
+			};
+		}
+
 		const active = [...runtime.activeTools.entries()];
 		if (active.length > 0) {
 			const [tool = "tool", count = 1] = active[0] ?? [];
@@ -19,20 +43,34 @@ export const activityModule = defineModule({
 				state: "active",
 				tool,
 				count: `${count}`,
+				...EMPTY_PROMPT_VALUES,
 				text: `${symbol} ${tool}${suffix}${more}`,
 			};
 		}
 		if (runtime.isStreaming) {
-			return { state: "thinking", tool: "", count: "0", text: `${symbol} thinking` };
+			return {
+				state: "thinking",
+				tool: "",
+				count: "0",
+				...EMPTY_PROMPT_VALUES,
+				text: `${symbol} thinking`,
+			};
 		}
 		if (runtime.lastCompletedTool) {
 			return {
 				state: "completed",
 				tool: runtime.lastCompletedTool,
 				count: "0",
+				...EMPTY_PROMPT_VALUES,
 				text: `${symbol} completed ${runtime.lastCompletedTool}`,
 			};
 		}
-		return { state: "idle", tool: "", count: "0", text: `${symbol} idle` };
+		return {
+			state: "idle",
+			tool: "",
+			count: "0",
+			...EMPTY_PROMPT_VALUES,
+			text: `${symbol} idle`,
+		};
 	},
 });

--- a/packages/pi-starship/src/modules/activity.ts
+++ b/packages/pi-starship/src/modules/activity.ts
@@ -2,13 +2,28 @@ import { sliceByColumn, visibleWidth } from "@earendil-works/pi-tui";
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { defineModule } from "./types.js";
 
+const MAX_UI_PROMPT_TITLE_CODE_POINTS = 256;
 const MAX_UI_PROMPT_TITLE_WIDTH = 40;
 const EMPTY_PROMPT_VALUES = { kind: "", title: "" } as const;
 
+function boundUIPromptTitleLength(title: string): string {
+	let end = 0;
+	let ellipsisEnd = 0;
+	let codePoints = 0;
+	while (end < title.length && codePoints < MAX_UI_PROMPT_TITLE_CODE_POINTS) {
+		const codePoint = title.codePointAt(end) ?? 0;
+		end += codePoint > 0xffff ? 2 : 1;
+		codePoints += 1;
+		if (codePoints < MAX_UI_PROMPT_TITLE_CODE_POINTS) ellipsisEnd = end;
+	}
+	return end < title.length ? `${title.slice(0, ellipsisEnd)}…` : title;
+}
+
 function formatUIPromptTitle(title: string | undefined): string {
 	const safeTitle = title ? sanitizeTerminalText(title).trim() : "";
-	if (visibleWidth(safeTitle) <= MAX_UI_PROMPT_TITLE_WIDTH) return safeTitle;
-	return `${sliceByColumn(safeTitle, 0, MAX_UI_PROMPT_TITLE_WIDTH - 1, true)}…`;
+	const boundedTitle = boundUIPromptTitleLength(safeTitle);
+	if (visibleWidth(boundedTitle) <= MAX_UI_PROMPT_TITLE_WIDTH) return boundedTitle;
+	return `${sliceByColumn(boundedTitle, 0, MAX_UI_PROMPT_TITLE_WIDTH - 1, true)}…`;
 }
 
 export const activityModule = defineModule({

--- a/packages/pi-starship/src/modules/catalog.ts
+++ b/packages/pi-starship/src/modules/catalog.ts
@@ -61,7 +61,7 @@ const MODULE_IMPLEMENTATIONS = [
 export type ModuleName = (typeof MODULE_IMPLEMENTATIONS)[number]["name"];
 
 const MODULE_DESCRIPTIONS = {
-	activity: "Current Pi activity or most recently completed tool.",
+	activity: "Current Pi activity, extension UI wait, or most recently completed tool.",
 	aws: "Active AWS profile and region.",
 	azure: "Active Azure subscription and optional username.",
 	brand: "pi-starship brand mark.",

--- a/packages/pi-starship/src/modules/types.ts
+++ b/packages/pi-starship/src/modules/types.ts
@@ -1,3 +1,4 @@
+import type { UIPromptKind } from "@earendil-works/pi-coding-agent";
 import type { StyledChunk } from "../format/style.js";
 
 export interface GitBranchSnapshot {
@@ -86,6 +87,7 @@ export interface StarshipRuntimeSnapshot {
 	turnCount: number;
 	activeTools: ReadonlyMap<string, number>;
 	isStreaming: boolean;
+	uiPrompt?: { kind: UIPromptKind; title?: string };
 	lastCompletedTool?: string;
 	contextUsage?: {
 		percent?: number | null;

--- a/packages/pi-starship/src/pi-starship.ts
+++ b/packages/pi-starship/src/pi-starship.ts
@@ -57,6 +57,7 @@ function loadStarshipCommands(): Promise<StarshipCommands> {
 interface RuntimeState {
 	activeTools: Map<string, number>;
 	isStreaming: boolean;
+	uiPrompt?: NonNullable<StarshipRuntimeSnapshot["uiPrompt"]>;
 	thinkingLevel: string;
 	lastCompletedTool?: string;
 	git?: GitSnapshot;
@@ -102,6 +103,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 	let githubPrGeneration = 0;
 
 	const refresh = () => runtime.requestRender?.();
+	const ownsRuntime = (ctx: ExtensionContext) => sessionOwner === ctx.sessionManager;
 	const githubPrExec = options.githubPrExec ?? execWorkspaceCommand;
 	const gitController = new AsyncRefreshController<GitRefreshInput, GitSnapshot | undefined>({
 		async read(input, signal) {
@@ -401,6 +403,10 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		runtime.activeTools.clear();
+		runtime.isStreaming = false;
+		runtime.uiPrompt = undefined;
+		runtime.lastCompletedTool = undefined;
 		loaded = loadStarshipConfig(configPath);
 		loadedRevision += 1;
 		if (loaded.diagnostics.length > 0 && (ctx.mode === "tui" || ctx.hasUI)) {
@@ -428,6 +434,10 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 		stopGithubPr();
 		runtime.git = undefined;
 		runtime.workspace = undefined;
+		runtime.activeTools.clear();
+		runtime.isStreaming = false;
+		runtime.uiPrompt = undefined;
+		runtime.lastCompletedTool = undefined;
 		runtime.requestRender = undefined;
 		runtime.renderPreview = undefined;
 		runtime.inspect = undefined;
@@ -450,6 +460,16 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 		scheduleRefresh(ctx);
 		const target = activeTarget;
 		if (target?.sessionManager === ctx.sessionManager) requestGithubPr(target);
+		refresh();
+	});
+	pi.on("ui_prompt_start", (event, ctx) => {
+		if (!ownsRuntime(ctx)) return;
+		runtime.uiPrompt = { kind: event.kind, title: event.title };
+		refresh();
+	});
+	pi.on("ui_prompt_end", (_event, ctx) => {
+		if (!ownsRuntime(ctx)) return;
+		runtime.uiPrompt = undefined;
 		refresh();
 	});
 	pi.on("turn_start", () => {
@@ -568,6 +588,7 @@ function runtimeSnapshot(
 		turnCount: userTurnCount(ctx),
 		activeTools: runtime.activeTools,
 		isStreaming: runtime.isStreaming,
+		uiPrompt: runtime.uiPrompt,
 		lastCompletedTool: runtime.lastCompletedTool,
 		contextUsage: ctx.getContextUsage() ?? undefined,
 		tokenTotals: summarizeFooterUsage(ctx.sessionManager.getEntries()),

--- a/packages/pi-starship/test/generated-entry.test.ts
+++ b/packages/pi-starship/test/generated-entry.test.ts
@@ -26,6 +26,8 @@ test("declared generated entry preserves registration and lifecycle behavior", a
 		assert.ok(mock.commands.has("starship"));
 		assert.ok(mock.events.has("session_start"));
 		assert.ok(mock.events.has("session_shutdown"));
+		assert.ok(mock.events.has("ui_prompt_start"));
+		assert.ok(mock.events.has("ui_prompt_end"));
 
 		const context = createMockContext({ mode: "tui" });
 		await emit(mock.events, "session_start", {}, context.ctx);

--- a/packages/pi-starship/test/lifecycle.test.ts
+++ b/packages/pi-starship/test/lifecycle.test.ts
@@ -105,6 +105,70 @@ test("non-TUI sessions install no footer and execute no Git or GitHub subprocess
 	assert.equal(calls, 0);
 });
 
+test("UI prompt waiting state restores activity and rejects stale session events", async (t) => {
+	useLifecycleConfig(t, "format = '$activity'\n");
+	const mock = createMockPi();
+	piStarship(mock.pi);
+	const oldContext = createMockContext({ mode: "tui" });
+	const newContext = createMockContext({ mode: "tui" });
+	await emit(mock.events, "session_start", {}, oldContext.ctx);
+	const footerData = {
+		getGitBranch: () => null,
+		getExtensionStatuses: () => new Map<string, string>(),
+		onBranchChange: () => () => undefined,
+	};
+	const oldFooter = (oldContext.footer as FooterFactory)({ requestRender() {} }, {}, footerData);
+	try {
+		await emit(mock.events, "agent_start", {}, oldContext.ctx);
+		await emit(mock.events, "tool_execution_start", { toolName: "read" }, oldContext.ctx);
+		await emit(
+			mock.events,
+			"ui_prompt_start",
+			{ kind: "confirm", title: "Deploy production?" },
+			oldContext.ctx,
+		);
+		assert.match(
+			stripAnsi(oldFooter.render(200).join("\n")),
+			/waiting for confirm · Deploy production\?/u,
+		);
+		await emit(mock.events, "ui_prompt_end", { kind: "confirm" }, oldContext.ctx);
+		assert.match(stripAnsi(oldFooter.render(200).join("\n")), /read/u);
+		await emit(mock.events, "tool_execution_end", { toolName: "read" }, oldContext.ctx);
+		assert.match(stripAnsi(oldFooter.render(200).join("\n")), /thinking/u);
+		await emit(mock.events, "ui_prompt_start", { kind: "custom" }, oldContext.ctx);
+		assert.match(stripAnsi(oldFooter.render(200).join("\n")), /waiting for custom/u);
+		await emit(mock.events, "ui_prompt_end", { kind: "custom" }, oldContext.ctx);
+		assert.match(stripAnsi(oldFooter.render(200).join("\n")), /thinking/u);
+
+		await emit(mock.events, "ui_prompt_start", { kind: "editor" }, oldContext.ctx);
+		await emit(mock.events, "session_start", {}, newContext.ctx);
+		const newFooter = (newContext.footer as FooterFactory)({ requestRender() {} }, {}, footerData);
+		try {
+			assert.match(stripAnsi(newFooter.render(200).join("\n")), /idle/u);
+			await emit(mock.events, "ui_prompt_end", { kind: "editor" }, oldContext.ctx);
+			await emit(
+				mock.events,
+				"ui_prompt_start",
+				{ kind: "input", title: "Current prompt" },
+				newContext.ctx,
+			);
+			await emit(mock.events, "ui_prompt_end", { kind: "editor" }, oldContext.ctx);
+			assert.match(
+				stripAnsi(newFooter.render(200).join("\n")),
+				/waiting for input · Current prompt/u,
+			);
+			await emit(mock.events, "ui_prompt_end", { kind: "input" }, newContext.ctx);
+			assert.match(stripAnsi(newFooter.render(200).join("\n")), /idle/u);
+			await emit(mock.events, "session_shutdown", {}, newContext.ctx);
+			assert.equal(newContext.footer, undefined);
+		} finally {
+			newFooter.dispose();
+		}
+	} finally {
+		oldFooter.dispose();
+	}
+});
+
 test("reachable directory alone collects repository-root metadata", async (t) => {
 	useLifecycleConfig(t, "format = '$directory'\n");
 	const mock = createMockPi();

--- a/packages/pi-starship/test/modules.test.ts
+++ b/packages/pi-starship/test/modules.test.ts
@@ -953,25 +953,47 @@ test("first-wave workspace modules render documented snapshot variables", () => 
 	assert.equal(rendered.split("|").length, names.length);
 });
 
-test("activity handles parallel active tools, thinking, completed, and idle", () => {
-	const text = (runtime: Partial<StarshipRuntimeSnapshot>) => {
+test("activity handles UI prompts, tools, thinking, completed, and idle", () => {
+	const text = (runtime: Partial<StarshipRuntimeSnapshot>, format = "$text") => {
 		const config = structuredClone(BUILT_IN_CONFIG);
 		config.format = "$activity";
 		config.formatAst = [{ type: "variable", name: "activity" }];
+		config.modules.activity.format = format;
+		config.modules.activity.formatAst = parseFormat(format);
 		return stripAnsi(renderStatusline(config, fixture(runtime)).ansi);
 	};
-	assert.match(
-		text({
-			activeTools: new Map([
-				["read", 2],
-				["bash", 1],
-			]),
-		}),
-		/read×2\+1/,
-	);
+	const activeTools = new Map([
+		["read", 2],
+		["bash", 1],
+	]);
+	assert.match(text({ activeTools }), /read×2\+1/);
 	assert.match(text({ isStreaming: true, lastCompletedTool: undefined }), /thinking/);
 	assert.match(text({ lastCompletedTool: "bash" }), /completed bash/);
 	assert.match(text({ lastCompletedTool: undefined }), /idle/);
+
+	const kinds = ["select", "confirm", "input", "editor", "custom"] as const;
+	for (const kind of kinds) {
+		assert.match(
+			text({ uiPrompt: { kind }, activeTools, isStreaming: true }),
+			new RegExp(`waiting for ${kind}`, "u"),
+		);
+	}
+	assert.equal(
+		text({ uiPrompt: { kind: "confirm", title: "Deploy production?" } }, "$state|$kind|$title"),
+		"waiting|confirm|Deploy production?",
+	);
+	const unsafeTitle = `Deploy\n\x1b[31mproduction\x1b[0m\u202e ${"界".repeat(30)}`;
+	const safeTitle = text({ uiPrompt: { kind: "confirm", title: unsafeTitle } }, "$title");
+	assert.equal(safeTitle.includes("\n"), false);
+	assert.equal(safeTitle.includes(ESC), false);
+	assert.equal(safeTitle.includes("\u202e"), false);
+	assert.match(safeTitle, /^Deploy production/u);
+	assert.ok(visibleWidth(safeTitle) <= 40);
+	assert.match(safeTitle, /…$/u);
+	assert.match(
+		text({ uiPrompt: { kind: "custom", title: "\x1b[31m\u202e" } }),
+		/waiting for custom$/u,
+	);
 });
 
 test("extension status icons match arbitrary exact keys and explicit namespace wildcards", () => {

--- a/packages/pi-starship/test/modules.test.ts
+++ b/packages/pi-starship/test/modules.test.ts
@@ -994,6 +994,13 @@ test("activity handles UI prompts, tools, thinking, completed, and idle", () => 
 		text({ uiPrompt: { kind: "custom", title: "\x1b[31m\u202e" } }),
 		/waiting for custom$/u,
 	);
+	const zeroWidthTitle = text(
+		{ uiPrompt: { kind: "input", title: `a${"\u0301".repeat(1_000)}` } },
+		"$title",
+	);
+	assert.equal([...zeroWidthTitle].length, 256);
+	assert.match(zeroWidthTitle, /…$/u);
+	assert.ok(visibleWidth(zeroWidthTitle) <= 40);
 });
 
 test("extension status icons match arbitrary exact keys and explicit namespace wildcards", () => {

--- a/packages/pi-starship/test/modules.test.ts
+++ b/packages/pi-starship/test/modules.test.ts
@@ -966,7 +966,7 @@ test("activity handles UI prompts, tools, thinking, completed, and idle", () => 
 		["read", 2],
 		["bash", 1],
 	]);
-	assert.match(text({ activeTools }), /read×2\+1/);
+	assert.match(text({ activeTools }), /⚙️ read×2\+1/);
 	assert.match(text({ isStreaming: true, lastCompletedTool: undefined }), /thinking/);
 	assert.match(text({ lastCompletedTool: "bash" }), /completed bash/);
 	assert.match(text({ lastCompletedTool: undefined }), /idle/);

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -14,7 +14,7 @@ A representative uncolored layout:
 
 - Works immediately with a balanced default for model, thinking, workspace, Git, context, activity, and time.
 - Removes lower-priority segments before important information is clipped.
-- Shows activity only while Pi is streaming or running tools.
+- Shows when Pi is waiting for an extension UI prompt, streaming, or running tools.
 - Adds optional token, prompt-cache, provider usage, and cost details.
 - Offers three information levels, seven previewable palettes, and advanced custom layouts.
 - Loads a generated split runtime to reduce Pi package startup work.
@@ -119,7 +119,9 @@ If the last remaining segment is itself wider than the row, that row renders emp
 - `cwd` uses Starship's directory presentation defaults: contract the home directory to `~`, contract to the Git repository root when available, then retain at most the last three path components.
   This changes display only; the configured segment list and Pi working directory are untouched.
 - Repository-root discovery is cached with Git status outside footer rendering; a failed root query falls back to home/path-component contraction without hiding the segment.
-- During active work, `tools` shows `💭 thinking` or `⚙ <tool>` with parallel counts.
+- During active work, `tools` shows `⌨ waiting for <kind>`, `💭 thinking`, or `⚙ <tool>` with parallel counts.
+- A sanitized prompt title follows the prompt kind when available.
+- Prompt waiting takes precedence without losing the underlying tool or streaming state, which returns when the prompt closes.
 - Activity disappears after the agent settles and resets across session replacement or shutdown.
 - Clean repositories show no Git counters.
 - Dirty counters are `⇡` ahead, `⇣` behind, `+` staged, `~` modified/deleted, `?` untracked, and `!`

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -119,7 +119,7 @@ If the last remaining segment is itself wider than the row, that row renders emp
 - `cwd` uses Starship's directory presentation defaults: contract the home directory to `~`, contract to the Git repository root when available, then retain at most the last three path components.
   This changes display only; the configured segment list and Pi working directory are untouched.
 - Repository-root discovery is cached with Git status outside footer rendering; a failed root query falls back to home/path-component contraction without hiding the segment.
-- During active work, `tools` shows `⌨ waiting for <kind>`, `💭 thinking`, or `⚙ <tool>` with parallel counts.
+- During active work, `tools` shows `⌨ waiting for <kind>`, `💭 thinking`, or `⚙️ <tool>` with parallel counts.
 - A sanitized prompt title follows the prompt kind when available.
 - Prompt waiting takes precedence without losing the underlying tool or streaming state, which returns when the prompt closes.
 - Activity disappears after the agent settles and resets across session replacement or shutdown.

--- a/packages/pi-statusline/src/render.ts
+++ b/packages/pi-statusline/src/render.ts
@@ -4,7 +4,9 @@ import type {
 	ReadonlyFooterDataProvider,
 	Theme,
 	ThemeColor,
+	UIPromptKind,
 } from "@earendil-works/pi-coding-agent";
+import { sliceByColumn, visibleWidth } from "@earendil-works/pi-tui";
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { formatDirectoryPath } from "./directory.js";
 import {
@@ -31,6 +33,7 @@ export interface RuntimeState extends ExtensionStatusRuntime {
 	turnCount: number;
 	activeTools: Map<string, number>;
 	isStreaming: boolean;
+	uiPrompt?: { kind: UIPromptKind; title?: string };
 	thinkingLevel: ThinkingLevel;
 	gitStatus?: GitStatusSummary;
 	requestRender?: () => void;
@@ -248,7 +251,20 @@ export function contextColor(percent: number | null | undefined): ThemeColor {
 	return "success";
 }
 
+const MAX_UI_PROMPT_TITLE_WIDTH = 40;
+
+function formatUIPromptTitle(title: string | undefined): string {
+	const safeTitle = title ? sanitizeTerminalText(title).trim() : "";
+	if (visibleWidth(safeTitle) <= MAX_UI_PROMPT_TITLE_WIDTH) return safeTitle;
+	return `${sliceByColumn(safeTitle, 0, MAX_UI_PROMPT_TITLE_WIDTH - 1, true)}…`;
+}
+
 export function formatToolActivity(runtime: RuntimeState): string | undefined {
+	if (runtime.uiPrompt) {
+		const title = formatUIPromptTitle(runtime.uiPrompt.title);
+		return `⌨ waiting for ${runtime.uiPrompt.kind}${title ? ` · ${title}` : ""}`;
+	}
+
 	const active = [...runtime.activeTools.entries()];
 	if (active.length > 0) {
 		const [name, count] = active[0] ?? ["tool", 1];

--- a/packages/pi-statusline/src/render.ts
+++ b/packages/pi-statusline/src/render.ts
@@ -251,12 +251,27 @@ export function contextColor(percent: number | null | undefined): ThemeColor {
 	return "success";
 }
 
+const MAX_UI_PROMPT_TITLE_CODE_POINTS = 256;
 const MAX_UI_PROMPT_TITLE_WIDTH = 40;
+
+function boundUIPromptTitleLength(title: string): string {
+	let end = 0;
+	let ellipsisEnd = 0;
+	let codePoints = 0;
+	while (end < title.length && codePoints < MAX_UI_PROMPT_TITLE_CODE_POINTS) {
+		const codePoint = title.codePointAt(end) ?? 0;
+		end += codePoint > 0xffff ? 2 : 1;
+		codePoints += 1;
+		if (codePoints < MAX_UI_PROMPT_TITLE_CODE_POINTS) ellipsisEnd = end;
+	}
+	return end < title.length ? `${title.slice(0, ellipsisEnd)}…` : title;
+}
 
 function formatUIPromptTitle(title: string | undefined): string {
 	const safeTitle = title ? sanitizeTerminalText(title).trim() : "";
-	if (visibleWidth(safeTitle) <= MAX_UI_PROMPT_TITLE_WIDTH) return safeTitle;
-	return `${sliceByColumn(safeTitle, 0, MAX_UI_PROMPT_TITLE_WIDTH - 1, true)}…`;
+	const boundedTitle = boundUIPromptTitleLength(safeTitle);
+	if (visibleWidth(boundedTitle) <= MAX_UI_PROMPT_TITLE_WIDTH) return boundedTitle;
+	return `${sliceByColumn(boundedTitle, 0, MAX_UI_PROMPT_TITLE_WIDTH - 1, true)}…`;
 }
 
 export function formatToolActivity(runtime: RuntimeState): string | undefined {

--- a/packages/pi-statusline/src/render.ts
+++ b/packages/pi-statusline/src/render.ts
@@ -284,7 +284,7 @@ export function formatToolActivity(runtime: RuntimeState): string | undefined {
 	if (active.length > 0) {
 		const [name, count] = active[0] ?? ["tool", 1];
 		const suffix = count > 1 ? `×${count}` : active.length > 1 ? `+${active.length - 1}` : "";
-		return `⚙ ${name}${suffix}`;
+		return `⚙️ ${name}${suffix}`;
 	}
 
 	return runtime.isStreaming ? "💭 thinking" : undefined;

--- a/packages/pi-statusline/src/statusline.ts
+++ b/packages/pi-statusline/src/statusline.ts
@@ -243,6 +243,7 @@ export default function statusline(pi: ExtensionAPI) {
 		runtime.turnCount = 0;
 		runtime.activeTools.clear();
 		runtime.isStreaming = false;
+		runtime.uiPrompt = undefined;
 		loaded = loadStatuslineSettingsForAgent(agentDir);
 		const settingsNotice = consumeStatuslineSettingsNotice();
 		if (settingsNotice) ctx.ui.notify(settingsNotice, "warning");
@@ -271,6 +272,7 @@ export default function statusline(pi: ExtensionAPI) {
 		runtime.gitStatus = undefined;
 		runtime.activeTools.clear();
 		runtime.isStreaming = false;
+		runtime.uiPrompt = undefined;
 		runtime.duplicateExtensions = [];
 		runtime.extensionStatusIconAliases = EMPTY_EXTENSION_STATUS_ICON_ALIASES;
 		ctx.ui.setFooter(undefined);
@@ -302,6 +304,18 @@ export default function statusline(pi: ExtensionAPI) {
 		if (!ownsRuntime(ctx)) return;
 		runtime.isStreaming = false;
 		runtime.activeTools.clear();
+		refresh();
+	});
+
+	pi.on("ui_prompt_start", (event, ctx) => {
+		if (!ownsRuntime(ctx)) return;
+		runtime.uiPrompt = { kind: event.kind, title: event.title };
+		refresh();
+	});
+
+	pi.on("ui_prompt_end", (_event, ctx) => {
+		if (!ownsRuntime(ctx)) return;
+		runtime.uiPrompt = undefined;
 		refresh();
 	});
 

--- a/packages/pi-statusline/test/generated-entry.test.ts
+++ b/packages/pi-statusline/test/generated-entry.test.ts
@@ -25,6 +25,8 @@ test("declared generated entry preserves registration and lifecycle behavior", a
 		assert.ok(mock.commands.has("statusline"));
 		assert.ok(mock.events.has("session_start"));
 		assert.ok(mock.events.has("session_shutdown"));
+		assert.ok(mock.events.has("ui_prompt_start"));
+		assert.ok(mock.events.has("ui_prompt_end"));
 
 		const context = createMockContext({ mode: "tui", cwd: root });
 		await emit(mock.events, "session_start", {}, context.ctx);

--- a/packages/pi-statusline/test/renderer.test.ts
+++ b/packages/pi-statusline/test/renderer.test.ts
@@ -7,6 +7,7 @@ import { createMockContext } from "../../../test/support.js";
 import { powerlineExtensionSeparator, renderPowerlineStatusline } from "../src/powerline.js";
 import {
 	formatConfiguredSegment,
+	formatToolActivity,
 	type RuntimeState,
 	renderStatusline,
 	truncateModel,
@@ -147,6 +148,37 @@ test("idle contextual activity rows collapse while explicit empty rows remain", 
 		renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime),
 	);
 	assert.deepEqual(explicitEmptyRows.split("\n"), ["", "░▒▓ 🤖 sonnet-4", ""]);
+});
+
+test("UI prompt activity sanitizes and bounds titles with kind-only fallbacks", () => {
+	const runtime: RuntimeState = {
+		turnCount: 0,
+		activeTools: new Map([["read", 2]]),
+		isStreaming: true,
+		thinkingLevel: "off",
+		duplicateExtensions: [],
+		extensionStatusIconAliases: new Map(),
+	};
+	const kinds = ["select", "confirm", "input", "editor", "custom"] as const;
+	for (const kind of kinds) {
+		runtime.uiPrompt = { kind };
+		assert.equal(formatToolActivity(runtime), `⌨ waiting for ${kind}`);
+	}
+
+	runtime.uiPrompt = {
+		kind: "confirm",
+		title: `Deploy\n\x1b[31mproduction\x1b[0m\u202e ${"界".repeat(30)}`,
+	};
+	const titled = formatToolActivity(runtime) ?? "";
+	assert.equal(titled.includes("\n"), false);
+	assert.equal(titled.includes(ESCAPE), false);
+	assert.equal(titled.includes("\u202e"), false);
+	assert.match(titled, /^⌨ waiting for confirm · Deploy production/u);
+	assert.ok(visibleWidth(titled) <= visibleWidth("⌨ waiting for confirm · ") + 40);
+	assert.match(titled, /…$/u);
+
+	runtime.uiPrompt = { kind: "custom", title: "\x1b[31m\u202e" };
+	assert.equal(formatToolActivity(runtime), "⌨ waiting for custom");
 });
 
 test("cwd uses Starship repository and three-component directory defaults", () => {

--- a/packages/pi-statusline/test/renderer.test.ts
+++ b/packages/pi-statusline/test/renderer.test.ts
@@ -179,6 +179,12 @@ test("UI prompt activity sanitizes and bounds titles with kind-only fallbacks", 
 
 	runtime.uiPrompt = { kind: "custom", title: "\x1b[31m\u202e" };
 	assert.equal(formatToolActivity(runtime), "⌨ waiting for custom");
+
+	runtime.uiPrompt = { kind: "input", title: `a${"\u0301".repeat(1_000)}` };
+	const zeroWidthTitle = (formatToolActivity(runtime) ?? "").replace("⌨ waiting for input · ", "");
+	assert.equal([...zeroWidthTitle].length, 256);
+	assert.match(zeroWidthTitle, /…$/u);
+	assert.ok(visibleWidth(zeroWidthTitle) <= 40);
 });
 
 test("cwd uses Starship repository and three-component directory defaults", () => {

--- a/packages/pi-statusline/test/responsive-statusline.test.ts
+++ b/packages/pi-statusline/test/responsive-statusline.test.ts
@@ -90,7 +90,7 @@ test("statusline activity appears only while streaming or tools are active and r
 		assert.match(footer.render(200)[0] ?? "", /💭 thinking/u);
 		await emit(mock.events, "tool_execution_start", { toolName: "read" }, context.ctx);
 		await emit(mock.events, "tool_execution_start", { toolName: "read" }, context.ctx);
-		assert.match(footer.render(200)[0] ?? "", /⚙ read×2/u);
+		assert.match(footer.render(200)[0] ?? "", /⚙️ read×2/u);
 		await emit(
 			mock.events,
 			"ui_prompt_start",
@@ -99,7 +99,7 @@ test("statusline activity appears only while streaming or tools are active and r
 		);
 		assert.match(footer.render(200)[0] ?? "", /⌨ waiting for confirm · Deploy production\?/u);
 		await emit(mock.events, "ui_prompt_end", { kind: "confirm" }, context.ctx);
-		assert.match(footer.render(200)[0] ?? "", /⚙ read×2/u);
+		assert.match(footer.render(200)[0] ?? "", /⚙️ read×2/u);
 		await emit(mock.events, "tool_execution_end", { toolName: "read" }, context.ctx);
 		await emit(mock.events, "tool_execution_end", { toolName: "read" }, context.ctx);
 		assert.match(footer.render(200)[0] ?? "", /💭 thinking/u);

--- a/packages/pi-statusline/test/responsive-statusline.test.ts
+++ b/packages/pi-statusline/test/responsive-statusline.test.ts
@@ -91,8 +91,21 @@ test("statusline activity appears only while streaming or tools are active and r
 		await emit(mock.events, "tool_execution_start", { toolName: "read" }, context.ctx);
 		await emit(mock.events, "tool_execution_start", { toolName: "read" }, context.ctx);
 		assert.match(footer.render(200)[0] ?? "", /⚙ read×2/u);
+		await emit(
+			mock.events,
+			"ui_prompt_start",
+			{ kind: "confirm", title: "Deploy production?" },
+			context.ctx,
+		);
+		assert.match(footer.render(200)[0] ?? "", /⌨ waiting for confirm · Deploy production\?/u);
+		await emit(mock.events, "ui_prompt_end", { kind: "confirm" }, context.ctx);
+		assert.match(footer.render(200)[0] ?? "", /⚙ read×2/u);
 		await emit(mock.events, "tool_execution_end", { toolName: "read" }, context.ctx);
 		await emit(mock.events, "tool_execution_end", { toolName: "read" }, context.ctx);
+		assert.match(footer.render(200)[0] ?? "", /💭 thinking/u);
+		await emit(mock.events, "ui_prompt_start", { kind: "custom" }, context.ctx);
+		assert.match(footer.render(200)[0] ?? "", /⌨ waiting for custom/u);
+		await emit(mock.events, "ui_prompt_end", { kind: "custom" }, context.ctx);
 		assert.match(footer.render(200)[0] ?? "", /💭 thinking/u);
 		await emit(mock.events, "agent_end", {}, context.ctx);
 		assert.match(footer.render(200)[0] ?? "", /💭 thinking/u);
@@ -107,9 +120,18 @@ test("statusline activity appears only while streaming or tools are active and r
 		try {
 			assert.doesNotMatch(replacementFooter.render(200)[0] ?? "", /write|💤|✅|⚙|💭/u);
 			await emit(mock.events, "agent_start", {}, replacement.ctx);
+			await emit(
+				mock.events,
+				"ui_prompt_start",
+				{ kind: "input", title: "Current prompt" },
+				replacement.ctx,
+			);
 			await emit(mock.events, "session_shutdown", {}, context.ctx);
 			await emit(mock.events, "agent_end", {}, context.ctx);
 			await emit(mock.events, "agent_settled", {}, context.ctx);
+			await emit(mock.events, "ui_prompt_end", { kind: "input" }, context.ctx);
+			assert.match(replacementFooter.render(200)[0] ?? "", /waiting for input · Current prompt/u);
+			await emit(mock.events, "ui_prompt_end", { kind: "input" }, replacement.ctx);
 			assert.match(replacementFooter.render(200)[0] ?? "", /💭 thinking/u);
 			await emit(mock.events, "agent_settled", {}, replacement.ctx);
 			assert.doesNotMatch(replacementFooter.render(200)[0] ?? "", /💤|✅|⚙|💭/u);

--- a/packages/pi-statusline/test/statusline.test.ts
+++ b/packages/pi-statusline/test/statusline.test.ts
@@ -562,7 +562,7 @@ test("formatToolActivity shows only active or streaming work", () => {
 
 	assert.equal(
 		formatToolActivity(runtime({ activeTools: new Map([["read", 2]]), isStreaming: false })),
-		"⚙ read×2",
+		"⚙️ read×2",
 	);
 	assert.equal(
 		formatToolActivity(runtime({ activeTools: new Map(), isStreaming: true })),


### PR DESCRIPTION
## Summary

- Show blocking extension UI prompt waits in `pi-statusline` and `pi-starship`.
- Preserve and restore underlying tool, streaming, completed, and idle activity.
- Sanitize and cell-bound prompt titles, and expose Starship `$state = "waiting"`, `$kind`, and `$title` variables.
- Add lifecycle and generated-runtime regression coverage plus minor Changesets for both packages.

## Verification

- `npm run check`
- `npm test` — 3,230 tests across 330 files
- Focused Vitest suite — 84 tests across 6 files
- Both package builds and generated-entry tests
- Isolated Pi Jiti RPC load smokes for both packages
- `just pack statusline`
- `just pack starship`
- `npm run changeset:status`

## Audits

- Reviewed against `docs/extension-conventions.md` and `packages/pi-statusline/AGENTS.md`.
- Audited session ownership, replacement, stale events, prompt end/cancellation, and shutdown cleanup.
- Audited terminal-control and bidi sanitization, cell-width bounds, and responsive rendering.
- No convention deviations or unverified implementation paths remain.
- `npm run changeset:status` reported only pre-existing compatible `pi-tui-kit` floor notices.

Closes #1105
