### PR TITLE
feat: add Fireworks rated API spend reporting

### DIFF
--- a/.changeset/fireworks-api-spend.md
+++ b/.changeset/fireworks-api-spend.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add Fireworks rated API spend reporting for the official fireworks provider, summarizing the trailing 30 days of rated costs per currency with serverless, dedicated-deployment, and training subtotals from the documented billing summary endpoint.
+
+The account slug is discovered through the documented account listing when exactly one account is visible; keys that can see several accounts set `FIREWORKS_ACCOUNT_ID`. Fireworks exposes no credit-balance or spend-cap endpoint, so the report claims only rated spend.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -15,6 +15,8 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
+- Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
+- Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
 - Reports xAI OAuth subscription allowances and credits.
 - Toggles persistent Codex Fast routing through `/fast` or the usage menu.
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
@@ -219,6 +221,22 @@ The balance endpoint does not provide historical spend, request windows, reset t
 The contract was verified on 2026-08-28 against [DeepSeek's Get User Balance documentation](https://api-docs.deepseek.com/api/get-user-balance) and Pi's [`deepseek.ts`](https://github.com/earendil-works/pi/blob/c49906ec77788625aacbdc53ebca6fbe65bd20f5/packages/ai/src/providers/deepseek.ts) at `c49906ec77788625aacbdc53ebca6fbe65bd20f5`.
 DeepSeek Harness `cd5ef8148158c3a752a658978873241fdf8e2bbc` reports only per-request model token usage and does not provide account balance data.
 
+### Fireworks API spend
+
+- Provider ID: `fireworks`
+- Semantics: rated 30-day account spend, not credit balance or spend-cap quota
+- Source: documented `GET https://api.fireworks.ai/v1/accounts` account discovery and `GET https://api.fireworks.ai/v1/accounts/{account_id}/billing/summary` rated costs using Pi's resolved inference API key
+- Displayed data: exact rated spend per currency with serverless, dedicated-deployment, and training subtotals for the trailing 30 days
+- Statusline example: `fireworks USD 12.345678901`
+
+The extension queries the fixed endpoints only when the selected model origin is `https://api.fireworks.ai` and any resolved-auth origin override, when present, has the same official origin.
+The account slug is discovered through the documented account listing; a key that can see several accounts must set `FIREWORKS_ACCOUNT_ID` to one of the listed account slugs, and the slug must remain visible to the key.
+Monetary `units` and `nanos` values are summed exactly with integer arithmetic and stay exact through display.
+Fireworks does not expose credit balance, spend caps, per-window quota, or reset times through its API, so `pi-usage` does not claim those Fireworks capabilities; the web console remains the authoritative balance source.
+Rated line items may differ from the final invoice once credits or adjustments are applied.
+
+The contract was verified on 2026-07-31 against Fireworks' [Usage & Cost Breakdown](https://docs.fireworks.ai/accounts/exporting-usage-and-costs), [Get billing summary](https://docs.fireworks.ai/api-reference/get-billing-summary), and [List Accounts](https://docs.fireworks.ai/api-reference/list-accounts) API references.
+
 ### OpenCode Go (Zen)
 
 - Provider ID: `opencode-go`
@@ -303,6 +321,7 @@ After the active runtime credential changes, the next command, turn, or schedule
 The `usage` status item is active only for selected providers that publish statusline usage.
 It refreshes every five minutes while the session remains on such a provider and is cleared when the model changes to an unsupported or menu-only provider.
 DeepSeek publishes each returned currency as a separate exact balance segment and reports when the API is unavailable.
+Fireworks publishes exact per-currency rated spend totals and reports when no rated usage exists.
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
@@ -334,6 +353,7 @@ Credential candidates are collected synchronously in memory and are not cached, 
 The protocol carries no account name or extension identity.
 Only the selected provider's exact runtime match is used, and secrets are sent only to its validated official origin.
 DeepSeek balance requests require Bearer authentication, send only that resolved credential from Pi's runtime auth to `https://api.deepseek.com/user/balance`, and refuse redirects.
+Fireworks spend requests send only that resolved credential to the official `https://api.fireworks.ai` account-listing and billing-summary endpoints and refuse redirects.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
 Install only trusted extensions because they can read user files and process memory.
 Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
@@ -348,6 +368,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
+- Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `FIREWORKS_ACCOUNT_ID`.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.
@@ -390,7 +411,7 @@ The generated runtime is built from the authoritative `src/index.ts` graph and d
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -13,6 +13,7 @@
 		"quota",
 		"balance",
 		"deepseek",
+		"fireworks",
 		"codex",
 		"kimi",
 		"kimi-coding",

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -12,13 +12,18 @@ const VALUE_COLUMN = 29;
 export function formatUsageReport(report: UsageReport, displayState: UsageDisplayState): string {
 	const stateLabel = displayState === "current" ? "Current" : "Configured";
 	const title =
-		report.providerId === "deepseek" ? "DeepSeek API Balance" : `${report.providerName} Usage`;
+		report.providerId === "deepseek"
+			? "DeepSeek API Balance"
+			: report.providerId === "fireworks"
+				? "Fireworks API Spend"
+				: `${report.providerName} Usage`;
 	const lines = [`${title} · ${stateLabel}`];
 	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
 	lines.push(`Semantics: ${report.semantics.label}`, "");
 
 	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
 	else if (report.providerId === "deepseek") formatDeepSeekReport(lines, report);
+	else if (report.providerId === "fireworks") formatFireworksReport(lines, report);
 	else if (report.providerId === "github-copilot") formatGitHubCopilotReport(lines, report);
 	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
 	else if (report.providerId === "opencode-go") formatOpenCodeZenReport(lines, report);
@@ -44,6 +49,7 @@ export function formatUsageStatusline(
 		return formatCodexStatusline(report, model, now, showCodexResetCountdown);
 	}
 	if (report.providerId === "deepseek") return formatDeepSeekStatusline(report);
+	if (report.providerId === "fireworks") return formatFireworksStatusline(report);
 	if (report.providerId === "github-copilot") return formatGitHubCopilotStatusline(report);
 	if (report.providerId === "openrouter") {
 		const limit = report.buckets.find((bucket) => bucket.id === "key-limit");
@@ -123,6 +129,32 @@ function formatDeepSeekStatusline(report: UsageReport): string {
 		return metric ? [`${currency} ${metric.value}`] : [];
 	});
 	return totals.length > 0 ? `deepseek ${totals.join(" · ")}` : "deepseek balance unavailable";
+}
+
+function formatFireworksReport(lines: string[], report: UsageReport): void {
+	lines.push(`${"Spend window:".padEnd(VALUE_COLUMN)}Last 30 days (rated)`);
+	for (const currency of fireworksCurrencies(report)) {
+		lines.push("", `${currency} rated spend:`);
+		for (const metric of report.metrics) {
+			if (metric.currency !== currency) continue;
+			lines.push(`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${currency} ${metric.value}`);
+		}
+	}
+}
+
+function formatFireworksStatusline(report: UsageReport): string {
+	const totals = report.metrics.filter((metric) => metric.id.endsWith("-total"));
+	if (totals.length === 0) return "fireworks no rated usage";
+	return `fireworks ${totals.map((metric) => `${metric.currency} ${metric.value}`).join(" · ")}`;
+}
+
+function fireworksCurrencies(report: UsageReport): string[] {
+	const currencies: string[] = [];
+	for (const metric of report.metrics) {
+		if (!metric.currency || currencies.includes(metric.currency)) continue;
+		currencies.push(metric.currency);
+	}
+	return currencies;
 }
 
 function formatGitHubCopilotReport(lines: string[], report: UsageReport): void {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -34,6 +34,10 @@ export {
 export { formatProviderStates, formatUsageReport, formatUsageStatusline } from "./format.js";
 export { normalizeCodexBackendPayload } from "./providers/codex.js";
 export { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
+export {
+	normalizeFireworksAccountsPayload,
+	normalizeFireworksBillingSummaryPayload,
+} from "./providers/fireworks.js";
 export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 export { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 export { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -64,6 +68,8 @@ export {
 } from "./settings.js";
 export type {
 	DeepSeekBalancePayload,
+	FireworksAccountsPayload,
+	FireworksBillingSummaryPayload,
 	KimiCodingUsagePayload,
 	ProviderUsageState,
 	ResolvedUsageAuth,

--- a/packages/pi-usage/src/providers/fireworks.ts
+++ b/packages/pi-usage/src/providers/fireworks.ts
@@ -1,0 +1,186 @@
+import { sanitizeDisplayText } from "../core.js";
+import type {
+	FireworksAccountsPayload,
+	FireworksBillingSummaryPayload,
+	UsageMetric,
+	UsageReport,
+} from "../types.js";
+
+const NANOS_PER_UNIT = 1_000_000_000n;
+const CURRENCY_PATTERN = /^[A-Z]{3}$/u;
+const ACCOUNT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u;
+const INTEGER_PATTERN = /^-?\d+$/u;
+const MAX_UNITS_CHARS = 16;
+const MAX_NANOS_CHARS = 10;
+
+const SERIES_KEYS = ["serverless", "dedicated", "training", "other"] as const;
+type SeriesKey = (typeof SERIES_KEYS)[number];
+
+const SERIES_LABELS: Readonly<Record<SeriesKey, string>> = {
+	serverless: "Serverless",
+	dedicated: "Dedicated deployments",
+	training: "Training",
+	other: "Other",
+};
+
+export function normalizeFireworksAccountsPayload(payload: FireworksAccountsPayload): string[] {
+	if (!Array.isArray(payload.accounts)) {
+		throw new Error("Fireworks accounts response did not contain an accounts array.");
+	}
+	const accounts: string[] = [];
+	for (const raw of payload.accounts) {
+		const account = asObject(raw);
+		if (!account) throw new Error("Fireworks accounts response row was not an object.");
+		if (typeof account.name !== "string") {
+			throw new Error("Fireworks accounts response omitted the account resource name.");
+		}
+		const match = /^accounts\/([^/]+)$/u.exec(account.name);
+		if (!match || !ACCOUNT_ID_PATTERN.test(match[1])) {
+			throw new Error("Fireworks accounts response returned an unsafe account resource name.");
+		}
+		const accountId = match[1];
+		if (accounts.includes(accountId)) {
+			throw new Error(`Fireworks accounts response repeated ${accountId}.`);
+		}
+		accounts.push(accountId);
+	}
+	return accounts;
+}
+
+export function normalizeFireworksBillingSummaryPayload(
+	payload: FireworksBillingSummaryPayload,
+	accountId: string,
+	capturedAt: number,
+): UsageReport {
+	if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+		throw new Error("Fireworks billing summary received an unsafe account identifier.");
+	}
+	if (payload.lineItems !== undefined && !Array.isArray(payload.lineItems)) {
+		throw new Error("Fireworks billing summary lineItems was not an array.");
+	}
+
+	const totals = new Map<string, Map<SeriesKey, bigint>>();
+	for (const raw of payload.lineItems ?? []) {
+		const lineItem = asObject(raw);
+		if (!lineItem) throw new Error("Fireworks billing line item was not an object.");
+		const cost = moneyAmount(lineItem.totalCost, "line item total cost");
+		const series = seriesKey(lineItem.series);
+		let amounts = totals.get(cost.currency);
+		if (!amounts) {
+			amounts = new Map<SeriesKey, bigint>();
+			totals.set(cost.currency, amounts);
+		}
+		amounts.set(series, (amounts.get(series) ?? 0n) + cost.amount);
+	}
+
+	const metrics: UsageMetric[] = [];
+	for (const [currency, amounts] of totals) {
+		metrics.push({
+			id: `${currency.toLowerCase()}-total`,
+			label: "Total spend",
+			value: formatMoneyAmount(sumSeries(amounts)),
+			unit: "currency",
+			currency,
+		});
+		for (const series of SERIES_KEYS) {
+			const amount = amounts.get(series);
+			if (amount === undefined) continue;
+			metrics.push({
+				id: `${currency.toLowerCase()}-${series}`,
+				label: SERIES_LABELS[series],
+				value: formatMoneyAmount(amount),
+				unit: "currency",
+				currency,
+			});
+		}
+	}
+
+	const notes = [
+		"Rated line items may differ from the final invoice once credits or adjustments are applied.",
+	];
+	if (metrics.length === 0) {
+		notes.push("Fireworks returned no rated line items for the last 30 days.");
+	}
+
+	return {
+		providerId: "fireworks",
+		providerName: "Fireworks",
+		capturedAt,
+		source: "fireworks-billing-summary",
+		semantics: { kind: "api-key", label: "Fireworks API spend" },
+		accountLabel: sanitizeDisplayText(accountId, 80),
+		buckets: [],
+		metrics,
+		notes,
+	};
+}
+
+type RatedMoney = { currency: string; amount: bigint };
+
+function moneyAmount(value: unknown, description: string): RatedMoney {
+	const money = asObject(value);
+	if (!money) throw new Error(`Fireworks billing ${description} was not a money object.`);
+	const currency = typeof money.currencyCode === "string" ? money.currencyCode : undefined;
+	if (!currency || !CURRENCY_PATTERN.test(currency)) {
+		throw new Error(`Fireworks billing ${description} currency was not an ISO 4217 code.`);
+	}
+	// proto3 JSON omits zero-valued money fields, so absent components default to zero.
+	const units =
+		money.units === undefined
+			? 0n
+			: integerComponent(money.units, description, "whole units", MAX_UNITS_CHARS);
+	const nanos =
+		money.nanos === undefined
+			? 0n
+			: integerComponent(money.nanos, description, "nano units", MAX_NANOS_CHARS);
+	if ((units > 0n && nanos < 0n) || (units < 0n && nanos > 0n)) {
+		throw new Error(`Fireworks billing ${description} mixed unit and nano signs.`);
+	}
+	return { currency, amount: units * NANOS_PER_UNIT + nanos };
+}
+
+function integerComponent(
+	value: unknown,
+	description: string,
+	component: string,
+	maxChars: number,
+): bigint {
+	const text =
+		typeof value === "number" && Number.isSafeInteger(value)
+			? String(value)
+			: typeof value === "string" && INTEGER_PATTERN.test(value)
+				? value
+				: undefined;
+	if (text === undefined || text.length > maxChars) {
+		throw new Error(`Fireworks billing ${description} ${component} was not a bounded integer.`);
+	}
+	return BigInt(text);
+}
+
+function seriesKey(value: unknown): SeriesKey {
+	if (value === undefined || value === null) return "other";
+	if (typeof value !== "string") throw new Error("Fireworks billing line item series was invalid.");
+	if (value === "SERVERLESS") return "serverless";
+	if (value === "DEDICATED_DEPLOYMENT") return "dedicated";
+	if (value === "TRAINING") return "training";
+	return "other";
+}
+
+function sumSeries(amounts: ReadonlyMap<SeriesKey, bigint>): bigint {
+	let total = 0n;
+	for (const amount of amounts.values()) total += amount;
+	return total;
+}
+
+function formatMoneyAmount(amount: bigint): string {
+	const negative = amount < 0n;
+	const magnitude = negative ? -amount : amount;
+	const units = magnitude / NANOS_PER_UNIT;
+	const nanos = (magnitude % NANOS_PER_UNIT).toString().padStart(9, "0").replace(/0+$/u, "");
+	return `${negative ? "-" : ""}${units.toString()}${nanos ? `.${nanos}` : ""}`;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -7,6 +7,10 @@ import {
 } from "./oauth-credential-source.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
 import { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
+import {
+	normalizeFireworksAccountsPayload,
+	normalizeFireworksBillingSummaryPayload,
+} from "./providers/fireworks.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -16,6 +20,8 @@ import { normalizeZaiQuotaPayload } from "./providers/zai.js";
 import type {
 	CodexBackendPayload,
 	DeepSeekBalancePayload,
+	FireworksAccountsPayload,
+	FireworksBillingSummaryPayload,
 	GitHubCopilotUsagePayload,
 	KimiCodingUsagePayload,
 	OpenCodeZenPayload,
@@ -31,6 +37,11 @@ import type {
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance";
+const FIREWORKS_BILLING_SUMMARY_ORIGIN = "https://api.fireworks.ai";
+const FIREWORKS_ACCOUNT_ID_ENV = "FIREWORKS_ACCOUNT_ID";
+const FIREWORKS_SPEND_WINDOW_DAYS = 30;
+const FIREWORKS_MAX_ACCOUNT_PAGES = 5;
+const SAFE_URL_TOKEN = /^[A-Za-z0-9._~-]+$/u;
 const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
@@ -120,6 +131,33 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				"OpenRouter key endpoint",
 			);
 			return normalizeOpenRouterKeyPayload(payload as OpenRouterKeyPayload, Date.now());
+		},
+	},
+	{
+		id: "fireworks",
+		displayName: "Fireworks",
+		semantics: { kind: "api-key", label: "Fireworks API spend" },
+		async query(auth, signal, timeoutMs, guard) {
+			if (!guard) throw new Error("Fireworks API spend requires request-boundary revalidation.");
+			const startedAt = Date.now();
+			await guard();
+			const accountId = await resolveFireworksAccountId(
+				auth,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "resolving the Fireworks account"),
+				guard,
+			);
+			await guard();
+			const payload = (await fetchProviderJson(
+				fireworksBillingSummaryUrl(accountId, startedAt),
+				auth,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "fetching Fireworks rated spend"),
+				"Fireworks billing summary endpoint",
+				{ redirect: "error" },
+			)) as FireworksBillingSummaryPayload;
+			await guard();
+			return normalizeFireworksBillingSummaryPayload(payload, accountId, Date.now());
 		},
 	},
 	{
@@ -733,6 +771,7 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 		const url = new URL(value);
 		if (providerId === "openai-codex") return url.origin === "https://chatgpt.com";
 		if (providerId === "deepseek") return url.origin === "https://api.deepseek.com";
+		if (providerId === "fireworks") return url.origin === FIREWORKS_BILLING_SUMMARY_ORIGIN;
 		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
 		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
 		if (providerId === "kimi-coding") return url.origin === "https://api.kimi.com";
@@ -771,10 +810,103 @@ function validatedXaiUserId(value: unknown): string {
 	return value;
 }
 
-function remainingTimeout(timeoutMs: number, startedAt: number): number {
+function remainingTimeout(
+	timeoutMs: number,
+	startedAt: number,
+	description = "fetching xAI consumer usage",
+): number {
 	const remaining = timeoutMs - (Date.now() - startedAt);
-	if (remaining <= 0) throw new Error("Timed out while fetching xAI consumer usage.");
+	if (remaining <= 0) throw new Error(`Timed out while ${description}.`);
 	return remaining;
+}
+
+// Fireworks requires an account slug for its billing endpoints; discover it through the
+// documented account listing, requiring an explicit slug when a key can see several accounts.
+async function resolveFireworksAccountId(
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+	guard: () => Promise<void>,
+): Promise<string> {
+	const accounts: string[] = [];
+	let pageToken: string | undefined;
+	for (let page = 0; page < FIREWORKS_MAX_ACCOUNT_PAGES; page += 1) {
+		await guard();
+		const payload = (await fetchProviderJson(
+			fireworksAccountsUrl(pageToken),
+			auth,
+			signal,
+			remainingTimeout(timeoutMs, Date.now(), "fetching Fireworks accounts"),
+			"Fireworks accounts endpoint",
+			{ redirect: "error" },
+		)) as FireworksAccountsPayload;
+		for (const accountId of normalizeFireworksAccountsPayload(
+			payload as FireworksAccountsPayload,
+		)) {
+			if (accounts.includes(accountId)) {
+				throw new Error(`Fireworks accounts listing repeated ${accountId}.`);
+			}
+			accounts.push(accountId);
+		}
+		pageToken = fireworksNextPageToken(payload.nextPageToken);
+		if (!pageToken) break;
+	}
+	if (pageToken) {
+		throw new Error(
+			`Fireworks account listing exceeded ${FIREWORKS_MAX_ACCOUNT_PAGES} pages; set ${FIREWORKS_ACCOUNT_ID_ENV} to the desired account slug.`,
+		);
+	}
+	if (accounts.length === 0) {
+		throw new Error("Fireworks account discovery returned no accounts for this API key.");
+	}
+	if (accounts.length === 1) return accounts[0] as string;
+	const configured = process.env[FIREWORKS_ACCOUNT_ID_ENV];
+	if (configured === undefined || configured.trim() === "") {
+		const preview = accounts.slice(0, 8).join(", ");
+		const suffix = accounts.length > 8 ? ` …and ${accounts.length - 8} more` : "";
+		throw new Error(
+			`The Fireworks key can see ${accounts.length} accounts (${preview}${suffix}); set ${FIREWORKS_ACCOUNT_ID_ENV} to one of them.`,
+		);
+	}
+	if (!/^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u.test(configured)) {
+		throw new Error(
+			`The ${FIREWORKS_ACCOUNT_ID_ENV} environment variable was not a safe account slug.`,
+		);
+	}
+	if (!accounts.includes(configured)) {
+		throw new Error(
+			`${FIREWORKS_ACCOUNT_ID_ENV} does not match an account visible to this Fireworks key.`,
+		);
+	}
+	return configured;
+}
+
+function fireworksAccountsUrl(pageToken: string | undefined): string {
+	const url = new URL("/v1/accounts", FIREWORKS_BILLING_SUMMARY_ORIGIN);
+	url.searchParams.set("pageSize", "200");
+	if (pageToken !== undefined) url.searchParams.set("pageToken", pageToken);
+	return url.toString();
+}
+
+function fireworksNextPageToken(value: unknown): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "string" || !value || value.length > 512 || !SAFE_URL_TOKEN.test(value)) {
+		throw new Error("Fireworks accounts listing returned an unsafe page token.");
+	}
+	return value;
+}
+
+function fireworksBillingSummaryUrl(accountId: string, startedAt: number): string {
+	const dayMs = 24 * 60 * 60 * 1000;
+	const dayFloor = (time: number) => `${new Date(time).toISOString().slice(0, 10)}T00:00:00Z`;
+	const url = new URL(
+		`/v1/accounts/${accountId}/billing/summary`,
+		FIREWORKS_BILLING_SUMMARY_ORIGIN,
+	);
+	// The endpoint aggregates by UTC date; endTime is exclusive, so tomorrow's floor includes today.
+	url.searchParams.set("startTime", dayFloor(startedAt - FIREWORKS_SPEND_WINDOW_DAYS * dayMs));
+	url.searchParams.set("endTime", dayFloor(startedAt + dayMs));
+	return url.toString();
 }
 
 function zaiMonitorUrl(baseUrl: string | undefined): string {

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -89,6 +89,15 @@ export type DeepSeekBalancePayload = {
 	balance_infos?: unknown;
 };
 
+export type FireworksAccountsPayload = {
+	accounts?: unknown;
+	nextPageToken?: unknown;
+};
+
+export type FireworksBillingSummaryPayload = {
+	lineItems?: unknown;
+};
+
 export type GitHubCopilotUsagePayload = {
 	login?: unknown;
 	copilot_plan?: unknown;

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -1,0 +1,442 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeFireworksAccountsPayload,
+	normalizeFireworksBillingSummaryPayload,
+	queryProviderUsage,
+	type ResolvedUsageAuth,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+	type UsageProviderAdapter,
+} from "../src/index.js";
+
+const FIREWORKS_MODEL = {
+	id: "accounts/fireworks/models/kimi-k2p6",
+	name: "Kimi K2.6",
+	provider: "fireworks",
+	baseUrl: "https://api.fireworks.ai/inference",
+};
+
+function fireworksAdapter(): UsageProviderAdapter {
+	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === "fireworks");
+	assert.ok(candidate);
+	return candidate;
+}
+
+const adapter = fireworksAdapter();
+
+function money(units: string, nanos: number): Record<string, unknown> {
+	return { currencyCode: "USD", units, nanos };
+}
+
+function lineItem(
+	series: string,
+	totalCost: unknown,
+	currencyCode = "USD",
+): Record<string, unknown> {
+	return { category: "Text Completion", series, totalCost, currencyCode };
+}
+
+function accountRow(slug: string): Record<string, unknown> {
+	return { name: `accounts/${slug}` };
+}
+
+function fireworksAuth(secret = "fw-test-secret"): ResolvedUsageAuth {
+	return {
+		apiKey: secret,
+		headers: { Authorization: `Bearer ${secret}` },
+		fingerprint: "fingerprint",
+		secrets: [secret, `Bearer ${secret}`],
+		model: FIREWORKS_MODEL as never,
+	};
+}
+
+function queryFireworks(signal = new AbortController().signal, timeoutMs = 1_000) {
+	return queryProviderUsage(adapter, fireworksAuth(), signal, timeoutMs, async () => undefined);
+}
+
+test("Fireworks billing summary sums rated line items exactly per currency and series", () => {
+	const report = normalizeFireworksBillingSummaryPayload(
+		{
+			lineItems: [
+				{ category: "Serverless", series: "SERVERLESS", totalCost: money("12", 345_678_901) },
+				{
+					category: "Dedicated",
+					series: "DEDICATED_DEPLOYMENT",
+					totalCost: money("0", 750_000_000),
+				},
+				{
+					category: "Training",
+					series: "TRAINING",
+					totalCost: { ...money("-1", -250_000_000), currencyCode: "USD" },
+				},
+				{
+					category: "Audio",
+					series: "SERVERLESS",
+					totalCost: { currencyCode: "EUR", units: "0", nanos: 5 },
+				},
+			],
+		},
+		"acme",
+		1_000,
+	);
+
+	assert.equal(report.providerId, "fireworks");
+	assert.equal(report.providerName, "Fireworks");
+	assert.equal(report.accountLabel, "acme");
+	assert.equal(report.source, "fireworks-billing-summary");
+	assert.deepEqual(report.semantics, { kind: "api-key", label: "Fireworks API spend" });
+	assert.deepEqual(report.buckets, []);
+	assert.deepEqual(
+		report.metrics.map((metric) => [metric.id, metric.value, metric.currency]),
+		[
+			["usd-total", "11.845678901", "USD"],
+			["usd-serverless", "12.345678901", "USD"],
+			["usd-dedicated", "0.75", "USD"],
+			["usd-training", "-1.25", "USD"],
+			["eur-total", "0.000000005", "EUR"],
+			["eur-serverless", "0.000000005", "EUR"],
+		],
+	);
+	const formatted = formatUsageReport(report, "current");
+	assert.match(formatted, /^Fireworks API Spend · Current/mu);
+	assert.match(formatted, /Account: acme/u);
+	assert.match(formatted, /Semantics: Fireworks API spend/u);
+	assert.match(formatted, /Spend window:\s+Last 30 days \(rated\)/u);
+	assert.match(formatted, /Total spend:\s+USD 11\.845678901/u);
+	assert.match(formatted, /Serverless:\s+USD 12\.345678901/u);
+	assert.match(formatted, /Dedicated deployments:\s+USD 0\.75/u);
+	assert.match(formatted, /Training:\s+USD -1\.25/u);
+	assert.ok(formatted.indexOf("USD rated spend:") < formatted.indexOf("EUR rated spend:"));
+	assert.equal(formatUsageStatusline(report), "fireworks USD 11.845678901 · EUR 0.000000005");
+});
+
+test("Fireworks billing summary accepts empty rated line items without inventing quota semantics", () => {
+	const report = normalizeFireworksBillingSummaryPayload({ lineItems: [] }, "acme", 2_000);
+
+	assert.equal(report.providerId, "fireworks");
+	assert.deepEqual(report.metrics, []);
+	assert.deepEqual(report.notes, [
+		"Rated line items may differ from the final invoice once credits or adjustments are applied.",
+		"Fireworks returned no rated line items for the last 30 days.",
+	]);
+	assert.equal(formatUsageStatusline(report), "fireworks no rated usage");
+	assert.doesNotMatch(formatUsageReport(report, "configured"), /quota|reset|remaining/iu);
+});
+
+test("Fireworks billing summary rejects malformed, ambiguous, or hostile payloads", () => {
+	const invalid: Array<[Record<string, unknown>, RegExp]> = [
+		[{ lineItems: "nope" }, /lineItems was not an array/iu],
+		[{ lineItems: [null] }, /line item was not an object/iu],
+		[{ lineItems: [{ category: "x" }] }, /total cost.*money object/iu],
+		[
+			{
+				lineItems: [
+					{ category: "Serverless", totalCost: { currencyCode: "usd", units: "1", nanos: 0 } },
+				],
+			},
+			/currency was not an ISO 4217/iu,
+		],
+		[
+			{
+				lineItems: [{ category: "Serverless", series: 5, totalCost: money("1", 0) }],
+			},
+			/series was invalid/iu,
+		],
+		[
+			{
+				lineItems: [
+					{
+						category: "Serverless",
+						series: "SERVERLESS",
+						totalCost: { ...money("1", 0), currencyCode: "EU" },
+					},
+				],
+			},
+			/ISO 4217/iu,
+		],
+		[
+			{
+				lineItems: [
+					{
+						...lineItem("SERVERLESS", money("1", 0)),
+						totalCost: { ...money("1", 0), units: "1e3" },
+					},
+				],
+			},
+			/whole units was not a bounded integer/iu,
+		],
+		[
+			{ lineItems: [{ series: "SERVERLESS", totalCost: { ...money("1", 0), nanos: 1.5 } }] },
+			/nano units was not a bounded integer/iu,
+		],
+		[
+			{
+				lineItems: [
+					{
+						series: "SERVERLESS",
+						totalCost: { currencyCode: "USD", units: "-1", nanos: 750_000_000 },
+					},
+				],
+			},
+			/mixed unit and nano signs/iu,
+		],
+		[
+			{
+				lineItems: [
+					{ series: "SERVERLESS", totalCost: { ...money("1", 0), currencyCode: "EURO" } },
+				],
+			},
+			/currency was not an ISO 4217/iu,
+		],
+	];
+	for (const [payload, pattern] of invalid) {
+		assert.throws(() => normalizeFireworksBillingSummaryPayload(payload, "acme", 0), pattern);
+	}
+});
+
+test("Fireworks account discovery normalizes and validates the documented listing", () => {
+	assert.deepEqual(
+		normalizeFireworksAccountsPayload({
+			accounts: [{ name: "accounts/acme" }, { name: "accounts/b.io" }],
+		}),
+		["acme", "b.io"],
+	);
+	const invalid: Array<[Record<string, unknown>, RegExp]> = [
+		[{}, /did not contain an accounts array/iu],
+		[{ accounts: "acme" }, /did not contain an accounts array/iu],
+		[{ accounts: [null] }, /row was not an object/iu],
+		[{ accounts: [{ displayName: "Acme" }] }, /omitted the account resource name/iu],
+		[{ accounts: [{ name: "accounts/../secrets" }] }, /unsafe account resource name/iu],
+		[{ accounts: [{ name: "accounts/acme/deployments/x" }] }, /unsafe account resource name/iu],
+		[{ accounts: [{ name: "accounts/acme" }, { name: "accounts/acme" }] }, /repeated acme/iu],
+	];
+	for (const [payload, pattern] of invalid) {
+		assert.throws(() => normalizeFireworksAccountsPayload(payload), pattern);
+	}
+});
+
+test("Fireworks runtime auth accepts only official model and resolved-auth origins", async () => {
+	const { ctx: officialContext } = createMockContext({
+		model: FIREWORKS_MODEL,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({
+				ok: true,
+				headers: {
+					Authorization: "Bearer fw-current-key",
+					"X-Private": "must-not-send",
+				},
+			}),
+			getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+			getAvailable: () => [FIREWORKS_MODEL],
+			getAll: () => [FIREWORKS_MODEL],
+		},
+	});
+	const auth = await resolveUsageAuth(officialContext, adapter);
+	assert.deepEqual(auth?.headers, { Authorization: "Bearer fw-current-key" });
+	assert.ok(!auth?.secrets.includes("must-not-send"));
+
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		for (const [modelBaseUrl, authBaseUrl, pattern] of [
+			["https://proxy.example.test/inference", undefined, /custom.*official/iu],
+			[FIREWORKS_MODEL.baseUrl, "https://proxy.example.test/v1", /proxy-resolved.*official/iu],
+		] as const) {
+			const model = { ...FIREWORKS_MODEL, baseUrl: modelBaseUrl };
+			const { ctx } = createMockContext({
+				model,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-send" }),
+					getProviderAuth: async () => ({
+						auth: {
+							apiKey: "must-not-send",
+							...(authBaseUrl ? { baseUrl: authBaseUrl } : {}),
+						},
+					}),
+					getAvailable: () => [model],
+					getAll: () => [model],
+				},
+			});
+			await assert.rejects(() => resolveUsageAuth(ctx, adapter), pattern);
+		}
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("Fireworks transport revalidates before network access and counts it against its deadline", async () => {
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		await assert.rejects(
+			() => queryProviderUsage(adapter, fireworksAuth(), new AbortController().signal, 1_000),
+			/request-boundary revalidation/iu,
+		);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					fireworksAuth(),
+					new AbortController().signal,
+					5,
+					() => new Promise<void>((resolve) => setTimeout(resolve, 10)),
+				),
+			/timed out.*resolving the fireworks account/iu,
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+function summaryResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			lineItems: [{ category: "Serverless", series: "SERVERLESS", totalCost: money("1", 0) }],
+		}),
+		{ status: 200 },
+	);
+}
+
+test("Fireworks transport auto-selects a single account and queries only the fixed endpoints", async () => {
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		requests.push({ url: String(input), init });
+		if (requests.length === 1) {
+			return new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 });
+		}
+		return summaryResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const report = await queryFireworks();
+		assert.equal(report.providerId, "fireworks");
+		assert.equal(report.accountLabel, "acme");
+		assert.equal(requests.length, 2);
+		assert.equal(requests[0]?.url, "https://api.fireworks.ai/v1/accounts?pageSize=200");
+		assert.match(
+			requests[1]?.url ?? "",
+			/^https:\/\/api\.fireworks\.ai\/v1\/accounts\/acme\/billing\/summary\?startTime=\d{4}-\d{2}-\d{2}T00%3A00%3A00Z&endTime=\d{4}-\d{2}-\d{2}T00%3A00%3A00Z$/u,
+		);
+		assert.equal(requests[1]?.init?.method, "GET");
+		assert.equal(requests[1]?.init?.redirect, "error");
+		assert.deepEqual(requests[1]?.init?.headers, {
+			Authorization: "Bearer fw-test-secret",
+			"User-Agent": "pi-usage",
+		});
+
+		const redirected = summaryResponse();
+		Object.defineProperty(redirected, "redirected", { value: true });
+		fetchMock.mockResolvedValueOnce(redirected);
+		await assert.rejects(() => queryFireworks(), /refused a redirected response/iu);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport follows documented pagination across account pages", async () => {
+	const requests: string[] = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request) => {
+		requests.push(String(input));
+		if (requests.length === 1) {
+			return new Response(
+				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "token-1" }),
+				{ status: 200 },
+			);
+		}
+		if (requests.length === 2) {
+			return new Response(JSON.stringify({ accounts: [accountRow("bold")] }), { status: 200 });
+		}
+		return summaryResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	vi.stubEnv("FIREWORKS_ACCOUNT_ID", "acme");
+	try {
+		const report = await queryFireworks();
+		assert.equal(report.accountLabel, "acme");
+		assert.equal(requests.length, 3);
+		assert.equal(requests[0], "https://api.fireworks.ai/v1/accounts?pageSize=200");
+		assert.equal(
+			requests[1],
+			"https://api.fireworks.ai/v1/accounts?pageSize=200&pageToken=token-1",
+		);
+		assert.match(requests[2] ?? "", /\/v1\/accounts\/acme\/billing\/summary\?/u);
+	} finally {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport fails closed for ambiguous, hostile, or unresolvable accounts", async () => {
+	const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+		return new Response(JSON.stringify({ accounts: [accountRow("acme"), accountRow("beta")] }), {
+			status: 200,
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() => queryFireworks(),
+			/see 2 accounts \(acme, beta\); set FIREWORKS_ACCOUNT_ID to one of them\./iu,
+		);
+
+		vi.stubEnv("FIREWORKS_ACCOUNT_ID", "../other");
+		await assert.rejects(
+			() => queryFireworks(),
+			/environment variable was not a safe account slug/iu,
+		);
+		vi.stubEnv("FIREWORKS_ACCOUNT_ID", "hidden-account");
+		await assert.rejects(
+			() => queryFireworks(),
+			/does not match an account visible to this Fireworks key/iu,
+		);
+	} finally {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport rejects unsafe page tokens and bounds bodies, JSON, and errors", async () => {
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(
+				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "bad token!" }),
+				{
+					status: 200,
+				},
+			),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(() => queryFireworks(), /unsafe page token/iu);
+
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 }),
+		);
+		fetchMock.mockResolvedValueOnce(new Response("x".repeat(70_000), { status: 200 }));
+		await assert.rejects(() => queryFireworks(), /exceeded.*bytes/iu);
+
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 }),
+		);
+		fetchMock.mockResolvedValueOnce(new Response("{broken", { status: 200 }));
+		await assert.rejects(() => queryFireworks(), /invalid JSON/iu);
+
+		fetchMock.mockResolvedValueOnce(
+			new Response("Bearer fw-test-secret failed\u001b[31m", { status: 401, statusText: "Denied" }),
+		);
+		await assert.rejects(
+			() => queryFireworks(),
+			(error: unknown) =>
+				error instanceof Error &&
+				error.message.includes("401") &&
+				!error.message.includes("fw-test-secret") &&
+				!error.message.includes("\u001b"),
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});


