### PR TITLE
feat(cbmem): add retrieval benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ vite.config.ts.timestamp-*
 **/.pi-*-dist-*/
 docs/plans/archived/
 docs/roadmaps/archived/
+packages/pi-cbmem/benchmark/results/

--- a/justfile
+++ b/justfile
@@ -87,6 +87,10 @@ smoke-chat-network:
 benchmark-codex-compact *args:
     node packages/pi-codex-compact/benchmark/run.mjs {{ args }}
 
+# Preview or explicitly run the pi-cbmem retrieval benchmark
+benchmark-cbmem *args:
+    node packages/pi-cbmem/benchmark/run.mjs {{ args }}
+
 # Install dependencies, build local package artifacts, and start every local extension package
 # pi-statusline and pi-tui-kit are intentionally excluded from Pi extension loading
 # PI_TIMING reports startup timing and PI_CODING_AGENT_DIR isolates local development state

--- a/packages/pi-cbmem/benchmark/README.md
+++ b/packages/pi-cbmem/benchmark/README.md
@@ -1,0 +1,229 @@
+# pi-cbmem retrieval benchmark
+
+This repository-only benchmark compares Pi without extension discovery against Pi with `npm:@narumitw/pi-cbmem` while requiring both arms to recover the same scored facts.
+
+It measures information acquisition only.
+It does not ask the agent to edit code or run tests.
+
+## Compared invocations
+
+The baseline is derived from:
+
+```bash
+pi -ne
+```
+
+The treatment is derived from:
+
+```bash
+pi -ne -e npm:@narumitw/pi-cbmem
+```
+
+The runner adds RPC mode, an ephemeral session, fixed model and thinking settings, disabled automatic retry and compaction, no discovered skills, prompts, themes, context files, or project resources, and a read-only tool allowlist.
+Explicit resources from the treatment package still load even though ordinary discovery is disabled.
+
+The baseline can use `read`, `grep`, `find`, and `ls` for same-evidence tasks.
+The treatment can use those tools plus the non-mutating pi-cbmem tools.
+Indexing, project deletion, ADR replacement, and trace ingestion are excluded from the active treatment tools.
+
+## Studies
+
+### Exact payload
+
+The runner calls the local Codebase Memory CLI before measured trials and captures one deterministic JSON evidence packet.
+The baseline receives that exact packet in its prompt and cannot call tools.
+The treatment must call the specified pi-cbmem tool exactly once with exact arguments.
+The treatment tool result must have the same SHA-256 as the baseline packet.
+
+This study measures the package schemas, skill, model tool-call turn, subprocess bridge, and tool-result envelope around the same evidence text.
+It does not claim that the full provider payload is identical between arms.
+
+### Same evidence
+
+Both arms inspect the same repository path and answer the same hidden exact-fact keys.
+The baseline must not call a Codebase Memory tool.
+The treatment must call at least one Codebase Memory tool and may use read-only Pi tools for source verification.
+A run succeeds only when every expected fact matches and its method policy is satisfied.
+
+This study measures whether graph retrieval can avoid irrelevant source context while preserving required-fact accuracy.
+
+## Safe dry run
+
+The command defaults to a provider-free plan:
+
+```bash
+just benchmark-cbmem
+```
+
+The dry run does not start Pi, invoke Codebase Memory, resolve the npm package, or contact a model provider.
+It prints the paired order, command shapes, minimum provider-request count, and live prerequisites.
+
+Filter one study with:
+
+```bash
+just benchmark-cbmem --kind exact-payload
+just benchmark-cbmem --kind same-evidence
+```
+
+Run the deterministic self-test with:
+
+```bash
+node packages/pi-cbmem/benchmark/self-test.mjs
+```
+
+The benchmark self-test remains outside normal CI because this is a manual measurement workflow.
+
+## Index prerequisite
+
+Create or refresh a Codebase Memory index for the exact repository path before a live run.
+The runner does not mutate the index.
+
+For example:
+
+```bash
+printf '%s\n' "$(jq -nc --arg path "$PWD" '{repo_path:$path,mode:"full",persistence:true}')" \
+  | ~/.local/bin/codebase-memory-mcp cli index_repository
+```
+
+List the resulting exact project name with:
+
+```bash
+printf '{}\n' | ~/.local/bin/codebase-memory-mcp cli list_projects
+```
+
+A live preflight rejects an index whose status is not `ready` or whose canonical root differs from `--repo`.
+It also requires `--cbmem-bin` to resolve to the `~/.local/bin/codebase-memory-mcp` executable that the npm extension invokes.
+The result records index status, root, node and edge counts, and a status-response hash.
+The runner rechecks the Git commit, Git status, and index-status hash after the final trial and labels detected changes as `runtime-drift`.
+The benchmark cannot prove index freshness from `index_status` alone, so an already stale graph can still cause treatment failures.
+
+## Live run
+
+Live execution requires explicit model, project, and estimated-cost guard options:
+
+```bash
+just benchmark-cbmem \
+  --live \
+  --model <provider/model> \
+  --project <exact-indexed-project> \
+  --runs 5 \
+  --max-cost-usd <approved-amount> \
+  --output packages/pi-cbmem/benchmark/results/<result>.json
+```
+
+Each task and arm runs once by default.
+Use at least five runs per arm for a useful diagnostic sample.
+The order alternates by repetition as baseline/treatment then treatment/baseline, producing ABBA across two repetitions.
+
+The cost guard is checked between trials.
+One in-flight trial can exceed the configured estimate.
+Pi catalog cost is an estimate and can remain zero for subscription-backed providers.
+
+## Cache regimes
+
+`--cache-mode warm` keeps the benchmark system prefix stable across repetitions.
+`--cache-mode cold` adds a deterministic per-task and repetition nonce to the system prompt.
+The paired baseline and treatment receive the same nonce.
+Provider caching remains provider-controlled, so always inspect reported `cacheRead` and `cacheWrite` tokens.
+
+Run cold and warm studies separately:
+
+```bash
+just benchmark-cbmem --cache-mode cold
+just benchmark-cbmem --cache-mode warm
+```
+
+## Metrics
+
+Every trial records these fields:
+
+| Metric | Meaning |
+| --- | --- |
+| `usage.input` | Provider-reported uncached input tokens. |
+| `usage.cacheRead` | Provider-reported cached input tokens. |
+| `usage.cacheWrite` | Provider-reported cache-write input tokens. |
+| `usage.output` | Provider-reported generated tokens. |
+| `usage.providerTokens` | Sum of input, cache read, cache write, and output tokens. |
+| `startupMs` | Process spawn through RPC controls and package provenance resolution. |
+| `agentWallMs` | Immediately before the prompt RPC command through `agent_settled`. |
+| `processWallMs` | Process spawn through `agent_settled`. |
+| `toolDurationSumMs` | Sum of completed tool-call durations. |
+| `nonToolResidualMsApprox` | Agent wall time minus summed tool duration, clamped at zero. |
+| `timeToFirstToolMs` | Prompt start to first tool execution. |
+| `timeToEvidenceCompleteMs` | Prompt start to the first tool-result point containing every expected literal. |
+| `turns` | Completed Pi turns. |
+| `providerRequests` | Completed assistant messages with usage. |
+| `requestUsage` | Provider-reported token and cost breakdown for each completed assistant request. |
+| `toolResultBytes` | Model-visible text bytes returned by tools. |
+
+`processWallMs` intentionally includes temporary npm resolution from `-e npm:@narumitw/pi-cbmem` because that is part of the requested CLI invocation.
+`agentWallMs` separates retrieval behavior from most startup and package-resolution work.
+`nonToolResidualMsApprox` is only a diagnostic remainder because parallel tool durations can overlap.
+
+The primary token efficiency metric is:
+
+```text
+all provider tokens spent by an arm / successful runs in that arm
+```
+
+The report also preserves successful-run medians, median absolute deviations, P95 values, failure counts, exact fact scores, tool names, result hashes, and package version provenance.
+Do not discard failed runs when interpreting token efficiency.
+
+## Indexing amortization
+
+Index creation is outside measured trial latency.
+Supply a separately measured indexing duration and expected reuse count when amortized treatment latency matters:
+
+```bash
+just benchmark-cbmem \
+  --indexing-ms <milliseconds> \
+  --index-reuse-count <expected-tasks-sharing-index>
+```
+
+The report adds `indexingMs / indexReuseCount` to the successful treatment median process time.
+
+## Suite format
+
+The default suite is [`suites/pi-extensions.json`](./suites/pi-extensions.json).
+It targets facts in this repository's pi-cbmem implementation.
+
+A custom suite must provide a unique id, exact expected facts, and at least one task.
+Exact-payload tasks also provide one pi-cbmem tool name and argument object.
+Use `${project}` in tool arguments to substitute the live `--project` value.
+
+Expected facts are hidden from prompts but remain in the suite and result for deterministic grading.
+Do not use tasks whose expected values can be inferred from their ids alone.
+
+## Interpretation
+
+Treat results as diagnostic unless the suite, model, package version, Codebase Memory binary, repository commit, index, run count, cache regime, and execution protocol were locked before inspecting outcomes.
+
+A practical adoption threshold can require all of the following:
+
+- Required-fact success does not decline materially.
+- Median provider tokens per successful run fall by at least 15%.
+- Median agent wall time per successful run falls by at least 10%.
+- P95 agent wall time does not develop an unacceptable tail.
+- Amortized indexing cost remains acceptable for the expected reuse count.
+
+Exact-payload treatment is expected to use more tokens and time because it adds tool definitions, a tool-call turn, a tool-result envelope, and a local subprocess.
+Same-evidence treatment can win only when more selective retrieval offsets that fixed overhead.
+
+## Privacy and cleanup
+
+Live trials send prompts and retrieved repository content to the selected model provider.
+The runner does not store raw assistant responses or raw tool results in the report.
+It stores hashes, byte counts, exact grader values, tool names, tool arguments, usage, timing, and package provenance.
+
+The runner uses `--no-session` and closes every RPC process after `agent_settled` or failure.
+SIGINT, SIGTERM, and per-trial deadlines terminate the active subprocess.
+The npm source is resolved by Pi using its normal temporary package behavior.
+
+## Limits
+
+- Hosted model behavior, provider load, and caching remain nondeterministic.
+- The default suite is small and repository-specific.
+- Exact string grading can reject semantically equivalent wording by design.
+- Tool-result literal detection is a timing proxy and does not prove when the model internally recognized a fact.
+- Summed tool duration can overlap when tools execute in parallel.
+- The benchmark does not measure code-edit correctness, test execution, or long-session memory behavior.

