### PR TITLE
docs: refresh architecture and implementation notes

### DIFF
--- a/docs/adr/pi-sync-git-backend.md
+++ b/docs/adr/pi-sync-git-backend.md
@@ -128,12 +128,11 @@ prevent silent overwrite. Users must assign a distinct branch to every Git setup
 
 ### Cache and filesystem ownership
 
-Each backend identity owns a private bare SHA-1 repository under the agent directory's
-`.pisync/git/<identity>/repository.git`. The backend never discovers or mutates the process cwd's
-repository, working tree, index, hooks, or config. A missing, partial, non-bare, non-SHA-1, malformed, or unusable ordinary cache is removed and rebuilt
-without modifying settings, local sync state, backups, or remote data. A symlinked cache fails closed
-and requires explicit user inspection/removal; the backend never follows or automatically removes
-that link.
+Each backend identity owns a private bare SHA-1 repository at `git/<identity>/repository.git` beneath the active Pi Sync state directory.
+The package README owns the current canonical and legacy state-directory paths and their reviewed migration procedure.
+The backend never discovers or mutates the process cwd's repository, working tree, index, hooks, or config.
+A missing, partial, non-bare, non-SHA-1, malformed, or unusable ordinary cache is removed and rebuilt without modifying settings, local sync state, backups, or remote data.
+A symlinked cache fails closed and requires explicit user inspection or removal; the backend never follows or automatically removes that link.
 
 Every operation against the initialized private repository supplies `--git-dir`; version discovery
 and explicit-path `git init --bare <cache>` do not require it. Commit construction also supplies a

--- a/docs/adr/pi-sync-portable-selection-policy.md
+++ b/docs/adr/pi-sync-portable-selection-policy.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted. The policy is implemented by pi-sync snapshots, orchestration, and Settings review.
+Accepted.
+The policy is implemented by Pi Sync snapshots, orchestration, and review and recovery flows.
 
 ## Context
 
@@ -41,12 +42,13 @@ duplicates, and overlaps fail before settings or synced files change.
 
 ### Divergence behavior
 
-Orchestration compares an explicit remote policy with the current local setup before applying remote
-content. Ordinary sync, automatic startup/shutdown sync, and pull—including forced pull—pause on a difference.
+Orchestration compares an explicit remote policy with the current local setup before applying remote content.
+Ordinary sync, automatic startup and shutdown sync, and pull—including forced pull—pause on a difference.
 Status names the difference and lists local-only and remote-only selections.
-The no-argument TUI manager converts only the typed selection mismatch into inline resolution.
-Direct routes remain deterministic and report exact remote-only, device-only, or order-only differences plus `/sync` recovery guidance.
-Automatic startup/shutdown work remains warning-only, RPC review remains read-only, and print/JSON command behavior remains rejected.
+The TUI manager, direct interactive Sync, Pull, and Push routes without `--yes`, and eligible automatic startup work can open the shared inline resolution flow.
+An unresolved mismatch remains visible as session attention until it is resolved, invalidated, replaced, or shut down.
+Deterministic `--yes` routes report exact remote-only, device-only, or order-only differences plus recovery guidance without opening a dialog.
+Automatic shutdown remains warning-only, RPC review remains read-only, and print and JSON command behavior remains rejected.
 
 A force push is the explicit keep-local publication path.
 Its confirmation says that the local selection will replace the differing remote policy, while preserved unmanaged remote files remain subject to the existing preservation rules.
@@ -56,7 +58,7 @@ prior sync behavior because no authoritative remote intent exists.
 
 ### Review and adoption
 
-The no-argument TUI manager and **Settings → Compare synced content** share one review-first flow for a differing explicit policy.
+Interactive mismatch entry points and **Settings → Compare synced content** share one review-first flow for a differing explicit policy.
 The first screen is **Synced content differs**, says that nothing changed, and offers:
 
 - **Review all paths (recommended)** — show exact remote-only paths, device-only paths, and both ordered lists;
@@ -109,3 +111,5 @@ Users can copy needed paths through **Add custom path…**.
   `sync.test.ts` and `sync-decision.test.ts`.
 - Review-first presentation, order-only wording, adoption, explicit continuation, local-wins routing, legacy review, stale refresh, RPC read-only behavior, and disposal:
   `remote-selection-ui.test.ts` and `sync-resolution-ui.test.ts`.
+- Direct and automatic recovery, persistent attention, invalidation, session replacement, and shutdown:
+  `sync.test.ts` and `sync-attention.test.ts`.

