### PR TITLE
fix(release): handle partial publication safely

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,3 +55,14 @@ jobs:
           push-with-git-cli: false
         env:
           NPM_CONFIG_PROVENANCE: "true"
+          PUBLISH_FAILURES_FILE: ${{ runner.temp }}/package-publish-failures.ndjson
+
+      - name: Fail after package publication errors
+        if: steps.changesets.outcome == 'success'
+        env:
+          PUBLISH_FAILURES_FILE: ${{ runner.temp }}/package-publish-failures.ndjson
+        run: |
+          if [[ -s "$PUBLISH_FAILURES_FILE" ]]; then
+            echo "::error::One or more packages failed to publish or were skipped."
+            exit 1
+          fi

--- a/scripts/publish-packages-sequentially.mjs
+++ b/scripts/publish-packages-sequentially.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,14 +9,19 @@ import { fileURLToPath } from "node:url";
 export function publishPackagesSequentially({
 	cwd = process.cwd(),
 	changesetsOutput = process.env.CHANGESETS_OUTPUT,
+	publishFailuresFile = process.env.PUBLISH_FAILURES_FILE,
 	run = spawnSync,
 } = {}) {
-	if (!changesetsOutput) {
-		throw new Error("CHANGESETS_OUTPUT is required by the Changesets Action.");
+	if (!changesetsOutput || !publishFailuresFile) {
+		throw new Error(
+			"CHANGESETS_OUTPUT and PUBLISH_FAILURES_FILE are required by the release workflow.",
+		);
 	}
 
 	mkdirSync(path.dirname(changesetsOutput), { recursive: true });
+	mkdirSync(path.dirname(publishFailuresFile), { recursive: true });
 	writeFileSync(changesetsOutput, "");
+	writeFileSync(publishFailuresFile, "");
 
 	const temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "pi-publish-plan-"));
 	const planPath = path.join(temporaryDirectory, "publish-plan.json");