### PR DESCRIPTION
## Summary

Add Fireworks usage support to `@narumitw/pi-usage` via the official `fireworks` provider. Fireworks exposes no credit-balance or spend-cap endpoint, so the adapter reports **exact rated spend for the trailing 30 days** from the documented billing summary API — the same contract used by `firectl billing get-usage`.

### Behavior

- **Source**: documented `GET https://api.fireworks.ai/v1/accounts` account discovery and `GET https://api.fireworks.ai/v1/accounts/{account_id}/billing/summary` rated costs, using Pi's resolved `FIREWORKS_API_KEY` credential.
- **Account selection**: single visible account is auto-selected; keys that can see several accounts set `FIREWORKS_ACCOUNT_ID` (validated against the account listing so a stale or guessed slug cannot look successful).
- **Displayed data**: exact per-currency spend with `SERVERLESS`, `DEDICATED_DEPLOYMENT`, and `TRAINING` subtotals for the last 30 days; empty summaries report "no rated usage" without inventing quota semantics.
- **Exactness**: monetary `units` + `nanos` are summed with BigInt integer arithmetic and stay exact through display (`fireworks USD 12.345678901`), matching the package's exactness convention.
- **Security posture unchanged**: requires request-boundary revalidation before each request, queries only the fixed official origins, refuses redirects, bounds bodies, and redacts resolved credentials from errors. Custom/proxy model or auth origins fail before any network access.
- Statusline: `fireworks USD 12.345678901` (or `fireworks no rated usage`).

