### PR TITLE
feat(btw): add manual fullscreen selection copying

### DIFF
--- a/.changeset/calm-owls-copy.md
+++ b/.changeset/calm-owls-copy.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": minor
+---
+
+Add configurable manual fullscreen selection copying through Pi's effective copy keybinding.

--- a/.changeset/calm-owls-copy.md
+++ b/.changeset/calm-owls-copy.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-btw": minor
 ---
 
-Add configurable manual fullscreen selection copying through Pi's effective copy keybinding.
+Add configurable manual fullscreen selection copying through Pi's effective copy keybinding, with paste-safe input and compatibility checks.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -74,7 +74,7 @@ When non-empty threads exist in memory, **Resume side thread** opens a bounded s
 Search matches the first question and question count while retaining each raw thread ID.
 Each row uses the first question as its fixed title and shows the question count.
 Rows are ordered by the newest recorded answer or visible error; opening and closing without a new result does not reorder them.
-**Settings** controls the starting thinking level and whether fixed-level shortcut changes are remembered.
+**Settings** controls the starting thinking level, fixed-level shortcut memory, and automatic selection copying.
 `/btw <question>` bypasses the manager and always starts a new thread.
 
 ### Use the side-thread workspace
@@ -88,9 +88,13 @@ Messages use Pi's normal user and assistant presentation without turn numbers or
 Type a question and press Enter for each turn.
 Previous successful questions and answers remain visible and available to the side model.
 
-Drag the primary mouse button across transcript text to request a copy through Pi's host clipboard helper.
-The view reports `Copied!` when Pi accepts the request and `Copy failed` when Pi rejects it.
+Drag the primary mouse button across transcript text to select it.
+Automatic selection copying is on by default and immediately requests a copy through Pi's host clipboard helper.
+When **Copy selection automatically** is off, the selection stays highlighted and Pi's effective `app.message.copy` binding copies it.
+The view reports `No selection to copy` when that binding is used without an active selection.
+It reports `Copied!` when Pi accepts a clipboard request and `Copy failed` when Pi rejects it.
 Actual clipboard access still depends on the operating system and terminal.
+Ctrl+C always cancels the side flow, even when `app.message.copy` is also mapped to Ctrl+C.
 
 Press `Ctrl+Shift+F` to search completed or in-progress transcript content.
 Press Enter or `Ctrl+G` for the next match, `Shift+Enter` or `Ctrl+Shift+G` for the previous match, and Escape to close search.