--- a/docs/adr/pi-sync-v3-settings-model.md
+++ b/docs/adr/pi-sync-v3-settings-model.md
@@ -65,8 +65,7 @@ concepts and failure boundaries are separate.
 `storageConnections` is the only reusable access catalog. Every own-property key names one strict
 discriminated connection:
 
-- `s3`: endpoint, region, and access-key credentials; Cloudflare R2 is an S3 setup preset, not a
-  persisted fourth type;
+- `s3`: endpoint, region, access-key credentials, and an optional temporary session token; Cloudflare R2 is an S3 setup preset, not a persisted fourth type;
 - `git`: credential-free SSH/HTTPS remote, relying on user Git/SSH authentication; or
 - `webdav`: HTTPS URL plus username/password credentials.
 

--- a/docs/implementation-notes/codex-compaction-mechanism.md
+++ b/docs/implementation-notes/codex-compaction-mechanism.md
@@ -1,6 +1,9 @@
-# Codex compaction mechanism research
+# Historical research: Codex compaction mechanism
 
-Research date: 2026-08-03.
+Research snapshot: 2026-08-03.
+
+Status: Historical and intentionally pinned to one Codex revision.
+Use the current Codex source for present behavior because provider selection, retained context, media budgeting, and context-window state have continued to evolve.
 
 ## Scope and authority
 
@@ -9,8 +12,9 @@ This note describes the implementation in the `~/workspace/codex` checkout at:
 - commit `bb5054fe47abe73ecbbd454751066a28c89f4bb9`;
 - commit subject `Capture rollout budget units from response usage (#36641)`.
 
-The Codex workspace source remains authoritative. Unless otherwise stated, source paths below are
-relative to `~/workspace/codex/codex-rs`. The main implementation surfaces are:
+The pinned Codex source revision remains authoritative for this historical note.
+Unless otherwise stated, source paths below are relative to `~/workspace/codex/codex-rs` at that revision.
+The main implementation surfaces were:
 
 - `~/workspace/codex/codex-rs/core/src/session/turn.rs`;
 - `~/workspace/codex/codex-rs/core/src/tasks/compact.rs`;
@@ -20,8 +24,9 @@ relative to `~/workspace/codex/codex-rs`. The main implementation surfaces are:
 - `~/workspace/codex/codex-rs/core/src/session/mod.rs`;
 - `~/workspace/codex/codex-rs/core/src/session/rollout_reconstruction.rs`.
 
-This is an internal implementation note, not a claim about every Codex release or the hosted
-backend's undocumented internals.
+This is an internal historical implementation note, not a current-version guide or a claim about every Codex release or the hosted backend's undocumented internals.
+Later Codex revisions added material changes, including provider-capability selection with Amazon Bedrock Remote V2 support, richer retained-content metadata, and revised image budgeting.
+All external Codex source paths, line numbers, provider claims, limits, and lifecycle details below apply only to the pinned commit; the final Pi extension section is maintained separately.
 
 ## Executive summary
 
@@ -783,7 +788,9 @@ The transferable design is the checkpoint protocol rather than any one summary p
 9. **Do not infer losslessness from persistence.** An exactly replayable summary checkpoint can still
    omit critical task state, so long conversations and repeated compactions remain accuracy risks.
 
-## Pi extension boundary
+## Current Pi extension boundary
+
+The external Codex research above remains pinned, while this section describes the maintained repository extension boundary and must be reconciled when that package changes.
 
 This repository contains
 [`packages/pi-codex-compact`](../../packages/pi-codex-compact/README.md), a stable Pi extension that

--- a/docs/implementation-notes/extension-independence-audit.md
+++ b/docs/implementation-notes/extension-independence-audit.md
@@ -1,5 +1,7 @@
 # Extension Independence Audit
 
+Last reviewed: 2026-08-30.
+
 This is a small snapshot of known gaps against the repository rule that extension packages remain
 independently installable and semantically self-contained. It records existing behavior; fixes belong
 in separate, package-focused changes.

--- a/docs/implementation-notes/pi-goal-interruption-research.md
+++ b/docs/implementation-notes/pi-goal-interruption-research.md
@@ -9,7 +9,10 @@ which races cannot be eliminated by an extension.
 The maintained implementation and tests are authoritative:
 
 - `packages/pi-goal/src/goal.ts`
+- `packages/pi-goal/src/lifecycle.ts`
 - `packages/pi-goal/src/runtime.ts`