--- a/packages/pi-cbmem/benchmark/config.mjs
+++ b/packages/pi-cbmem/benchmark/config.mjs
@@ -1,0 +1,152 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { validateSuite } from "./core.mjs";
+
+const BENCHMARK_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(BENCHMARK_ROOT, "../../..");
+const DEFAULT_SUITE = path.join(BENCHMARK_ROOT, "suites", "pi-extensions.json");
+
+export const DEFAULT_TIMEOUT_MS = 180_000;
+
+export async function parseArguments(args) {
+	const options = {
+		cacheMode: "warm",
+		cbmemBin:
+			process.env.PI_CBMEM_BENCHMARK_BIN ??
+			path.join(process.env.HOME ?? "", ".local", "bin", "codebase-memory-mcp"),
+		extension: "npm:@narumitw/pi-cbmem",
+		help: false,
+		indexingMs: undefined,
+		indexReuseCount: undefined,
+		kind: "all",
+		live: false,
+		maxCostUsd: undefined,
+		model: process.env.PI_CBMEM_BENCHMARK_MODEL,
+		output: undefined,
+		pi: process.env.PI_CBMEM_BENCHMARK_PI ?? "pi",
+		project: undefined,
+		repo: REPOSITORY_ROOT,
+		runs: 1,
+		suitePath: DEFAULT_SUITE,
+		thinking: "off",
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+	};
+
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+		if (argument === "--help" || argument === "-h") options.help = true;
+		else if (argument === "--live") options.live = true;
+		else if (argument === "--cache-mode") {
+			options.cacheMode = enumValue(args, ++index, argument, ["warm", "cold"]);
+		} else if (argument === "--cbmem-bin") {
+			options.cbmemBin = requireValue(args, ++index, argument);
+		} else if (argument === "--extension") {
+			options.extension = requireValue(args, ++index, argument);
+		} else if (argument === "--indexing-ms") {
+			options.indexingMs = nonNegativeNumber(requireValue(args, ++index, argument), argument);
+		} else if (argument === "--index-reuse-count") {
+			options.indexReuseCount = positiveInteger(requireValue(args, ++index, argument), argument);
+		} else if (argument === "--kind") {
+			options.kind = enumValue(args, ++index, argument, ["all", "exact-payload", "same-evidence"]);
+		} else if (argument === "--max-cost-usd") {
+			options.maxCostUsd = nonNegativeNumber(requireValue(args, ++index, argument), argument);
+		} else if (argument === "--model") options.model = requireValue(args, ++index, argument);
+		else if (argument === "--output") options.output = requireValue(args, ++index, argument);
+		else if (argument === "--pi") options.pi = requireValue(args, ++index, argument);
+		else if (argument === "--project") options.project = requireValue(args, ++index, argument);
+		else if (argument === "--repo") options.repo = requireValue(args, ++index, argument);
+		else if (argument === "--runs") {
+			options.runs = positiveInteger(requireValue(args, ++index, argument), argument);
+		} else if (argument === "--suite") {
+			options.suitePath = requireValue(args, ++index, argument);
+		} else if (argument === "--thinking") {
+			options.thinking = enumValue(args, ++index, argument, [
+				"off",
+				"minimal",
+				"low",
+				"medium",
+				"high",
+				"xhigh",
+				"max",
+			]);
+		} else if (argument === "--timeout-ms") {
+			options.timeoutMs = positiveInteger(requireValue(args, ++index, argument), argument);
+		} else throw new Error(`unknown argument: ${argument}`);
+	}
+
+	options.repo = path.resolve(options.repo);
+	options.suitePath = path.resolve(options.suitePath);
+	if (options.output) options.output = path.resolve(options.output);
+	const suite = validateSuite(JSON.parse(await readFile(options.suitePath, "utf8")));
+	options.suite = {
+		...suite,
+		tasks: suite.tasks.filter((task) => options.kind === "all" || task.kind === options.kind),
+	};
+	if (options.suite.tasks.length === 0) throw new Error("the selected suite has no matching tasks");
+	if ((options.indexingMs === undefined) !== (options.indexReuseCount === undefined)) {
+		throw new Error("--indexing-ms and --index-reuse-count must be supplied together");
+	}
+	if (options.live) {
+		if (!options.model) throw new Error("--live requires --model <provider/model>");
+		if (!options.project) throw new Error("--live requires --project <indexed-project>");
+		if (options.maxCostUsd === undefined) {
+			throw new Error("--live requires --max-cost-usd <amount>");
+		}
+	}
+	return options;
+}
+
+export function printHelp() {
+	process.stdout.write("Usage: just benchmark-cbmem [options]\n\n");
+	process.stdout.write("Without --live, the command makes no provider request.\n\n");
+	process.stdout.write("  --live                    Execute paired Pi subprocess trials.\n");
+	process.stdout.write("  --model <provider/model>  Fixed model for both arms.\n");
+	process.stdout.write("  --project <name>          Exact indexed Codebase Memory project name.\n");
+	process.stdout.write("  --repo <path>             Repository visible to both arms.\n");
+	process.stdout.write("  --suite <path>            Versioned benchmark suite JSON.\n");
+	process.stdout.write("  --kind <kind>             all, exact-payload, or same-evidence.\n");
+	process.stdout.write("  --runs <count>            Trials per task and arm (default: 1).\n");
+	process.stdout.write("  --indexing-ms <ms>        Optional one-time indexing duration.\n");
+	process.stdout.write("  --index-reuse-count <n>   Tasks expected to share that index.\n");
+	process.stdout.write("  --cache-mode <mode>       warm or cold (default: warm).\n");
+	process.stdout.write("  --thinking <level>        Fixed Pi thinking level (default: off).\n");
+	process.stdout.write(
+		"  --extension <source>      Treatment source (default: npm:@narumitw/pi-cbmem).\n",
+	);
+	process.stdout.write("  --max-cost-usd <amount>   Between-trial Pi-catalog cost guard.\n");
+	process.stdout.write("  --timeout-ms <ms>         Per-trial deadline.\n");
+	process.stdout.write("  --output <path>           Atomically write the JSON result.\n");
+	process.stdout.write("  --pi <path>               Pi executable (default: pi).\n");
+	process.stdout.write("  --cbmem-bin <path>        Codebase Memory CLI path.\n");
+	process.stdout.write("  -h, --help                Show this help.\n");
+}
+
+function requireValue(args, index, option) {
+	const value = args[index];
+	if (!value) throw new Error(`${option} requires a value`);
+	return value;
+}
+
+function positiveInteger(value, option) {
+	const number = Number(value);
+	if (!Number.isSafeInteger(number) || number <= 0) {
+		throw new Error(`${option} must be a positive integer`);
+	}
+	return number;
+}
+
+function nonNegativeNumber(value, option) {
+	const number = Number(value);
+	if (!Number.isFinite(number) || number < 0) {
+		throw new Error(`${option} must be a non-negative number`);
+	}
+	return number;
+}
+
+function enumValue(args, index, option, values) {
+	const value = requireValue(args, index, option);
+	if (!values.includes(value)) throw new Error(`${option} must be one of: ${values.join(", ")}`);
+	return value;
+}

