### PR TITLE
feat: honor terminal capability overrides

### DIFF
--- a/.changeset/honor-terminal-capabilities.md
+++ b/.changeset/honor-terminal-capabilities.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-github-pr": patch
+"@narumitw/pi-starship": patch
+"@narumitw/pi-statusline": patch
+---
+
+Honor Pi's effective terminal capabilities when rendering pull request hyperlinks and RGB footer colors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6244,9 +6244,13 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.5.11",
 				"@earendil-works/pi-coding-agent": "0.84.4",
+				"@earendil-works/pi-tui": "0.84.4",
 				"@types/node": "26.4.0",
 				"esbuild": "0.28.2",
 				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"packages/pi-goal": {

--- a/packages/pi-github-pr/README.md
+++ b/packages/pi-github-pr/README.md
@@ -26,6 +26,7 @@ PR #123: checks pending (5), commented, 12 comments
 PR #123: no checks, draft, no comments
 ```
 
+The pull request number is an OSC 8 link when Pi's effective terminal capabilities enable hyperlinks and plain text otherwise.
 The check wording follows GitHub's Checks terminology.
 The trailing comment count is the combined comments + reviews count.
 When rendered by `pi-statusline`, the `github-pr` icon comes from pi-statusline icon settings.

--- a/packages/pi-github-pr/package.json
+++ b/packages/pi-github-pr/package.json
@@ -13,6 +13,9 @@
 		"pull-request",
 		"gh"
 	],
+	"peerDependencies": {
+		"@earendil-works/pi-tui": "*"
+	},
 	"files": [
 		"src",
 		"dist",
@@ -34,6 +37,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.5.11",
 		"@earendil-works/pi-coding-agent": "0.84.4",
+		"@earendil-works/pi-tui": "0.84.4",
 		"@types/node": "26.4.0",
 		"typescript": "7.0.2",
 		"esbuild": "0.28.2"

--- a/packages/pi-github-pr/src/github-pr.ts
+++ b/packages/pi-github-pr/src/github-pr.ts
@@ -1,6 +1,7 @@
 import { type FSWatcher, watch } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 import type { ExecResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getCapabilities } from "@earendil-works/pi-tui";
 
 export type ReviewDecision = "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "UNKNOWN";
 export type CheckState = "pass" | "fail" | "pending" | "none";
@@ -579,7 +580,7 @@ function clearExpiryTimer(branchWatch: BranchWatchState) {
 
 export function formatLinkedStatus(status: PullRequestStatus): string {
 	const text = formatCompactStatus(status);
-	if (!status.url) return text;
+	if (!status.url || !getCapabilities().hyperlinks) return text;
 	const label = `#${status.number}`;
 	return text.replace(label, osc8Link(status.url, label));
 }

