### PR TITLE
feat(release): summarize published packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,38 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: "true"
           PUBLISH_FAILURES_FILE: ${{ runner.temp }}/package-publish-failures.ndjson
+          PUBLISHED_PACKAGES_FILE: ${{ runner.temp }}/published-packages.ndjson
+
+      - name: Summarize published packages
+        if: always()
+        env:
+          PUBLISHED_PACKAGES_FILE: ${{ runner.temp }}/published-packages.ndjson
+        run: |
+          if [[ ! -s "$PUBLISHED_PACKAGES_FILE" ]]; then
+            exit 0
+          fi
+
+          node --input-type=module <<'NODE'
+          import { appendFileSync, readFileSync } from "node:fs";
+
+          const releases = readFileSync(process.env.PUBLISHED_PACKAGES_FILE, "utf8")
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+          const rows = releases.map(
+            (release) => `| \`${release.packageName}\` | \`${release.version}\` |`,
+          );
+          const summary = [
+            "## Successfully published packages",
+            "",
+            "| Package | Version |",
+            "| --- | --- |",
+            ...rows,
+            "",
+          ].join("\n");
+
+          appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+          NODE
 
       - name: Fail after package publication errors
         if: steps.changesets.outcome == 'success'

--- a/scripts/publish-packages-sequentially.mjs
+++ b/scripts/publish-packages-sequentially.mjs
@@ -10,18 +10,21 @@ export function publishPackagesSequentially({
 	cwd = process.cwd(),
 	changesetsOutput = process.env.CHANGESETS_OUTPUT,
 	publishFailuresFile = process.env.PUBLISH_FAILURES_FILE,
+	publishedPackagesFile = process.env.PUBLISHED_PACKAGES_FILE,
 	run = spawnSync,
 } = {}) {
-	if (!changesetsOutput || !publishFailuresFile) {
+	if (!changesetsOutput || !publishFailuresFile || !publishedPackagesFile) {
 		throw new Error(
-			"CHANGESETS_OUTPUT and PUBLISH_FAILURES_FILE are required by the release workflow.",
+			"CHANGESETS_OUTPUT, PUBLISH_FAILURES_FILE, and PUBLISHED_PACKAGES_FILE are required by the release workflow.",
 		);
 	}
 
 	mkdirSync(path.dirname(changesetsOutput), { recursive: true });
 	mkdirSync(path.dirname(publishFailuresFile), { recursive: true });
+	mkdirSync(path.dirname(publishedPackagesFile), { recursive: true });
 	writeFileSync(changesetsOutput, "");
 	writeFileSync(publishFailuresFile, "");
+	writeFileSync(publishedPackagesFile, "");
 
 	const temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "pi-publish-plan-"));
 	const planPath = path.join(temporaryDirectory, "publish-plan.json");
@@ -82,6 +85,7 @@ export function publishPackagesSequentially({
 
 				if (!result.error && result.status === 0) {
 					writeTagEvent(changesetsOutput, release, tag);
+					recordPublishedPackage(publishedPackagesFile, release);
 					published.push(tag);
 					continue;
 				}
@@ -154,6 +158,14 @@ function recordFailure(outputPath, release, reason) {
 	writeFileSync(
 		outputPath,
 		`${JSON.stringify({ packageName: release.name, version: release.version, reason })}\n`,
+		{ flag: "a" },
+	);
+}
+
+function recordPublishedPackage(outputPath, release) {
+	writeFileSync(
+		outputPath,
+		`${JSON.stringify({ packageName: release.name, version: release.version })}\n`,
 		{ flag: "a" },
 	);
 }

--- a/test/changesets-release.test.ts
+++ b/test/changesets-release.test.ts
@@ -196,6 +196,7 @@ test("sequential publishing reports a failure and continues with later packages"
 
 		const changesetsOutput = path.join(fixture, "changesets-output.ndjson");
 		const failuresPath = path.join(fixture, "publish-failures.ndjson");
+		const publishedPackagesPath = path.join(fixture, "published-packages.ndjson");
 		const callsPath = path.join(fixture, "publish-calls.ndjson");
 		const script = path.join(repositoryRoot, "scripts/publish-packages-sequentially.mjs");
 		const result = spawnSync(process.execPath, [script], {
@@ -207,6 +208,7 @@ test("sequential publishing reports a failure and continues with later packages"
 				PATH: `${binDirectory}${path.delimiter}${process.env.PATH ?? ""}`,
 				PUBLISH_CALLS: callsPath,
 				PUBLISH_FAILURES_FILE: failuresPath,
+				PUBLISHED_PACKAGES_FILE: publishedPackagesPath,
 			},
 		});
 
@@ -280,20 +282,38 @@ test("sequential publishing reports a failure and continues with later packages"
 				},
 			],
 		);
+		assert.deepEqual(
+			readFileSync(publishedPackagesPath, "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line)),
+			[
+				{ packageName: "@fixture/pi-alpha", version: "1.0.0" },
+				{ packageName: "@fixture/pi-omega", version: "3.0.0" },
+			],
+		);
 	} finally {
 		rmSync(fixture, { recursive: true, force: true });
 	}
 });
 
-test("publish workflow fails only after Changesets Action processes successful releases", () => {
+test("publish workflow summarizes successes before reporting publication failures", () => {
 	const workflow = readFileSync(path.join(repositoryRoot, ".github/workflows/publish.yml"), "utf8");
 	const actionStep = workflow.indexOf("uses: changesets/action@");
+	const summaryStep = workflow.indexOf("- name: Summarize published packages");
 	const failureStep = workflow.indexOf("- name: Fail after package publication errors");
 
 	assert.notEqual(actionStep, -1);
-	assert.ok(failureStep > actionStep);
+	assert.ok(summaryStep > actionStep);
+	assert.ok(failureStep > summaryStep);
 	const failuresFilePattern =
 		/PUBLISH_FAILURES_FILE: \$\{\{ runner\.temp \}\}\/package-publish-failures\.ndjson/u;
+	const publishedPackagesFilePattern =
+		/PUBLISHED_PACKAGES_FILE: \$\{\{ runner\.temp \}\}\/published-packages\.ndjson/u;
+	assert.match(workflow.slice(actionStep, summaryStep), publishedPackagesFilePattern);
+	assert.match(workflow.slice(summaryStep, failureStep), publishedPackagesFilePattern);
+	assert.match(workflow.slice(summaryStep, failureStep), /if: always\(\)/u);
+	assert.match(workflow.slice(summaryStep, failureStep), /process\.env\.GITHUB_STEP_SUMMARY/u);
 	assert.match(workflow.slice(actionStep, failureStep), failuresFilePattern);
 	assert.match(workflow.slice(failureStep), failuresFilePattern);
 	assert.match(workflow.slice(failureStep), /if: steps\.changesets\.outcome == 'success'/u);


### PR DESCRIPTION
## Summary

- record each package that completes `npm publish` successfully
- add a GitHub Actions job summary table with package names and versions
- keep failed, skipped, and tag-only releases out of the success summary

## Verification

- `npm run check`
- `npm test` (330 files, 3262 tests)
- manual Job Summary rendering smoke

## Notes

- no changeset is needed because this changes repository release tooling only