### PR TITLE
perf(ci): scope checks and tests to PR changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      PI_EXTENSIONS_AFFECTED_BASE: ${{ github.event.pull_request.base.sha || '' }}
 
     steps:
       - name: Check out repository
@@ -40,10 +42,10 @@ jobs:
           test "$installed_version" = "$expected_version"
           test "$cli_version" = "$expected_version"
 
-      - name: Run checks
+      - name: Run affected checks
         run: npm run check
 
       - name: Run affected tests
         env:
-          PI_EXTENSIONS_TEST_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          PI_EXTENSIONS_BUILD_READY: "1"
         run: npm test

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"smoke:chat-network": "node ./scripts/run-pi-chat-network-smoke.mjs",
 		"smoke:caffeinate-dbus": "node ./packages/pi-caffeinate/test/docker/run-docker.mjs",
 		"smoke:pi-fleet:ghostty": "cd packages/pi-fleet && tsc -p tsconfig.process-smoke.json && node ../../node_modules/.cache/pi-fleet-process/scripts/ghostty-smoke.js",
-		"check": "npm run build && node ./scripts/run-checks.mjs",
+		"check": "node ./scripts/run-checks.mjs",
 		"precommit": "biome check --staged --no-errors-on-unmatched && node ./scripts/run-typechecks.mjs --staged",
 		"prepare": "node .husky/install.mjs",
 		"changeset": "changeset",