@@ -162,7 +166,8 @@ The normal location is `~/.pi/agent/pi-btw.json`.
 {
   "model": "anthropic/claude-sonnet-4-5",
   "thinkingLevel": "low",
-  "rememberThinkingLevelChanges": true
+  "rememberThinkingLevelChanges": true,
+  "fullscreenCopyOnSelect": true
 }
 ```
 
@@ -189,6 +194,10 @@ When a fixed thinking level is selected and remembering is on, the concrete leve
 When **Same as main thread** is selected, shortcut changes stay local even when remembering is on.
 If a shortcut write fails, the local change remains active and pi-btw warns that it was not remembered.
 A failed Settings-screen save instead restores the previous displayed value.
+
+`fullscreenCopyOnSelect` controls only pi-btw's dedicated fullscreen view and defaults to `true` when omitted.
+Turn **Copy selection automatically** off to retain highlighted selections and copy them with Pi's effective `app.message.copy` binding.
+Pi-btw does not inherit Pi core's setting of the same name because Pi's public extension API does not expose its effective value.
 
 Reading a missing settings file has no side effects.
 Pi-btw creates it only after a Settings change or a remembered shortcut change.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -91,6 +91,8 @@ Previous successful questions and answers remain visible and available to the si
 Drag the primary mouse button across transcript text to select it.
 Automatic selection copying is on by default and immediately requests a copy through Pi's host clipboard helper.
 When **Copy selection automatically** is off, the selection stays highlighted and Pi's effective `app.message.copy` binding copies it.
+Manual mode requires Pi's current fullscreen selection APIs.
+If those APIs are unavailable, pi-btw restores the main TUI and asks you to update Pi or re-enable automatic copying.
 The view reports `No selection to copy` when that binding is used without an active selection.
 It reports `Copied!` when Pi accepts a clipboard request and `Copy failed` when Pi rejects it.
 Actual clipboard access still depends on the operating system and terminal.

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -33,6 +33,7 @@ import {
 } from "./menu.js";
 import {
 	type BtwSettings,
+	effectiveFullscreenCopyOnSelect,
 	effectiveRememberThinkingLevelChanges,
 	parseBtwModelReference,
 	readBtwSettings,
@@ -193,7 +194,7 @@ export async function loadBtwThinkingLevel(
 
 	options.warn?.(
 		sanitizeSingleLine(
-			`pi-btw settings ignored: ${settings.reason}; expected optional model "provider/model-id", omitted thinkingLevel for Same as main thread or thinkingLevel "${BTW_THINKING_LEVELS.join('" | "')}", and boolean rememberThinkingLevelChanges. Using current Pi thinking level.`,
+			`pi-btw settings ignored: ${settings.reason}; expected optional model "provider/model-id", omitted thinkingLevel for Same as main thread or thinkingLevel "${BTW_THINKING_LEVELS.join('" | "')}", boolean rememberThinkingLevelChanges, and boolean fullscreenCopyOnSelect. Using current Pi thinking level.`,
 		),
 	);
 	return currentThinkingLevel;
@@ -314,31 +315,35 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 			const startingTurnCount = state?.thread.turns.length ?? 0;
 
 			try {
-				await runFullscreen(ctx, (fullscreenCtx) => {
-					if (!state) {
-						const createdAt = Date.now();
-						state = {
-							id: `btw-${nextThreadNumber}`,
-							thread: createSideThread(
-								selectedConversationContext ??
-									buildConversationContext(fullscreenCtx.sessionManager.getBranch()),
-							),
-							thinkingLevel: settings.thinkingLevel ?? pi.getThinkingLevel(),
-							createdAt,
-							updatedAt: createdAt,
-						};
-						nextThreadNumber += 1;
-					}
-					return runThread({
-						initialQuestion: question || undefined,
-						selected: resolution.selected,
-						thinkingLevel: state.thinkingLevel,
-						rememberThinkingLevelChanges:
-							!sameAsMainThinkingLevel && effectiveRememberThinkingLevelChanges(settings),
-						state,
-						ctx: fullscreenCtx,
-					});
-				});
+				await runFullscreen(
+					ctx,
+					(fullscreenCtx) => {
+						if (!state) {
+							const createdAt = Date.now();
+							state = {
+								id: `btw-${nextThreadNumber}`,
+								thread: createSideThread(
+									selectedConversationContext ??
+										buildConversationContext(fullscreenCtx.sessionManager.getBranch()),
+								),
+								thinkingLevel: settings.thinkingLevel ?? pi.getThinkingLevel(),
+								createdAt,
+								updatedAt: createdAt,
+							};
+							nextThreadNumber += 1;
+						}
+						return runThread({
+							initialQuestion: question || undefined,
+							selected: resolution.selected,
+							thinkingLevel: state.thinkingLevel,
+							rememberThinkingLevelChanges:
+								!sameAsMainThinkingLevel && effectiveRememberThinkingLevelChanges(settings),
+							state,
+							ctx: fullscreenCtx,
+						});
+					},
+					{ copyOnSelect: effectiveFullscreenCopyOnSelect(settings) },
+				);
 			} finally {
 				if (state?.title && state.thread.turns.length > 0) {
 					if (state.thread.turns.length > startingTurnCount) {

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -37,7 +37,16 @@ export interface BtwFullscreenLayoutComponent extends Component {
 	getFullscreenLayout(): Component;
 }
 
-export type BtwFullscreenTuiFactory = (parent: TUI, theme: Theme) => BtwFullscreenTui;
+export interface BtwFullscreenOptions {
+	copyOnSelect?: boolean;
+}
+
+export type BtwFullscreenTuiFactory = (
+	parent: TUI,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	options: BtwFullscreenOptions,
+) => BtwFullscreenTui;
 
 export interface BtwFullscreenDependencies {
 	createTui?: BtwFullscreenTuiFactory;
@@ -48,6 +57,7 @@ export interface BtwFullscreenDependencies {
 export type RunBtwFullscreen = <T>(
 	ctx: ExtensionCommandContext,
 	run: (ctx: ExtensionCommandContext) => Promise<T>,
+	options?: BtwFullscreenOptions,
 ) => Promise<T>;
 
 type FullscreenOutcome<T> = { kind: "completed"; value: T } | { kind: "failed"; error: unknown };
@@ -62,14 +72,22 @@ class FullscreenUiDisposedError extends Error {
 export async function runBtwFullscreen<T>(
 	ctx: ExtensionCommandContext,
 	run: (ctx: ExtensionCommandContext) => Promise<T>,
+	options: BtwFullscreenOptions = {},
 	dependencies: BtwFullscreenDependencies = {},
 ): Promise<T> {
 	const createTui =
 		dependencies.createTui ??
-		((parent: TUI, theme: Theme) =>
+		((
+			parent: TUI,
+			theme: Theme,
+			keybindings: KeybindingsManager,
+			fullscreenOptions: BtwFullscreenOptions,
+		) =>
 			createBtwFullscreenTui(
 				parent,
 				theme,
+				keybindings,
+				fullscreenOptions.copyOnSelect ?? true,
 				dependencies.openUrl ?? openUrlInBrowser,
 				dependencies.copyToClipboard ?? copyToHostClipboard,
 			));
@@ -94,6 +112,7 @@ export async function runBtwFullscreen<T>(
 					done(value);
 				},
 				createTui,
+				options,
 			);
 			return host;
 		},
@@ -169,25 +188,47 @@ class BtwTuiAltScreen extends TuiAltScreen {
 function createBtwFullscreenTui(
 	parent: TUI,
 	theme: Theme,
+	keybindings: KeybindingsManager,
+	copyOnSelect: boolean,
 	openUrl: (url: string) => void,
 	copyToClipboard: (text: string) => Promise<void>,
 ): BtwFullscreenTui {
 	const styleSearchMatch = (text: string) =>
 		theme.bg("searchMatchBg", theme.fg("searchMatchText", text));
-	return new BtwTuiAltScreen(parent.terminal, parent.getShowHardwareCursor(), undefined, {
-		mouse: true,
-		searchMatchStyle: (text) => theme.underline(styleSearchMatch(text)),
-		searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
-		openUrl,
-		copySelection: async (text) => {
-			try {
-				await copyToClipboard(text);
-				return true;
-			} catch {
-				return false;
-			}
+	const fullscreen = new BtwTuiAltScreen(
+		parent.terminal,
+		parent.getShowHardwareCursor(),
+		undefined,
+		{
+			mouse: true,
+			copyOnSelect,
+			searchMatchStyle: (text) => theme.underline(styleSearchMatch(text)),
+			searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
+			openUrl,
+			copySelection: async (text) => {
+				try {
+					await copyToClipboard(text);
+					return true;
+				} catch {
+					return false;
+				}
+			},
 		},
-	});
+	);
+	if (!copyOnSelect) {
+		fullscreen.addInputListener((data) => {
+			if (isKeyRelease(data) || !keybindings.matches(data, "app.message.copy")) {
+				return undefined;
+			}
+			if (!fullscreen.hasActiveSelection()) {
+				fullscreen.flash("No selection to copy");
+				return { consume: true };
+			}
+			void fullscreen.copyActiveSelectionToClipboard().catch(() => fullscreen.flash("Copy failed"));
+			return { consume: true };
+		});
+	}
+	return fullscreen;
 }
 
 // Pi does not export its browser opener, so mirror its shell-free launcher for this isolated TUI.
@@ -226,6 +267,7 @@ class BtwFullscreenHost<T> implements Component {
 		private readonly run: (ctx: ExtensionCommandContext) => Promise<T>,
 		private readonly done: (outcome: FullscreenOutcome<T>) => void,
 		private readonly createTui: BtwFullscreenTuiFactory,
+		private readonly options: BtwFullscreenOptions,
 	) {
 		queueMicrotask(() => void this.start());
 	}
@@ -255,7 +297,7 @@ class BtwFullscreenHost<T> implements Component {
 			this.parent.stop({ preserveScreen: true });
 			this.parentStopped = true;
 			if (this.disposed) throw new FullscreenUiDisposedError();
-			this.fullscreen = this.createTui(this.parent, this.theme);
+			this.fullscreen = this.createTui(this.parent, this.theme, this.keybindings, this.options);
 			this.fullscreenCreated = true;
 			this.fullscreen.start();
 			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -30,6 +30,7 @@ type BtwCustomFactory<T> = (
 type BtwFullscreenTui = TUI & {
 	flash?: (message: string, durationMs?: number) => void;
 	setLayoutRoot(component: Component | undefined): void;
+	addInputListenerBeforeAll?(listener: TuiInputListener): () => void;
 	addInputListenerBeforeViewport?(listener: TuiInputListener): () => void;
 };
 
@@ -135,6 +136,7 @@ export async function runBtwFullscreen<T>(
 }
 
 type BtwInputListeners = {
+	beforeAll: Set<TuiInputListener>;
 	beforeViewport: Set<TuiInputListener>;
 	regular: Set<TuiInputListener>;
 };
@@ -143,7 +145,7 @@ const btwInputListeners = new WeakMap<BtwTuiAltScreen, BtwInputListeners>();
 
 function dispatchBtwInput(listeners: BtwInputListeners, data: string): TuiInputListenerResult {
 	let current = data;
-	for (const group of [listeners.beforeViewport, listeners.regular]) {
+	for (const group of [listeners.beforeAll, listeners.beforeViewport, listeners.regular]) {
 		for (const listener of group) {
 			const result = listener(current);
 			if (result?.consume) return result;
@@ -162,6 +164,7 @@ class BtwTuiAltScreen extends TuiAltScreen {
 		let listeners = btwInputListeners.get(this);
 		if (!listeners) {
 			const registeredListeners: BtwInputListeners = {
+				beforeAll: new Set(),
 				beforeViewport: new Set(),
 				regular: new Set(),
 			};
@@ -171,6 +174,13 @@ class BtwTuiAltScreen extends TuiAltScreen {
 		}
 		listeners.regular.add(listener);
 		return () => listeners.regular.delete(listener);
+	}
+
+	addInputListenerBeforeAll(listener: TuiInputListener): () => void {
+		const listeners = btwInputListeners.get(this);
+		if (!listeners) return super.addInputListener(listener);
+		listeners.beforeAll.add(listener);
+		return () => listeners.beforeAll.delete(listener);
 	}
 
 	addInputListenerBeforeViewport(listener: TuiInputListener): () => void {
@@ -186,6 +196,7 @@ class BtwTuiAltScreen extends TuiAltScreen {
 			super.removeInputListener(listener);
 			return;
 		}
+		listeners.beforeAll.delete(listener);
 		listeners.beforeViewport.delete(listener);
 		listeners.regular.delete(listener);
 	}
@@ -239,7 +250,7 @@ function createBtwFullscreenTui(
 	);
 	if (!copyOnSelect) {
 		let isInBracketedPaste = false;
-		fullscreen.addInputListener((data) => {
+		fullscreen.addInputListenerBeforeViewport((data) => {
 			const wasInBracketedPaste = isInBracketedPaste;
 			const startsBracketedPaste = data.includes(BRACKETED_PASTE_START);
 			if (startsBracketedPaste) isInBracketedPaste = true;
@@ -337,6 +348,7 @@ class BtwFullscreenHost<T> implements Component {
 			this.fullscreen.start();
 			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.
 			const addHardCancelListener =
+				this.fullscreen.addInputListenerBeforeAll?.bind(this.fullscreen) ??
 				this.fullscreen.addInputListenerBeforeViewport?.bind(this.fullscreen) ??
 				this.fullscreen.addInputListener.bind(this.fullscreen);
 			this.removeHardCancelListener = addHardCancelListener((data) => {

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -52,6 +52,7 @@ export interface BtwFullscreenDependencies {
 	createTui?: BtwFullscreenTuiFactory;
 	openUrl?: (url: string) => void;
 	copyToClipboard?: (text: string) => Promise<void>;
+	manualSelectionCopySupported?: boolean;
 }
 
 export type RunBtwFullscreen = <T>(
@@ -88,6 +89,7 @@ export async function runBtwFullscreen<T>(
 				theme,
 				keybindings,
 				fullscreenOptions.copyOnSelect ?? true,
+				dependencies.manualSelectionCopySupported ?? hasManualSelectionCopyApi(),
 				dependencies.openUrl ?? openUrlInBrowser,
 				dependencies.copyToClipboard ?? copyToHostClipboard,
 			));
@@ -185,14 +187,30 @@ class BtwTuiAltScreen extends TuiAltScreen {
 	}
 }
 
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+
+function hasManualSelectionCopyApi(): boolean {
+	return (
+		typeof TuiAltScreen.prototype.hasActiveSelection === "function" &&
+		typeof TuiAltScreen.prototype.copyActiveSelectionToClipboard === "function"
+	);
+}
+
 function createBtwFullscreenTui(
 	parent: TUI,
 	theme: Theme,
 	keybindings: KeybindingsManager,
 	copyOnSelect: boolean,
+	manualSelectionCopySupported: boolean,
 	openUrl: (url: string) => void,
 	copyToClipboard: (text: string) => Promise<void>,
 ): BtwFullscreenTui {
+	if (!copyOnSelect && !manualSelectionCopySupported) {
+		throw new Error(
+			"Manual fullscreen selection copying is unavailable in this Pi version; update Pi or enable automatic selection copying.",
+		);
+	}
 	const styleSearchMatch = (text: string) =>
 		theme.bg("searchMatchBg", theme.fg("searchMatchText", text));
 	const fullscreen = new BtwTuiAltScreen(
@@ -216,8 +234,20 @@ function createBtwFullscreenTui(
 		},
 	);
 	if (!copyOnSelect) {
+		let isInBracketedPaste = false;
 		fullscreen.addInputListener((data) => {
-			if (isKeyRelease(data) || !keybindings.matches(data, "app.message.copy")) {
+			const wasInBracketedPaste = isInBracketedPaste;
+			const startsBracketedPaste = data.includes(BRACKETED_PASTE_START);
+			if (startsBracketedPaste) isInBracketedPaste = true;
+			if (isInBracketedPaste && data.includes(BRACKETED_PASTE_END)) {
+				isInBracketedPaste = false;
+			}
+			if (
+				wasInBracketedPaste ||
+				startsBracketedPaste ||
+				isKeyRelease(data) ||
+				!keybindings.matches(data, "app.message.copy")
+			) {
 				return undefined;
 			}
 			if (!fullscreen.hasActiveSelection()) {

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -154,6 +154,10 @@ function dispatchBtwInput(listeners: BtwInputListeners, data: string): TuiInputL
 }
 
 class BtwTuiAltScreen extends TuiAltScreen {
+	hasFocusedOverlay(): boolean {
+		return this.isOverlayFocused();
+	}
+
 	override addInputListener(listener: TuiInputListener): () => void {
 		let listeners = btwInputListeners.get(this);
 		if (!listeners) {
@@ -245,6 +249,7 @@ function createBtwFullscreenTui(
 			if (
 				wasInBracketedPaste ||
 				startsBracketedPaste ||
+				fullscreen.hasFocusedOverlay() ||
 				isKeyRelease(data) ||
 				!keybindings.matches(data, "app.message.copy")
 			) {

--- a/packages/pi-btw/src/menu.ts
+++ b/packages/pi-btw/src/menu.ts
@@ -9,6 +9,7 @@ import {
 	type BtwSettings,
 	type BtwSettingsPatch,
 	btwSettingsPath,
+	effectiveFullscreenCopyOnSelect,
 	effectiveRememberThinkingLevelChanges,
 	readBtwSettings,
 	type UpdateBtwSettingsOptions,
@@ -48,7 +49,13 @@ export type BtwCommandMenuResult =
 	| { kind: "resume"; threadId: string };
 
 type BtwMenuScreen = "main" | "resume" | "settings" | "invalid";
-type BtwMenuAction = "start" | "start-tree" | "resume" | "set-thinking" | "set-remember";
+type BtwMenuAction =
+	| "start"
+	| "start-tree"
+	| "resume"
+	| "set-thinking"
+	| "set-remember"
+	| "set-fullscreen-copy";
 const SAME_AS_MAIN_THREAD = "Same as main thread";
 type BtwCustomOptions = Parameters<ExtensionCommandContext["ui"]["custom"]>[1];
 
@@ -111,6 +118,7 @@ export async function showBtwCommandMenu(
 				title: "Pi BTW",
 				lines: [
 					`Thinking: ${displayThinkingSummary(state.settings)} · Remember changes: ${displayRememberSummary(state.settings)}`,
+					`Copy on select: ${effectiveFullscreenCopyOnSelect(state.settings) ? "On" : "Off"}`,
 				],
 				items: [
 					{
@@ -138,7 +146,7 @@ export async function showBtwCommandMenu(
 					{
 						id: "settings",
 						label: "Settings",
-						description: "Choose pi-btw thinking level and fixed-level shortcut memory",
+						description: "Choose thinking, shortcut memory, and selection copying",
 						to: state.kind === "invalid" ? "invalid" : "settings",
 					},
 				],
@@ -177,6 +185,15 @@ export async function showBtwCommandMenu(
 						currentValue: effectiveRememberThinkingLevelChanges(state.settings) ? "On" : "Off",
 						values: ["On", "Off"],
 						action: "set-remember",
+					},
+					{
+						id: "fullscreenCopyOnSelect",
+						label: "Copy selection automatically",
+						description:
+							"Copy mouse selections immediately instead of with the configured copy key.",
+						currentValue: effectiveFullscreenCopyOnSelect(state.settings) ? "On" : "Off",
+						values: ["On", "Off"],
+						action: "set-fullscreen-copy",
 					},
 				],
 			}),
@@ -234,6 +251,21 @@ export async function showBtwCommandMenu(
 					);
 					if (signal.aborted) return { kind: "rejected" };
 					notifySafely(ctx, `Remember thinking level changes: ${value}.`, "info");
+					return { kind: "stay" };
+				} catch (error) {
+					if (!signal.aborted) notifySaveFailure(ctx, error);
+					return { kind: "rejected" };
+				}
+			},
+			"set-fullscreen-copy": async ({ value, signal }) => {
+				if (value !== "On" && value !== "Off") return { kind: "rejected" };
+				try {
+					await updateSettings(
+						{ fullscreenCopyOnSelect: value === "On" },
+						{ settingsPath, signal },
+					);
+					if (signal.aborted) return { kind: "rejected" };
+					notifySafely(ctx, `Copy selection automatically: ${value}.`, "info");
 					return { kind: "stay" };
 				} catch (error) {
 					if (!signal.aborted) notifySaveFailure(ctx, error);

--- a/packages/pi-btw/src/settings.ts
+++ b/packages/pi-btw/src/settings.ts
@@ -6,6 +6,7 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { BTW_THINKING_LEVELS, type BtwThinkingLevel } from "./side-thread.js";
 
 export const BTW_SETTINGS_FILE = "pi-btw.json";
+export const DEFAULT_FULLSCREEN_COPY_ON_SELECT = true;
 export const DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES = true;
 const MAX_SETTINGS_BYTES = 64 * 1024;
 
@@ -13,6 +14,7 @@ export interface BtwSettings {
 	model?: string;
 	thinkingLevel?: BtwThinkingLevel;
 	rememberThinkingLevelChanges?: boolean;
+	fullscreenCopyOnSelect?: boolean;
 }
 
 export type BtwSettingsLoadResult =
@@ -23,6 +25,7 @@ export type BtwSettingsLoadResult =
 export interface BtwSettingsPatch {
 	thinkingLevel?: BtwThinkingLevel;
 	rememberThinkingLevelChanges?: boolean;
+	fullscreenCopyOnSelect?: boolean;
 }
 
 export interface UpdateBtwSettingsOptions {
@@ -58,6 +61,11 @@ export function normalizeBtwSettings(value: unknown): BtwSettings | undefined {
 		if (typeof remember !== "boolean") return undefined;
 		settings.rememberThinkingLevelChanges = remember;
 	}
+	if (Object.hasOwn(value, "fullscreenCopyOnSelect")) {
+		const copyOnSelect = Reflect.get(value, "fullscreenCopyOnSelect");
+		if (typeof copyOnSelect !== "boolean") return undefined;
+		settings.fullscreenCopyOnSelect = copyOnSelect;
+	}
 	return settings;
 }
 
@@ -68,6 +76,10 @@ export function parseBtwModelReference(
 	const separator = reference.indexOf("/");
 	if (separator <= 0 || separator === reference.length - 1) return undefined;
 	return { provider: reference.slice(0, separator), modelId: reference.slice(separator + 1) };
+}
+
+export function effectiveFullscreenCopyOnSelect(settings: BtwSettings): boolean {
+	return settings.fullscreenCopyOnSelect ?? DEFAULT_FULLSCREEN_COPY_ON_SELECT;
 }
 
 export function effectiveRememberThinkingLevelChanges(settings: BtwSettings): boolean {
@@ -232,6 +244,10 @@ function applyBtwSettingsPatch(
 	}
 	if (Object.hasOwn(patch, "rememberThinkingLevelChanges")) {
 		updated.rememberThinkingLevelChanges = patch.rememberThinkingLevelChanges;
+	}
+	if (Object.hasOwn(patch, "fullscreenCopyOnSelect")) {
+		if (patch.fullscreenCopyOnSelect === undefined) delete updated.fullscreenCopyOnSelect;
+		else updated.fullscreenCopyOnSelect = patch.fullscreenCopyOnSelect;
 	}
 	return updated;
 }

--- a/packages/pi-btw/test/btw.test.ts
+++ b/packages/pi-btw/test/btw.test.ts
@@ -348,6 +348,7 @@ test("btw command routes no arguments through the menu and preserves direct ques
 	};
 	const menuCalls: string[] = [];
 	let fullscreenRuns = 0;
+	const fullscreenCopyModes: Array<boolean | undefined> = [];
 	const threadStarts: Array<{
 		initialQuestion?: string;
 		thinkingLevel: string;
@@ -360,8 +361,9 @@ test("btw command routes no arguments through the menu and preserves direct ques
 		},
 		loadSettings: async () => ({ thinkingLevel: "medium" }),
 		resolveModel: async () => ({ kind: "selected", selected }),
-		runFullscreen: async (ctx, run) => {
+		runFullscreen: async (ctx, run, options) => {
 			fullscreenRuns += 1;
+			fullscreenCopyModes.push(options?.copyOnSelect);
 			return run(ctx);
 		},
 		runThread: async (options) => {
@@ -389,6 +391,7 @@ test("btw command routes no arguments through the menu and preserves direct ques
 
 	assert.deepEqual(menuCalls, ["menu"]);
 	assert.equal(fullscreenRuns, 2);
+	assert.deepEqual(fullscreenCopyModes, [true, true]);
 	assert.equal(idleWaits, 0);
 	assert.deepEqual(threadStarts, [
 		{
@@ -403,6 +406,36 @@ test("btw command routes no arguments through the menu and preserves direct ques
 		},
 	]);
 	assert.deepEqual(mock.thinkingLevels, []);
+});
+
+test("btw resolves automatic selection copying once from each invocation's loaded settings", async () => {
+	const mock = createMockPi();
+	const selected = {
+		model: { provider: "test", id: "side" } as Model<Api>,
+		auth: { apiKey: "key" },
+	};
+	const loaded = [{}, {}, { fullscreenCopyOnSelect: false }] as const;
+	const copyModes: Array<boolean | undefined> = [];
+	let settingsReads = 0;
+	btw(mock.pi, {
+		loadSettings: async () => loaded[settingsReads++] ?? {},
+		resolveModel: async () => ({ kind: "selected", selected }),
+		runFullscreen: async (ctx, run, options) => {
+			copyModes.push(options?.copyOnSelect);
+			return run(ctx);
+		},
+		runThread: async () => ({ kind: "closed" }),
+	});
+	const command = mock.commands.get("btw");
+	assert.ok(command);
+	const interactive = createMockContext({ mode: "tui", hasUI: true });
+
+	await command.handler("missing default", interactive.ctx);
+	await command.handler("omitted default", interactive.ctx);
+	await command.handler("manual override", interactive.ctx);
+
+	assert.equal(settingsReads, 3);
+	assert.deepEqual(copyModes, [true, true, false]);
 });
 
 test("btw same-as-main mode starts fresh threads from the current main level without remembering shortcut changes", async () => {
@@ -636,6 +669,7 @@ test("btw keeps multiple in-memory threads, resumes the selected one, and keeps 
 		updatedAt: number;
 	}> = [];
 	const initialQuestions: Array<string | undefined> = [];
+	const fullscreenCopyModes: Array<boolean | undefined> = [];
 	let modelResolutions = 0;
 	btw(mock.pi, {
 		showCommandMenu: (async (
@@ -651,7 +685,10 @@ test("btw keeps multiple in-memory threads, resumes the selected one, and keeps 
 			modelResolutions += 1;
 			return { kind: "selected", selected };
 		},
-		runFullscreen: async (ctx, run) => run(ctx),
+		runFullscreen: async (ctx, run, options) => {
+			fullscreenCopyModes.push(options?.copyOnSelect);
+			return run(ctx);
+		},
 		runThread: (async (options: {
 			initialQuestion?: string;
 			state: {
@@ -700,6 +737,7 @@ test("btw keeps multiple in-memory threads, resumes the selected one, and keeps 
 	assert.notEqual(states[2], states[0]);
 	assert.equal(states[2]?.thread.turns.length, 1);
 	assert.equal(modelResolutions, 3);
+	assert.deepEqual(fullscreenCopyModes, [true, true, true]);
 	assert.deepEqual(menuSnapshots, [
 		[],
 		[{ id: "btw-1", title: "First side topic", questionCount: 1 }],

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 import {
 	type Component,
 	Container,
@@ -27,9 +28,9 @@ const BTW_TEST_KEYBINDINGS = {
 	},
 } as const;
 
-function createBtwTestKeybindings(
-	copyBinding: "ctrl+c" | "ctrl+x" | "ctrl+y" = "ctrl+y",
-): KeybindingsManager {
+type BtwTestCopyBinding = "ctrl+c" | "ctrl+x" | "ctrl+y" | "x";
+
+function createBtwTestKeybindings(copyBinding: BtwTestCopyBinding = "ctrl+y"): KeybindingsManager {
 	return new KeybindingsManager(BTW_TEST_KEYBINDINGS, {
 		"app.message.copy": copyBinding,
 	});
@@ -38,6 +39,7 @@ function createBtwTestKeybindings(
 function inputForCopyBinding(keybindings: KeybindingsManager): string {
 	const [binding] = keybindings.getKeys("app.message.copy");
 	assert.ok(binding);
+	if (binding.length === 1) return binding;
 	assert.match(binding, /^ctrl\+[a-z]$/u);
 	return String.fromCharCode(binding.charCodeAt("ctrl+".length) & 31);
 }
@@ -347,7 +349,7 @@ async function startClipboardSelection(
 	copy: (text: string) => Promise<void>,
 	options: {
 		copyOnSelect?: boolean;
-		copyBinding?: "ctrl+c" | "ctrl+x" | "ctrl+y";
+		copyBinding?: BtwTestCopyBinding;
 		select?: boolean;
 		onInput?: (data: string) => void;
 	} = {},
@@ -654,6 +656,28 @@ test("manual fullscreen retains a selection and copies it through a non-default 
 	sideTui.renderNow(true);
 	assert.deepEqual(copied, ["copy me"]);
 	assert.equal(harness.writes.join("").includes("Copied!"), true);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
+test("manual fullscreen defers a printable copy binding while transcript search owns focus", async () => {
+	let copyCalls = 0;
+	const { harness, running, sideTui, closeSide, copyInput } = await startClipboardSelection(
+		async () => {
+			copyCalls += 1;
+		},
+		{ copyOnSelect: false, copyBinding: "x" },
+	);
+	const searchableTui = sideTui as TUI & { hasFocusedOverlay(): boolean };
+
+	harness.input("\u001b[102;6u");
+	assert.equal(searchableTui.hasFocusedOverlay(), true);
+	harness.writes.length = 0;
+	harness.input(copyInput);
+	await flushAsyncWork();
+	sideTui.renderNow(true);
+	assert.equal(copyCalls, 0);
+	assert.match(stripVTControlCharacters(harness.writes.join("")), />\s+x/u);
 	closeSide();
 	assert.equal(await running, "closed");
 });

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -28,7 +28,7 @@ const BTW_TEST_KEYBINDINGS = {
 	},
 } as const;
 
-type BtwTestCopyBinding = "ctrl+c" | "ctrl+x" | "ctrl+y" | "x";
+type BtwTestCopyBinding = "ctrl+c" | "ctrl+x" | "ctrl+y" | "pageUp" | "x";
 
 function createBtwTestKeybindings(copyBinding: BtwTestCopyBinding = "ctrl+y"): KeybindingsManager {
 	return new KeybindingsManager(BTW_TEST_KEYBINDINGS, {
@@ -39,6 +39,7 @@ function createBtwTestKeybindings(copyBinding: BtwTestCopyBinding = "ctrl+y"): K
 function inputForCopyBinding(keybindings: KeybindingsManager): string {
 	const [binding] = keybindings.getKeys("app.message.copy");
 	assert.ok(binding);
+	if (binding === "pageUp") return "\u001b[5~";
 	if (binding.length === 1) return binding;
 	assert.match(binding, /^ctrl\+[a-z]$/u);
 	return String.fromCharCode(binding.charCodeAt("ctrl+".length) & 31);
@@ -656,6 +657,22 @@ test("manual fullscreen retains a selection and copies it through a non-default 
 	sideTui.renderNow(true);
 	assert.deepEqual(copied, ["copy me"]);
 	assert.equal(harness.writes.join("").includes("Copied!"), true);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
+test("manual fullscreen prioritizes its copy binding over a conflicting viewport shortcut", async () => {
+	let copyCalls = 0;
+	const { harness, running, closeSide, copyInput } = await startClipboardSelection(
+		async () => {
+			copyCalls += 1;
+		},
+		{ copyOnSelect: false, copyBinding: "pageUp" },
+	);
+
+	harness.input(copyInput);
+	await flushAsyncWork();
+	assert.equal(copyCalls, 1);
 	closeSide();
 	assert.equal(await running, "closed");
 });

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -349,6 +349,7 @@ async function startClipboardSelection(
 		copyOnSelect?: boolean;
 		copyBinding?: "ctrl+c" | "ctrl+x" | "ctrl+y";
 		select?: boolean;
+		onInput?: (data: string) => void;
 	} = {},
 ) {
 	const copyBinding = options.copyBinding ?? "ctrl+y";
@@ -364,6 +365,7 @@ async function startClipboardSelection(
 				closeSide = () => done("closed");
 				return {
 					render: () => ["\u001b[31mcopy me\u001b[39m"],
+					handleInput: options.onInput,
 					invalidate() {},
 					dispose() {},
 				};
@@ -656,6 +658,32 @@ test("manual fullscreen retains a selection and copies it through a non-default 
 	assert.equal(await running, "closed");
 });
 
+test("manual fullscreen forwards split bracketed paste containing the copy binding", async () => {
+	let copyCalls = 0;
+	const receivedInput: string[] = [];
+	const { harness, running, closeSide, copyInput } = await startClipboardSelection(
+		async () => {
+			copyCalls += 1;
+		},
+		{
+			copyOnSelect: false,
+			copyBinding: "ctrl+x",
+			select: false,
+			onInput: (data) => receivedInput.push(data),
+		},
+	);
+
+	harness.input("\u001b[200~");
+	harness.input(copyInput);
+	harness.input("pasted");
+	harness.input("\u001b[201~");
+	await flushAsyncWork();
+	assert.equal(copyCalls, 0);
+	assert.deepEqual(receivedInput, ["\u001b[200~", copyInput, "pasted", "\u001b[201~"]);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
 test("manual fullscreen reports no selection without using another copy source", async () => {
 	let copyCalls = 0;
 	const { harness, running, sideTui, closeSide, copyInput } = await startClipboardSelection(
@@ -688,6 +716,25 @@ test("manual fullscreen contains clipboard failure and reports it", async () => 
 	assert.equal(harness.writes.join("").includes("Copy failed"), true);
 	closeSide();
 	assert.equal(await running, "closed");
+});
+
+test("manual fullscreen fails safely when Pi lacks manual selection APIs", async () => {
+	const harness = createNativeFullscreenHarness();
+	let runCalled = false;
+	await assert.rejects(
+		runBtwFullscreen(
+			harness.ctx,
+			async () => {
+				runCalled = true;
+				return "unused";
+			},
+			{ copyOnSelect: false },
+			{ manualSelectionCopySupported: false },
+		),
+		/update Pi or enable automatic selection copying/i,
+	);
+	assert.equal(runCalled, false);
+	assert.deepEqual(harness.events, ["parent.stop:true", "parent.start", "parent.renderNow:false"]);
 });
 
 test("manual fullscreen ignores a release event for the configured copy binding", async () => {

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -14,8 +14,32 @@ import {
 import { test } from "vitest";
 import { type BtwFullscreenTuiFactory, runBtwFullscreen } from "../src/fullscreen-ui.js";
 
+// Keep these tests together because selection, input priority, and cleanup share stateful harnesses.
 interface FakeComponent extends Component {
 	dispose(): void;
+}
+
+const BTW_TEST_KEYBINDINGS = {
+	...TUI_KEYBINDINGS,
+	"app.message.copy": {
+		defaultKeys: "ctrl+y",
+		description: "Copy the active fullscreen selection",
+	},
+} as const;
+
+function createBtwTestKeybindings(
+	copyBinding: "ctrl+c" | "ctrl+x" | "ctrl+y" = "ctrl+y",
+): KeybindingsManager {
+	return new KeybindingsManager(BTW_TEST_KEYBINDINGS, {
+		"app.message.copy": copyBinding,
+	});
+}
+
+function inputForCopyBinding(keybindings: KeybindingsManager): string {
+	const [binding] = keybindings.getKeys("app.message.copy");
+	assert.ok(binding);
+	assert.match(binding, /^ctrl\+[a-z]$/u);
+	return String.fromCharCode(binding.charCodeAt("ctrl+".length) & 31);
 }
 
 function createHarness(options: { fullscreenStopError?: Error; layoutMountError?: Error } = {}) {
@@ -184,7 +208,7 @@ class MainInput implements Component, Focusable {
 	invalidate(): void {}
 }
 
-function createInputHandoffHarness() {
+function createInputHandoffHarness(keybindings = createBtwTestKeybindings()) {
 	const terminal = new InputHandoffTerminal();
 	const parent = new TuiMainScreen(terminal, false);
 	const editorContainer = new Container();
@@ -228,7 +252,7 @@ function createInputHandoffHarness() {
 							inverse: (text: string) => text,
 							bold: (text: string) => text,
 						},
-						{},
+						keybindings,
 						done,
 					);
 					const overlay = parent.showOverlay(component);
@@ -243,7 +267,7 @@ function createInputHandoffHarness() {
 	return { ctx, mainInput, parent, terminal };
 }
 
-function createNativeFullscreenHarness() {
+function createNativeFullscreenHarness(keybindings = createBtwTestKeybindings()) {
 	const events: string[] = [];
 	const writes: string[] = [];
 	let handleInput: ((data: string) => void) | undefined;
@@ -294,7 +318,7 @@ function createNativeFullscreenHarness() {
 				outerComponent = factory(
 					parent as never,
 					theme as never,
-					{} as never,
+					keybindings as never,
 					((value: unknown) => outerDone?.(value)) as never,
 				);
 				return result;
@@ -319,8 +343,17 @@ function createNativeFullscreenHarness() {
 	};
 }
 
-async function startClipboardSelection(copy: (text: string) => Promise<void>) {
-	const harness = createNativeFullscreenHarness();
+async function startClipboardSelection(
+	copy: (text: string) => Promise<void>,
+	options: {
+		copyOnSelect?: boolean;
+		copyBinding?: "ctrl+c" | "ctrl+x" | "ctrl+y";
+		select?: boolean;
+	} = {},
+) {
+	const copyBinding = options.copyBinding ?? "ctrl+y";
+	const keybindings = createBtwTestKeybindings(copyBinding);
+	const harness = createNativeFullscreenHarness(keybindings);
 	let sideTui: TUI | undefined;
 	let closeSide: (() => void) | undefined;
 	const running = runBtwFullscreen(
@@ -335,6 +368,7 @@ async function startClipboardSelection(copy: (text: string) => Promise<void>) {
 					dispose() {},
 				};
 			}),
+		{ copyOnSelect: options.copyOnSelect },
 		{ copyToClipboard: copy },
 	);
 	await flushAsyncWork();
@@ -342,9 +376,17 @@ async function startClipboardSelection(copy: (text: string) => Promise<void>) {
 	assert.ok(closeSide);
 	sideTui.renderNow(true);
 	harness.writes.length = 0;
-	harness.input("\u001b[<0;1;1M");
-	harness.input("\u001b[<0;7;1m");
-	return { harness, running, sideTui, closeSide };
+	if (options.select !== false) {
+		harness.input("\u001b[<0;1;1M");
+		harness.input("\u001b[<0;7;1m");
+	}
+	return {
+		harness,
+		running,
+		sideTui,
+		closeSide,
+		copyInput: inputForCopyBinding(keybindings),
+	};
 }
 
 test("Ctrl+C hands input back without closing another parent overlay", async () => {
@@ -544,6 +586,20 @@ test("default fullscreen enables application-owned mouse selection and restores 
 	}
 });
 
+test("fullscreen also copies mouse selections when automatic copying is explicitly enabled", async () => {
+	const copied: string[] = [];
+	const { running, closeSide } = await startClipboardSelection(
+		async (text) => {
+			copied.push(text);
+		},
+		{ copyOnSelect: true },
+	);
+	await flushAsyncWork();
+	assert.deepEqual(copied, ["copy me"]);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
 test.each([
 	{
 		name: "successful host copy",
@@ -579,6 +635,126 @@ test.each([
 	assert.deepEqual(harness.events, ["parent.stop:true", "parent.start", "parent.renderNow:false"]);
 });
 
+test("manual fullscreen retains a selection and copies it through a non-default injected binding", async () => {
+	const copied: string[] = [];
+	const { harness, running, sideTui, closeSide, copyInput } = await startClipboardSelection(
+		async (text) => {
+			copied.push(text);
+		},
+		{ copyOnSelect: false, copyBinding: "ctrl+x" },
+	);
+	await flushAsyncWork();
+	assert.deepEqual(copied, []);
+	assert.equal((sideTui as TUI & { hasActiveSelection(): boolean }).hasActiveSelection(), true);
+
+	harness.input(copyInput);
+	await flushAsyncWork();
+	sideTui.renderNow(true);
+	assert.deepEqual(copied, ["copy me"]);
+	assert.equal(harness.writes.join("").includes("Copied!"), true);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
+test("manual fullscreen reports no selection without using another copy source", async () => {
+	let copyCalls = 0;
+	const { harness, running, sideTui, closeSide, copyInput } = await startClipboardSelection(
+		async () => {
+			copyCalls += 1;
+		},
+		{ copyOnSelect: false, copyBinding: "ctrl+x", select: false },
+	);
+
+	harness.input(copyInput);
+	await flushAsyncWork();
+	sideTui.renderNow(true);
+	assert.equal(copyCalls, 0);
+	assert.equal(harness.writes.join("").includes("No selection to copy"), true);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
+test("manual fullscreen contains clipboard failure and reports it", async () => {
+	const { harness, running, sideTui, closeSide, copyInput } = await startClipboardSelection(
+		async () => {
+			throw new Error("clipboard unavailable");
+		},
+		{ copyOnSelect: false },
+	);
+
+	harness.input(copyInput);
+	await flushAsyncWork();
+	sideTui.renderNow(true);
+	assert.equal(harness.writes.join("").includes("Copy failed"), true);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
+test("manual fullscreen ignores a release event for the configured copy binding", async () => {
+	let copyCalls = 0;
+	const { harness, running, closeSide, copyInput } = await startClipboardSelection(
+		async () => {
+			copyCalls += 1;
+		},
+		{ copyOnSelect: false, copyBinding: "ctrl+x" },
+	);
+
+	harness.input("\u001b[120;5:3u");
+	await flushAsyncWork();
+	assert.equal(copyCalls, 0);
+	harness.input(copyInput);
+	await flushAsyncWork();
+	assert.equal(copyCalls, 1);
+	closeSide();
+	assert.equal(await running, "closed");
+});
+
+test("Ctrl+C preempts a conflicting manual-copy binding and restores same-batch parent input", async () => {
+	const keybindings = createBtwTestKeybindings("ctrl+c");
+	const harness = createInputHandoffHarness(keybindings);
+	let sideTui: TUI | undefined;
+	let copyCalls = 0;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(ctx) =>
+			ctx.ui.custom<"closed">((tui, _theme, _keys, done) => {
+				sideTui = tui;
+				return {
+					focused: false,
+					render: () => ["copy me"],
+					handleInput(data: string) {
+						if (data === "\u0003") done("closed");
+					},
+					invalidate() {},
+				};
+			}),
+		{ copyOnSelect: false },
+		{
+			copyToClipboard: async () => {
+				copyCalls += 1;
+			},
+		},
+	);
+	try {
+		await flushAsyncWork();
+		assert.ok(sideTui);
+		sideTui.renderNow(true);
+		harness.terminal.send("\u001b[<0;1;1M");
+		harness.terminal.send("\u001b[<0;7;1m");
+		assert.equal((sideTui as TUI & { hasActiveSelection(): boolean }).hasActiveSelection(), true);
+
+		harness.terminal.send(inputForCopyBinding(keybindings));
+		harness.terminal.send("x");
+
+		assert.equal(await running, "closed");
+		assert.equal(copyCalls, 0);
+		assert.equal(harness.mainInput.text, "x");
+	} finally {
+		await running.catch(() => undefined);
+		harness.parent.stop();
+	}
+});
+
 test.each(["resolve", "reject"] as const)(
 	"a host clipboard promise may %s after close without blocking restoration or rejecting outward",
 	async (settlement) => {
@@ -594,7 +770,12 @@ test.each(["resolve", "reject"] as const)(
 		const onUnhandled = (error: unknown) => unhandled.push(error);
 		process.on("unhandledRejection", onUnhandled);
 		try {
-			const { harness, running, closeSide } = await startClipboardSelection(copy);
+			const { harness, running, closeSide, copyInput } = await startClipboardSelection(copy, {
+				copyOnSelect: false,
+			});
+			await flushAsyncWork();
+			assert.equal(Boolean(settleCopy), false);
+			harness.input(copyInput);
 			await flushAsyncWork();
 			assert.ok(settleCopy);
 			closeSide();
@@ -624,7 +805,12 @@ test("disposal restores the parent while a clipboard copy is pending and contain
 	const onUnhandled = (error: unknown) => unhandled.push(error);
 	process.on("unhandledRejection", onUnhandled);
 	try {
-		const { harness, running } = await startClipboardSelection(copy);
+		const { harness, running, copyInput } = await startClipboardSelection(copy, {
+			copyOnSelect: false,
+		});
+		await flushAsyncWork();
+		assert.equal(Boolean(rejectCopy), false);
+		harness.input(copyInput);
 		await flushAsyncWork();
 		assert.ok(rejectCopy);
 		assert.ok(harness.outerComponent);
@@ -704,6 +890,7 @@ test("default fullscreen activates OSC-8 links through the configured URL opener
 					dispose() {},
 				};
 			}),
+		{},
 		{ openUrl: (target: string) => opened.push(target) },
 	);
 	await flushAsyncWork();
@@ -733,6 +920,7 @@ test("dedicated fullscreen owns the terminal while side custom UI runs and resto
 				return immediateComponent(done, harness.events);
 			});
 		},
+		{},
 		{ createTui: harness.createTui },
 	);
 
@@ -769,6 +957,7 @@ test("dedicated fullscreen mounts only opt-in components as explicit viewport la
 					getFullscreenLayout: () => layoutRoot,
 				};
 			}),
+		{},
 		{ createTui: harness.createTui },
 	);
 	await flushAsyncWork();
@@ -798,6 +987,7 @@ test("a layout mount failure clears the root, disposes the component, and restor
 						invalidate() {},
 					}),
 				})),
+			{},
 			{ createTui: harness.createTui },
 		),
 		/layout mount failed/,
@@ -823,6 +1013,7 @@ test("dedicated fullscreen keeps ordinary custom components on the implicit docu
 					dispose() {},
 				};
 			}),
+		{},
 		{ createTui: harness.createTui },
 	);
 	await flushAsyncWork();
@@ -843,6 +1034,7 @@ test("dedicated fullscreen restores the parent before propagating a side-flow er
 			async () => {
 				throw new Error("side failed");
 			},
+			{},
 			{ createTui: harness.createTui },
 		),
 		/side failed/,
@@ -860,7 +1052,7 @@ test("dedicated fullscreen restores the parent before propagating a side-flow er
 test("a fullscreen stop failure still restarts the parent before it propagates", async () => {
 	const harness = createHarness({ fullscreenStopError: new Error("fullscreen stop failed") });
 	await assert.rejects(
-		runBtwFullscreen(harness.ctx, async () => "done", { createTui: harness.createTui }),
+		runBtwFullscreen(harness.ctx, async () => "done", {}, { createTui: harness.createTui }),
 		/fullscreen stop failed/,
 	);
 
@@ -890,6 +1082,7 @@ test("disposing the fullscreen host closes active side UI and restores terminal 
 					},
 				};
 			}),
+		{},
 		{ createTui: harness.createTui },
 	);
 	await Promise.resolve();
@@ -916,6 +1109,7 @@ test("disposal restores the parent and disposes a custom component whose factory
 						releaseFactory = resolve;
 					}),
 			),
+		{},
 		{ createTui: harness.createTui },
 	);
 	await Promise.resolve();
@@ -948,6 +1142,7 @@ test("done wins over a later asynchronous custom factory rejection", async () =>
 				done("completed result");
 				return Promise.reject(new Error("factory failed after done"));
 			}),
+		{},
 		{ createTui: harness.createTui },
 	);
 
@@ -970,6 +1165,7 @@ test("done restores the parent without waiting for an asynchronous custom factor
 					releaseFactory = resolve;
 				});
 			}),
+		{},
 		{ createTui: harness.createTui },
 	);
 	let observed: unknown = "pending";

--- a/packages/pi-btw/test/menu.test.ts
+++ b/packages/pi-btw/test/menu.test.ts
@@ -256,6 +256,7 @@ test("btw menu opens Pi-style thinking settings and cancellation is read-only", 
 		assert.match(settings, /Thinking level\s+Same as main thread/);
 		assert.match(settings, /Currently medium/);
 		assert.match(settings, /Remember thinking level changes\s+On/);
+		assert.match(settings, /Copy selection automatically\s+On/);
 		tui.press("ctrl+c");
 
 		assert.equal(await running, "closed");
@@ -333,6 +334,33 @@ test("btw settings save thinking and remembering immediately while preserving un
 	});
 });
 
+test("btw settings save automatic selection copying immediately and preserve unknown fields", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
+		await writeFile(settingsPath, '{"future":{"kept":true}}\n', "utf8");
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "medium",
+			availableThinkingLevels: ["off", "low", "medium", "high"],
+		});
+		await openSettings(tui);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		assert.match(tui.render().join("\n"), /Copy selection automatically\s+On/);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			future: { kept: true },
+			fullscreenCopyOnSelect: false,
+		});
+		assert.match(tui.render().join("\n"), /Copy selection automatically\s+Off/);
+		assert.ok(notifications.some(({ message }) => /automatically: Off/i.test(message)));
+		tui.press("ctrl+c");
+		assert.equal(await running, "closed");
+	});
+});
+
 test("btw settings reject failed saves and restore the prior displayed value", async () => {
 	await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
 		const running = showBtwCommandMenu(ctx, {
@@ -344,12 +372,14 @@ test("btw settings reject failed saves and restore the prior displayed value", a
 			},
 		});
 		await openSettings(tui);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		await tui.waitForOpen();
 		const narrow = tui.render(32);
 		assert.ok(narrow.every((line) => visibleWidth(line) <= 32));
-		assert.match(tui.render(80).join("\n"), /Thinking level\s+Same as main thread/);
+		assert.match(tui.render(80).join("\n"), /Copy selection automatically\s+On/);
 		const failureMessage = notifications[0]?.message ?? "";
 		assert.match(failureMessage, /previous value remains active.*disk full/i);
 		assert.equal(
@@ -425,6 +455,8 @@ test("disposing btw settings aborts and drains an in-flight save without notific
 			},
 		});
 		await openSettings(tui);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await saveStarted;
 		tui.dispose();

--- a/packages/pi-btw/test/settings.test.ts
+++ b/packages/pi-btw/test/settings.test.ts
@@ -5,7 +5,9 @@ import { join } from "node:path";
 import { test } from "vitest";
 import {
 	BTW_SETTINGS_FILE,
+	DEFAULT_FULLSCREEN_COPY_ON_SELECT,
 	DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES,
+	effectiveFullscreenCopyOnSelect,
 	effectiveRememberThinkingLevelChanges,
 	normalizeBtwSettings,
 	readBtwSettings,
@@ -21,23 +23,35 @@ async function withTempSettings(run: (settingsPath: string) => Promise<void>): P
 	}
 }
 
-test("btw settings default remembering on without materializing a missing file", async () => {
+test("btw settings defaults remain side-effect free when the file is missing", async () => {
 	await withTempSettings(async (settingsPath) => {
+		assert.equal(DEFAULT_FULLSCREEN_COPY_ON_SELECT, true);
 		assert.equal(DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES, true);
 		assert.deepEqual(await readBtwSettings(settingsPath), { kind: "missing" });
+		assert.equal(effectiveFullscreenCopyOnSelect({}), true);
 		assert.equal(effectiveRememberThinkingLevelChanges({}), true);
 		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
 	});
 });
 
-test("btw settings validate the optional remembered-change setting", () => {
-	assert.deepEqual(normalizeBtwSettings({ rememberThinkingLevelChanges: true }), {
-		rememberThinkingLevelChanges: true,
-	});
-	assert.deepEqual(normalizeBtwSettings({ rememberThinkingLevelChanges: false }), {
-		rememberThinkingLevelChanges: false,
-	});
+test("btw settings validate optional boolean settings", () => {
+	assert.deepEqual(
+		normalizeBtwSettings({
+			rememberThinkingLevelChanges: true,
+			fullscreenCopyOnSelect: false,
+		}),
+		{ rememberThinkingLevelChanges: true, fullscreenCopyOnSelect: false },
+	);
+	assert.deepEqual(
+		normalizeBtwSettings({
+			rememberThinkingLevelChanges: false,
+			fullscreenCopyOnSelect: true,
+		}),
+		{ rememberThinkingLevelChanges: false, fullscreenCopyOnSelect: true },
+	);
+	assert.equal(effectiveFullscreenCopyOnSelect({ fullscreenCopyOnSelect: false }), false);
 	assert.equal(normalizeBtwSettings({ rememberThinkingLevelChanges: "yes" }), undefined);
+	assert.equal(normalizeBtwSettings({ fullscreenCopyOnSelect: "no" }), undefined);
 });
 
 test("btw settings preserve omitted thinking levels for backward compatibility", async () => {
@@ -80,23 +94,43 @@ test("btw settings can clear thinking level while preserving other fields", asyn
 test("btw settings updates preserve unknown fields and create only on explicit save", async () => {
 	await withTempSettings(async (settingsPath) => {
 		await updateBtwSettings(
-			{ thinkingLevel: "low", rememberThinkingLevelChanges: true },
+			{
+				thinkingLevel: "low",
+				rememberThinkingLevelChanges: true,
+				fullscreenCopyOnSelect: false,
+			},
 			{ settingsPath },
 		);
 		const first = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
-		assert.deepEqual(first, { thinkingLevel: "low", rememberThinkingLevelChanges: true });
+		assert.deepEqual(first, {
+			thinkingLevel: "low",
+			rememberThinkingLevelChanges: true,
+			fullscreenCopyOnSelect: false,
+		});
 
-		await writeFile(settingsPath, '{"future":{"kept":true},"thinkingLevel":"low"}\n', "utf8");
+		await writeFile(
+			settingsPath,
+			'{"future":{"kept":true},"thinkingLevel":"low","fullscreenCopyOnSelect":false}\n',
+			"utf8",
+		);
 		await updateBtwSettings({ thinkingLevel: "high" }, { settingsPath });
 		const updated = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
-		assert.deepEqual(updated, { future: { kept: true }, thinkingLevel: "high" });
+		assert.deepEqual(updated, {
+			future: { kept: true },
+			thinkingLevel: "high",
+			fullscreenCopyOnSelect: false,
+		});
 	});
 });
 
 test("btw settings reject malformed or invalid documents without changing their bytes", async () => {
 	await withTempSettings(async (settingsPath) => {
 		await updateBtwSettings({ thinkingLevel: "low" }, { settingsPath });
-		for (const contents of ["{broken", '{"thinkingLevel":"huge"}\n']) {
+		for (const contents of [
+			"{broken",
+			'{"thinkingLevel":"huge"}\n',
+			'{"fullscreenCopyOnSelect":"yes"}\n',
+		]) {
 			await writeFile(settingsPath, contents, "utf8");
 			await assert.rejects(
 				updateBtwSettings({ thinkingLevel: "high" }, { settingsPath }),
@@ -223,13 +257,14 @@ test("btw settings serialize rapid updates in invocation order and recover after
 			},
 		);
 		const second = updateBtwSettings({ thinkingLevel: "medium" }, { settingsPath });
+		const third = updateBtwSettings({ fullscreenCopyOnSelect: false }, { settingsPath });
 		const coordinatedRead = readBtwSettings(settingsPath);
 		await firstReached;
 		releaseFirst();
-		await Promise.all([first, second]);
+		await Promise.all([first, second, third]);
 		assert.deepEqual(await coordinatedRead, {
 			kind: "loaded",
-			settings: { thinkingLevel: "medium" },
+			settings: { thinkingLevel: "medium", fullscreenCopyOnSelect: false },
 		});
 		assert.equal(
 			(JSON.parse(await readFile(settingsPath, "utf8")) as { thinkingLevel: string }).thinkingLevel,


### PR DESCRIPTION
## Summary

- add an extension-owned `fullscreenCopyOnSelect` setting that defaults to automatic copying
- retain fullscreen selections in manual mode and copy them through Pi's effective `app.message.copy` binding
- preserve `Ctrl+C` hard-cancel priority, bracketed-paste and focused-overlay input, clipboard feedback, settings safety, and terminal restoration
- prioritize configured copy actions over conflicting fullscreen viewport shortcuts
- fail safely and restore the parent TUI when the current Pi runtime lacks manual selection APIs
- document the behavior and add a minor `@narumitw/pi-btw` Changeset

Fixes #1107.

## Verification

- `npm --workspace @narumitw/pi-tui-kit run build`
- `npm --workspace @narumitw/pi-btw run check`
- focused Vitest suite: 10 files, 195 tests passed
- `npm run check`
- `npm test`: 330 files, 3,242 tests passed
- `npm exec changeset status --verbose`: minor `@narumitw/pi-btw` intent confirmed
- `just pack btw`: 15 files, including `dist/index.ts` and its source map
- `pi --no-extensions --no-skills -e ./packages/pi-btw --list-models`: loader smoke passed

## Notes

- Review hardening adds split bracketed-paste coverage where pasted input exactly matches the configured copy binding.
- A printable copy-binding regression proves transcript search receives input while its overlay owns focus without triggering clipboard work.
- A `PageUp` copy-binding regression proves the configured copy action runs before conflicting viewport shortcuts while the existing `Ctrl+C` conflict test preserves hard-cancel priority.
- Manual-mode capability failure is covered for parent restoration and prevents the side flow from starting on an incompatible Pi runtime.
- The Changesets status command also reports pre-existing dependency-floor advisories and unrelated pending Changesets from `main`.
- An interactive manual TUI smoke was not run in the non-interactive agent environment; deterministic fullscreen terminal harnesses cover mouse selection, paste input, focused overlays, custom and conflicting bindings, search/root cancellation, compatibility failure, late clipboard settlement, disposal, and same-batch input restoration.
