### PR TITLE
fix(release): respect dependency ranges when blocking

### DIFF
--- a/scripts/publish-packages-sequentially.mjs
+++ b/scripts/publish-packages-sequentially.mjs
@@ -5,6 +5,7 @@ import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSyn
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import Range from "semver/classes/range.js";
 
 export function publishPackagesSequentially({
 	cwd = process.cwd(),
@@ -138,20 +139,35 @@ function readInternalDependencies(cwd) {
 		.map((entry) =>
 			JSON.parse(readFileSync(path.join(cwd, "packages", entry.name, "package.json"), "utf8")),
 		);
-	const packageNames = new Set(manifests.map((manifest) => manifest.name));
+	const internalVersions = new Map(manifests.map((manifest) => [manifest.name, manifest.version]));
 	return new Map(
 		manifests.map((manifest) => {
 			const runtimeDependencies = {
+				...manifest.dependencies,
 				...manifest.peerDependencies,
 				...manifest.optionalDependencies,
-				...manifest.dependencies,
 			};
 			return [
 				manifest.name,
-				new Set(Object.keys(runtimeDependencies).filter((name) => packageNames.has(name))),
+				new Set(
+					Object.entries(runtimeDependencies)
+						.filter(([name, range]) => acceptsInternalVersion(range, internalVersions.get(name)))
+						.map(([name]) => name),
+				),
 			];
 		}),
 	);
+}
+
+function acceptsInternalVersion(range, version) {
+	if (typeof range !== "string" || typeof version !== "string" || range.includes(":")) {
+		return false;
+	}
+	try {
+		return new Range(range).test(version);
+	} catch {
+		return false;
+	}
 }
 
 function recordFailure(outputPath, release, reason) {

--- a/test/changesets-release.test.ts
+++ b/test/changesets-release.test.ts
@@ -122,6 +122,13 @@ test("sequential publishing reports a failure and continues with later packages"
 					},
 					{
 						kind: "publish",
+						name: "@fixture/pi-range-independent",
+						version: "2.2.0",
+						access: "public",
+						tag: "latest",
+					},
+					{
+						kind: "publish",
 						name: "@fixture/pi-omega",
 						version: "3.0.0",
 						access: "public",
@@ -147,24 +154,35 @@ test("sequential publishing reports a failure and continues with later packages"
 		writeJson(path.join(fixture, "publish-plan.fixture.json"), plan);
 		writeJson(path.join(fixture, "packages/pi-alpha/package.json"), {
 			name: "@fixture/pi-alpha",
+			version: "1.0.0",
 		});
 		writeJson(path.join(fixture, "packages/pi-broken/package.json"), {
 			name: "@fixture/pi-broken",
+			version: "2.0.0",
 		});
 		writeJson(path.join(fixture, "packages/pi-dependent/package.json"), {
 			name: "@fixture/pi-dependent",
+			version: "2.1.0",
 			dependencies: { "@fixture/pi-broken": "^2.0.0" },
+		});
+		writeJson(path.join(fixture, "packages/pi-range-independent/package.json"), {
+			name: "@fixture/pi-range-independent",
+			version: "2.2.0",
+			dependencies: { "@fixture/pi-broken": "^1.0.0" },
 		});
 		writeJson(path.join(fixture, "packages/pi-omega/package.json"), {
 			name: "@fixture/pi-omega",
+			version: "3.0.0",
 			devDependencies: { "@fixture/pi-broken": "^2.0.0" },
 		});
 		writeJson(path.join(fixture, "packages/pi-transitive/package.json"), {
 			name: "@fixture/pi-transitive",
+			version: "3.1.0",
 			peerDependencies: { "@fixture/pi-dependent": "^2.1.0" },
 		});
 		writeJson(path.join(fixture, "packages/pi-tag-only/package.json"), {
 			name: "@fixture/pi-tag-only",
+			version: "4.0.0",
 		});
 
 		const changesetsBin = path.join(fixture, "node_modules/@changesets/cli/bin.js");
@@ -233,6 +251,15 @@ test("sequential publishing reports a failure and continues with later packages"
 			[
 				["publish", "--workspace", "@fixture/pi-alpha", "--access", "public", "--tag", "latest"],
 				["publish", "--workspace", "@fixture/pi-broken", "--access", "restricted", "--tag", "next"],
+				[
+					"publish",
+					"--workspace",
+					"@fixture/pi-range-independent",
+					"--access",
+					"public",
+					"--tag",
+					"latest",
+				],
 				["publish", "--workspace", "@fixture/pi-omega", "--access", "public", "--tag", "latest"],
 			],
 		);
@@ -272,6 +299,11 @@ test("sequential publishing reports a failure and continues with later packages"
 				},
 				{
 					type: "git-tag",
+					tag: "@fixture/pi-range-independent@2.2.0",
+					packageName: "@fixture/pi-range-independent",
+				},
+				{
+					type: "git-tag",
 					tag: "@fixture/pi-omega@3.0.0",
 					packageName: "@fixture/pi-omega",
 				},
@@ -289,6 +321,7 @@ test("sequential publishing reports a failure and continues with later packages"
 				.map((line) => JSON.parse(line)),
 			[
 				{ packageName: "@fixture/pi-alpha", version: "1.0.0" },
+				{ packageName: "@fixture/pi-range-independent", version: "2.2.0" },
 				{ packageName: "@fixture/pi-omega", version: "3.0.0" },
 			],
 		);


### PR DESCRIPTION
## Summary

- filter internal runtime dependency edges by whether the declared semver range accepts the current workspace version
- keep matching direct and transitive dependents blocked after a publication failure
- allow independently versioned packages with incompatible ranges to continue publishing

## Review feedback

Follow-up to #1115 after `discussion_r3886695289` was submitted after merge.

## Verification

- `npx vitest run test/changesets-release.test.ts` (3 tests)
- `npm run check`
- `npm test` (330 files, 3262 tests)
- signed commit and pre-commit checks

## Release notes

- No Changeset because this only changes repository release automation and regression tests.
- Live npm publication was not run because verification must not publish packages.