--- a/packages/pi-cbmem/benchmark/core.mjs
+++ b/packages/pi-cbmem/benchmark/core.mjs
@@ -1,0 +1,336 @@
+import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+
+export const BENCHMARK_ID = "pi-cbmem-retrieval-comparison:v1";
+export const ARMS = ["baseline", "cbmem"];
+export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls"];
+export const CBMEM_TOOLS = [
+	"index_repository",
+	"search_graph",
+	"query_graph",
+	"trace_path",
+	"get_code_snippet",
+	"get_graph_schema",
+	"get_architecture",
+	"search_code",
+	"list_projects",
+	"delete_project",
+	"index_status",
+	"check_index_coverage",
+	"detect_changes",
+	"manage_adr",
+	"ingest_traces",
+];
+export const CBMEM_READ_ONLY_TOOLS = CBMEM_TOOLS.filter(
+	(name) => !["index_repository", "delete_project", "manage_adr", "ingest_traces"].includes(name),
+);
+
+const TASK_FIELDS = new Set(["id", "kind", "question", "facts", "exactTool"]);
+const SUITE_FIELDS = new Set(["schemaVersion", "id", "description", "tasks"]);
+const PROJECT_PLACEHOLDER = `$${"{project}"}`;
+
+export function validateSuite(input) {
+	requireObject(input, "suite");
+	rejectUnknown(input, SUITE_FIELDS, "suite");
+	if (input.schemaVersion !== 1) throw new Error("suite.schemaVersion must equal 1");
+	requireString(input.id, "suite.id");
+	requireString(input.description, "suite.description");
+	if (!Array.isArray(input.tasks) || input.tasks.length === 0) {
+		throw new Error("suite.tasks must be a non-empty array");
+	}
+	const ids = new Set();
+	for (const [index, task] of input.tasks.entries()) {
+		const label = `suite.tasks[${index}]`;
+		requireObject(task, label);
+		rejectUnknown(task, TASK_FIELDS, label);
+		requireString(task.id, `${label}.id`);
+		if (ids.has(task.id)) throw new Error(`duplicate task id: ${task.id}`);
+		ids.add(task.id);
+		if (task.kind !== "exact-payload" && task.kind !== "same-evidence") {
+			throw new Error(`${label}.kind must be exact-payload or same-evidence`);
+		}
+		requireString(task.question, `${label}.question`);
+		if (!Array.isArray(task.facts) || task.facts.length === 0) {
+			throw new Error(`${label}.facts must be a non-empty array`);
+		}
+		const factIds = new Set();
+		for (const [factIndex, fact] of task.facts.entries()) {
+			const factLabel = `${label}.facts[${factIndex}]`;
+			requireObject(fact, factLabel);
+			rejectUnknown(fact, new Set(["id", "expected"]), factLabel);
+			requireString(fact.id, `${factLabel}.id`);
+			requireString(fact.expected, `${factLabel}.expected`);
+			if (factIds.has(fact.id)) throw new Error(`duplicate fact id in ${task.id}: ${fact.id}`);
+			factIds.add(fact.id);
+		}
+		if (task.kind === "exact-payload") validateExactTool(task.exactTool, label);
+		else if (task.exactTool !== undefined) {
+			throw new Error(`${label}.exactTool is allowed only for exact-payload tasks`);
+		}
+	}
+	return structuredClone(input);
+}
+
+export function materializeTask(task, project) {
+	return replaceProject(structuredClone(task), project);
+}
+
+export function createSchedule(tasks, runs) {
+	const schedule = [];
+	for (const task of tasks) {
+		for (let repetition = 0; repetition < runs; repetition += 1) {
+			const order = repetition % 2 === 0 ? ARMS : [...ARMS].reverse();
+			for (const arm of order) {
+				schedule.push({ taskId: task.id, kind: task.kind, repetition: repetition + 1, arm });
+			}
+		}
+	}
+	return schedule;
+}
+
+export function buildPrompt({ arm, task, evidencePacket }) {
+	const factIds = task.facts.map((fact) => fact.id);
+	const schema = JSON.stringify({ answers: Object.fromEntries(factIds.map((id) => [id, "..."])) });
+	const lines = [
+		"You are a deterministic codebase fact-recovery benchmark agent.",
+		"Return only one JSON object with exactly this shape:",
+		schema,
+		"Every answer must be a string.",
+		"Do not include Markdown, commentary, or additional keys.",
+		`Question: ${task.question}`,
+	];
+
+	if (task.kind === "exact-payload" && arm === "baseline") {
+		lines.push("Do not call tools. Use only this evidence packet:", evidencePacket ?? "");
+	} else if (task.kind === "exact-payload") {
+		lines.push(
+			`Call ${task.exactTool.name} exactly once with these exact arguments:`,
+			JSON.stringify(task.exactTool.args),
+			"Do not call any other tool.",
+		);
+	} else if (arm === "baseline") {
+		lines.push("Use only the available read-only Pi tools to inspect the repository.");
+	} else {
+		lines.push(
+			"Use at least one Codebase Memory tool to acquire evidence.",
+			"Target source verification with read-only Pi tools is allowed when needed.",
+		);
+	}
+	return lines.join("\n");
+}
+
+export function scoreTrial({ arm, task, responseText, toolCalls, toolResults, evidencePacket }) {
+	const errors = [];
+	let parsed;
+	try {
+		parsed = JSON.parse(responseText.trim());
+	} catch (error) {
+		errors.push(`response is not strict JSON: ${error instanceof Error ? error.message : error}`);
+	}
+	const answers = parsed?.answers;
+	if (!isPlainObject(parsed) || !isPlainObject(answers) || Object.keys(parsed).length !== 1) {
+		errors.push("response must contain only an answers object");
+	}
+	const expectedIds = task.facts.map((fact) => fact.id).sort();
+	const actualIds = isPlainObject(answers) ? Object.keys(answers).sort() : [];
+	if (JSON.stringify(expectedIds) !== JSON.stringify(actualIds)) {
+		errors.push("answer keys do not match the required facts");
+	}
+	const facts = task.facts.map((fact) => {
+		const actual = isPlainObject(answers) ? answers[fact.id] : undefined;
+		const matched = typeof actual === "string" && actual === fact.expected;
+		if (!matched) errors.push(`fact mismatch: ${fact.id}`);
+		return { id: fact.id, expected: fact.expected, actual, matched };
+	});
+
+	const cbmemCalls = toolCalls.filter((call) => CBMEM_TOOLS.includes(call.name));
+	const successfulCbmemResults = toolResults.filter(
+		(result) => CBMEM_TOOLS.includes(result.name) && result.isError !== true,
+	);
+	if (arm === "baseline" && cbmemCalls.length > 0) errors.push("baseline called a cbmem tool");
+	if (task.kind === "exact-payload" && arm === "baseline" && toolCalls.length > 0) {
+		errors.push("exact-payload baseline called a tool");
+	}
+	if (task.kind === "same-evidence" && arm === "cbmem" && cbmemCalls.length === 0) {
+		errors.push("cbmem arm did not call a cbmem tool");
+	}
+	if (task.kind === "same-evidence" && arm === "cbmem" && successfulCbmemResults.length === 0) {
+		errors.push("cbmem arm had no successful cbmem tool result");
+	}
+	let exactPayload;
+	if (task.kind === "exact-payload" && arm === "cbmem") {
+		const expectedCalls = toolCalls.filter((call) => call.name === task.exactTool.name);
+		if (toolCalls.length !== 1 || expectedCalls.length !== 1) {
+			errors.push("exact-payload cbmem arm did not call only the required tool once");
+		}
+		if (expectedCalls[0] && !deepEqual(expectedCalls[0].args, task.exactTool.args)) {
+			errors.push("exact-payload tool arguments changed");
+		}
+		const resultText = toolResults.find((result) => result.name === task.exactTool.name)?.text;
+		exactPayload = {
+			expectedSha256: evidencePacket ? sha256(evidencePacket) : undefined,
+			actualSha256: typeof resultText === "string" ? sha256(resultText) : undefined,
+			matched: typeof resultText === "string" && resultText === evidencePacket,
+		};
+		if (!exactPayload.matched) errors.push("exact evidence payload did not match");
+	}
+
+	return {
+		success: errors.length === 0,
+		errors: [...new Set(errors)],
+		facts,
+		...(exactPayload ? { exactPayload } : {}),
+	};
+}
+
+export function summarizeTrials(trials) {
+	const byArm = Object.fromEntries(ARMS.map((arm) => [arm, summarizeArm(trials, arm)]));
+	return {
+		attempts: trials.length,
+		byArm,
+		comparison: {
+			successRateDelta: round(byArm.cbmem.successRate - byArm.baseline.successRate),
+			medianProviderTokensPerSuccessfulRunDelta: delta(
+				byArm.cbmem.successful.providerTokens?.median,
+				byArm.baseline.successful.providerTokens?.median,
+			),
+			medianAgentWallMsPerSuccessfulRunDelta: delta(
+				byArm.cbmem.successful.agentWallMs?.median,
+				byArm.baseline.successful.agentWallMs?.median,
+			),
+			p95AgentWallMsDelta: delta(
+				byArm.cbmem.successful.agentWallMs?.p95,
+				byArm.baseline.successful.agentWallMs?.p95,
+			),
+		},
+	};
+}
+
+export function summarizeNumbers(values) {
+	if (values.length === 0) return undefined;
+	const ordered = [...values].sort((left, right) => left - right);
+	const center = median(ordered);
+	return {
+		count: ordered.length,
+		median: round(center),
+		medianAbsoluteDeviation: round(
+			median(ordered.map((value) => Math.abs(value - center)).sort((left, right) => left - right)),
+		),
+		p95: round(percentile(ordered, 0.95)),
+		min: round(ordered[0]),
+		max: round(ordered.at(-1)),
+	};
+}
+
+export function extractLastJson(output) {
+	const trimmed = output.trim();
+	if (!trimmed) throw new Error("output contained no JSON");
+	try {
+		JSON.parse(trimmed);
+		return trimmed;
+	} catch {
+		for (const line of trimmed.split("\n").reverse()) {
+			const candidate = line.trim();
+			if (!candidate) continue;
+			try {
+				JSON.parse(candidate);
+				return candidate;
+			} catch {
+				// Continue to the previous complete line.
+			}
+		}
+	}
+	throw new Error("output contained no complete JSON response");
+}
+
+export function sha256(value) {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function summarizeArm(trials, arm) {
+	const selected = trials.filter((trial) => trial.arm === arm);
+	const successful = selected.filter((trial) => trial.score.success);
+	const totalProviderTokens = selected.reduce(
+		(total, trial) => total + trial.metrics.usage.providerTokens,
+		0,
+	);
+	return {
+		attempts: selected.length,
+		successes: successful.length,
+		successRate: selected.length === 0 ? 0 : round(successful.length / selected.length),
+		failures: selected.length - successful.length,
+		providerTokensPerSuccess:
+			successful.length === 0 ? undefined : round(totalProviderTokens / successful.length),
+		successful: {
+			providerTokens: summarizeNumbers(
+				successful.map((trial) => trial.metrics.usage.providerTokens),
+			),
+			agentWallMs: summarizeNumbers(successful.map((trial) => trial.metrics.agentWallMs)),
+			processWallMs: summarizeNumbers(successful.map((trial) => trial.metrics.processWallMs)),
+			startupMs: summarizeNumbers(successful.map((trial) => trial.metrics.startupMs)),
+		},
+	};
+}
+
+function validateExactTool(input, label) {
+	requireObject(input, `${label}.exactTool`);
+	rejectUnknown(input, new Set(["name", "args"]), `${label}.exactTool`);
+	requireString(input.name, `${label}.exactTool.name`);
+	if (!CBMEM_TOOLS.includes(input.name)) {
+		throw new Error(`${label}.exactTool.name is not a pi-cbmem tool`);
+	}
+	requireObject(input.args, `${label}.exactTool.args`);
+}
+
+function replaceProject(value, project) {
+	if (typeof value === "string") return value.replaceAll(PROJECT_PLACEHOLDER, project);
+	if (Array.isArray(value)) return value.map((item) => replaceProject(item, project));
+	if (!isPlainObject(value)) return value;
+	return Object.fromEntries(
+		Object.entries(value).map(([key, item]) => [key, replaceProject(item, project)]),
+	);
+}
+
+function rejectUnknown(input, allowed, label) {
+	for (const key of Object.keys(input)) {
+		if (!allowed.has(key)) throw new Error(`${label} has unknown field: ${key}`);
+	}
+}
+
+function requireObject(value, label) {
+	if (!isPlainObject(value)) throw new Error(`${label} must be an object`);
+}
+
+function requireString(value, label) {
+	if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+}
+
+function isPlainObject(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepEqual(left, right) {
+	return isDeepStrictEqual(left, right);
+}
+
+function median(ordered) {
+	const middle = Math.floor(ordered.length / 2);
+	return ordered.length % 2 === 0 ? (ordered[middle - 1] + ordered[middle]) / 2 : ordered[middle];
+}
+
+function percentile(ordered, fraction) {
+	if (ordered.length === 1) return ordered[0];
+	const position = (ordered.length - 1) * fraction;
+	const lower = Math.floor(position);
+	const upper = Math.ceil(position);
+	if (lower === upper) return ordered[lower];
+	return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower);
+}
+
+function delta(left, right) {
+	return left === undefined || right === undefined ? undefined : round(left - right);
+}
+
+function round(value) {
+	return Number(value.toFixed(3));
+}

--- a/packages/pi-cbmem/benchmark/rpc-runner.mjs
+++ b/packages/pi-cbmem/benchmark/rpc-runner.mjs
@@ -1,0 +1,449 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { StringDecoder } from "node:string_decoder";
+import {
+	buildPrompt,
+	CBMEM_READ_ONLY_TOOLS,
+	READ_ONLY_TOOLS,
+	scoreTrial,
+	sha256,
+} from "./core.mjs";
+
+const STDERR_LIMIT = 16 * 1024;
+
+export async function runPiTrial({ arm, evidencePacket, options, repetition, signal, task }) {
+	signal?.throwIfAborted();
+	const cacheNonce =
+		options.cacheMode === "cold" ? `${options.suite.id}:${task.id}:${repetition}` : undefined;
+	const args = buildPiArguments({ arm, cacheNonce, options, task });
+	const processStarted = performance.now();
+	const rpc = new RpcProcess(options.pi, args, {
+		cwd: options.repo,
+		env: process.env,
+	});
+	const onAbort = () => rpc.kill(abortReason(signal));
+	signal?.addEventListener("abort", onAbort, { once: true });
+	let timeout;
+	try {
+		const execution = executeTrial({
+			arm,
+			evidencePacket,
+			processStarted,
+			rpc,
+			task,
+		});
+		const deadline = new Promise((_, reject) => {
+			timeout = setTimeout(() => {
+				const error = new Error(`trial exceeded ${options.timeoutMs}ms`);
+				rpc.kill(error);
+				reject(error);
+			}, options.timeoutMs);
+		});
+		return await Promise.race([execution, deadline]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+		signal?.removeEventListener("abort", onAbort);
+		await rpc.close();
+	}
+}
+
+export function buildPiArguments({ arm, cacheNonce, options, task }) {
+	const activeTools =
+		task.kind === "exact-payload" && arm === "baseline"
+			? []
+			: arm === "baseline"
+				? READ_ONLY_TOOLS
+				: [...READ_ONLY_TOOLS, ...CBMEM_READ_ONLY_TOOLS];
+	const args = [
+		"--mode",
+		"rpc",
+		"--no-session",
+		"-ne",
+		"-ns",
+		"-np",
+		"--no-themes",
+		"-nc",
+		"-na",
+		"--model",
+		options.model ?? "<required-for-live>",
+		"--thinking",
+		options.thinking,
+	];
+	if (activeTools.length === 0) args.push("--no-tools");
+	else args.push("--tools", activeTools.join(","));
+	if (arm === "cbmem") args.push("-e", options.extension);
+	if (cacheNonce) {
+		args.push("--append-system-prompt", `Benchmark cold-cache nonce: ${cacheNonce}`);
+	}
+	return args;
+}
+
+async function executeTrial({ arm, evidencePacket, processStarted, rpc, task }) {
+	await rpc.send({ type: "set_auto_compaction", enabled: false });
+	await rpc.send({ type: "set_auto_retry", enabled: false });
+	const commandsResponse = await rpc.send({ type: "get_commands" });
+	const startupMs = performance.now() - processStarted;
+	const packageProvenance =
+		arm === "cbmem"
+			? await readPackageProvenance(commandsResponse.data?.commands ?? [])
+			: undefined;
+	if (arm === "cbmem" && !packageProvenance) {
+		throw new Error("treatment did not expose the codebase-memory package skill");
+	}
+
+	const prompt = buildPrompt({ arm, task, evidencePacket });
+	rpc.beginPrompt(task);
+	const promptStarted = performance.now();
+	const promptResponse = await rpc.send({ type: "prompt", message: prompt });
+	if (!promptResponse.success)
+		throw new Error(`prompt rejected: ${promptResponse.error ?? "unknown"}`);
+	await rpc.waitForSettled();
+	const settledAt = performance.now();
+	const statsResponse = await rpc.send({ type: "get_session_stats" });
+	const processWallMs = settledAt - processStarted;
+	const agentWallMs = settledAt - promptStarted;
+	const captured = rpc.capture();
+	const usage = normalizeUsage(statsResponse.data?.tokens, statsResponse.data?.cost);
+	const score = scoreTrial({
+		arm,
+		task,
+		responseText: captured.responseText,
+		toolCalls: captured.toolCalls,
+		toolResults: captured.toolResults,
+		evidencePacket,
+	});
+	if (captured.extensionErrors.length > 0) {
+		score.success = false;
+		score.errors.push("Pi reported an extension error");
+	}
+	return {
+		arm,
+		taskId: task.id,
+		kind: task.kind,
+		score,
+		metrics: {
+			startupMs: round(startupMs),
+			agentWallMs: round(agentWallMs),
+			processWallMs: round(processWallMs),
+			nonToolResidualMsApprox: round(
+				Math.max(0, agentWallMs - captured.toolDurationsMs.reduce((sum, value) => sum + value, 0)),
+			),
+			toolDurationSumMs: round(captured.toolDurationsMs.reduce((sum, value) => sum + value, 0)),
+			timeToFirstToolMs: captured.timeToFirstToolMs,
+			timeToEvidenceCompleteMs: captured.timeToEvidenceCompleteMs,
+			turns: captured.turns,
+			providerRequests: captured.assistantUsages.length,
+			toolCalls: captured.toolCalls.length,
+			toolResultBytes: captured.toolResults.reduce(
+				(total, result) => total + Buffer.byteLength(result.text, "utf8"),
+				0,
+			),
+			usage,
+			requestUsage: captured.assistantUsages.map(normalizeAssistantUsage),
+		},
+		method: {
+			piArguments: redactArguments(rpc.args),
+			toolCalls: captured.toolCalls,
+			toolResults: captured.toolResults.map(({ text, ...result }) => ({
+				...result,
+				bytes: Buffer.byteLength(text, "utf8"),
+				sha256: sha256(text),
+			})),
+			extensionErrors: captured.extensionErrors,
+		},
+		response: {
+			bytes: Buffer.byteLength(captured.responseText, "utf8"),
+			sha256: sha256(captured.responseText),
+		},
+		...(packageProvenance ? { package: packageProvenance } : {}),
+	};
+}
+
+class RpcProcess {
+	constructor(command, args, options) {
+		this.args = args;
+		this.child = spawn(command, args, { ...options, stdio: ["pipe", "pipe", "pipe"] });
+		this.commandId = 0;
+		this.pending = new Map();
+		this.stderr = "";
+		this.failed = undefined;
+		this.settledResolve = undefined;
+		this.settledReject = undefined;
+		this.settledPromise = new Promise((resolve, reject) => {
+			this.settledResolve = resolve;
+			this.settledReject = reject;
+		});
+		this.settledPromise.catch(() => undefined);
+		this.promptStarted = undefined;
+		this.task = undefined;
+		this.toolStarts = new Map();
+		this.toolCalls = [];
+		this.toolResults = [];
+		this.toolDurationsMs = [];
+		this.assistantUsages = [];
+		this.responseText = "";
+		this.turns = 0;
+		this.timeToFirstToolMs = undefined;
+		this.timeToEvidenceCompleteMs = undefined;
+		this.extensionErrors = [];
+		this.evidenceText = "";
+		this.closed = false;
+
+		attachJsonlReader(this.child.stdout, (line) => this.onLine(line));
+		this.child.stderr.on("data", (chunk) => {
+			this.stderr = boundedTail(this.stderr + chunk.toString("utf8"), STDERR_LIMIT);
+		});
+		this.exitPromise = new Promise((resolve) => {
+			this.child.once("exit", (code, exitSignal) => {
+				if (!this.closed && this.promptStarted !== undefined && !this.failed) {
+					this.fail(
+						new Error(
+							`Pi exited before agent_settled (code=${code}, signal=${exitSignal ?? "none"})`,
+						),
+					);
+				}
+				resolve({ code, signal: exitSignal });
+			});
+		});
+		this.child.stdin.on("error", () => {
+			// Command callbacks and child events report protocol/process failures.
+		});
+		this.child.once("error", (error) => this.fail(error));
+	}
+
+	beginPrompt(task) {
+		this.task = task;
+		this.promptStarted = performance.now();
+	}
+
+	send(command) {
+		if (this.failed) return Promise.reject(this.failed);
+		const id = `benchmark-${++this.commandId}`;
+		return new Promise((resolve, reject) => {
+			this.pending.set(id, { resolve, reject });
+			this.child.stdin.write(`${JSON.stringify({ id, ...command })}\n`, (error) => {
+				if (!error) return;
+				this.pending.delete(id);
+				reject(error);
+			});
+		});
+	}
+
+	waitForSettled() {
+		return this.settledPromise;
+	}
+
+	capture() {
+		return {
+			assistantUsages: structuredClone(this.assistantUsages),
+			extensionErrors: structuredClone(this.extensionErrors),
+			responseText: this.responseText,
+			timeToEvidenceCompleteMs: this.timeToEvidenceCompleteMs,
+			timeToFirstToolMs: this.timeToFirstToolMs,
+			toolCalls: structuredClone(this.toolCalls),
+			toolDurationsMs: [...this.toolDurationsMs],
+			toolResults: structuredClone(this.toolResults),
+			turns: this.turns,
+		};
+	}
+
+	onLine(line) {
+		if (!line.trim()) return;
+		let message;
+		try {
+			message = JSON.parse(line);
+		} catch (error) {
+			this.fail(new Error(`Pi emitted invalid RPC JSON: ${error}`));
+			return;
+		}
+		if (message.type === "response" && message.id) {
+			const waiter = this.pending.get(message.id);
+			if (!waiter) return;
+			this.pending.delete(message.id);
+			if (message.success) waiter.resolve(message);
+			else waiter.reject(new Error(`${message.command} failed: ${message.error ?? "unknown"}`));
+			return;
+		}
+		this.onEvent(message);
+	}
+
+	onEvent(event) {
+		const elapsed =
+			this.promptStarted === undefined ? undefined : performance.now() - this.promptStarted;
+		if (event.type === "tool_execution_start") {
+			this.toolStarts.set(event.toolCallId, performance.now());
+			this.toolCalls.push({ name: event.toolName, args: event.args });
+			if (this.timeToFirstToolMs === undefined && elapsed !== undefined) {
+				this.timeToFirstToolMs = round(elapsed);
+			}
+		} else if (event.type === "tool_execution_end") {
+			const started = this.toolStarts.get(event.toolCallId);
+			if (started !== undefined) this.toolDurationsMs.push(performance.now() - started);
+			const text = resultText(event.result);
+			this.toolResults.push({ name: event.toolName, isError: event.isError, text });
+			this.evidenceText += `\n${text}`;
+			if (
+				this.timeToEvidenceCompleteMs === undefined &&
+				this.task?.facts.every((fact) => this.evidenceText.includes(fact.expected)) &&
+				elapsed !== undefined
+			) {
+				this.timeToEvidenceCompleteMs = round(elapsed);
+			}
+		} else if (event.type === "message_end" && event.message?.role === "assistant") {
+			this.responseText = assistantText(event.message);
+			if (event.message.usage) this.assistantUsages.push(event.message.usage);
+		} else if (event.type === "turn_end") this.turns += 1;
+		else if (event.type === "extension_error") this.extensionErrors.push(event);
+		else if (event.type === "agent_settled") this.settledResolve();
+	}
+
+	fail(error) {
+		if (this.failed) return;
+		this.failed = error instanceof Error ? error : new Error(String(error));
+		for (const waiter of this.pending.values()) waiter.reject(this.failed);
+		this.pending.clear();
+		this.settledReject(this.failed);
+	}
+
+	kill(error) {
+		this.fail(error);
+		if (this.child.exitCode === null && this.child.signalCode === null) this.child.kill("SIGTERM");
+		setTimeout(() => {
+			if (this.child.exitCode === null && this.child.signalCode === null)
+				this.child.kill("SIGKILL");
+		}, 1_000).unref();
+	}
+
+	async close() {
+		if (this.closed) return;
+		this.closed = true;
+		if (this.child.exitCode === null && this.child.signalCode === null) this.child.stdin.end();
+		let cleanupTimer;
+		const cleanupDeadline = new Promise((resolve) => {
+			cleanupTimer = setTimeout(() => {
+				if (this.child.exitCode === null && this.child.signalCode === null)
+					this.child.kill("SIGKILL");
+				resolve(undefined);
+			}, 5_000);
+		});
+		await Promise.race([this.exitPromise, cleanupDeadline]);
+		if (cleanupTimer) clearTimeout(cleanupTimer);
+		const exit = await this.exitPromise;
+		if (!this.failed && exit.code !== 0) {
+			throw new Error(
+				`Pi exited with code ${exit.code} (signal=${exit.signal ?? "none"}): ${this.stderr.trim()}`,
+			);
+		}
+	}
+}
+
+async function readPackageProvenance(commands) {
+	const skill = commands.find((command) => command.name === "skill:codebase-memory");
+	const skillPath = skill?.path ?? skill?.sourceInfo?.path;
+	if (!skillPath) return undefined;
+	let current = path.dirname(skillPath);
+	while (true) {
+		const manifestPath = path.join(current, "package.json");
+		try {
+			const text = await readFile(manifestPath, "utf8");
+			const manifest = JSON.parse(text);
+			if (manifest.name === "@narumitw/pi-cbmem") {
+				return {
+					name: manifest.name,
+					version: manifest.version,
+					manifestSha256: createHash("sha256").update(text).digest("hex"),
+				};
+			}
+		} catch (error) {
+			if (error?.code !== "ENOENT") throw error;
+		}
+		const parent = path.dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+function normalizeAssistantUsage(usage) {
+	return normalizeUsage(usage, usage?.cost?.total);
+}
+
+function normalizeUsage(tokens, cost) {
+	const input = finite(tokens?.input);
+	const output = finite(tokens?.output);
+	const cacheRead = finite(tokens?.cacheRead);
+	const cacheWrite = finite(tokens?.cacheWrite);
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		providerTokens: input + output + cacheRead + cacheWrite,
+		costUsd: finite(cost),
+	};
+}
+
+function assistantText(message) {
+	return (message.content ?? [])
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function resultText(result) {
+	return (result?.content ?? [])
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function attachJsonlReader(stream, onLine) {
+	const decoder = new StringDecoder("utf8");
+	let buffer = "";
+	stream.on("data", (chunk) => {
+		buffer += decoder.write(chunk);
+		while (true) {
+			const index = buffer.indexOf("\n");
+			if (index < 0) break;
+			let line = buffer.slice(0, index);
+			buffer = buffer.slice(index + 1);
+			if (line.endsWith("\r")) line = line.slice(0, -1);
+			onLine(line);
+		}
+	});
+	stream.on("end", () => {
+		buffer += decoder.end();
+		if (buffer) onLine(buffer.endsWith("\r") ? buffer.slice(0, -1) : buffer);
+	});
+}
+
+function redactArguments(args) {
+	return args.map((argument) =>
+		argument.startsWith("Benchmark cold-cache nonce:")
+			? "Benchmark cold-cache nonce: <redacted>"
+			: argument,
+	);
+}
+
+function boundedTail(value, maxBytes) {
+	const buffer = Buffer.from(value, "utf8");
+	return buffer.length <= maxBytes
+		? value
+		: buffer.subarray(buffer.length - maxBytes).toString("utf8");
+}
+
+function finite(value) {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function abortReason(signal) {
+	return signal?.reason instanceof Error
+		? signal.reason
+		: new DOMException("benchmark trial aborted", "AbortError");
+}
+
+function round(value) {
+	return Number(value.toFixed(3));
+}

--- a/packages/pi-cbmem/benchmark/run.mjs
+++ b/packages/pi-cbmem/benchmark/run.mjs
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { parseArguments, printHelp } from "./config.mjs";
+import {
+	BENCHMARK_ID,
+	createSchedule,
+	extractLastJson,
+	materializeTask,
+	sha256,
+	summarizeTrials,
+} from "./core.mjs";
+import { buildPiArguments, runPiTrial } from "./rpc-runner.mjs";
+
+try {
+	const options = await parseArguments(process.argv.slice(2));
+	if (options.help) printHelp();
+	else {
+		const result = options.live ? await runLive(options) : createDryRun(options);
+		await publishResult(result, options.output);
+		if (result.status === "failed") process.exitCode = 1;
+	}
+} catch (error) {
+	process.stderr.write(`Benchmark failed: ${safeText(errorMessage(error))}\n`);
+	process.exitCode = 1;
+}
+
+function createDryRun(options) {
+	const tasks = options.suite.tasks.map((task) =>
+		materializeTask(task, options.project ?? "<indexed-project>"),
+	);
+	const schedule = createSchedule(tasks, options.runs);
+	return {
+		benchmark: BENCHMARK_ID,
+		mode: "dry-run",
+		createdAt: new Date().toISOString(),
+		note: "No Pi subprocess, Codebase Memory command, or provider request was made. Pass --live to execute.",
+		config: publicConfig(options),
+		suite: suiteMetadata(options.suite),
+		plannedTrials: schedule.length,
+		plannedOrder: schedule,
+		minimumProviderRequests: schedule.reduce(
+			(total, trial) =>
+				total + (trial.arm === "baseline" && trial.kind === "exact-payload" ? 1 : 2),
+			0,
+		),
+		commandShapes: commandShapes(options, tasks),
+		liveRequirements: [
+			"A prepared Codebase Memory index whose root exactly matches --repo.",
+			"A fixed --model and explicit --max-cost-usd guard.",
+			"Provider credentials available to the selected Pi installation.",
+		],
+	};
+}
+
+async function runLive(options) {
+	const controller = new AbortController();
+	const cancel = () => controller.abort(new DOMException("benchmark cancelled", "AbortError"));
+	process.once("SIGINT", cancel);
+	process.once("SIGTERM", cancel);
+	const trials = [];
+	let status = "completed";
+	let failure;
+	try {
+		const provenance = await collectProvenance(options, controller.signal);
+		const tasks = options.suite.tasks.map((task) => materializeTask(task, options.project));
+		const exactPayloads = await captureExactPayloads(options, tasks, controller.signal);
+		const schedule = createSchedule(tasks, options.runs);
+		for (const [index, entry] of schedule.entries()) {
+			controller.signal.throwIfAborted();
+			const recordedCost = trials.reduce((total, trial) => total + trial.metrics.usage.costUsd, 0);
+			if (trials.length > 0 && recordedCost >= options.maxCostUsd) {
+				status = "estimated-cost-guard";
+				break;
+			}
+			const task = tasks.find((candidate) => candidate.id === entry.taskId);
+			process.stderr.write(
+				`[${index + 1}/${schedule.length}] ${entry.taskId} ${entry.arm} repetition ${entry.repetition}\n`,
+			);
+			try {
+				const trial = await runPiTrial({
+					arm: entry.arm,
+					evidencePacket: exactPayloads.get(entry.taskId)?.text,
+					options,
+					repetition: entry.repetition,
+					signal: controller.signal,
+					task,
+				});
+				trials.push({ ...entry, ...trial });
+			} catch (error) {
+				status = "failed";
+				failure = errorMessage(error);
+				break;
+			}
+			if (options.output) {
+				await writeResult(
+					options.output,
+					createLiveResult({
+						exactPayloads,
+						failure: undefined,
+						options,
+						provenance,
+						status: "in-progress",
+						tasks,
+						trials,
+					}),
+				);
+			}
+		}
+		try {
+			provenance.runtimeDrift = await checkRuntimeDrift(options, provenance, controller.signal);
+			provenance.treatmentPackages = treatmentPackageVariants(trials);
+			provenance.runtimeDrift.checks.treatmentPackage = provenance.treatmentPackages.length <= 1;
+			provenance.runtimeDrift.detected ||= provenance.treatmentPackages.length > 1;
+			if (provenance.runtimeDrift.detected && status === "completed") status = "runtime-drift";
+		} catch (error) {
+			status = "failed";
+			failure = failure ? `${failure}\n${errorMessage(error)}` : errorMessage(error);
+		}
+		return createLiveResult({
+			exactPayloads,
+			failure,
+			options,
+			provenance,
+			status,
+			tasks,
+			trials,
+		});
+	} finally {
+		process.off("SIGINT", cancel);
+		process.off("SIGTERM", cancel);
+	}
+}
+
+function createLiveResult({ exactPayloads, failure, options, provenance, status, tasks, trials }) {
+	const summary = summarizeTrials(trials);
+	const amortizedIndexing =
+		options.indexingMs === undefined
+			? undefined
+			: {
+					indexingMs: options.indexingMs,
+					indexReuseCount: options.indexReuseCount,
+					indexingMsPerRun: round(options.indexingMs / options.indexReuseCount),
+					cbmemMedianAmortizedProcessWallMs:
+						summary.byArm.cbmem.successful.processWallMs?.median === undefined
+							? undefined
+							: round(
+									summary.byArm.cbmem.successful.processWallMs.median +
+										options.indexingMs / options.indexReuseCount,
+								),
+				};
+	return {
+		benchmark: BENCHMARK_ID,
+		mode: "live",
+		status,
+		measuredAt: new Date().toISOString(),
+		...(failure ? { failure: safeText(failure) } : {}),
+		config: publicConfig(options),
+		suite: suiteMetadata(options.suite),
+		provenance,
+		exactPayloads: Object.fromEntries(
+			[...exactPayloads.entries()].map(([id, packet]) => [
+				id,
+				{ bytes: Buffer.byteLength(packet.text, "utf8"), sha256: sha256(packet.text) },
+			]),
+		),
+		plannedTrials: createSchedule(tasks, options.runs).length,
+		completedTrials: trials.length,
+		trials,
+		summary: {
+			...summary,
+			...(amortizedIndexing ? { amortizedIndexing } : {}),
+		},
+		interpretation: {
+			primarySuccessRule:
+				"A run must recover every exact fact and obey its arm's retrieval-method policy.",
+			tokensPerSuccess:
+				"All provider-reported tokens spent by an arm divided by that arm's successful runs.",
+			latency:
+				"processWallMs includes Pi startup and temporary npm package resolution; agentWallMs begins immediately before the RPC prompt command.",
+		},
+	};
+}
+
+async function collectProvenance(options, signal) {
+	const processOptions = { cwd: options.repo, signal };
+	const [repoRoot, binaryPath, piVersion, cbmemVersion, gitCommit, gitStatus, indexPacket] =
+		await Promise.all([
+			realpath(options.repo),
+			realpath(options.cbmemBin),
+			runText(options.pi, ["--version"], processOptions),
+			runText(options.cbmemBin, ["--version"], processOptions),
+			runText("git", ["-C", options.repo, "rev-parse", "HEAD"], { signal }),
+			runText("git", ["-C", options.repo, "status", "--short"], { signal }),
+			callCbmem(options, "index_status", { project: options.project }, signal),
+		]);
+	const index = JSON.parse(indexPacket);
+	if (index.status !== "ready")
+		throw new Error(`Codebase Memory index is not ready: ${index.status}`);
+	if ((await realpath(index.root_path)) !== repoRoot) {
+		throw new Error(`indexed root ${index.root_path} does not match repository ${repoRoot}`);
+	}
+	const bridgeBinaryPath = await realpath(
+		path.join(homedir(), ".local", "bin", "codebase-memory-mcp"),
+	);
+	if (binaryPath !== bridgeBinaryPath) {
+		throw new Error(
+			`--cbmem-bin resolves to ${binaryPath}, but pi-cbmem invokes ${bridgeBinaryPath}`,
+		);
+	}
+	const binary = await readFile(binaryPath);
+	return {
+		pi: { command: options.pi, version: piVersion.trim() },
+		cbmem: {
+			path: binaryPath,
+			version: cbmemVersion.trim(),
+			sha256: createHash("sha256").update(binary).digest("hex"),
+		},
+		repository: {
+			root: repoRoot,
+			gitCommit: gitCommit.trim(),
+			dirty: gitStatus.trim().length > 0,
+			statusSha256: sha256(gitStatus),
+		},
+		index: {
+			project: index.project,
+			status: index.status,
+			rootPath: index.root_path,
+			nodes: index.nodes,
+			edges: index.edges,
+			statusSha256: sha256(indexPacket),
+		},
+	};
+}
+
+function treatmentPackageVariants(trials) {
+	const variants = new Map();
+	for (const trial of trials.filter((candidate) => candidate.arm === "cbmem")) {
+		if (!trial.package) continue;
+		const key = `${trial.package.name}@${trial.package.version}:${trial.package.manifestSha256}`;
+		variants.set(key, trial.package);
+	}
+	return [...variants.values()];
+}
+
+async function checkRuntimeDrift(options, provenance, signal) {
+	const [gitCommit, gitStatus, indexPacket] = await Promise.all([
+		runText("git", ["-C", options.repo, "rev-parse", "HEAD"], { signal }),
+		runText("git", ["-C", options.repo, "status", "--short"], { signal }),
+		callCbmem(options, "index_status", { project: options.project }, signal),
+	]);
+	const checks = {
+		gitCommit: gitCommit.trim() === provenance.repository.gitCommit,
+		gitStatus: sha256(gitStatus) === provenance.repository.statusSha256,
+		indexStatus: sha256(indexPacket) === provenance.index.statusSha256,
+	};
+	return { detected: Object.values(checks).includes(false), checks };
+}
+
+async function captureExactPayloads(options, tasks, signal) {
+	const packets = new Map();
+	for (const task of tasks.filter((candidate) => candidate.kind === "exact-payload")) {
+		signal.throwIfAborted();
+		packets.set(task.id, {
+			text: await callCbmem(options, task.exactTool.name, task.exactTool.args, signal),
+		});
+	}
+	return packets;
+}
+
+async function callCbmem(options, tool, args, signal) {
+	const result = await runProcess(options.cbmemBin, ["cli", tool], {
+		cwd: options.repo,
+		env: { ...process.env, CBM_LOG_LEVEL: "error" },
+		input: JSON.stringify(args),
+		maxBytes: 512 * 1024,
+		signal,
+		timeoutMs: options.timeoutMs,
+	});
+	return extractLastJson(result.stdout);
+}
+
+function commandShapes(options, tasks) {
+	const representative = Object.fromEntries(
+		["exact-payload", "same-evidence"].flatMap((kind) => {
+			const task = tasks.find((candidate) => candidate.kind === kind);
+			if (!task) return [];
+			return [
+				[
+					kind,
+					{
+						baseline: [options.pi, ...buildPiArguments({ arm: "baseline", options, task })],
+						cbmem: [options.pi, ...buildPiArguments({ arm: "cbmem", options, task })],
+					},
+				],
+			];
+		}),
+	);
+	return representative;
+}
+
+function publicConfig(options) {
+	return {
+		model: options.model ?? "<required-for-live>",
+		thinking: options.thinking,
+		runsPerTaskAndArm: options.runs,
+		cacheMode: options.cacheMode,
+		repository: options.repo,
+		project: options.project ?? "<required-for-live>",
+		extension: options.extension,
+		baselineInvocation: "pi -ne",
+		cbmemInvocation: `pi -ne -e ${options.extension}`,
+		readOnly: true,
+		timeoutMs: options.timeoutMs,
+		maxEstimatedCostUsd: options.maxCostUsd,
+		...(options.indexingMs === undefined
+			? {}
+			: { indexingMs: options.indexingMs, indexReuseCount: options.indexReuseCount }),
+	};
+}
+
+function suiteMetadata(suite) {
+	return {
+		id: suite.id,
+		description: suite.description,
+		tasks: suite.tasks.map((task) => ({
+			id: task.id,
+			kind: task.kind,
+			factIds: task.facts.map((fact) => fact.id),
+		})),
+	};
+}
+
+async function publishResult(value, outputPath) {
+	if (outputPath) {
+		await writeResult(outputPath, value);
+		process.stderr.write(`Wrote benchmark result to ${safeText(outputPath)}\n`);
+	}
+	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writeResult(outputPath, value) {
+	await mkdir(path.dirname(outputPath), { recursive: true });
+	const temporary = `${outputPath}.tmp-${process.pid}`;
+	try {
+		await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+		await rename(temporary, outputPath);
+	} finally {
+		await rm(temporary, { force: true });
+	}
+}
+
+async function runText(command, args, options = {}) {
+	const result = await runProcess(command, args, {
+		...options,
+		maxBytes: 1024 * 1024,
+		timeoutMs: options.timeoutMs ?? 30_000,
+	});
+	return result.stdout;
+}
+
+async function runProcess(command, args, options) {
+	return await new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			env: options.env ?? process.env,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		let settled = false;
+		let stdout = Buffer.alloc(0);
+		let stderr = Buffer.alloc(0);
+		const finish = (callback, value) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			options.signal?.removeEventListener("abort", onAbort);
+			callback(value);
+		};
+		const fail = (error) => {
+			finish(reject, error instanceof Error ? error : new Error(String(error)));
+		};
+		const append = (current, chunk) => {
+			const next = Buffer.concat([current, chunk]);
+			if (next.length <= options.maxBytes) return next;
+			child.kill("SIGKILL");
+			fail(new Error(`${command} output exceeded ${options.maxBytes} bytes`));
+			return current;
+		};
+		const onAbort = () => {
+			child.kill("SIGKILL");
+			fail(abortReason(options.signal));
+		};
+		const timeout = setTimeout(() => {
+			child.kill("SIGKILL");
+			fail(new Error(`${command} exceeded ${options.timeoutMs}ms`));
+		}, options.timeoutMs);
+		options.signal?.addEventListener("abort", onAbort, { once: true });
+		if (options.signal?.aborted) onAbort();
+		child.stdout.on("data", (chunk) => {
+			stdout = append(stdout, chunk);
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr = append(stderr, chunk);
+		});
+		child.stdin.on("error", () => {
+			// Spawn and exit failures are handled by the child events below.
+		});
+		child.once("error", fail);
+		child.once("exit", (code, exitSignal) => {
+			if (code !== 0) {
+				fail(
+					new Error(
+						`${command} exited with code ${code} (signal=${exitSignal ?? "none"}): ${stderr.toString("utf8").trim()}`,
+					),
+				);
+				return;
+			}
+			finish(resolve, { stdout: stdout.toString("utf8"), stderr: stderr.toString("utf8") });
+		});
+		child.stdin.end(options.input);
+	});
+}
+
+function errorMessage(error) {
+	return error instanceof Error ? (error.stack ?? error.message) : String(error);
+}
+
+function abortReason(signal) {
+	return signal?.reason instanceof Error
+		? signal.reason
+		: new DOMException("benchmark command aborted", "AbortError");
+}
+
+function safeText(value) {
+	return [...String(value)]
+		.filter((character) => {
+			const point = character.codePointAt(0);
+			return point > 31 && (point < 127 || point > 159);
+		})
+		.join("");
+}
+
+function round(value) {
+	return Number(value.toFixed(3));
+}

--- a/packages/pi-cbmem/benchmark/self-test.mjs
+++ b/packages/pi-cbmem/benchmark/self-test.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseArguments } from "./config.mjs";
+import {
+	BENCHMARK_ID,
+	buildPrompt,
+	createSchedule,
+	extractLastJson,
+	materializeTask,
+	scoreTrial,
+	summarizeNumbers,
+	summarizeTrials,
+	validateSuite,
+} from "./core.mjs";
+import { buildPiArguments, runPiTrial } from "./rpc-runner.mjs";
+
+assert.equal(BENCHMARK_ID, "pi-cbmem-retrieval-comparison:v1");
+
+const projectPlaceholder = `$${"{project}"}`;
+const suiteInput = {
+	schemaVersion: 1,
+	id: "test:v1",
+	description: "Test suite.",
+	tasks: [
+		{
+			id: "exact",
+			kind: "exact-payload",
+			question: "Recover the value.",
+			facts: [{ id: "value", expected: "alpha" }],
+			exactTool: {
+				name: "search_code",
+				args: { project: projectPlaceholder, pattern: "alpha" },
+			},
+		},
+		{
+			id: "same",
+			kind: "same-evidence",
+			question: "Recover the second value.",
+			facts: [{ id: "value", expected: "beta" }],
+		},
+	],
+};
+const suite = validateSuite(suiteInput);
+assert.deepEqual(suite, suiteInput);
+assert.throws(() => validateSuite({ ...suiteInput, unknown: true }), /unknown field/);
+assert.throws(
+	() => validateSuite({ ...suiteInput, tasks: [suiteInput.tasks[1], suiteInput.tasks[1]] }),
+	/duplicate task id/,
+);
+const exact = materializeTask(suite.tasks[0], "project-name");
+assert.equal(exact.exactTool.args.project, "project-name");
+assert.equal(suite.tasks[0].exactTool.args.project, projectPlaceholder);
+
+assert.deepEqual(
+	createSchedule(suite.tasks, 3).map(({ taskId, arm }) => `${taskId}:${arm}`),
+	[
+		"exact:baseline",
+		"exact:cbmem",
+		"exact:cbmem",
+		"exact:baseline",
+		"exact:baseline",
+		"exact:cbmem",
+		"same:baseline",
+		"same:cbmem",
+		"same:cbmem",
+		"same:baseline",
+		"same:baseline",
+		"same:cbmem",
+	],
+);
+
+const packet = '{"value":"alpha"}';
+const baselinePrompt = buildPrompt({ arm: "baseline", task: exact, evidencePacket: packet });
+assert.match(baselinePrompt, /Do not call tools/);
+assert.match(baselinePrompt, /alpha/);
+const cbmemPrompt = buildPrompt({ arm: "cbmem", task: exact, evidencePacket: packet });
+assert.match(cbmemPrompt, /Call search_code exactly once/);
+assert.doesNotMatch(cbmemPrompt, /"value":"alpha"/);
+
+const responseText = '{"answers":{"value":"alpha"}}';
+const exactScore = scoreTrial({
+	arm: "cbmem",
+	task: exact,
+	responseText,
+	toolCalls: [{ name: "search_code", args: exact.exactTool.args }],
+	toolResults: [{ name: "search_code", text: packet }],
+	evidencePacket: packet,
+});
+assert.equal(exactScore.success, true);
+assert.equal(exactScore.exactPayload.matched, true);
+assert.equal(
+	scoreTrial({
+		arm: "cbmem",
+		task: exact,
+		responseText,
+		toolCalls: [{ name: "search_code", args: exact.exactTool.args }],
+		toolResults: [{ name: "search_code", text: `${packet}\n` }],
+		evidencePacket: packet,
+	}).success,
+	false,
+);
+assert.equal(
+	scoreTrial({
+		arm: "baseline",
+		task: exact,
+		responseText,
+		toolCalls: [{ name: "read", args: { path: "x" } }],
+		toolResults: [],
+		evidencePacket: packet,
+	}).success,
+	false,
+);
+assert.equal(
+	scoreTrial({
+		arm: "cbmem",
+		task: suite.tasks[1],
+		responseText: '{"answers":{"value":"beta"}}',
+		toolCalls: [],
+		toolResults: [],
+	}).success,
+	false,
+);
+
+assert.equal(extractLastJson('noise\n{"ok":true}\n'), '{"ok":true}');
+assert.throws(() => extractLastJson("noise"), /no complete JSON/);
+assert.deepEqual(summarizeNumbers([1, 2, 3, 4]), {
+	count: 4,
+	median: 2.5,
+	medianAbsoluteDeviation: 1,
+	p95: 3.85,
+	min: 1,
+	max: 4,
+});
+
+const makeTrial = (arm, success, tokens, wall) => ({
+	arm,
+	score: { success },
+	metrics: {
+		agentWallMs: wall,
+		processWallMs: wall + 10,
+		startupMs: 10,
+		usage: { providerTokens: tokens },
+	},
+});
+const summary = summarizeTrials([
+	makeTrial("baseline", true, 100, 1000),
+	makeTrial("baseline", false, 50, 500),
+	makeTrial("cbmem", true, 80, 800),
+	makeTrial("cbmem", true, 90, 900),
+]);
+assert.equal(summary.byArm.baseline.providerTokensPerSuccess, 150);
+assert.equal(summary.byArm.cbmem.providerTokensPerSuccess, 85);
+assert.equal(summary.comparison.medianProviderTokensPerSuccessfulRunDelta, -15);
+assert.equal(summary.comparison.medianAgentWallMsPerSuccessfulRunDelta, -150);
+
+const options = {
+	cacheMode: "warm",
+	extension: "npm:@narumitw/pi-cbmem",
+	model: "provider/model",
+	pi: "pi",
+	repo: "/repo",
+	thinking: "off",
+};
+const baselineArguments = buildPiArguments({ arm: "baseline", options, task: suite.tasks[1] });
+const treatmentArguments = buildPiArguments({ arm: "cbmem", options, task: suite.tasks[1] });
+assert.ok(baselineArguments.includes("-ne"));
+assert.equal(baselineArguments.includes("-e"), false);
+assert.deepEqual(treatmentArguments.slice(-2), ["-e", "npm:@narumitw/pi-cbmem"]);
+assert.match(treatmentArguments[treatmentArguments.indexOf("--tools") + 1], /search_graph/);
+assert.doesNotMatch(
+	treatmentArguments[treatmentArguments.indexOf("--tools") + 1],
+	/delete_project/,
+);
+
+const parsed = await parseArguments(["--runs", "2", "--kind", "same-evidence"]);
+assert.equal(parsed.live, false);
+assert.equal(parsed.runs, 2);
+assert.equal(
+	parsed.suite.tasks.every((task) => task.kind === "same-evidence"),
+	true,
+);
+await assert.rejects(parseArguments(["--live"]), /requires --model/);
+await assert.rejects(parseArguments(["--indexing-ms", "10"]), /must be supplied together/);
+
+const rpcRoot = await mkdtemp(path.join(tmpdir(), "pi-cbmem-benchmark-rpc-"));
+try {
+	const packageRoot = path.join(rpcRoot, "package");
+	const skillPath = path.join(packageRoot, "skills", "codebase-memory", "SKILL.md");
+	await mkdir(path.dirname(skillPath), { recursive: true });
+	await writeFile(
+		path.join(packageRoot, "package.json"),
+		'{"name":"@narumitw/pi-cbmem","version":"9.9.9"}\n',
+	);
+	await writeFile(skillPath, "# Test skill\n");
+	const fakePiPath = path.join(rpcRoot, "fake-pi.mjs");
+	await writeFile(
+		fakePiPath,
+		`#!/usr/bin/env node
+import process from "node:process";
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+	buffer += chunk;
+	while (buffer.includes("\\n")) {
+		const index = buffer.indexOf("\\n");
+		const line = buffer.slice(0, index);
+		buffer = buffer.slice(index + 1);
+		if (line) handle(JSON.parse(line));
+	}
+});
+function send(value) { process.stdout.write(JSON.stringify(value) + "\\n"); }
+function response(command, data) {
+	send({ id: command.id, type: "response", command: command.type, success: true, ...(data ? { data } : {}) });
+}
+function handle(command) {
+	if (command.type === "get_commands") {
+		response(command, { commands: [{ name: "skill:codebase-memory", sourceInfo: { path: ${JSON.stringify(skillPath)} } }] });
+	} else if (command.type === "prompt") {
+		response(command);
+		if (process.argv.includes("hang-model")) return;
+		send({ type: "tool_execution_start", toolCallId: "call-1", toolName: "search_code", args: ${JSON.stringify(exact.exactTool.args)} });
+		send({ type: "tool_execution_end", toolCallId: "call-1", toolName: "search_code", result: { content: [{ type: "text", text: ${JSON.stringify(packet)} }] }, isError: false });
+		send({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: ${JSON.stringify(responseText)} }], usage: { input: 10, output: 2, cacheRead: 3, cacheWrite: 1, totalTokens: 16, cost: { total: 0.01 } } } });
+		send({ type: "turn_end", message: {}, toolResults: [] });
+		send({ type: "agent_settled" });
+	} else if (command.type === "get_session_stats") {
+		response(command, { tokens: { input: 10, output: 2, cacheRead: 3, cacheWrite: 1, total: 16 }, cost: 0.01 });
+	} else response(command);
+}
+`,
+	);
+	await chmod(fakePiPath, 0o755);
+	const rpcTrial = await runPiTrial({
+		arm: "cbmem",
+		evidencePacket: packet,
+		options: {
+			...options,
+			cacheMode: "warm",
+			pi: fakePiPath,
+			repo: rpcRoot,
+			suite: { id: "test:v1" },
+			timeoutMs: 2_000,
+		},
+		repetition: 1,
+		task: exact,
+	});
+	assert.equal(rpcTrial.score.success, true);
+	assert.equal(rpcTrial.metrics.usage.providerTokens, 16);
+	assert.equal(rpcTrial.metrics.providerRequests, 1);
+	assert.equal(rpcTrial.metrics.requestUsage[0].providerTokens, 16);
+	assert.equal(rpcTrial.package.version, "9.9.9");
+	assert.equal(rpcTrial.method.toolResults[0].bytes, Buffer.byteLength(packet));
+	await assert.rejects(
+		runPiTrial({
+			arm: "baseline",
+			evidencePacket: packet,
+			options: {
+				...options,
+				cacheMode: "warm",
+				model: "hang-model",
+				pi: fakePiPath,
+				repo: rpcRoot,
+				suite: { id: "test:v1" },
+				timeoutMs: 100,
+			},
+			repetition: 1,
+			task: exact,
+		}),
+		/exceeded 100ms/,
+	);
+} finally {
+	await rm(rpcRoot, { recursive: true, force: true });
+}
+
+process.stdout.write("pi-cbmem benchmark self-test passed\n");

--- a/packages/pi-cbmem/benchmark/suites/pi-extensions.json
+++ b/packages/pi-cbmem/benchmark/suites/pi-extensions.json
@@ -1,0 +1,58 @@
+{
+	"schemaVersion": 1,
+	"id": "pi-cbmem-repository-facts:v1",
+	"description": "Fact-recovery tasks about the pi-cbmem implementation in this repository.",
+	"tasks": [
+		{
+			"id": "exact-cli-bridge",
+			"kind": "exact-payload",
+			"question": "From the supplied evidence, report the bridge executable as a home-relative path and the CBM_LOG_LEVEL value.",
+			"facts": [
+				{ "id": "executable", "expected": "~/.local/bin/codebase-memory-mcp" },
+				{ "id": "log_level", "expected": "error" }
+			],
+			"exactTool": {
+				"name": "search_code",
+				"args": {
+					"project": "${project}",
+					"pattern": "const BIN|CBM_LOG_LEVEL",
+					"path_filter": "packages/pi-cbmem/src/cbmem.ts",
+					"mode": "full",
+					"context": 4,
+					"regex": true,
+					"limit": 20
+				}
+			}
+		},
+		{
+			"id": "destructive-confirmation",
+			"kind": "same-evidence",
+			"question": "Inspect pi-cbmem and identify both destructive operations that require confirmation and the two Pi modes where confirmation is allowed. Normalize the operation answers as tool or tool:mode and modes as a comma-separated list in source order.",
+			"facts": [
+				{ "id": "delete_operation", "expected": "delete_project" },
+				{ "id": "adr_operation", "expected": "manage_adr:update" },
+				{ "id": "allowed_modes", "expected": "tui,rpc" }
+			]
+		},
+		{
+			"id": "output-contract",
+			"kind": "same-evidence",
+			"question": "Inspect pi-cbmem and report its maximum output lines, maximum output size label, and which complete JSON response is selected from noisy stdout. Return the JSON selection rule as last_complete_json.",
+			"facts": [
+				{ "id": "max_lines", "expected": "2000" },
+				{ "id": "max_size", "expected": "50KB" },
+				{ "id": "json_selection", "expected": "last_complete_json" }
+			]
+		},
+		{
+			"id": "cancellation-contract",
+			"kind": "same-evidence",
+			"question": "Inspect pi-cbmem and report the first cancellation signal, fallback signal, and force-kill delay in milliseconds.",
+			"facts": [
+				{ "id": "first_signal", "expected": "SIGTERM" },
+				{ "id": "fallback_signal", "expected": "SIGKILL" },
+				{ "id": "force_kill_delay_ms", "expected": "250" }
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- Add a repository-only benchmark that compares `pi -ne` with `pi -ne -e npm:@narumitw/pi-cbmem`.
- Measure exact-payload overhead and same-evidence retrieval efficiency with hidden exact-fact grading.
- Record provider usage, cache tokens, timing, tool activity, package and index provenance, runtime drift, and estimated cost.
- Add a documented `just benchmark-cbmem` workflow, deterministic self-test, and default repository suite.

## Verification

- `node packages/pi-cbmem/benchmark/self-test.mjs`
- `just benchmark-cbmem --kind same-evidence --runs 1`
- `npm run check`
- `npm test` — 330 test files and 3,262 tests passed.
- Live exact-payload and same-evidence smokes completed against a fixed `~/workspace/codex` snapshot and existing Codebase Memory index.

## Release

No Changeset is included because this adds a repository-only measurement workflow and does not change published package behavior.