+- `packages/pi-goal/src/tools.ts`
+- `packages/pi-goal/src/tool-policy.ts`
 - `packages/pi-goal/src/accounting.ts`
 - `packages/pi-goal/src/safety.ts`
 - `packages/pi-goal/src/prompts.ts`
@@ -68,6 +71,13 @@ An active or waiting Goal retains cooperative ownership across normal work, cont
 Admission rejects another cooperating workflow before Goal state, tools, persistence, prompts, status, or timers change.
 The mutex does not reserve a Pi turn and cannot coordinate trusted extensions that do not participate in the protocol.
 
+## Stable helper-tool envelope
+
+`goal_complete`, `goal_blocked`, and `goal_wait` are registered once and keep stable provider-visible schemas from startup.
+Their visibility alone does not activate Goal mode because each tool requires the latest effective active Goal contract and matching goal id.
+The extension does not add mode-only `promptSnippet` or `promptGuidelines` metadata and does not mutate the active tool set during Goal lifecycle transitions.
+A restrictive external allowlist can still hide Goal tools; Goal start and restore require `goal_complete` and `goal_blocked` without widening that allowlist, while `goal_wait` remains optional for ordinary Goal work.
+
 ## Retry, compaction, and stopped states
 
 Retryable provider failures and context-overflow compaction remain Pi-owned recovery:
@@ -99,7 +109,9 @@ Goal prompts and compacted context use the same objective trust boundary, stale 
 The first accepted handoff for a Goal identity and its versioned hidden `goal-contract` are persisted together at the agent-start boundary after retained conversation history.
 Every active or inactive contract explicitly supersedes earlier contracts, and historical contracts remain in their appended positions so provider input grows monotonically.
 Failed Goal handoff delivery persists no contract.
-Stopped transitions persist one inactive revision, while the `context` hook supplies a missing current revision after leading summaries as a correctness fallback.
+Stopped transitions persist one inactive revision, but terminal Goal tools defer that revision until `turn_end` so Pi first persists the real `goal_complete` or `goal_blocked` tool result.
+This ordering prevents a synthetic missing-result fallback from appearing before the inactive contract in later provider input.
+The `context` hook supplies a missing current revision after leading summaries as a correctness fallback.
 Compaction and session restore persist a missing current revision without waking an external wait.
 Mutable accounting remains outside the retained provider prompt prefix.
 Prompt wording is a guardrail; current files, commands, tests, runtime behavior, and external state remain the completion evidence.
@@ -144,7 +156,8 @@ settled, retry, compaction, accounting, and stale-delivery guarantees.
 
 - Settled exactly-once dispatch, pending-message priority, replacement, pause, clear, and lost-start races: `packages/pi-goal/test/goal-continuation.test.ts`.
 - Workflow Mutex acquisition, rejection before mutation, restore fallbacks, release, and reacquisition: `packages/pi-goal/test/workflow-mutex.test.ts` and the Goal package lifecycle tests.
-- Stable leading prompt prefix, canonical context reinjection, and compaction-sensitive Goal contract: `packages/pi-goal/test/goal-cache-contract.test.ts`.
+- Stable helper-tool schemas and restrictive allowlist behavior: `packages/pi-goal/test/goal-tool-policy.test.ts` and `packages/pi-goal/test/tool-policy.test.ts`.
+- Stable leading prompt prefix, canonical context reinjection, compaction-sensitive Goal contracts, and terminal tool-result ordering: `packages/pi-goal/test/goal-cache-contract.test.ts`.
 - Retry, overflow, compaction, provider-exhaustion waiting, wake-up, restored waiting, and stopped-state classification: `packages/pi-goal/test/goal-error-lifecycle.test.ts`.
 - External-wait deadlines, cleanup, quiet elapsed time, and wake boundaries: `packages/pi-goal/test/goal-wait.test.ts`.
 - Managed-run active waiting and later terminal completion: `packages/pi-goal/test/goal-run-protocol.test.ts`.


### PR DESCRIPTION
## Summary

- refresh Pi Sync ADRs for the current state directory, selection recovery flow, and temporary S3 credentials
- mark the Codex compaction research as a pinned historical snapshot while keeping the Pi extension boundary current
- document Pi Goal's stable helper-tool envelope and terminal tool-result ordering
- record the latest extension-independence audit review

## Verification

- `npm run check`
- `npm test` — 332 files and 3279 tests passed
- `git diff --check`

The external Codex test suite was not run because this pull request changes documentation only; its current source was inspected for the historical-boundary update.
No Changeset is required for repository-only documentation changes.
