### PR TITLE
fix(release): continue publishing after package failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           version-script: npm run version-packages
-          publish-script: npm run publish-packages
+          publish-script: npm run publish-packages:sequential
           commit-message: "chore(release): version packages"
           pr-title: "chore(release): version packages"
           create-github-releases: true

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"changeset:status": "changeset status --verbose",
 		"version-packages": "changeset version && npm install --package-lock-only --ignore-scripts",
 		"publish-packages": "changeset publish",
+		"publish-packages:sequential": "node ./scripts/publish-packages-sequentially.mjs",
 		"pack:btw": "npm --workspace @narumitw/pi-btw pack --dry-run",
 		"pack:caffeinate": "npm --workspace @narumitw/pi-caffeinate pack --dry-run",
 		"pack:chrome-devtools": "npm --workspace @narumitw/pi-chrome-devtools pack --dry-run",

--- a/scripts/publish-packages-sequentially.mjs
+++ b/scripts/publish-packages-sequentially.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function publishPackagesSequentially({
+	cwd = process.cwd(),
+	changesetsOutput = process.env.CHANGESETS_OUTPUT,
+	run = spawnSync,
+} = {}) {
+	if (!changesetsOutput) {
+		throw new Error("CHANGESETS_OUTPUT is required by the Changesets Action.");
+	}
+
+	mkdirSync(path.dirname(changesetsOutput), { recursive: true });
+	writeFileSync(changesetsOutput, "");
+
+	const temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "pi-publish-plan-"));
+	const planPath = path.join(temporaryDirectory, "publish-plan.json");
+
+	try {
+		const changesetsCli = path.join(cwd, "node_modules", "@changesets", "cli", "bin.js");
+		const planResult = run(
+			process.execPath,
+			[changesetsCli, "publish-plan", "--output", planPath],
+			{ cwd, env: process.env, stdio: "inherit" },
+		);
+		if (planResult.error) throw planResult.error;
+		if (planResult.status !== 0) return planResult.status ?? 1;
+
+		const plan = readPublishPlan(planPath);
+		const published = [];
+		const failed = [];
+		const tagged = [];
+
+		for (const chunk of plan) {
+			for (const release of chunk) {
+				const tag = `${release.name}@${release.version}`;
+				if (release.kind === "tag-only") {
+					writeTagEvent(changesetsOutput, release, tag);
+					tagged.push(tag);
+					continue;
+				}
+
+				console.log(`Publishing ${tag}...`);
+				const result = run(
+					"npm",
+					[
+						"publish",
+						"--workspace",
+						release.name,
+						"--access",
+						release.access,
+						"--tag",
+						release.tag,
+					],
+					{ cwd, env: process.env, stdio: "inherit" },
+				);
+
+				if (!result.error && result.status === 0) {
+					writeTagEvent(changesetsOutput, release, tag);
+					published.push(tag);
+					continue;
+				}
+
+				const reason =
+					result.error?.message ?? `npm publish exited with code ${result.status ?? 1}`;
+				failed.push(`${tag}: ${reason}`);
+				writeErrorAnnotation(`Failed to publish ${tag}`, reason);
+			}
+		}
+
+		printSummary("Published", published);
+		printSummary("Tags to create", tagged);
+		printSummary("Failed", failed);
+		return failed.length > 0 ? 1 : 0;
+	} finally {
+		rmSync(temporaryDirectory, { recursive: true, force: true });
+	}
+}
+
+function readPublishPlan(planPath) {
+	const value = JSON.parse(readFileSync(planPath, "utf8"));
+	if (value?.version !== 1 || !Array.isArray(value.plan)) {
+		throw new Error("Changesets returned an invalid publish plan.");
+	}
+	for (const chunk of value.plan) {
+		if (!Array.isArray(chunk))
+			throw new Error("Changesets returned an invalid publish plan chunk.");
+		for (const release of chunk) {
+			if (
+				(release?.kind !== "publish" && release?.kind !== "tag-only") ||
+				typeof release.name !== "string" ||
+				typeof release.version !== "string" ||
+				(release.kind === "publish" &&
+					(typeof release.access !== "string" || typeof release.tag !== "string"))
+			) {
+				throw new Error("Changesets returned an invalid publish plan entry.");
+			}
+		}
+	}
+	return value.plan;
+}
+
+function writeTagEvent(outputPath, release, tag) {
+	writeFileSync(
+		outputPath,
+		`${JSON.stringify({ type: "git-tag", tag, packageName: release.name })}\n`,
+		{ flag: "a" },
+	);
+}
+
+function writeErrorAnnotation(title, message) {
+	console.error(`::error title=${escapeWorkflowProperty(title)}::${escapeWorkflowData(message)}`);
+}
+
+function escapeWorkflowData(value) {
+	return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+function escapeWorkflowProperty(value) {
+	return escapeWorkflowData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+function printSummary(title, entries) {
+	if (entries.length === 0) return;
+	console.log(`${title}:\n${entries.map((entry) => `- ${entry}`).join("\n")}`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+	try {
+		process.exitCode = publishPackagesSequentially();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		writeErrorAnnotation("Package publication failed", message);
+		process.exitCode = 1;
+	}
+}

--- a/test/changesets-release.test.ts
+++ b/test/changesets-release.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
 	copyFileSync,
 	existsSync,
@@ -83,6 +83,133 @@ test("Changesets bumps selected packages independently and preserves ordinary in
 			/## 1\.2\.4/u,
 		);
 		assert.deepEqual(readdirSync(path.join(fixture, ".changeset")).sort(), ["config.json"]);
+	} finally {
+		rmSync(fixture, { recursive: true, force: true });
+	}
+});
+
+test("sequential publishing reports a failure and continues with later packages", () => {
+	const fixture = mkdtempSync(path.join(tmpdir(), "pi-sequential-publish-"));
+	try {
+		const plan = {
+			version: 1,
+			plan: [
+				[
+					{
+						kind: "publish",
+						name: "@fixture/pi-alpha",
+						version: "1.0.0",
+						access: "public",
+						tag: "latest",
+					},
+				],
+				[
+					{
+						kind: "publish",
+						name: "@fixture/pi-broken",
+						version: "2.0.0",
+						access: "restricted",
+						tag: "next",
+					},
+				],
+				[
+					{
+						kind: "publish",
+						name: "@fixture/pi-omega",
+						version: "3.0.0",
+						access: "public",
+						tag: "latest",
+					},
+					{
+						kind: "tag-only",
+						name: "@fixture/pi-tag-only",
+						version: "4.0.0",
+					},
+				],
+			],
+		};
+		writeJson(path.join(fixture, "publish-plan.fixture.json"), plan);
+
+		const changesetsBin = path.join(fixture, "node_modules/@changesets/cli/bin.js");
+		mkdirSync(path.dirname(changesetsBin), { recursive: true });
+		writeFileSync(
+			changesetsBin,
+			[
+				'const fs = require("node:fs");',
+				'const path = require("node:path");',
+				'const output = process.argv[process.argv.indexOf("--output") + 1];',
+				'fs.copyFileSync(path.join(process.cwd(), "publish-plan.fixture.json"), output);',
+			].join("\n"),
+		);
+
+		const binDirectory = path.join(fixture, "bin");
+		const npmBin = path.join(binDirectory, "npm");
+		mkdirSync(binDirectory, { recursive: true });
+		writeFileSync(
+			npmBin,
+			[
+				"#!/usr/bin/env node",
+				'const fs = require("node:fs");',
+				'const workspace = process.argv[process.argv.indexOf("--workspace") + 1];',
+				'fs.appendFileSync(process.env.PUBLISH_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n");',
+				'if (workspace === "@fixture/pi-broken") process.exit(17);',
+			].join("\n"),
+			{ mode: 0o755 },
+		);
+
+		const changesetsOutput = path.join(fixture, "changesets-output.ndjson");
+		const callsPath = path.join(fixture, "publish-calls.ndjson");
+		const script = path.join(repositoryRoot, "scripts/publish-packages-sequentially.mjs");
+		const result = spawnSync(process.execPath, [script], {
+			cwd: fixture,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				CHANGESETS_OUTPUT: changesetsOutput,
+				PATH: `${binDirectory}${path.delimiter}${process.env.PATH ?? ""}`,
+				PUBLISH_CALLS: callsPath,
+			},
+		});
+
+		assert.equal(result.status, 1);
+		assert.match(
+			result.stderr,
+			/::error title=Failed to publish @fixture\/pi-broken@2\.0\.0::npm publish exited with code 17/u,
+		);
+		assert.deepEqual(
+			readFileSync(callsPath, "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line)),
+			[
+				["publish", "--workspace", "@fixture/pi-alpha", "--access", "public", "--tag", "latest"],
+				["publish", "--workspace", "@fixture/pi-broken", "--access", "restricted", "--tag", "next"],
+				["publish", "--workspace", "@fixture/pi-omega", "--access", "public", "--tag", "latest"],
+			],
+		);
+		assert.deepEqual(
+			readFileSync(changesetsOutput, "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line)),
+			[
+				{
+					type: "git-tag",
+					tag: "@fixture/pi-alpha@1.0.0",
+					packageName: "@fixture/pi-alpha",
+				},
+				{
+					type: "git-tag",
+					tag: "@fixture/pi-omega@3.0.0",
+					packageName: "@fixture/pi-omega",
+				},
+				{
+					type: "git-tag",
+					tag: "@fixture/pi-tag-only@4.0.0",
+					packageName: "@fixture/pi-tag-only",
+				},
+			],
+		);
 	} finally {
 		rmSync(fixture, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- publish packages sequentially from the dependency-aware Changesets publish plan
- emit a GitHub Actions error annotation for each failed package and continue with later packages
- preserve Changesets output events for successful publishes, tags, and GitHub releases
- fail the job after all packages are attempted if any publication failed

## Verification

- `npm run check`
- `npm test` (330 files, 3261 tests)
- signed commit and pre-commit checks

## Release notes

- No Changeset because this only changes repository release automation.
- Live npm publication was not run to avoid publishing packages during verification.