--- a/packages/pi-github-pr/test/github-pr.test.ts
+++ b/packages/pi-github-pr/test/github-pr.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExecResult } from "@earendil-works/pi-coding-agent";
-import { afterAll, test, vi } from "vitest";
+import { getCapabilities, setCapabilities } from "@earendil-works/pi-tui";
+import { afterAll, beforeEach, test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import githubPr, {
 	formatCompactStatus,
@@ -19,8 +20,13 @@ type ExecCall = { command: string; args: string[]; options?: ExecOptions };
 type ExecFunction = (command: string, args: string[], options?: ExecOptions) => Promise<ExecResult>;
 
 const ambientGhHost = process.env.GH_HOST;
+const ambientCapabilities = getCapabilities();
 delete process.env.GH_HOST;
+beforeEach(() => {
+	setCapabilities({ ...ambientCapabilities, hyperlinks: true });
+});
 afterAll(() => {
+	setCapabilities(ambientCapabilities);
 	if (ambientGhHost !== undefined) process.env.GH_HOST = ambientGhHost;
 });
 
@@ -105,6 +111,15 @@ test("formatLinkedStatus falls back to plain text when the PR url is missing", (
 
 	assert.equal(status.url, "");
 	assert.equal(formatLinkedStatus(status), formatCompactStatus(status));
+});
+
+test("formatLinkedStatus honors disabled effective hyperlink capability", () => {
+	setCapabilities({ ...ambientCapabilities, hyperlinks: false });
+	const status = normalizeGhPrView(samplePr);
+	const rendered = formatLinkedStatus(status);
+
+	assert.equal(rendered, "PR #123: checks failing (1), approved, 5 comments");
+	assert.equal(rendered.includes("\u001b]8;;"), false);
 });
 
 test("formatLinkedStatus rejects invalid and non-http PR urls", () => {

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -251,7 +251,7 @@ Module output keeps its own style when embedded in an outer styled group.
 Style expressions support:
 
 - Named colors and ANSI numbers `0`–`255`.
-- Hex RGB (`#7aa2f7`).
+- Hex RGB (`#7aa2f7`), rendered as ANSI-256 when Pi's effective terminal capabilities disable true color.
 - `fg:<color>` and `bg:<color>`; an unprefixed color is foreground.
 - `bold`, `dimmed`, `italic`, `underline`, `blink`, `inverted`, `hidden`, and `strikethrough`.
 - `none` and `fg:none`, which make the complete expression unstyled regardless of position.
@@ -521,7 +521,7 @@ It never mutates Pi's environment, calls the GitHub API directly, or manages tok
 Variables have these values:
 
 - `$number`: digits such as `123`.
-- `$link`: an OSC 8 `#123` link for a safe HTTP(S) URL, otherwise plain `#123`.
+- `$link`: an OSC 8 `#123` link for a safe HTTP(S) URL when Pi's effective terminal capabilities enable hyperlinks, otherwise plain `#123`.
 - `$state`: `open`, `draft`, `merged`, or `closed`.
 - `$checks`: all non-zero check counts in passed, failed, pending order, or `-` when no checks exist.
 - `$review`: `R✓` for approved, `R×` for changes requested, `R?` for review required, or empty when unknown.

--- a/packages/pi-starship/src/format/style.ts
+++ b/packages/pi-starship/src/format/style.ts
@@ -208,7 +208,7 @@ interface ResolvedStyle
 	background?: ColorSpec;
 }
 
-export function renderChunksToAnsi(chunks: readonly LayoutChunk[]): string {
+export function renderChunksToAnsi(chunks: readonly LayoutChunk[], trueColor = true): string {
 	const runs: Array<{ text: string; style: ResolvedStyle }> = [];
 	let previous: ResolvedStyle | undefined;
 	for (const chunk of chunks) {
@@ -221,7 +221,7 @@ export function renderChunksToAnsi(chunks: readonly LayoutChunk[]): string {
 	}
 	return runs
 		.map(({ text, style }) => {
-			const codes = ansiCodes(style);
+			const codes = ansiCodes(style, trueColor);
 			return codes.length > 0 ? `\u001b[${codes.join(";")}m${text}\u001b[0m` : text;
 		})
 		.join("");
@@ -253,10 +253,10 @@ function resolveColor(
 	return source === "foreground" ? previous.foreground : previous.background;
 }
 
-function ansiCodes(style: ResolvedStyle): string[] {
+function ansiCodes(style: ResolvedStyle, trueColor: boolean): string[] {
 	const codes: string[] = [];
-	if (style.foreground) codes.push(...colorCodes(style.foreground, false));
-	if (style.background) codes.push(...colorCodes(style.background, true));
+	if (style.foreground) codes.push(...colorCodes(style.foreground, false, trueColor));
+	if (style.background) codes.push(...colorCodes(style.background, true, trueColor));
 	if (style.bold) codes.push("1");
 	if (style.dimmed) codes.push("2");
 	if (style.italic) codes.push("3");
@@ -268,11 +268,19 @@ function ansiCodes(style: ResolvedStyle): string[] {
 	return codes;
 }
 
-function colorCodes(color: ColorSpec, background: boolean): string[] {
+function colorCodes(color: ColorSpec, background: boolean, trueColor: boolean): string[] {
 	if (color.kind === "named") {
 		const foreground = FOREGROUND_CODES[color.name];
 		return [`${background ? foreground + 10 : foreground}`];
 	}
 	if (color.kind === "fixed") return [background ? "48" : "38", "5", `${color.value}`];
+	if (!trueColor) {
+		return [background ? "48" : "38", "5", `${rgbToAnsi256(color.red, color.green, color.blue)}`];
+	}
 	return [background ? "48" : "38", "2", `${color.red}`, `${color.green}`, `${color.blue}`];
+}
+
+function rgbToAnsi256(red: number, green: number, blue: number): number {
+	const channels = [red, green, blue].map((value) => Math.round((value / 255) * 5));
+	return 16 + 36 * (channels[0] ?? 0) + 6 * (channels[1] ?? 0) + (channels[2] ?? 0);
 }

--- a/packages/pi-starship/src/modules/render.ts
+++ b/packages/pi-starship/src/modules/render.ts
@@ -14,6 +14,7 @@ export function renderStatusline(
 	config: StarshipConfig,
 	runtime: StarshipRuntimeSnapshot,
 	width = 80,
+	trueColor = true,
 ): RenderedStatusline<ModuleName> {
 	const palette = activePalette(config);
 	const modules = {} as Record<ModuleName, StyledChunk[]>;
@@ -61,7 +62,7 @@ export function renderStatusline(
 	const layout = renderFormat(config.formatAst, { variables: rootVariables, palette });
 	const chunks = resolveFillLayout(layout, width);
 	return {
-		ansi: renderChunksToAnsi(chunks),
+		ansi: renderChunksToAnsi(chunks, trueColor),
 		chunks,
 		modules,
 	};

--- a/packages/pi-starship/src/pi-starship.ts
+++ b/packages/pi-starship/src/pi-starship.ts
@@ -5,7 +5,7 @@ import {
 	getAgentDir,
 	type ReadonlyFooterDataProvider,
 } from "@earendil-works/pi-coding-agent";
-import { wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { getCapabilities, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { completeStarshipArguments } from "./command-contract.js";
 import type { StarshipCommandOptions } from "./commands.js";
 import {
@@ -282,7 +282,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 			runtime.renderPreview = (preview, width) => {
 				const snapshot = runtimeSnapshot(ctx, footerData, runtime);
 				return wrapFormattedStatusline(
-					renderStatusline(preview.config, snapshot, width).ansi,
+					renderStatusline(preview.config, snapshot, width, getCapabilities().trueColor).ansi,
 					width,
 				);
 			};
@@ -337,7 +337,7 @@ export default function piStarship(pi: ExtensionAPI, options: PiStarshipOptions 
 					if (!current) return [];
 					const snapshot = runtimeSnapshot(ctx, footerData, runtime);
 					return wrapFormattedStatusline(
-						renderStatusline(current.config, snapshot, width).ansi,
+						renderStatusline(current.config, snapshot, width, getCapabilities().trueColor).ansi,
 						width,
 					);
 				},

--- a/packages/pi-starship/src/runtime/github-pr.ts
+++ b/packages/pi-starship/src/runtime/github-pr.ts
@@ -1,3 +1,4 @@
+import { getCapabilities } from "@earendil-works/pi-tui";
 import type { GithubPrSnapshot, GithubPrState } from "../modules/types.js";
 import type { WorkspaceExec } from "./types.js";
 
@@ -219,7 +220,7 @@ function compactStatus(
 }
 
 function osc8Link(value: string, label: string): string {
-	if (hasTerminalControls(value)) return label;
+	if (!getCapabilities().hyperlinks || hasTerminalControls(value)) return label;
 	try {
 		const url = new URL(value);
 		if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password) {

--- a/packages/pi-starship/test/formatter.test.ts
+++ b/packages/pi-starship/test/formatter.test.ts
@@ -94,6 +94,18 @@ test("styles support named, ANSI, RGB, modifiers, none, and palettes", () => {
 	assert.ok(render("[x](bold fg:red bg:none)").includes("\u001b[31;1mx"));
 });
 
+test("RGB styles fall back to ANSI-256 when true color is disabled", () => {
+	const output = renderChunksToAnsi(
+		renderFormat(parseFormat("[status](fg:#010203 bg:#a3aed2 bold)"), { variables: {} }),
+		false,
+	);
+
+	assert.equal(output.includes("38;2"), false);
+	assert.equal(output.includes("48;2"), false);
+	assert.ok(output.includes("\u001b[38;5;16;48;5;146;1mstatus"));
+	assert.equal(stripAnsi(output), "status");
+});
+
 test("none and fg:none override the complete style expression", () => {
 	for (const style of [
 		"none fg:red bg:green bold",

--- a/packages/pi-starship/test/github-pr.test.ts
+++ b/packages/pi-starship/test/github-pr.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { getCapabilities, setCapabilities } from "@earendil-works/pi-tui";
+import { afterAll, beforeEach, test } from "vitest";
 import { BUILT_IN_CONFIG } from "../src/config.js";
 import { parseFormat } from "../src/format/formatter.js";
 import { githubPrModule } from "../src/modules/github-pr.js";
@@ -15,6 +16,15 @@ import type { WorkspaceExec, WorkspaceExecResult } from "../src/runtime/workspac
 
 const NOW = Date.parse("2026-08-01T12:00:00.000Z");
 const GH_FIELDS = "number,isDraft,url,state,closedAt,mergedAt,reviewDecision,statusCheckRollup";
+const ambientCapabilities = getCapabilities();
+
+beforeEach(() => {
+	setCapabilities({ ...ambientCapabilities, hyperlinks: true });
+});
+
+afterAll(() => {
+	setCapabilities(ambientCapabilities);
+});
 
 function rawPr(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	return {
@@ -222,6 +232,14 @@ test("github_pr creates terminal-safe GitHub Enterprise links and falls back to 
 		const snapshot = buildGithubPrSnapshot(rawPr({ url }), NOW);
 		assert.equal(snapshot?.link, "#123");
 	}
+});
+
+test("github_pr honors disabled effective hyperlink capability", () => {
+	setCapabilities({ ...ambientCapabilities, hyperlinks: false });
+	const snapshot = buildGithubPrSnapshot(rawPr(), NOW);
+
+	assert.equal(snapshot?.link, "#123");
+	assert.equal(snapshot?.link.includes("\u001b]8;;"), false);
 });
 
 test("gh invocation is direct on POSIX and Windows and strips repository overrides", () => {

--- a/packages/pi-starship/test/lifecycle.test.ts
+++ b/packages/pi-starship/test/lifecycle.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { getCapabilities, setCapabilities, visibleWidth } from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { afterAll, test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
@@ -103,6 +103,38 @@ test("non-TUI sessions install no footer and execute no Git or GitHub subprocess
 	await emit(mock.events, "tool_execution_end", { toolName: "read" }, context.ctx);
 	assert.equal(context.footer, undefined);
 	assert.equal(calls, 0);
+});
+
+test("the footer honors the effective true-color capability", async (t) => {
+	useLifecycleConfig(t, 'format = "[status](fg:#010203 bg:#a3aed2)"\n');
+	const previousCapabilities = getCapabilities();
+	setCapabilities({ ...previousCapabilities, trueColor: false });
+	const mock = createMockPi();
+	piStarship(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	let footer: ReturnType<FooterFactory> | undefined;
+
+	try {
+		await emit(mock.events, "session_start", {}, context.ctx);
+		const footerData = {
+			getGitBranch: () => null,
+			getExtensionStatuses: () => new Map<string, string>(),
+			onBranchChange: () => () => undefined,
+		};
+		footer = (context.footer as FooterFactory)({ requestRender() {} }, {}, footerData);
+		const rendered = footer.render(80).join("\n");
+		assert.equal(rendered.includes("\u001b[38;2;"), false);
+		assert.equal(rendered.includes("\u001b[48;2;"), false);
+		assert.equal(rendered.includes("\u001b[38;5;") || rendered.includes("\u001b[48;5;"), true);
+		assert.equal(stripAnsi(rendered), "status");
+	} finally {
+		footer?.dispose();
+		try {
+			await emit(mock.events, "session_shutdown", {}, context.ctx);
+		} finally {
+			setCapabilities(previousCapabilities);
+		}
+	}
 });
 
 test("UI prompt waiting state restores activity and rejects stale session events", async (t) => {

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -17,6 +17,7 @@ A representative uncolored layout:
 - Shows when Pi is waiting for an extension UI prompt, streaming, or running tools.
 - Adds optional token, prompt-cache, provider usage, and cost details.
 - Offers three information levels, seven previewable palettes, and advanced custom layouts.
+- Uses ANSI-256 palette colors when Pi's effective terminal capabilities disable true color.
 - Loads a generated split runtime to reduce Pi package startup work.
 
 > **Need more customization?**
@@ -126,7 +127,7 @@ If the last remaining segment is itself wider than the row, that row renders emp
 - Clean repositories show no Git counters.
 - Dirty counters are `⇡` ahead, `⇣` behind, `+` staged, `~` modified/deleted, `?` untracked, and `!`
   conflicts.
-- A linked GitHub PR appears with the branch when possible, avoiding a duplicate extension status.
+- A linked or plain GitHub PR reference appears with the branch when possible, avoiding a duplicate extension status.
 - Context color changes to warning at 70% and error at 90%.
 - Git state is cached outside footer rendering and stale session results are ignored.
 
@@ -225,6 +226,7 @@ When `palettePreset` is `custom`, `palette` maps segment names to foreground/bac
 - Legacy string palettes such as `"palette": "ocean"` remain accepted.
 - Missing custom colors remain unstyled instead of inheriting Tokyo Night.
 - Adjacent segments with identical colors share one block; transitions use ``.
+- Hex palette colors render as ANSI-256 when Pi's effective terminal capabilities disable true color.
 
 `segmentText` values must be single-line text without terminal control characters.
 Use `line_break` for another row rather than inserting a newline into a prefix or suffix.

--- a/packages/pi-statusline/src/ansi.ts
+++ b/packages/pi-statusline/src/ansi.ts
@@ -1,19 +1,30 @@
-export function ansiStyle(text: string, colors: { fg?: string; bg?: string }): string {
+export function ansiStyle(
+	text: string,
+	colors: { fg?: string; bg?: string },
+	trueColor = true,
+): string {
 	const codes = [
-		colors.fg ? truecolorCode("38", colors.fg) : undefined,
-		colors.bg ? truecolorCode("48", colors.bg) : undefined,
+		colors.fg ? colorCode("38", colors.fg, trueColor) : undefined,
+		colors.bg ? colorCode("48", colors.bg, trueColor) : undefined,
 	].filter((code): code is string => code !== undefined);
 	if (codes.length === 0) return text;
 	return `\u001b[${codes.join(";")}m${text}\u001b[0m`;
 }
 
-export function ansiFg(hex: string, text: string): string {
-	return ansiStyle(text, { fg: hex });
+export function ansiFg(hex: string, text: string, trueColor = true): string {
+	return ansiStyle(text, { fg: hex }, trueColor);
 }
 
-function truecolorCode(prefix: "38" | "48", hex: string): string {
+function colorCode(prefix: "38" | "48", hex: string, trueColor: boolean): string {
 	const { red, green, blue } = hexToRgb(hex);
-	return `${prefix};2;${red};${green};${blue}`;
+	return trueColor
+		? `${prefix};2;${red};${green};${blue}`
+		: `${prefix};5;${rgbToAnsi256(red, green, blue)}`;
+}
+
+function rgbToAnsi256(red: number, green: number, blue: number): number {
+	const channels = [red, green, blue].map((value) => Math.round((value / 255) * 5));
+	return 16 + 36 * (channels[0] ?? 0) + 6 * (channels[1] ?? 0) + (channels[2] ?? 0);
 }
 
 function hexToRgb(hex: string): { red: number; green: number; blue: number } {

--- a/packages/pi-statusline/src/extension-status.ts
+++ b/packages/pi-statusline/src/extension-status.ts
@@ -20,8 +20,12 @@ const COMPATIBLE_STATUS_ICON_KEYS: Readonly<Record<string, string>> = {
 	pisync: "sync",
 };
 const EMPTY_EXTENSION_STATUS_ICON_ALIASES: ExtensionStatusIconAliasMap = new Map();
-function extensionStatusSeparator(config: StatuslineConfig, theme: Theme): string {
-	return powerlineExtensionSeparator(theme, config.palettePreset);
+function extensionStatusSeparator(
+	config: StatuslineConfig,
+	theme: Theme,
+	trueColor: boolean,
+): string {
+	return powerlineExtensionSeparator(theme, config.palettePreset, trueColor);
 }
 
 export function formatExtensionStatuses(
@@ -30,8 +34,9 @@ export function formatExtensionStatuses(
 	config: StatuslineConfig,
 	runtime: ExtensionStatusRuntime,
 	hiddenKeys: ReadonlySet<string> = new Set(),
+	trueColor = true,
 ): string {
-	const separator = extensionStatusSeparator(config, theme);
+	const separator = extensionStatusSeparator(config, theme, trueColor);
 	const visibleStatuses = [
 		...formatDuplicateExtensionStatus(runtime, theme),
 		...[...statuses.entries()]

--- a/packages/pi-statusline/src/powerline.ts
+++ b/packages/pi-statusline/src/powerline.ts
@@ -24,10 +24,11 @@ export function renderPowerlineStatusline(
 	width: number,
 	items: RenderItem[],
 	config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,
+	trueColor = true,
 ): string {
 	if (items.length === 0 || width <= 0) return "";
 	return splitLines(items)
-		.map((segments) => fitPowerlineSegments(segments, width, config))
+		.map((segments) => fitPowerlineSegments(segments, width, config, trueColor))
 		.join("\n");
 }
 
@@ -60,11 +61,12 @@ function fitPowerlineSegments(
 	segments: readonly RenderSegment[],
 	width: number,
 	config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,
+	trueColor: boolean,
 ): string {
 	if (segments.length === 0) return "";
 	const fitted = [...segments];
 	while (fitted.length > 1) {
-		const rendered = joinPowerlineSegments(fitted, config);
+		const rendered = joinPowerlineSegments(fitted, config, trueColor);
 		if (visibleWidth(rendered) <= width) return rendered;
 		let removalIndex = 0;
 		for (let index = 1; index < fitted.length; index += 1) {
@@ -80,33 +82,37 @@ function fitPowerlineSegments(
 		}
 		fitted.splice(removalIndex, 1);
 	}
-	const rendered = joinPowerlineSegments(fitted, config);
+	const rendered = joinPowerlineSegments(fitted, config, trueColor);
 	return visibleWidth(rendered) <= width ? rendered : "";
 }
 
 export function powerlineExtensionSeparator(
 	_theme: Theme,
 	palettePreset: PalettePreset = "tokyo-night",
+	trueColor = true,
 ): string {
-	return ansiStyle(" • ", { fg: resolvePreset(palettePreset).extensionSeparator });
+	return ansiStyle(" • ", { fg: resolvePreset(palettePreset).extensionSeparator }, trueColor);
 }
 
 function joinPowerlineSegments(
 	segments: RenderSegment[],
 	config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,
+	trueColor: boolean,
 ): string {
 	const preset = resolvePreset(config.palettePreset);
 	const blocks = contiguousBlocks(segments, preset, config.palettePreset, config.palette);
-	let line = ansiStyle("░▒▓", { fg: preset.lead });
+	let line = ansiStyle("░▒▓", { fg: preset.lead }, trueColor);
 
 	for (const [index, block] of blocks.entries()) {
 		const previous = index === 0 ? undefined : blocks[index - 1]?.colors;
-		if (previous) line += ansiStyle("", { fg: previous.bg, bg: block.colors.bg });
-		line += ansiStyle(formatBlockText(block, config), block.colors);
+		if (previous) {
+			line += ansiStyle("", { fg: previous.bg, bg: block.colors.bg }, trueColor);
+		}
+		line += ansiStyle(formatBlockText(block, config), block.colors, trueColor);
 	}
 
 	const lastBlock = blocks.at(-1);
-	if (lastBlock) line += ansiStyle("", { fg: lastBlock.colors.bg });
+	if (lastBlock) line += ansiStyle("", { fg: lastBlock.colors.bg }, trueColor);
 	return line;
 }
 

--- a/packages/pi-statusline/src/render.ts
+++ b/packages/pi-statusline/src/render.ts
@@ -47,6 +47,7 @@ export function renderStatusline(
 	_theme: Theme,
 	config: StatuslineConfig,
 	runtime: RuntimeState,
+	trueColor = true,
 ): string {
 	if (width <= 0) return "";
 
@@ -76,7 +77,7 @@ export function renderStatusline(
 		segments.push(...row.segments);
 	}
 
-	return renderPowerlineStatusline(width, segments, config);
+	return renderPowerlineStatusline(width, segments, config, trueColor);
 }
 
 export function renderExtensionStatusline(
@@ -86,6 +87,7 @@ export function renderExtensionStatusline(
 	config: StatuslineConfig,
 	runtime: RuntimeState,
 	mainLine: string,
+	trueColor = true,
 ): string[] {
 	const statuses = footerData.getExtensionStatuses();
 	const prContext = prContextFromStatuses(statuses);
@@ -96,6 +98,7 @@ export function renderExtensionStatusline(
 		config,
 		runtime,
 		rendersPrInline ? GITHUB_PR_STATUS_KEYS : undefined,
+		trueColor,
 	);
 	return wrapExtensionStatusline(status, width);
 }
@@ -305,11 +308,17 @@ export function prLinkFromStatuses(statuses: ReadonlyMap<string, string>): strin
 
 export function prContextFromStatuses(statuses: ReadonlyMap<string, string>): string | undefined {
 	const value = statuses.get(GITHUB_PR_KEY);
+	if (!value) return undefined;
 	const link = prLinkFromStatuses(statuses);
-	if (!value || !link) return undefined;
+	const reference = link ?? plainPrReference(value);
+	if (!reference) return undefined;
 
-	const state = compactPrState(value.replace(link, ""));
-	return state ? `${link} · ${state}` : undefined;
+	const state = compactPrState(link ? value.replace(link, "") : value);
+	return state ? `${reference} · ${state}` : undefined;
+}
+
+function plainPrReference(value: string): string | undefined {
+	return /^PR\s+(#\d+):/u.exec(value)?.[1];
 }
 
 function compactPrState(value: string): string | undefined {

--- a/packages/pi-statusline/src/statusline.ts
+++ b/packages/pi-statusline/src/statusline.ts
@@ -4,6 +4,7 @@ import {
 	type ExtensionContext,
 	getAgentDir,
 } from "@earendil-works/pi-coding-agent";
+import { getCapabilities } from "@earendil-works/pi-tui";
 import { completeStatuslineArguments } from "./command-contract.js";
 import type { StatuslineCommandOptions } from "./commands.js";
 import {
@@ -193,10 +194,27 @@ export default function statusline(pi: ExtensionAPI) {
 					const config = previewPalettePreset
 						? { ...loaded.config, palettePreset: previewPalettePreset }
 						: loaded.config;
-					const mainLine = renderStatusline(width, ctx, footerData, theme, config, runtime);
+					const trueColor = getCapabilities().trueColor;
+					const mainLine = renderStatusline(
+						width,
+						ctx,
+						footerData,
+						theme,
+						config,
+						runtime,
+						trueColor,
+					);
 					const lines = mainLine ? mainLine.split("\n") : [];
 					lines.push(
-						...renderExtensionStatusline(width, footerData, theme, config, runtime, mainLine),
+						...renderExtensionStatusline(
+							width,
+							footerData,
+							theme,
+							config,
+							runtime,
+							mainLine,
+							trueColor,
+						),
 					);
 					return lines;
 				},

--- a/packages/pi-statusline/test/lifecycle-settings.test.ts
+++ b/packages/pi-statusline/test/lifecycle-settings.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getKeybindings } from "@earendil-works/pi-tui";
+import { getCapabilities, getKeybindings, setCapabilities } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import statusline from "../src/statusline.js";
@@ -61,7 +61,9 @@ test("session start uses defaults without materializing missing statusline setti
 test("palette picker previews the highlighted preset and restores on cancel", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-statusline-lifecycle-"));
 	const previous = process.env.PI_CODING_AGENT_DIR;
+	const previousCapabilities = getCapabilities();
 	process.env.PI_CODING_AGENT_DIR = root;
+	setCapabilities({ ...previousCapabilities, trueColor: true });
 	try {
 		writeFileSync(
 			join(root, "pi-statusline.json"),
@@ -110,6 +112,7 @@ test("palette picker previews the highlighted preset and restores on cancel", as
 		footer.dispose();
 		await emit(mock.events, "session_shutdown", {}, context.ctx);
 	} finally {
+		setCapabilities(previousCapabilities);
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;
 		rmSync(root, { recursive: true, force: true });

--- a/packages/pi-statusline/test/renderer.test.ts
+++ b/packages/pi-statusline/test/renderer.test.ts
@@ -54,6 +54,20 @@ test("Tokyo Night default retains the exact powerline colors", () => {
 	);
 });
 
+test("powerline colors fall back to ANSI-256 when true color is disabled", () => {
+	const rendered = renderPowerlineStatusline(
+		300,
+		[segment("model", "model", "header")],
+		createDefaultConfig(),
+		false,
+	);
+	assert.equal(rendered.includes("\u001b[38;2;"), false);
+	assert.equal(rendered.includes("\u001b[48;2;"), false);
+	assert.equal(rendered.includes("\u001b[38;5;146m"), true);
+	assert.equal(rendered.includes("\u001b[38;5;16;48;5;146m"), true);
+	assert.equal(plain(rendered), "░▒▓ model");
+});
+
 test("configured palette joins reordered time to an adjacent header block", () => {
 	const config = createDefaultConfig();
 	config.palettePreset = "custom";

--- a/packages/pi-statusline/test/statusline.test.ts
+++ b/packages/pi-statusline/test/statusline.test.ts
@@ -12,7 +12,7 @@ import fs, {
 import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { getCapabilities, setCapabilities, visibleWidth } from "@earendil-works/pi-tui";
 import { afterAll, test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import { consumeStatuslineSettingsNotice } from "../src/settings.js";
@@ -148,9 +148,53 @@ test("statusline renders PR context inline only when a branch is available", asy
 
 		branch = "feature";
 		statuses.set("github-pr", "PR #123: checks failing (2), approved, 5 comments");
-		assert.match(footer.render(300).slice(1).join(" "), /PR/);
+		const plainLines = footer.render(300);
+		assert.ok(plainLines[0]?.includes("🌿 feature (#123 · 2 failing)"));
+		assert.equal(plainLines.length, 1);
 	} finally {
 		footer.dispose();
+	}
+});
+
+test("statusline honors the effective true-color capability", async () => {
+	const previousCapabilities = getCapabilities();
+	setCapabilities({ ...previousCapabilities, trueColor: false });
+	const mock = createMockPi();
+	statusline(mock.pi);
+	const context = createMockContext({ mode: "tui" });
+	let footer: { render(width: number): string[]; dispose(): void } | undefined;
+
+	try {
+		await emit(mock.events, "session_start", {}, context.ctx);
+		const footerFactory = context.footer as (
+			tui: { requestRender(): void },
+			theme: { fg(color: string, text: string): string; bold(text: string): string },
+			footerData: {
+				getGitBranch(): string | null;
+				getExtensionStatuses(): ReadonlyMap<string, string>;
+				onBranchChange(callback: () => void): () => void;
+			},
+		) => { render(width: number): string[]; dispose(): void };
+		footer = footerFactory(
+			{ requestRender() {} },
+			{ fg: (_color, text) => text, bold: (text) => text },
+			{
+				getGitBranch: () => null,
+				getExtensionStatuses: () => new Map(),
+				onBranchChange: () => () => undefined,
+			},
+		);
+		const rendered = footer.render(200).join("\n");
+		assert.equal(rendered.includes("\u001b[38;2;"), false);
+		assert.equal(rendered.includes("\u001b[48;2;"), false);
+		assert.equal(rendered.includes("\u001b[38;5;") || rendered.includes("\u001b[48;5;"), true);
+	} finally {
+		footer?.dispose();
+		try {
+			await emit(mock.events, "session_shutdown", {}, context.ctx);
+		} finally {
+			setCapabilities(previousCapabilities);
+		}
 	}
 });
 
@@ -614,6 +658,15 @@ test("prContextFromStatuses chooses one actionable state by precedence", () => {
 	assert.equal(context("checks passing"), `${link} · checks passing`);
 	assert.equal(context("no checks"), `${link} · no checks`);
 	assert.equal(context("unknown"), undefined);
+	assert.equal(
+		prContextFromStatuses(new Map([["github-pr", "PR #123: checks failing (2), approved"]])),
+		"#123 · 2 failing",
+	);
+	assert.equal(
+		prContextFromStatuses(new Map([["github-pr", "PR #123\u001b[31m: checks passing"]])),
+		undefined,
+	);
+	assert.equal(prContextFromStatuses(new Map([["github-pr", "PR gh missing"]])), undefined);
 });
 
 test("Git status remains available when repository-root discovery fails", async () => {


### PR DESCRIPTION
## Summary

- honor Pi's effective hyperlink capability in `pi-github-pr` and `pi-starship`, with plain pull request references as the fallback
- downgrade package-owned RGB footer colors to ANSI-256 in `pi-starship` and `pi-statusline` when true color is disabled
- preserve compact PR context in `pi-statusline`, and update tests, documentation, metadata, and Changesets

## Verification

- `npm run check`
- `npm test` — 3,248 tests passed across 330 files
- focused capability tests — 147 tests passed across 7 files
- `just pack github-pr`, `just pack starship`, and `just pack statusline`
- Pi `DefaultResourceLoader`/Jiti smoke loaded all three generated runtimes and exercised both lazy command chunks

Closes #1106