--- a/scripts/run-affected-biome.mjs
+++ b/scripts/run-affected-biome.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { changedFilesSince } from "./select-affected-tests.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const base = process.env.PI_EXTENSIONS_AFFECTED_BASE;
+if (!base) {
+	console.error("PI_EXTENSIONS_AFFECTED_BASE is required for affected Biome checks.");
+	process.exit(1);
+}
+
+const targets = changedFilesSince(root, base)
+	.map((file) => file.split(path.sep).join("/").replace(/^\.\//u, ""))
+	.filter((file) => safeExistingTarget(file));
+if (targets.length === 0) {
+	console.log("Skipping Biome: no changed files remain to check.");
+	process.exit(0);
+}
+
+const biome = path.join(
+	root,
+	"node_modules",
+	".bin",
+	process.platform === "win32" ? "biome.cmd" : "biome",
+);
+const result = spawnSync(biome, ["check", "--no-errors-on-unmatched", ...targets], {
+	cwd: root,
+	stdio: "inherit",
+});
+if (result.error) {
+	console.error(result.error.message);
+	process.exit(1);
+}
+process.exit(result.status ?? 1);
+
+function safeExistingTarget(file) {
+	if (!file || file.startsWith("../") || path.posix.isAbsolute(file)) return false;
+	if (file === "package-lock.json" || file.startsWith("deprecated/")) return false;
+	return fs.existsSync(path.join(root, file));
+}

--- a/scripts/run-checks.mjs
+++ b/scripts/run-checks.mjs
@@ -1,18 +1,91 @@
 #!/usr/bin/env node
 
+import { spawnSync } from "node:child_process";
 import concurrently from "concurrently";
+import { changedFilesSince } from "./select-affected-tests.mjs";
+import { selectAffectedTypechecks } from "./select-staged-typechecks.mjs";
 
 const checks = ["biome:check", "check:boundaries", "typecheck"];
-const env = { ...process.env, PI_EXTENSIONS_BUILD_READY: "1" };
+const affectedBase = process.env.PI_EXTENSIONS_AFFECTED_BASE;
 
-console.log(`Running checks in parallel: ${checks.join(", ")}`);
-const { result } = concurrently(
-	checks.map((check) => ({ command: `npm:${check}`, name: check, env })),
-	{ prefix: "name", prefixColors: ["auto"] },
-);
+if (!affectedBase) {
+	runNpm(["run", "build"]);
+	await runChecks(checks.map((check) => ({ command: `npm:${check}`, name: check })));
+	process.exit(process.exitCode ?? 0);
+}
 
+let selection;
 try {
-	await result;
-} catch {
-	process.exitCode = 1;
+	selection = selectAffectedTypechecks(
+		process.cwd(),
+		changedFilesSince(process.cwd(), affectedBase),
+	);
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	console.warn(`Could not select affected checks (${message}); falling back to all checks.`);
+	runNpm(["run", "build"]);
+	await runChecks(checks.map((check) => ({ command: `npm:${check}`, name: check })));
+	process.exit(process.exitCode ?? 0);
+}
+
+if (selection.mode === "full") {
+	console.log(`Running all checks: ${selection.reason}.`);
+	runNpm(["run", "build"]);
+	await runChecks(checks.map((check) => ({ command: `npm:${check}`, name: check })));
+	process.exit(process.exitCode ?? 0);
+}
+
+console.log(
+	selection.mode === "skip"
+		? `Running change-scoped checks without workspace typechecks: ${selection.reason}.`
+		: `Running checks for ${selection.workspaceDirectories.join(", ")}: ${selection.reason}.`,
+);
+if (selection.buildWorkspaceNames.length > 0) {
+	runWorkspaceScript("build", selection.buildWorkspaceNames, true);
+}
+process.env.PI_EXTENSIONS_BUILD_READY = "1";
+
+const affectedChecks = [
+	{ command: "node ./scripts/run-affected-biome.mjs", name: "biome:check" },
+	{ command: "npm run check:boundaries", name: "check:boundaries" },
+];
+if (selection.mode !== "skip") {
+	affectedChecks.push({ command: "npm run typecheck -- --affected", name: "typecheck" });
+}
+await runChecks(affectedChecks);
+
+async function runChecks(tasks) {
+	console.log(`Running checks in parallel: ${tasks.map(({ name }) => name).join(", ")}`);
+	const env = { ...process.env, PI_EXTENSIONS_BUILD_READY: "1" };
+	const { result } = concurrently(
+		tasks.map((task) => ({ ...task, env })),
+		{ prefix: "name", prefixColors: ["auto"] },
+	);
+
+	try {
+		await result;
+	} catch {
+		process.exitCode = 1;
+	}
+}
+
+function runWorkspaceScript(script, workspaceNames, ifPresent = false) {
+	const workspaceArgs = workspaceNames.flatMap((workspaceName) => ["--workspace", workspaceName]);
+	if (ifPresent) workspaceArgs.push("--if-present");
+	runNpm([...workspaceArgs, "run", script]);
+}
+
+function runNpm(args) {
+	const command = process.env.npm_execpath
+		? process.execPath
+		: process.platform === "win32"
+			? "npm.cmd"
+			: "npm";
+	const commandArgs = process.env.npm_execpath ? [process.env.npm_execpath, ...args] : args;
+	const result = spawnSync(command, commandArgs, { stdio: "inherit" });
+	if (result.error) {
+		console.error(result.error.message);
+		process.exit(1);
+	}
+	if (result.status !== 0) process.exit(result.status ?? 1);
 }

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -37,9 +37,6 @@ console.log(
 );
 
 if (process.env.PI_EXTENSIONS_BUILD_READY !== "1") runNpm(["run", "build"]);
-fs.rmSync(outDir, { recursive: true, force: true });
-run(tsc, ["-p", "tsconfig.test.json"]);
-
 const sourceTestFiles = [
 	...findFiles(path.join(root, "test"), ".test.ts"),
 	...findFiles(path.join(root, "packages"), ".test.ts"),
@@ -48,6 +45,27 @@ const testFiles = sourceTestFiles.filter((testFile) => selectedTestFile(testFile
 if (testFiles.length === 0) {
 	console.error("No selected test files found.");
 	process.exit(1);
+}
+
+fs.rmSync(outDir, { recursive: true, force: true });
+if (selection.mode === "full") {
+	run(tsc, ["-p", "tsconfig.test.json"]);
+} else {
+	fs.mkdirSync(outDir, { recursive: true });
+	const selectedTsconfig = path.join(outDir, "tsconfig.selected.json");
+	fs.writeFileSync(
+		selectedTsconfig,
+		`${JSON.stringify({
+			extends: path.join(root, "tsconfig.test.json"),
+			files: testFiles,
+			include: [
+				path.join(root, "packages/*/src/**/*.d.ts"),
+				path.join(root, "packages/*/test/**/*.d.ts"),
+				path.join(root, "test/**/*.d.ts"),
+			],
+		})}\n`,
+	);
+	run(tsc, ["-p", selectedTsconfig]);
 }
 
 const canonicalTempDir = fs.realpathSync(os.tmpdir());
@@ -59,7 +77,7 @@ run(process.execPath, [vitest, "run", ...testFiles], {
 });
 
 function testSelection() {
-	const base = process.env.PI_EXTENSIONS_TEST_BASE;
+	const base = process.env.PI_EXTENSIONS_AFFECTED_BASE || process.env.PI_EXTENSIONS_TEST_BASE;
 	if (!base) {
 		return {
 			mode: "full",

--- a/scripts/run-typechecks.mjs
+++ b/scripts/run-typechecks.mjs
@@ -3,22 +3,44 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { selectStagedTypechecks, stagedFiles } from "./select-staged-typechecks.mjs";
+import { changedFilesSince } from "./select-affected-tests.mjs";
+import {
+	selectAffectedTypechecks,
+	selectStagedTypechecks,
+	stagedFiles,
+} from "./select-staged-typechecks.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const stagedOnly = process.argv.slice(2).includes("--staged");
+const args = process.argv.slice(2);
+const stagedOnly = args.includes("--staged");
+const affectedOnly = args.includes("--affected");
 
-if (!stagedOnly) {
+if (!stagedOnly && !affectedOnly) {
 	runFullTypechecks();
 	process.exit(0);
 }
+if (stagedOnly && affectedOnly) {
+	console.error("Choose either --staged or --affected, not both.");
+	process.exit(2);
+}
 
 let selection;
+let selectionLabel;
 try {
-	selection = selectStagedTypechecks(root, stagedFiles(root));
+	if (affectedOnly) {
+		const base = process.env.PI_EXTENSIONS_AFFECTED_BASE;
+		if (!base) throw new Error("PI_EXTENSIONS_AFFECTED_BASE is not set");
+		selection = selectAffectedTypechecks(root, changedFilesSince(root, base));
+		selectionLabel = "affected";
+	} else {
+		selection = selectStagedTypechecks(root, stagedFiles(root));
+		selectionLabel = "staged";
+	}
 } catch (error) {
 	const message = error instanceof Error ? error.message : String(error);
-	console.warn(`Could not select staged typechecks (${message}); falling back to all workspaces.`);
+	console.warn(
+		`Could not select ${selectionLabel ?? "requested"} typechecks (${message}); falling back to all workspaces.`,
+	);
 	runFullTypechecks();
 	process.exit(0);
 }
@@ -34,7 +56,7 @@ if (selection.mode === "full") {
 }
 
 console.log(
-	`Running affected workspace typechecks for ${selection.workspaceDirectories.join(", ")}: ${selection.reason}.`,
+	`Running ${selectionLabel} workspace typechecks for ${selection.workspaceDirectories.join(", ")}: ${selection.reason}.`,
 );
 if (process.env.PI_EXTENSIONS_BUILD_READY !== "1" && selection.buildWorkspaceNames.length > 0) {
 	runWorkspaceScript("build", selection.buildWorkspaceNames, true);

--- a/scripts/select-staged-typechecks.mjs
+++ b/scripts/select-staged-typechecks.mjs
@@ -65,6 +65,10 @@ function gitPaths(root, args) {
 }
 
 export function selectStagedTypechecks(root, changedFiles) {
+	return selectAffectedTypechecks(root, changedFiles, "staged");
+}
+
+export function selectAffectedTypechecks(root, changedFiles, changeLabel = "changed") {
 	const workspaces = readWorkspaces(root);
 	const workspaceByDirectory = new Map(
 		workspaces.map((workspace) => [workspace.directoryName, workspace]),
@@ -75,7 +79,7 @@ export function selectStagedTypechecks(root, changedFiles) {
 	for (const changedFile of changedFiles) {
 		const normalized = changedFile.split(path.sep).join("/").replace(/^\.\//u, "");
 		if (!normalized || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
-			fullReason = `unsafe staged path: ${changedFile}`;
+			fullReason = `unsafe ${changeLabel} path: ${changedFile}`;
 			break;
 		}
 
@@ -94,13 +98,13 @@ export function selectStagedTypechecks(root, changedFiles) {
 		}
 
 		if (ROOT_FULL_TYPECHECK_FILES.has(normalized) || normalized.startsWith("scripts/")) {
-			fullReason = `shared typecheck input staged: ${normalized}`;
+			fullReason = `shared typecheck input ${changeLabel}: ${normalized}`;
 			break;
 		}
 
 		if (isIgnoredRootFile(normalized)) continue;
 		if (/\.(?:[cm]?[jt]sx?|json)$/u.test(normalized)) {
-			fullReason = `unscoped code or configuration staged: ${normalized}`;
+			fullReason = `unscoped code or configuration ${changeLabel}: ${normalized}`;
 			break;
 		}
 	}
@@ -114,7 +118,7 @@ export function selectStagedTypechecks(root, changedFiles) {
 			buildWorkspaceNames: [],
 			workspaceDirectories: [],
 			workspaceNames: [],
-			reason: "no typecheck-relevant files are staged",
+			reason: `no typecheck-relevant files ${changeLabel}`,
 		};
 	}
 
@@ -133,7 +137,7 @@ export function selectStagedTypechecks(root, changedFiles) {
 			.filter(({ name }) => affectedNames.has(name))
 			.map(({ directoryName }) => directoryName),
 		workspaceNames: orderDependenciesFirst(workspaces, affectedNames),
-		reason: `${directlyAffected.size} directly staged workspace(s), ${affectedNames.size} affected workspace(s)`,
+		reason: `${directlyAffected.size} directly ${changeLabel} workspace(s), ${affectedNames.size} affected workspace(s)`,
 	};
 }
 

--- a/test/check-test-separation.test.ts
+++ b/test/check-test-separation.test.ts
@@ -31,6 +31,17 @@ test("check and test remain separate CI gates", () => {
 	assert.ok(testIndex > checkIndex, "CI must run tests after checks");
 });
 
+test("pull requests scope checks and tests to their base revision", () => {
+	const ciWorkflow = read(".github/workflows/ci.yml");
+	assert.match(
+		ciWorkflow,
+		/PI_EXTENSIONS_AFFECTED_BASE: \$\{\{ github\.event\.pull_request\.base\.sha \|\| '' \}\}/u,
+	);
+	assert.match(ciWorkflow, /PI_EXTENSIONS_BUILD_READY: "1"/u);
+	assert.match(read("scripts/run-checks.mjs"), /PI_EXTENSIONS_AFFECTED_BASE/u);
+	assert.match(read("scripts/run-tests.mjs"), /PI_EXTENSIONS_AFFECTED_BASE/u);
+});
+
 test("publish releases only the revision from a successful main CI push", () => {
 	const publishWorkflow = read(".github/workflows/publish.yml");
 	assert.match(


### PR DESCRIPTION
## Summary

- Scope PR builds, Biome checks, typechecks, and tests to affected workspaces and reverse dependents.
- Reuse check-step build output and compile only selected test files.
- Fall back to the full repository gates for shared inputs, selection failures, main pushes, and manual runs.

## Verification

- `npm run check`
- `npm exec -- vitest run test/check-test-separation.test.ts test/affected-precommit-typechecks.test.ts` (11 tests passed)
- `PI_EXTENSIONS_AFFECTED_BASE=$(git rev-parse HEAD) npm run check`
- Affected TypeScript configuration smoke for root and `pi-ticker` tests
- `npm test` did not pass locally: 3,168 tests passed and 26 failed, primarily from 5-second Git integration timeouts plus one periodic-refresh assertion.

## Notes

- Reviewed against `docs/extension-conventions.md`.
- No changeset is required because this changes repository-only CI tooling.