@@ -32,8 +37,11 @@ export function publishPackagesSequentially({
 		if (planResult.status !== 0) return planResult.status ?? 1;
 
 		const plan = readPublishPlan(planPath);
+		const internalDependencies = readInternalDependencies(cwd);
+		const blockedPackages = new Set();
 		const published = [];
 		const failed = [];
+		const skipped = [];
 		const tagged = [];
 
 		for (const chunk of plan) {
@@ -42,6 +50,18 @@ export function publishPackagesSequentially({
 				if (release.kind === "tag-only") {
 					writeTagEvent(changesetsOutput, release, tag);
 					tagged.push(tag);
+					continue;
+				}
+
+				const blockers = [...(internalDependencies.get(release.name) ?? [])].filter((dependency) =>
+					blockedPackages.has(dependency),
+				);
+				if (blockers.length > 0) {
+					const reason = `blocked by failed release(s): ${blockers.join(", ")}`;
+					blockedPackages.add(release.name);
+					skipped.push(`${tag}: ${reason}`);
+					recordFailure(publishFailuresFile, release, reason);
+					writeErrorAnnotation(`Skipped dependent release ${tag}`, reason);
 					continue;
 				}
 
@@ -68,7 +88,9 @@ export function publishPackagesSequentially({
 
 				const reason =
 					result.error?.message ?? `npm publish exited with code ${result.status ?? 1}`;
+				blockedPackages.add(release.name);
 				failed.push(`${tag}: ${reason}`);
+				recordFailure(publishFailuresFile, release, reason);
 				writeErrorAnnotation(`Failed to publish ${tag}`, reason);
 			}
 		}
@@ -76,7 +98,8 @@ export function publishPackagesSequentially({
 		printSummary("Published", published);
 		printSummary("Tags to create", tagged);
 		printSummary("Failed", failed);
-		return failed.length > 0 ? 1 : 0;
+		printSummary("Skipped dependents", skipped);
+		return 0;
 	} finally {
 		rmSync(temporaryDirectory, { recursive: true, force: true });
 	}
@@ -103,6 +126,36 @@ function readPublishPlan(planPath) {
 		}
 	}
 	return value.plan;
+}
+
+function readInternalDependencies(cwd) {
+	const manifests = readdirSync(path.join(cwd, "packages"), { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) =>
+			JSON.parse(readFileSync(path.join(cwd, "packages", entry.name, "package.json"), "utf8")),
+		);
+	const packageNames = new Set(manifests.map((manifest) => manifest.name));
+	return new Map(
+		manifests.map((manifest) => {
+			const runtimeDependencies = {
+				...manifest.peerDependencies,
+				...manifest.optionalDependencies,
+				...manifest.dependencies,
+			};
+			return [
+				manifest.name,
+				new Set(Object.keys(runtimeDependencies).filter((name) => packageNames.has(name))),
+			];
+		}),
+	);
+}
+
+function recordFailure(outputPath, release, reason) {
+	writeFileSync(
+		outputPath,
+		`${JSON.stringify({ packageName: release.name, version: release.version, reason })}\n`,
+		{ flag: "a" },
+	);
 }
 
 function writeTagEvent(outputPath, release, tag) {

--- a/test/changesets-release.test.ts
+++ b/test/changesets-release.test.ts
@@ -115,8 +115,24 @@ test("sequential publishing reports a failure and continues with later packages"
 				[
 					{
 						kind: "publish",
+						name: "@fixture/pi-dependent",
+						version: "2.1.0",
+						access: "public",
+						tag: "latest",
+					},
+					{
+						kind: "publish",
 						name: "@fixture/pi-omega",
 						version: "3.0.0",
+						access: "public",
+						tag: "latest",
+					},
+				],
+				[
+					{
+						kind: "publish",
+						name: "@fixture/pi-transitive",
+						version: "3.1.0",
 						access: "public",
 						tag: "latest",
 					},
@@ -129,6 +145,27 @@ test("sequential publishing reports a failure and continues with later packages"
 			],
 		};
 		writeJson(path.join(fixture, "publish-plan.fixture.json"), plan);
+		writeJson(path.join(fixture, "packages/pi-alpha/package.json"), {
+			name: "@fixture/pi-alpha",
+		});
+		writeJson(path.join(fixture, "packages/pi-broken/package.json"), {
+			name: "@fixture/pi-broken",
+		});
+		writeJson(path.join(fixture, "packages/pi-dependent/package.json"), {
+			name: "@fixture/pi-dependent",
+			dependencies: { "@fixture/pi-broken": "^2.0.0" },
+		});
+		writeJson(path.join(fixture, "packages/pi-omega/package.json"), {
+			name: "@fixture/pi-omega",
+			devDependencies: { "@fixture/pi-broken": "^2.0.0" },
+		});
+		writeJson(path.join(fixture, "packages/pi-transitive/package.json"), {
+			name: "@fixture/pi-transitive",
+			peerDependencies: { "@fixture/pi-dependent": "^2.1.0" },
+		});
+		writeJson(path.join(fixture, "packages/pi-tag-only/package.json"), {
+			name: "@fixture/pi-tag-only",
+		});
 
 		const changesetsBin = path.join(fixture, "node_modules/@changesets/cli/bin.js");
 		mkdirSync(path.dirname(changesetsBin), { recursive: true });
@@ -158,6 +195,7 @@ test("sequential publishing reports a failure and continues with later packages"
 		);
 
 		const changesetsOutput = path.join(fixture, "changesets-output.ndjson");
+		const failuresPath = path.join(fixture, "publish-failures.ndjson");
 		const callsPath = path.join(fixture, "publish-calls.ndjson");
 		const script = path.join(repositoryRoot, "scripts/publish-packages-sequentially.mjs");
 		const result = spawnSync(process.execPath, [script], {
@@ -168,13 +206,22 @@ test("sequential publishing reports a failure and continues with later packages"
 				CHANGESETS_OUTPUT: changesetsOutput,
 				PATH: `${binDirectory}${path.delimiter}${process.env.PATH ?? ""}`,
 				PUBLISH_CALLS: callsPath,
+				PUBLISH_FAILURES_FILE: failuresPath,
 			},
 		});
 
-		assert.equal(result.status, 1);
+		assert.equal(result.status, 0);
 		assert.match(
 			result.stderr,
 			/::error title=Failed to publish @fixture\/pi-broken@2\.0\.0::npm publish exited with code 17/u,
+		);
+		assert.match(
+			result.stderr,
+			/::error title=Skipped dependent release @fixture\/pi-dependent@2\.1\.0::blocked by failed release\(s\): @fixture\/pi-broken/u,
+		);
+		assert.match(
+			result.stderr,
+			/::error title=Skipped dependent release @fixture\/pi-transitive@3\.1\.0::blocked by failed release\(s\): @fixture\/pi-dependent/u,
 		);
 		assert.deepEqual(
 			readFileSync(callsPath, "utf8")
@@ -185,6 +232,29 @@ test("sequential publishing reports a failure and continues with later packages"
 				["publish", "--workspace", "@fixture/pi-alpha", "--access", "public", "--tag", "latest"],
 				["publish", "--workspace", "@fixture/pi-broken", "--access", "restricted", "--tag", "next"],
 				["publish", "--workspace", "@fixture/pi-omega", "--access", "public", "--tag", "latest"],
+			],
+		);
+		assert.deepEqual(
+			readFileSync(failuresPath, "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line)),
+			[
+				{
+					packageName: "@fixture/pi-broken",
+					version: "2.0.0",
+					reason: "npm publish exited with code 17",
+				},
+				{
+					packageName: "@fixture/pi-dependent",
+					version: "2.1.0",
+					reason: "blocked by failed release(s): @fixture/pi-broken",
+				},
+				{
+					packageName: "@fixture/pi-transitive",
+					version: "3.1.0",
+					reason: "blocked by failed release(s): @fixture/pi-dependent",
+				},
 			],
 		);
 		assert.deepEqual(
@@ -213,6 +283,22 @@ test("sequential publishing reports a failure and continues with later packages"
 	} finally {
 		rmSync(fixture, { recursive: true, force: true });
 	}
+});
+
+test("publish workflow fails only after Changesets Action processes successful releases", () => {
+	const workflow = readFileSync(path.join(repositoryRoot, ".github/workflows/publish.yml"), "utf8");
+	const actionStep = workflow.indexOf("uses: changesets/action@");
+	const failureStep = workflow.indexOf("- name: Fail after package publication errors");
+
+	assert.notEqual(actionStep, -1);
+	assert.ok(failureStep > actionStep);
+	const failuresFilePattern =
+		/PUBLISH_FAILURES_FILE: \$\{\{ runner\.temp \}\}\/package-publish-failures\.ndjson/u;
+	assert.match(workflow.slice(actionStep, failureStep), failuresFilePattern);
+	assert.match(workflow.slice(failureStep), failuresFilePattern);
+	assert.match(workflow.slice(failureStep), /if: steps\.changesets\.outcome == 'success'/u);
+	assert.match(workflow.slice(failureStep), /if \[\[ -s "\$PUBLISH_FAILURES_FILE" \]\]; then/u);
+	assert.match(workflow.slice(failureStep), /exit 1/u);
 });
 
 function readJson(filePath: string): {


### PR DESCRIPTION
## Summary

- defer the workflow failure until Changesets Action has consumed successful publication events and created their tags and GitHub releases
- record failed and skipped releases in a workflow-owned NDJSON file, then fail in a later step
- skip direct and transitive runtime dependents of failed releases while continuing unrelated packages
- cover successful output preservation, dependency blocking, unrelated continuation, and workflow step ordering

## Review feedback

Follow-up to #1114:

- resolves `discussion_r3886667998` by moving the failing status after Changesets Action
- resolves `discussion_r3886667999` by propagating failed release blocks through internal runtime dependencies

## Verification

- `npx vitest run test/changesets-release.test.ts` (3 tests)
- `npm run check`
- `npm test` (330 files, 3262 tests)
- signed commit and pre-commit checks

## Release notes

- No Changeset because this only changes repository release automation and regression tests.
- Live npm publication was not run because verification must not publish packages.
- `actionlint` was unavailable; deterministic tests verify the required workflow step ordering and shared failure-file configuration.