### Contract sources

- [Usage & Cost Breakdown](https://docs.fireworks.ai/accounts/exporting-usage-and-costs) — `GET /billingUsage` (quantities) vs `GET /billing/summary` (rated dollars), cURL examples
- [Get billing summary](https://docs.fireworks.ai/api-reference/get-billing-summary) — OpenAPI: `lineItems[].totalCost` as `typeMoney` (`currencyCode`, int64 `units` string, `nanos` int32, sign-consistency rules), startTime/endTime date-portion aggregation with exclusive endTime
- [List Accounts](https://docs.fireworks.ai/api-reference/list-accounts) — `GET /v1/accounts` with `pageSize`/`nextPageToken`
- Pi's built-in `fireworks` provider (base URL `https://api.fireworks.ai/inference`, `FIREWORKS_API_KEY`)

## Verification

- `npm --workspace @narumitw/pi-usage run check` (build + Biome + typecheck) ✅
- `npm test` (full monorepo suite): 331 files / 3272 tests ✅, including 10 new tests in `packages/pi-usage/test/fireworks.test.ts` and the `generated-entry` runtime-loading test against the built `dist` bundle
- `node ./scripts/run-typechecks.mjs` and `node ./scripts/check-extension-boundaries.mjs` ✅
- Runtime smoke of `dist/index.ts` through Jiti (Pi's loader): adapter registration, report formatting, and `fireworks USD 12.345678901` statusline confirmed ✅

## Notes

- Adds a minor changeset (`.changeset/fireworks-api-spend.md`).
- Unverified against a live Fireworks account; the contract is pinned to the published OpenAPI references above and covered by deterministic transport/normalization tests.