### PR TITLE
feat(cbmem): reuse matching worktree base indexes

### DIFF
--- a/.changeset/calm-worktrees-borrow.md
+++ b/.changeset/calm-worktrees-borrow.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-cbmem": minor
+---
+
+Add safe `@current` resolution for exact current indexes and matching clean canonical worktree graphs.
+
+Keep borrowed graph access read-only, revalidate it around each call, and read borrowed snippets from the current worktree.

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -9,6 +9,7 @@ Connect Pi to the local Codebase Memory CLI and give the model graph-first opera
 - Registers 15 Codebase Memory tools for graph queries, search, indexing, coverage, tracing, and architecture.
 - Runs the local `codebase-memory-mcp` CLI with cancellation, failure reporting, and bounded output.
 - Bundles the `codebase-memory` skill for graph-first, evidence-tier workflows.
+- Resolves `@current` to an exact current-root index or a matching clean canonical-checkout graph for approved read tools.
 - Loads the extension and skill from one package.
 
 ## 📦 Install
@@ -41,6 +42,21 @@ Install only trusted packages, and review the source before loading this extensi
 
 Install `codebase-memory-mcp` at `~/.local/bin/codebase-memory-mcp`, load pi-cbmem, and ask Pi a structural codebase question.
 The bundled skill directs Pi to identify the active graph project before exploration and verify material claims with snippets and index-coverage evidence.
+
+## 🌳 Worktree base reuse
+
+Approved read tools accept `project="@current"`.
+An index whose stored root is the current worktree wins.
+When the linked worktree has no index, pi-cbmem can borrow the canonical checkout project only when both trees are clean, share one Git common directory and `HEAD`, and the graph-recorded Branch metadata matches that snapshot.
+The extension validates the borrowed state before and after every call and identifies the borrowed project in `pi_cbmem_resolution`.
+Borrowing is read-only and never copies, remaps, updates, or deletes an index.
+Borrowed `get_code_snippet` results read the selected lines from the current worktree and report its path.
+
+The `@current` alias is available for `search_graph`, `query_graph`, `trace_path`, `get_code_snippet`, `get_graph_schema`, `get_architecture`, and `index_status`.
+It is intentionally unavailable for `search_code`, `check_index_coverage`, `detect_changes`, `manage_adr`, `ingest_traces`, `delete_project`, and `index_repository` because those operations read project-root state or mutate persisted data.
+Use an explicit indexed project for those tools.
+If the worktree is dirty, at another commit, ambiguous, or backed by a stale Branch snapshot, create its own index or use normal file tools.
+Codebase Memory does not expose an immutable generation lease or complete semantic-input comparison, so this fallback is a conservative best-effort read optimization rather than worktree overlay indexing.
 
 ## 🛠️ Tools
 
@@ -82,6 +98,7 @@ Cancelling the tool call terminates that child process.
 - The package requires `~/.local/bin/codebase-memory-mcp` for the current user.
 - It does not install or update the Codebase Memory binary.
 - Static tool schemas match the bundled skill, while the installed CLI performs final argument validation.
+- Worktree base reuse requires an exact clean snapshot and does not cover branch changes, dirty files, source-code search, change detection, index mutation, project forking, or overlays.
 
 ## 🗂️ Package layout
 
@@ -94,7 +111,8 @@ packages/pi-cbmem/
 │   ├── index.ts                    # Thin Pi entrypoint
 │   ├── cbmem.ts                    # Bounded Codebase Memory CLI runner
 │   ├── render-result.ts            # Terminal-safe result rendering
-│   └── tool-definitions.ts         # Pi tool metadata and TypeBox schemas
+│   ├── tool-definitions.ts         # Pi tool metadata and TypeBox schemas
+│   └── worktree-project.ts         # Safe current-worktree project resolution
 ├── skills/codebase-memory/
 │   └── SKILL.md                    # Graph-first operating guidance
 ├── test/

--- a/packages/pi-cbmem/skills/codebase-memory/SKILL.md
+++ b/packages/pi-cbmem/skills/codebase-memory/SKILL.md
@@ -20,7 +20,8 @@ Always prefer MCP graph tools over grep, glob, or file search for code discovery
 
 ## Quick Decision Matrix
 
-Use the exact `project="<name>"` returned by `list_projects` in every project-scoped call.
+Use `project="@current"` for eligible graph reads in the active checkout, or use the exact `project="<name>"` returned by `list_projects`.
+Never replace `@current` with its borrowed source project in later graph calls because the alias revalidates the worktree on every call.
 
 | Question | Tool call |
 |----------|----------|
@@ -34,13 +35,30 @@ Use the exact `project="<name>"` returned by `list_projects` in every project-sc
 | Risk-classified trace | `trace_path(project="<name>", function_name="X", risk_labels=true)` |
 | Text search | `search_code(project="<name>", pattern="...")` or Grep |
 
+## Current Worktree Resolution
+
+- `index_status(project="@current")` resolves an existing current-root index first.
+- In an unindexed linked worktree, `@current` borrows a canonical checkout graph only when both trees are clean, share one Git common directory and `HEAD`, and the graph-recorded Branch snapshot matches.
+- Keep using `@current` for `search_graph`, `query_graph`, `trace_path`, `get_code_snippet`, `get_graph_schema`, `get_architecture`, and `index_status` so each call revalidates the borrowed snapshot.
+- Inspect `pi_cbmem_resolution`; `borrowed_canonical_base` means the result is read-only borrowed graph evidence rather than a worktree index.
+- Borrowed `get_code_snippet` reads the reported lines from the current worktree.
+- Do not use `@current` with `search_code`, `check_index_coverage`, `detect_changes`, `manage_adr`, `ingest_traces`, `delete_project`, or `index_repository`.
+- For required coverage on borrowed evidence, call `check_index_coverage` once with the reported source project, read flagged paths from the current worktree, then rerun `index_status(project="@current")` before relying on the result.
+  Do not use the reported source project for graph reads.
+- If `@current` rejects a dirty, divergent, stale, missing, or ambiguous context, do not bypass the guard with the canonical project name.
+  Index the worktree or use current-root file reads and grep instead.
+- Treat borrowed coverage as best-effort because Codebase Memory exposes no immutable generation lease or complete semantic-input comparison.
+
 ## Exploration Workflow
 
-1. `list_projects` — check whether the project is indexed and copy its exact name.
-2. `get_graph_schema(project="<name>")` — understand node and edge types.
-3. `search_graph(project="<name>", label="Function", name_pattern=".*Pattern.*")` — find code.
-4. `get_code_snippet(project="<name>", qualified_name="project.path.FuncName")` — read source.
-5. `check_index_coverage(project="<name>", paths=["path/to/file"])` — validate every evidence path.
+Use `@current` for eligible calls below when the first step succeeds; otherwise substitute the exact project discovered by `list_projects`.
+
+1. `index_status(project="@current")` — resolve and validate the active checkout when supported.
+2. `list_projects` — fall back to discovering and copying an exact project name when `@current` is unavailable.
+3. `get_graph_schema(project="<name>")` — understand node and edge types.
+4. `search_graph(project="<name>", label="Function", name_pattern=".*Pattern.*")` — find code.
+5. `get_code_snippet(project="<name>", qualified_name="project.path.FuncName")` — read source.
+6. `check_index_coverage(project="<name>", paths=["path/to/file"])` — validate every evidence path.
 
 ## Tracing Workflow
 
@@ -75,7 +93,7 @@ Use the exact `project="<name>"` returned by `list_projects` in every project-sc
 
 ## Session Resets and Subagents
 
-- At session start or after compaction, confirm the nearest graph project and generation with `list_projects` or `index_status`, then choose Scout, Verify, or Auditor.
+- At session start or after compaction, try `index_status(project="@current")`, then use `list_projects` or an exact-name `index_status` fallback before choosing Scout, Verify, or Auditor.
 - Before spawning a subagent, query the graph and coverage in the parent.
   Pass the tier, project, generation or freshness, bounded scope, queries and pagination state, qualified symbols, paths, call-chain findings, coverage evidence with ranges and reasons, source fallback already performed, and unresolved questions in the delegated task context.
 - Do not assume subagents inherit MCP access or the parent conversation.
@@ -112,3 +130,4 @@ MATCH (a)-[r:CALLS]->(b) WHERE a.name = 'main' RETURN b.name
 3. `trace_path` needs exact names — use `search_graph(project="<name>", name_pattern="...")` first.
 4. `direction="outbound"` misses cross-service callers — use `direction="both"`.
 5. `search_graph` results default to 50 per page — check `has_more` and use `offset`.
+6. `@current` is a pi-cbmem read alias, not a Codebase Memory project or a shared-index identity.

--- a/packages/pi-cbmem/src/cbmem.ts
+++ b/packages/pi-cbmem/src/cbmem.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { lstat, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -10,6 +11,14 @@ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-work
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { renderCodebaseMemoryResult } from "./render-result.js";
 import { type BridgeToolDefinition, TOOL_DEFINITIONS, type ToolName } from "./tool-definitions.js";
+import {
+	BORROWABLE_TOOL_NAMES,
+	CURRENT_PROJECT_ALIAS,
+	currentRelativePath,
+	defaultProjectResolutionService,
+	type ProjectResolution,
+	type ProjectResolutionService,
+} from "./worktree-project.js";
 
 export { TOOL_NAMES } from "./tool-definitions.js";
 
@@ -21,6 +30,7 @@ export interface CbmemToolDetails {
 	truncated: boolean;
 	totalBytes: number;
 	totalLines: number;
+	projectResolution?: ProjectResolution;
 }
 
 class BoundedPrefixCollector {
@@ -178,25 +188,184 @@ export async function callCodebaseMemory(
 	});
 }
 
-export default function cbmem(pi: ExtensionAPI, binary = BIN): void {
-	for (const definition of TOOL_DEFINITIONS) registerBridgeTool(pi, definition, binary);
+export default function cbmem(
+	pi: ExtensionAPI,
+	binary = BIN,
+	projectResolutionService = defaultProjectResolutionService,
+): void {
+	for (const definition of TOOL_DEFINITIONS) {
+		registerBridgeTool(pi, definition, binary, projectResolutionService);
+	}
 }
 
 function registerBridgeTool(
 	pi: ExtensionAPI,
 	definition: BridgeToolDefinition,
 	binary: string,
+	projectResolutionService: ProjectResolutionService,
 ): void {
 	pi.registerTool({
 		...definition,
 		renderResult: renderCodebaseMemoryResult,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const tool = definition.name as ToolName;
-			const args = params as Record<string, unknown>;
+			let args = params as Record<string, unknown>;
+			let resolution: ProjectResolution | undefined;
+			const query = async (
+				queryTool: ToolName,
+				queryArgs: Record<string, unknown>,
+				querySignal: AbortSignal | undefined,
+			): Promise<unknown> => {
+				const result = await callCodebaseMemory(queryTool, queryArgs, querySignal, ctx.cwd, binary);
+				querySignal?.throwIfAborted();
+				return parseJsonResult(result, queryTool);
+			};
+
+			if (args.project === CURRENT_PROJECT_ALIAS) {
+				if (!BORROWABLE_TOOL_NAMES.has(tool)) {
+					throw new Error(
+						`${CURRENT_PROJECT_ALIAS} is available only for read-only graph tools; specify an indexed project for ${tool}`,
+					);
+				}
+				resolution = await projectResolutionService.resolve(ctx.cwd, signal, query);
+				signal?.throwIfAborted();
+				args = { ...args, project: resolution.project };
+			}
+
 			await confirmDestructiveCall(tool, args, signal, ctx);
-			return await callCodebaseMemory(tool, args, signal, ctx.cwd, binary);
+			signal?.throwIfAborted();
+			let result = await callCodebaseMemory(tool, args, signal, ctx.cwd, binary);
+			signal?.throwIfAborted();
+			if (!resolution) return result;
+			if (resolution.kind === "borrowed" && tool === "get_code_snippet") {
+				result = await rewriteBorrowedSnippet(result, resolution, signal);
+				signal?.throwIfAborted();
+			}
+			await projectResolutionService.revalidate(resolution, signal, query);
+			signal?.throwIfAborted();
+			return attachProjectResolution(result, resolution);
 		},
 	});
+}
+
+function parseJsonResult(result: AgentToolResult<CbmemToolDetails>, tool: ToolName): unknown {
+	const content = result.content[0];
+	if (content?.type !== "text") {
+		throw new Error(`codebase-memory-mcp ${tool} returned no text result`);
+	}
+	try {
+		return JSON.parse(content.text);
+	} catch (error) {
+		throw new Error(`codebase-memory-mcp ${tool} returned invalid JSON`, { cause: error });
+	}
+}
+
+async function rewriteBorrowedSnippet(
+	result: AgentToolResult<CbmemToolDetails>,
+	resolution: ProjectResolution,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<CbmemToolDetails>> {
+	const snippet = parseJsonResult(result, "get_code_snippet");
+	if (!snippet || typeof snippet !== "object" || Array.isArray(snippet)) {
+		throw new Error("Codebase Memory returned an invalid borrowed code snippet");
+	}
+	const record = snippet as Record<string, unknown>;
+	if (
+		typeof record.file_path !== "string" ||
+		typeof record.start_line !== "number" ||
+		typeof record.end_line !== "number"
+	) {
+		throw new Error("Codebase Memory returned incomplete borrowed code snippet metadata");
+	}
+	const currentPath = currentRelativePath(resolution, record.file_path);
+	const file = await lstat(currentPath);
+	signal?.throwIfAborted();
+	if (!file.isFile() || file.isSymbolicLink()) {
+		throw new Error("Borrowed code snippet does not resolve to a regular worktree file");
+	}
+	const source = await readFile(currentPath, "utf8");
+	signal?.throwIfAborted();
+	const lines = source.split(/(?<=\n)/u);
+	const start = record.start_line;
+	const end = record.end_line;
+	if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 1 || end < start) {
+		throw new Error("Codebase Memory returned an invalid borrowed code snippet range");
+	}
+	const selected = lines.slice(start - 1, end);
+	if (selected.length !== end - start + 1) {
+		throw new Error("The borrowed code snippet range is outside the current worktree file");
+	}
+	record.file_path = currentPath;
+	record.source = selected.join("");
+	return replaceTextResult(result, JSON.stringify(record));
+}
+
+function attachProjectResolution(
+	result: AgentToolResult<CbmemToolDetails>,
+	resolution: ProjectResolution,
+): AgentToolResult<CbmemToolDetails> {
+	const content = result.content[0];
+	if (content?.type !== "text") return result;
+	const metadata = {
+		kind: resolution.kind === "borrowed" ? "borrowed_canonical_base" : "current_index",
+		project: resolution.project,
+		current_root: resolution.currentRoot,
+		source_root: resolution.sourceRoot,
+		head_sha: resolution.headSha,
+		read_only: resolution.kind === "borrowed",
+	};
+	let text: string;
+	try {
+		const parsed = JSON.parse(content.text);
+		text = JSON.stringify(
+			parsed && typeof parsed === "object" && !Array.isArray(parsed)
+				? { ...parsed, pi_cbmem_resolution: metadata }
+				: { result: parsed, pi_cbmem_resolution: metadata },
+		);
+	} catch {
+		text = `[pi-cbmem project resolution: ${JSON.stringify(metadata)}]\n${content.text}`;
+	}
+	const replaced = replaceTextResult(result, text);
+	return {
+		...replaced,
+		details: { ...replaced.details, projectResolution: resolution },
+	};
+}
+
+function replaceTextResult(
+	result: AgentToolResult<CbmemToolDetails>,
+	text: string,
+): AgentToolResult<CbmemToolDetails> {
+	const bounded = boundStandaloneOutput(text);
+	return {
+		...result,
+		content: [{ type: "text", text: bounded.text }],
+		details: {
+			...result.details,
+			truncated: result.details.truncated || bounded.truncated,
+			totalBytes: Buffer.byteLength(text, "utf8"),
+			totalLines: countLines(text),
+		},
+	};
+}
+
+function boundStandaloneOutput(text: string): { text: string; truncated: boolean } {
+	const totalBytes = Buffer.byteLength(text, "utf8");
+	const totalLines = countLines(text);
+	if (totalBytes <= DEFAULT_MAX_BYTES && totalLines <= DEFAULT_MAX_LINES) {
+		return { text, truncated: false };
+	}
+	const notice = `[Output truncated after pi-cbmem project resolution: ${totalLines} lines (${formatSize(totalBytes)}).]`;
+	const separator = "\n";
+	const body = takeUtf8Prefix(
+		text,
+		Math.max(0, DEFAULT_MAX_BYTES - Buffer.byteLength(notice + separator, "utf8")),
+		Math.max(0, DEFAULT_MAX_LINES - 1),
+	);
+	return {
+		text: body ? `${body}${body.endsWith("\n") ? "" : separator}${notice}` : notice,
+		truncated: true,
+	};
 }
 
 async function confirmDestructiveCall(

--- a/packages/pi-cbmem/src/cbmem.ts
+++ b/packages/pi-cbmem/src/cbmem.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { lstat, readFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { lstat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -277,26 +278,23 @@ async function rewriteBorrowedSnippet(
 	) {
 		throw new Error("Codebase Memory returned incomplete borrowed code snippet metadata");
 	}
+	const start = record.start_line;
+	const end = record.end_line;
+	if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 1 || end < start) {
+		throw new Error("Codebase Memory returned an invalid borrowed code snippet range");
+	}
+	if (end - start + 1 > DEFAULT_MAX_LINES) {
+		throw new Error("The borrowed code snippet range exceeds Pi's line limit");
+	}
 	const currentPath = currentRelativePath(resolution, record.file_path);
 	const file = await lstat(currentPath);
 	signal?.throwIfAborted();
 	if (!file.isFile() || file.isSymbolicLink()) {
 		throw new Error("Borrowed code snippet does not resolve to a regular worktree file");
 	}
-	const source = await readFile(currentPath, "utf8");
-	signal?.throwIfAborted();
-	const lines = source.split(/(?<=\n)/u);
-	const start = record.start_line;
-	const end = record.end_line;
-	if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 1 || end < start) {
-		throw new Error("Codebase Memory returned an invalid borrowed code snippet range");
-	}
-	const selected = lines.slice(start - 1, end);
-	if (selected.length !== end - start + 1) {
-		throw new Error("The borrowed code snippet range is outside the current worktree file");
-	}
 	record.file_path = currentPath;
-	record.source = selected.join("");
+	record.source = await readLineRange(currentPath, start, end, signal);
+	signal?.throwIfAborted();
 	return replaceTextResult(result, JSON.stringify(record));
 }
 
@@ -336,36 +334,76 @@ function replaceTextResult(
 	result: AgentToolResult<CbmemToolDetails>,
 	text: string,
 ): AgentToolResult<CbmemToolDetails> {
-	const bounded = boundStandaloneOutput(text);
+	const totalBytes = Buffer.byteLength(text, "utf8");
+	const totalLines = countLines(text);
+	if (totalBytes > DEFAULT_MAX_BYTES || totalLines > DEFAULT_MAX_LINES) {
+		throw new Error(
+			`pi-cbmem project-resolved output exceeded ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)} (${totalLines} lines, ${formatSize(totalBytes)}); refusing to return truncated structured data`,
+		);
+	}
 	return {
 		...result,
-		content: [{ type: "text", text: bounded.text }],
+		content: [{ type: "text", text }],
 		details: {
 			...result.details,
-			truncated: result.details.truncated || bounded.truncated,
-			totalBytes: Buffer.byteLength(text, "utf8"),
-			totalLines: countLines(text),
+			totalBytes,
+			totalLines,
 		},
 	};
 }
 
-function boundStandaloneOutput(text: string): { text: string; truncated: boolean } {
-	const totalBytes = Buffer.byteLength(text, "utf8");
-	const totalLines = countLines(text);
-	if (totalBytes <= DEFAULT_MAX_BYTES && totalLines <= DEFAULT_MAX_LINES) {
-		return { text, truncated: false };
+export async function readLineRange(
+	path: string,
+	startLine: number,
+	endLine: number,
+	signal: AbortSignal | undefined,
+): Promise<string> {
+	signal?.throwIfAborted();
+	const stream = createReadStream(path, {
+		encoding: "utf8",
+		highWaterMark: 64 * 1024,
+		signal,
+	});
+	let currentLine = 1;
+	let completedLine = 0;
+	let currentLineHasContent = false;
+	let selected = "";
+	let selectedBytes = 0;
+	try {
+		for await (const value of stream) {
+			signal?.throwIfAborted();
+			const chunk = String(value);
+			let offset = 0;
+			while (offset < chunk.length) {
+				const newline = chunk.indexOf("\n", offset);
+				const end = newline >= 0 ? newline + 1 : chunk.length;
+				const segment = chunk.slice(offset, end);
+				currentLineHasContent ||= segment.length > 0;
+				if (currentLine >= startLine && currentLine <= endLine) {
+					selectedBytes += Buffer.byteLength(segment, "utf8");
+					if (selectedBytes > DEFAULT_MAX_BYTES) {
+						throw new Error("The borrowed code snippet exceeds Pi's byte limit");
+					}
+					selected += segment;
+				}
+				if (newline >= 0) {
+					completedLine = currentLine;
+					if (currentLine === endLine) return selected;
+					currentLine += 1;
+					currentLineHasContent = false;
+				}
+				offset = end;
+			}
+		}
+		signal?.throwIfAborted();
+		if (currentLineHasContent) completedLine = currentLine;
+		if (completedLine < endLine) {
+			throw new Error("The borrowed code snippet range is outside the current worktree file");
+		}
+		return selected;
+	} finally {
+		stream.destroy();
 	}
-	const notice = `[Output truncated after pi-cbmem project resolution: ${totalLines} lines (${formatSize(totalBytes)}).]`;
-	const separator = "\n";
-	const body = takeUtf8Prefix(
-		text,
-		Math.max(0, DEFAULT_MAX_BYTES - Buffer.byteLength(notice + separator, "utf8")),
-		Math.max(0, DEFAULT_MAX_LINES - 1),
-	);
-	return {
-		text: body ? `${body}${body.endsWith("\n") ? "" : separator}${notice}` : notice,
-		truncated: true,
-	};
 }
 
 async function confirmDestructiveCall(

--- a/packages/pi-cbmem/src/tool-definitions.ts
+++ b/packages/pi-cbmem/src/tool-definitions.ts
@@ -9,7 +9,11 @@ export type BridgeToolDefinition = Pick<
 	"name" | "label" | "description" | "parameters"
 >;
 
-const Project = Type.String({ description: "Indexed project name from list_projects." });
+const ExactProject = Type.String({ description: "Indexed project name from list_projects." });
+const ReadProject = Type.String({
+	description:
+		'Indexed project name from list_projects, or "@current" for safe current-worktree resolution.',
+});
 const outputLimit = `Output is limited to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}; byte-oversized responses fail validation instead of returning partial JSON.`;
 
 export const TOOL_DEFINITIONS = [
@@ -32,7 +36,7 @@ export const TOOL_DEFINITIONS = [
 		label: "Search Graph",
 		description: `Search indexed symbols by text, name, file, relationship, or degree. ${outputLimit}`,
 		parameters: Type.Object({
-			project: Project,
+			project: ReadProject,
 			query: Type.Optional(Type.String({ description: "Natural-language or keyword search." })),
 			label: Type.Optional(Type.String()),
 			name_pattern: Type.Optional(Type.String()),
@@ -57,7 +61,7 @@ export const TOOL_DEFINITIONS = [
 		description: `Execute a Cypher query against the code or missed-coverage graph. ${outputLimit}`,
 		parameters: Type.Object({
 			query: Type.String({ description: "Cypher query." }),
-			project: Project,
+			project: ReadProject,
 			graph: Type.Optional(StringEnum(["code", "missed"] as const)),
 			max_rows: Type.Optional(Type.Integer()),
 		}),
@@ -68,7 +72,7 @@ export const TOOL_DEFINITIONS = [
 		description: `Trace callers, callees, data flow, or cross-service paths. ${outputLimit}`,
 		parameters: Type.Object({
 			function_name: Type.String(),
-			project: Project,
+			project: ReadProject,
 			direction: Type.Optional(StringEnum(["inbound", "outbound", "both"] as const)),
 			depth: Type.Optional(Type.Integer()),
 			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 5000 })),
@@ -88,7 +92,7 @@ export const TOOL_DEFINITIONS = [
 		description: `Read source for an indexed symbol by qualified name. ${outputLimit}`,
 		parameters: Type.Object({
 			qualified_name: Type.String(),
-			project: Project,
+			project: ReadProject,
 			include_neighbors: Type.Optional(Type.Boolean()),
 		}),
 	},
@@ -96,14 +100,14 @@ export const TOOL_DEFINITIONS = [
 		name: "get_graph_schema",
 		label: "Get Graph Schema",
 		description: `Get graph node labels and edge types. ${outputLimit}`,
-		parameters: Type.Object({ project: Project }),
+		parameters: Type.Object({ project: ReadProject }),
 	},
 	{
 		name: "get_architecture",
 		label: "Get Architecture",
 		description: `Summarize architecture, dependencies, boundaries, clusters, or hotspots. ${outputLimit}`,
 		parameters: Type.Object({
-			project: Project,
+			project: ReadProject,
 			path: Type.Optional(Type.String()),
 			aspects: Type.Optional(
 				Type.Array(
@@ -133,7 +137,7 @@ export const TOOL_DEFINITIONS = [
 		description: `Search source text and enrich matches with graph context. ${outputLimit}`,
 		parameters: Type.Object({
 			pattern: Type.String(),
-			project: Project,
+			project: ExactProject,
 			file_pattern: Type.Optional(Type.String()),
 			path_filter: Type.Optional(Type.String()),
 			mode: Type.Optional(StringEnum(["compact", "full", "files"] as const)),
@@ -158,14 +162,14 @@ export const TOOL_DEFINITIONS = [
 		name: "delete_project",
 		label: "Delete Project",
 		description: `Delete a project from the Codebase Memory index. ${outputLimit}`,
-		parameters: Type.Object({ project: Project }),
+		parameters: Type.Object({ project: ExactProject }),
 	},
 	{
 		name: "index_status",
 		label: "Index Status",
 		description: `Get project index health, Git context, and coverage gaps. ${outputLimit}`,
 		parameters: Type.Object({
-			project: Project,
+			project: ReadProject,
 			verbose: Type.Optional(Type.Boolean()),
 		}),
 	},
@@ -174,7 +178,7 @@ export const TOOL_DEFINITIONS = [
 		label: "Check Index Coverage",
 		description: `Check best-effort index coverage for exact paths or bounded scopes. ${outputLimit}`,
 		parameters: Type.Object({
-			project: Project,
+			project: ExactProject,
 			paths: Type.Optional(Type.Array(Type.String(), { maxItems: 128 })),
 			scopes: Type.Optional(Type.Array(Type.String(), { maxItems: 32 })),
 			scope_limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
@@ -186,7 +190,7 @@ export const TOOL_DEFINITIONS = [
 		label: "Detect Changes",
 		description: `Map a Git diff to changed files and impacted graph symbols. ${outputLimit}`,
 		parameters: Type.Object({
-			project: Project,
+			project: ExactProject,
 			scope: Type.Optional(StringEnum(["files", "impact"] as const)),
 			direction: Type.Optional(StringEnum(["inbound", "outbound", "both"] as const)),
 			depth: Type.Optional(Type.Integer()),
@@ -202,7 +206,7 @@ export const TOOL_DEFINITIONS = [
 		description: `Read or replace Architecture Decision Records. ${outputLimit}`,
 		parameters: Type.Object(
 			{
-				project: Project,
+				project: ExactProject,
 				mode: Type.Optional(StringEnum(["get", "update", "sections"] as const)),
 				content: Type.Optional(Type.String()),
 			},
@@ -224,7 +228,7 @@ export const TOOL_DEFINITIONS = [
 					{ additionalProperties: false },
 				),
 			),
-			project: Project,
+			project: ExactProject,
 		}),
 	},
 ] as const satisfies readonly BridgeToolDefinition[];

--- a/packages/pi-cbmem/src/worktree-project.ts
+++ b/packages/pi-cbmem/src/worktree-project.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { ToolName } from "./tool-definitions.js";
 
 export const CURRENT_PROJECT_ALIAS = "@current";
@@ -48,7 +48,7 @@ interface GitContext {
 	root: string;
 	gitDir: string;
 	commonDir: string;
-	canonicalRoot: string;
+	canonicalRoot?: string;
 	headSha: string;
 	isWorktree: boolean;
 }
@@ -60,7 +60,7 @@ interface IndexedProject {
 
 interface IndexedBranch {
 	headSha: string;
-	canonicalRoot: string;
+	gitCommonDir: string;
 	worktreeRoot: string;
 	isWorktree: boolean;
 }
@@ -106,14 +106,13 @@ export async function resolveCurrentProject(
 	await assertClean(current.root, signal);
 	signal?.throwIfAborted();
 
-	const sourceProjects = projectsAtRoot(projects, current.canonicalRoot);
+	const sourceProjects = await findCanonicalProjects(current, projects, signal);
+	signal?.throwIfAborted();
 	if (sourceProjects.length === 0) {
-		throw new Error(
-			`Codebase Memory has no canonical checkout index for this linked worktree: ${current.canonicalRoot}`,
-		);
+		throw new Error("Codebase Memory has no canonical checkout index for this linked worktree");
 	}
 	if (sourceProjects.length > 1) {
-		throw ambiguousProjectError(current.canonicalRoot, sourceProjects);
+		throw ambiguousProjectError("this Git repository", sourceProjects);
 	}
 
 	const sourceProject = sourceProjects[0];
@@ -146,10 +145,22 @@ export async function revalidateProjectResolution(
 	signal: AbortSignal | undefined,
 	query: CbmemJsonQuery,
 ): Promise<void> {
-	if (resolution.kind !== "borrowed") return;
 	signal?.throwIfAborted();
 	const current = await resolveGitContext(resolution.currentRoot, signal);
 	signal?.throwIfAborted();
+	if (
+		normalizePath(current.root) !== normalizePath(resolution.currentRoot) ||
+		current.headSha !== resolution.headSha
+	) {
+		throw changedDuringCallError();
+	}
+	if (resolution.kind === "current") {
+		const project = { name: resolution.project, rootPath: resolution.currentRoot };
+		const status = await query("index_status", { project: resolution.project }, signal);
+		signal?.throwIfAborted();
+		assertReadyStatus(status, project);
+		return;
+	}
 	const source = await resolveGitContext(resolution.sourceRoot, signal);
 	signal?.throwIfAborted();
 	await assertClean(current.root, signal);
@@ -157,9 +168,6 @@ export async function revalidateProjectResolution(
 	await assertClean(source.root, signal);
 	signal?.throwIfAborted();
 	assertMatchingGitContexts(current, source);
-	if (current.headSha !== resolution.headSha) {
-		throw changedDuringCallError();
-	}
 	const branch = await readIndexedBranch(resolution.project, query, signal);
 	signal?.throwIfAborted();
 	assertMatchingIndexedBranch(current, source, branch);
@@ -168,6 +176,47 @@ export async function revalidateProjectResolution(
 function projectsAtRoot(projects: IndexedProject[], root: string): IndexedProject[] {
 	const normalizedRoot = normalizePath(root);
 	return projects.filter((project) => normalizePath(project.rootPath) === normalizedRoot);
+}
+
+async function findCanonicalProjects(
+	current: GitContext,
+	projects: IndexedProject[],
+	signal: AbortSignal | undefined,
+): Promise<IndexedProject[]> {
+	if (current.canonicalRoot) {
+		const direct = await projectsSharingCommonDir(
+			current,
+			projectsAtRoot(projects, current.canonicalRoot),
+			signal,
+		);
+		if (direct.length > 0) return direct;
+	}
+	return await projectsSharingCommonDir(current, projects, signal);
+}
+
+async function projectsSharingCommonDir(
+	current: GitContext,
+	projects: IndexedProject[],
+	signal: AbortSignal | undefined,
+): Promise<IndexedProject[]> {
+	const matches: IndexedProject[] = [];
+	for (const project of projects) {
+		if (normalizePath(project.rootPath) === normalizePath(current.root)) continue;
+		try {
+			const candidate = await resolveGitContext(project.rootPath, signal);
+			signal?.throwIfAborted();
+			if (
+				!candidate.isWorktree &&
+				normalizePath(candidate.commonDir) === normalizePath(current.commonDir)
+			) {
+				matches.push(project);
+			}
+		} catch {
+			if (signal?.aborted) throw abortReason(signal);
+			// Missing, stale, and non-Git project roots are unrelated candidates.
+		}
+	}
+	return matches;
 }
 
 async function listIndexedProjects(
@@ -227,7 +276,7 @@ async function readIndexedBranch(
 		"search_graph",
 		{
 			detail: "default",
-			fields: ["head_sha", "canonical_root", "worktree_root", "is_worktree"],
+			fields: ["head_sha", "git_common_dir", "worktree_root", "is_worktree"],
 			format: "json",
 			label: "Branch",
 			limit: 2,
@@ -255,31 +304,31 @@ async function readIndexedBranch(
 		return index >= 0 ? row[index] : undefined;
 	};
 	const headSha = value("head_sha");
-	const canonicalRoot = value("canonical_root");
+	const gitCommonDir = value("git_common_dir");
 	const worktreeRoot = value("worktree_root");
 	const isWorktree = value("is_worktree");
 	if (
 		typeof headSha !== "string" ||
-		typeof canonicalRoot !== "string" ||
+		typeof gitCommonDir !== "string" ||
 		typeof worktreeRoot !== "string" ||
 		typeof isWorktree !== "boolean"
 	) {
 		throw invalidResponse("indexed Branch metadata");
 	}
-	return { headSha, canonicalRoot, worktreeRoot, isWorktree };
+	return { headSha, gitCommonDir, worktreeRoot, isWorktree };
 }
 
 function assertMatchingGitContexts(current: GitContext, source: GitContext): void {
-	if (
-		normalizePath(current.commonDir) !== normalizePath(source.commonDir) ||
-		normalizePath(current.canonicalRoot) !== normalizePath(source.canonicalRoot)
-	) {
+	if (normalizePath(current.commonDir) !== normalizePath(source.commonDir)) {
 		throw new Error("The current worktree and canonical checkout no longer share a Git repository");
 	}
 	if (current.headSha !== source.headSha) {
 		throw new Error("The current worktree and canonical checkout are at different Git HEADs");
 	}
-	if (source.isWorktree || normalizePath(source.root) !== normalizePath(current.canonicalRoot)) {
+	if (
+		source.isWorktree ||
+		(current.canonicalRoot && normalizePath(source.root) !== normalizePath(current.canonicalRoot))
+	) {
 		throw new Error("The indexed source project is not the canonical checkout");
 	}
 }
@@ -289,9 +338,12 @@ function assertMatchingIndexedBranch(
 	source: GitContext,
 	branch: IndexedBranch,
 ): void {
+	const branchCommonDir = isAbsolute(branch.gitCommonDir)
+		? normalizePath(branch.gitCommonDir)
+		: normalizePath(resolve(branch.worktreeRoot, branch.gitCommonDir));
 	if (
 		branch.headSha !== current.headSha ||
-		normalizePath(branch.canonicalRoot) !== normalizePath(current.canonicalRoot) ||
+		branchCommonDir !== normalizePath(current.commonDir) ||
 		normalizePath(branch.worktreeRoot) !== normalizePath(source.root) ||
 		branch.isWorktree
 	) {
@@ -323,15 +375,21 @@ async function resolveGitContext(
 		throw new Error(`Unable to resolve Git worktree context from: ${cwd}`);
 	}
 	const [root, gitDir, commonDir, headSha] = lines as [string, string, string, string];
-	const canonicalRoot =
-		commonDir.endsWith("/.git") || commonDir.endsWith("\\.git") ? dirname(commonDir) : commonDir;
+	const normalizedRoot = normalizePath(root);
+	const normalizedGitDir = normalizePath(gitDir);
+	const normalizedCommonDir = normalizePath(commonDir);
+	const isWorktree = normalizedGitDir !== normalizedCommonDir;
+	const conventionalRoot =
+		commonDir.endsWith("/.git") || commonDir.endsWith("\\.git")
+			? normalizePath(resolve(commonDir, ".."))
+			: undefined;
 	return {
-		root: normalizePath(root),
-		gitDir: normalizePath(gitDir),
-		commonDir: normalizePath(commonDir),
-		canonicalRoot: normalizePath(canonicalRoot),
+		root: normalizedRoot,
+		gitDir: normalizedGitDir,
+		commonDir: normalizedCommonDir,
+		canonicalRoot: isWorktree ? conventionalRoot : normalizedRoot,
 		headSha,
-		isWorktree: normalizePath(gitDir) !== normalizePath(commonDir),
+		isWorktree,
 	};
 }
 
@@ -436,7 +494,12 @@ function normalizePath(path: string): string {
 export function currentRelativePath(resolution: ProjectResolution, sourcePath: string): string {
 	if (!isAbsolute(sourcePath)) throw new Error("Borrowed source path is not absolute");
 	const relativePath = relative(resolution.sourceRoot, sourcePath);
-	if (relativePath === "" || relativePath.startsWith("..") || isAbsolute(relativePath)) {
+	if (
+		relativePath === "" ||
+		relativePath === ".." ||
+		relativePath.startsWith(`..${sep}`) ||
+		isAbsolute(relativePath)
+	) {
 		throw new Error("Borrowed source path escapes the canonical project root");
 	}
 	return resolve(resolution.currentRoot, relativePath);

--- a/packages/pi-cbmem/src/worktree-project.ts
+++ b/packages/pi-cbmem/src/worktree-project.ts
@@ -1,0 +1,471 @@
+import { spawn } from "node:child_process";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import type { ToolName } from "./tool-definitions.js";
+
+export const CURRENT_PROJECT_ALIAS = "@current";
+
+export const BORROWABLE_TOOL_NAMES = new Set<ToolName>([
+	"get_architecture",
+	"get_code_snippet",
+	"get_graph_schema",
+	"index_status",
+	"query_graph",
+	"search_graph",
+	"trace_path",
+]);
+
+const PROJECT_PAGE_SIZE = 100;
+const GIT_OUTPUT_LIMIT = 64 * 1024;
+
+export interface ProjectResolution {
+	kind: "current" | "borrowed";
+	project: string;
+	currentRoot: string;
+	sourceRoot: string;
+	headSha: string;
+}
+
+export type CbmemJsonQuery = (
+	tool: ToolName,
+	args: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+) => Promise<unknown>;
+
+export interface ProjectResolutionService {
+	resolve(
+		cwd: string,
+		signal: AbortSignal | undefined,
+		query: CbmemJsonQuery,
+	): Promise<ProjectResolution>;
+	revalidate(
+		resolution: ProjectResolution,
+		signal: AbortSignal | undefined,
+		query: CbmemJsonQuery,
+	): Promise<void>;
+}
+
+interface GitContext {
+	root: string;
+	gitDir: string;
+	commonDir: string;
+	canonicalRoot: string;
+	headSha: string;
+	isWorktree: boolean;
+}
+
+interface IndexedProject {
+	name: string;
+	rootPath: string;
+}
+
+interface IndexedBranch {
+	headSha: string;
+	canonicalRoot: string;
+	worktreeRoot: string;
+	isWorktree: boolean;
+}
+
+export const defaultProjectResolutionService: ProjectResolutionService = {
+	resolve: resolveCurrentProject,
+	revalidate: revalidateProjectResolution,
+};
+
+export async function resolveCurrentProject(
+	cwd: string,
+	signal: AbortSignal | undefined,
+	query: CbmemJsonQuery,
+): Promise<ProjectResolution> {
+	signal?.throwIfAborted();
+	const current = await resolveGitContext(cwd, signal);
+	signal?.throwIfAborted();
+	const projects = await listIndexedProjects(query, signal);
+	signal?.throwIfAborted();
+
+	const exact = projectsAtRoot(projects, current.root);
+	if (exact.length > 1) throw ambiguousProjectError(current.root, exact);
+	if (exact.length === 1) {
+		const exactProject = exact[0];
+		if (!exactProject) throw invalidResponse("current project resolution");
+		const status = await query("index_status", { project: exactProject.name }, signal);
+		signal?.throwIfAborted();
+		assertReadyStatus(status, exactProject);
+		return {
+			kind: "current",
+			project: exactProject.name,
+			currentRoot: current.root,
+			sourceRoot: current.root,
+			headSha: current.headSha,
+		};
+	}
+
+	if (!current.isWorktree) {
+		throw new Error(
+			`Codebase Memory has no index for the current repository root: ${current.root}`,
+		);
+	}
+	await assertClean(current.root, signal);
+	signal?.throwIfAborted();
+
+	const sourceProjects = projectsAtRoot(projects, current.canonicalRoot);
+	if (sourceProjects.length === 0) {
+		throw new Error(
+			`Codebase Memory has no canonical checkout index for this linked worktree: ${current.canonicalRoot}`,
+		);
+	}
+	if (sourceProjects.length > 1) {
+		throw ambiguousProjectError(current.canonicalRoot, sourceProjects);
+	}
+
+	const sourceProject = sourceProjects[0];
+	if (!sourceProject) throw invalidResponse("canonical project resolution");
+	const status = await query("index_status", { project: sourceProject.name }, signal);
+	signal?.throwIfAborted();
+	assertReadyStatus(status, sourceProject);
+
+	const source = await resolveGitContext(sourceProject.rootPath, signal);
+	signal?.throwIfAborted();
+	await assertClean(source.root, signal);
+	signal?.throwIfAborted();
+	assertMatchingGitContexts(current, source);
+
+	const branch = await readIndexedBranch(sourceProject.name, query, signal);
+	signal?.throwIfAborted();
+	assertMatchingIndexedBranch(current, source, branch);
+
+	return {
+		kind: "borrowed",
+		project: sourceProject.name,
+		currentRoot: current.root,
+		sourceRoot: source.root,
+		headSha: current.headSha,
+	};
+}
+
+export async function revalidateProjectResolution(
+	resolution: ProjectResolution,
+	signal: AbortSignal | undefined,
+	query: CbmemJsonQuery,
+): Promise<void> {
+	if (resolution.kind !== "borrowed") return;
+	signal?.throwIfAborted();
+	const current = await resolveGitContext(resolution.currentRoot, signal);
+	signal?.throwIfAborted();
+	const source = await resolveGitContext(resolution.sourceRoot, signal);
+	signal?.throwIfAborted();
+	await assertClean(current.root, signal);
+	signal?.throwIfAborted();
+	await assertClean(source.root, signal);
+	signal?.throwIfAborted();
+	assertMatchingGitContexts(current, source);
+	if (current.headSha !== resolution.headSha) {
+		throw changedDuringCallError();
+	}
+	const branch = await readIndexedBranch(resolution.project, query, signal);
+	signal?.throwIfAborted();
+	assertMatchingIndexedBranch(current, source, branch);
+}
+
+function projectsAtRoot(projects: IndexedProject[], root: string): IndexedProject[] {
+	const normalizedRoot = normalizePath(root);
+	return projects.filter((project) => normalizePath(project.rootPath) === normalizedRoot);
+}
+
+async function listIndexedProjects(
+	query: CbmemJsonQuery,
+	signal: AbortSignal | undefined,
+): Promise<IndexedProject[]> {
+	const projects: IndexedProject[] = [];
+	let offset = 0;
+	while (true) {
+		const response = await query(
+			"list_projects",
+			{
+				include_details: true,
+				limit: PROJECT_PAGE_SIZE,
+				metadata_only: true,
+				offset,
+			},
+			signal,
+		);
+		signal?.throwIfAborted();
+		const page = asRecord(response, "list_projects response");
+		const entries = page.projects;
+		if (!Array.isArray(entries)) throw invalidResponse("list_projects projects");
+		for (const entry of entries) {
+			const project = asRecord(entry, "list_projects project");
+			if (typeof project.name !== "string" || typeof project.root_path !== "string") {
+				throw invalidResponse("list_projects project metadata");
+			}
+			projects.push({ name: project.name, rootPath: project.root_path });
+		}
+		if (page.has_more !== true) return projects;
+		const returned = typeof page.returned === "number" ? page.returned : entries.length;
+		if (returned <= 0) throw invalidResponse("list_projects pagination");
+		offset += returned;
+	}
+}
+
+function assertReadyStatus(status: unknown, project: IndexedProject): void {
+	const response = asRecord(status, "index_status response");
+	if (response.status !== "ready") {
+		throw new Error(`Codebase Memory project is not ready: ${project.name}`);
+	}
+	if (
+		typeof response.root_path !== "string" ||
+		normalizePath(response.root_path) !== normalizePath(project.rootPath)
+	) {
+		throw new Error(`Codebase Memory project root changed while resolving: ${project.name}`);
+	}
+}
+
+async function readIndexedBranch(
+	project: string,
+	query: CbmemJsonQuery,
+	signal: AbortSignal | undefined,
+): Promise<IndexedBranch> {
+	const response = await query(
+		"search_graph",
+		{
+			detail: "default",
+			fields: ["head_sha", "canonical_root", "worktree_root", "is_worktree"],
+			format: "json",
+			label: "Branch",
+			limit: 2,
+			project,
+		},
+		signal,
+	);
+	signal?.throwIfAborted();
+	const result = asRecord(response, "Branch search response");
+	if (!Array.isArray(result.cols) || !Array.isArray(result.groups) || result.total !== 1) {
+		throw new Error(`Codebase Memory project has no unique indexed Branch snapshot: ${project}`);
+	}
+	const cols = result.cols;
+	const groups = result.groups;
+	const rows = groups.flatMap((group) => {
+		const value = asRecord(group, "Branch search group").rows;
+		return Array.isArray(value) ? value : [];
+	});
+	const row = rows[0];
+	if (rows.length !== 1 || !Array.isArray(row)) {
+		throw new Error(`Codebase Memory project has no unique indexed Branch snapshot: ${project}`);
+	}
+	const value = (field: string): unknown => {
+		const index = cols.indexOf(field);
+		return index >= 0 ? row[index] : undefined;
+	};
+	const headSha = value("head_sha");
+	const canonicalRoot = value("canonical_root");
+	const worktreeRoot = value("worktree_root");
+	const isWorktree = value("is_worktree");
+	if (
+		typeof headSha !== "string" ||
+		typeof canonicalRoot !== "string" ||
+		typeof worktreeRoot !== "string" ||
+		typeof isWorktree !== "boolean"
+	) {
+		throw invalidResponse("indexed Branch metadata");
+	}
+	return { headSha, canonicalRoot, worktreeRoot, isWorktree };
+}
+
+function assertMatchingGitContexts(current: GitContext, source: GitContext): void {
+	if (
+		normalizePath(current.commonDir) !== normalizePath(source.commonDir) ||
+		normalizePath(current.canonicalRoot) !== normalizePath(source.canonicalRoot)
+	) {
+		throw new Error("The current worktree and canonical checkout no longer share a Git repository");
+	}
+	if (current.headSha !== source.headSha) {
+		throw new Error("The current worktree and canonical checkout are at different Git HEADs");
+	}
+	if (source.isWorktree || normalizePath(source.root) !== normalizePath(current.canonicalRoot)) {
+		throw new Error("The indexed source project is not the canonical checkout");
+	}
+}
+
+function assertMatchingIndexedBranch(
+	current: GitContext,
+	source: GitContext,
+	branch: IndexedBranch,
+): void {
+	if (
+		branch.headSha !== current.headSha ||
+		normalizePath(branch.canonicalRoot) !== normalizePath(current.canonicalRoot) ||
+		normalizePath(branch.worktreeRoot) !== normalizePath(source.root) ||
+		branch.isWorktree
+	) {
+		throw new Error(
+			"The canonical Codebase Memory index does not match this worktree's clean HEAD",
+		);
+	}
+}
+
+async function resolveGitContext(
+	cwd: string,
+	signal: AbortSignal | undefined,
+): Promise<GitContext> {
+	const output = await runGit(
+		cwd,
+		[
+			"rev-parse",
+			"--path-format=absolute",
+			"--show-toplevel",
+			"--git-dir",
+			"--git-common-dir",
+			"HEAD",
+		],
+		signal,
+	);
+	signal?.throwIfAborted();
+	const lines = output.trim().split(/\r?\n/u);
+	if (lines.length !== 4 || lines.some((line) => !line)) {
+		throw new Error(`Unable to resolve Git worktree context from: ${cwd}`);
+	}
+	const [root, gitDir, commonDir, headSha] = lines as [string, string, string, string];
+	const canonicalRoot =
+		commonDir.endsWith("/.git") || commonDir.endsWith("\\.git") ? dirname(commonDir) : commonDir;
+	return {
+		root: normalizePath(root),
+		gitDir: normalizePath(gitDir),
+		commonDir: normalizePath(commonDir),
+		canonicalRoot: normalizePath(canonicalRoot),
+		headSha,
+		isWorktree: normalizePath(gitDir) !== normalizePath(commonDir),
+	};
+}
+
+async function assertClean(root: string, signal: AbortSignal | undefined): Promise<void> {
+	try {
+		await runGit(
+			root,
+			["diff", "--quiet", "HEAD", "--", ".", ":(exclude).codebase-memory"],
+			signal,
+		);
+	} catch (error) {
+		if (signal?.aborted) throw abortReason(signal);
+		throw new Error(
+			`Git worktree must be clean before borrowing a Codebase Memory index: ${root}`,
+			{ cause: error },
+		);
+	}
+	signal?.throwIfAborted();
+	const untracked = await runGit(
+		root,
+		["ls-files", "-z", "--others", "--exclude-standard", "--", ".", ":(exclude).codebase-memory"],
+		signal,
+	);
+	signal?.throwIfAborted();
+	if (untracked.length > 0) {
+		throw new Error(`Git worktree must be clean before borrowing a Codebase Memory index: ${root}`);
+	}
+}
+
+async function runGit(
+	cwd: string,
+	args: string[],
+	signal: AbortSignal | undefined,
+): Promise<string> {
+	signal?.throwIfAborted();
+	return await new Promise((resolvePromise, reject) => {
+		const child = spawn("git", ["-C", cwd, ...args], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		let forceKillTimer: NodeJS.Timeout | undefined;
+		const cleanup = () => {
+			signal?.removeEventListener("abort", onAbort);
+			if (forceKillTimer) clearTimeout(forceKillTimer);
+		};
+		const fail = (error: unknown) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+			reject(error);
+		};
+		const onAbort = () => {
+			if (child.exitCode !== null || child.signalCode !== null) return;
+			child.kill("SIGTERM");
+			forceKillTimer = setTimeout(() => {
+				if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+			}, 250);
+			forceKillTimer.unref();
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal?.aborted) onAbort();
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdout += chunk;
+			if (Buffer.byteLength(stdout, "utf8") > GIT_OUTPUT_LIMIT) {
+				fail(new Error("Git metadata output exceeded 64 KB"));
+			}
+		});
+		child.stderr.on("data", (chunk: string) => {
+			stderr += chunk;
+			if (Buffer.byteLength(stderr, "utf8") > GIT_OUTPUT_LIMIT) {
+				stderr = stderr.slice(-GIT_OUTPUT_LIMIT);
+			}
+		});
+		child.on("error", fail);
+		child.on("close", (code) => {
+			if (settled) return;
+			if (signal?.aborted) {
+				fail(abortReason(signal));
+				return;
+			}
+			if (code !== 0) {
+				fail(new Error(stderr.trim() || `git exited with code ${code ?? "unknown"}`));
+				return;
+			}
+			settled = true;
+			cleanup();
+			resolvePromise(stdout);
+		});
+	});
+}
+
+function normalizePath(path: string): string {
+	const normalized = resolve(path).replaceAll("\\", "/");
+	return normalized.length > 1 ? normalized.replace(/\/+$/u, "") : normalized;
+}
+
+export function currentRelativePath(resolution: ProjectResolution, sourcePath: string): string {
+	if (!isAbsolute(sourcePath)) throw new Error("Borrowed source path is not absolute");
+	const relativePath = relative(resolution.sourceRoot, sourcePath);
+	if (relativePath === "" || relativePath.startsWith("..") || isAbsolute(relativePath)) {
+		throw new Error("Borrowed source path escapes the canonical project root");
+	}
+	return resolve(resolution.currentRoot, relativePath);
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw invalidResponse(label);
+	return value as Record<string, unknown>;
+}
+
+function invalidResponse(label: string): Error {
+	return new Error(`Codebase Memory returned invalid ${label}`);
+}
+
+function ambiguousProjectError(root: string, projects: IndexedProject[]): Error {
+	return new Error(
+		`Multiple Codebase Memory projects use ${root}; specify one explicitly: ${projects
+			.map(({ name }) => name)
+			.sort()
+			.join(", ")}`,
+	);
+}
+
+function changedDuringCallError(): Error {
+	return new Error("The borrowed Codebase Memory snapshot changed during the tool call; retry");
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("Codebase Memory project resolution was aborted", "AbortError");
+}

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -12,7 +12,8 @@ import {
 	type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { afterAll, beforeAll, test } from "vitest";
-import cbmem, { callCodebaseMemory, TOOL_NAMES } from "../src/cbmem.js";
+import cbmem, { type CbmemToolDetails, callCodebaseMemory, TOOL_NAMES } from "../src/cbmem.js";
+import type { ProjectResolution, ProjectResolutionService } from "../src/worktree-project.js";
 
 const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 let fixtureDirectory: string;
@@ -62,8 +63,19 @@ process.stdin.on("end", () => {
       setInterval(() => {}, 1000);
       return;
     }
+    case "snippet":
+      process.stdout.write(JSON.stringify({
+        name: "answer",
+        qualified_name: "source-project.example.answer",
+        label: "Variable",
+        file_path: args.sourcePath,
+        start_line: 2,
+        end_line: 2,
+        source: "source copy\\n",
+      }));
+      return;
     default:
-      process.stdout.write(JSON.stringify({ ok: true }));
+      process.stdout.write(JSON.stringify({ ok: true, args, tool: process.argv[3] }));
   }
 });
 `,
@@ -90,13 +102,176 @@ test("cbmem registers complete Pi tool definitions", () => {
 		registered.map((tool) => tool.name),
 		TOOL_NAMES,
 	);
+	const aliasTools = new Set([
+		"get_architecture",
+		"get_code_snippet",
+		"get_graph_schema",
+		"index_status",
+		"query_graph",
+		"search_graph",
+		"trace_path",
+	]);
 	for (const tool of registered) {
 		assert.ok(tool.label);
 		assert.match(tool.description, /output is limited/i);
 		assert.equal((tool.parameters as { type?: unknown }).type, "object");
 		assert.equal(typeof tool.execute, "function");
 		assert.equal(typeof tool.renderResult, "function");
+		const projectDescription = (
+			tool.parameters as { properties?: { project?: { description?: string } } }
+		).properties?.project?.description;
+		if (aliasTools.has(tool.name)) assert.match(projectDescription ?? "", /@current/u);
+		else assert.doesNotMatch(projectDescription ?? "", /@current/u);
 	}
+});
+
+test("@current routes read-only graph tools and annotates the resolved project", async () => {
+	const resolution: ProjectResolution = {
+		kind: "borrowed",
+		project: "source-project",
+		currentRoot: "/worktree",
+		sourceRoot: "/source",
+		headSha: "a".repeat(40),
+	};
+	let revalidated = 0;
+	const tools = registerTools(
+		fixtureBinary,
+		resolutionService(resolution, async () => {
+			revalidated += 1;
+		}),
+	);
+	const result = await executeTool(
+		tools,
+		"search_graph",
+		{ project: "@current", name_pattern: ".*Answer.*" },
+		toolContext(async () => true),
+	);
+	const payload = JSON.parse(resultText(result)) as {
+		args?: Record<string, unknown>;
+		pi_cbmem_resolution?: Record<string, unknown>;
+	};
+
+	assert.equal(payload.args?.project, "source-project");
+	assert.equal(payload.pi_cbmem_resolution?.kind, "borrowed_canonical_base");
+	assert.equal(payload.pi_cbmem_resolution?.current_root, "/worktree");
+	assert.equal(revalidated, 1);
+	assert.deepEqual((result.details as CbmemToolDetails).projectResolution, resolution);
+});
+
+test("@current rejects filesystem-bound and mutating tools before resolution", async () => {
+	let resolved = false;
+	const tools = registerTools(
+		path.join(fixtureDirectory, "missing-binary"),
+		resolutionService(
+			{
+				kind: "current",
+				project: "current-project",
+				currentRoot: fixtureDirectory,
+				sourceRoot: fixtureDirectory,
+				headSha: "a".repeat(40),
+			},
+			async () => {},
+			() => {
+				resolved = true;
+			},
+		),
+	);
+	for (const name of [
+		"search_code",
+		"check_index_coverage",
+		"detect_changes",
+		"delete_project",
+		"manage_adr",
+		"ingest_traces",
+	] as const) {
+		await assert.rejects(
+			executeTool(
+				tools,
+				name,
+				{ project: "@current" },
+				toolContext(async () => true),
+			),
+			/available only for read-only graph tools/u,
+		);
+	}
+	assert.equal(resolved, false);
+});
+
+test("borrowed snippets are read from and point to the current worktree", async () => {
+	const sourceRoot = await mkdtemp(path.join(fixtureDirectory, "snippet-source-"));
+	const currentRoot = await mkdtemp(path.join(fixtureDirectory, "snippet-current-"));
+	const sourcePath = path.join(sourceRoot, "example.ts");
+	const currentPath = path.join(currentRoot, "example.ts");
+	await writeFile(sourcePath, "first\nsource copy\nthird\n", "utf8");
+	await writeFile(currentPath, "first\ncurrent copy\nthird\n", "utf8");
+	const resolution: ProjectResolution = {
+		kind: "borrowed",
+		project: "source-project",
+		currentRoot,
+		sourceRoot,
+		headSha: "a".repeat(40),
+	};
+	const tools = registerTools(fixtureBinary, resolutionService(resolution));
+	const result = await executeTool(
+		tools,
+		"get_code_snippet",
+		{
+			project: "@current",
+			qualified_name: "source-project.example.answer",
+			testMode: "snippet",
+			sourcePath,
+		},
+		toolContext(async () => true),
+	);
+	const payload = JSON.parse(resultText(result)) as {
+		file_path?: string;
+		source?: string;
+		pi_cbmem_resolution?: Record<string, unknown>;
+	};
+
+	assert.equal(payload.file_path, currentPath);
+	assert.equal(payload.source, "current copy\n");
+	assert.equal(payload.pi_cbmem_resolution?.kind, "borrowed_canonical_base");
+
+	await assert.rejects(
+		executeTool(
+			tools,
+			"get_code_snippet",
+			{
+				project: "@current",
+				qualified_name: "source-project.escape",
+				testMode: "snippet",
+				sourcePath: path.join(sourceRoot, "..", "escape.ts"),
+			},
+			toolContext(async () => true),
+		),
+		/escapes the canonical project root/u,
+	);
+});
+
+test("borrowed results are discarded when post-call revalidation fails", async () => {
+	const resolution: ProjectResolution = {
+		kind: "borrowed",
+		project: "source-project",
+		currentRoot: "/worktree",
+		sourceRoot: "/source",
+		headSha: "a".repeat(40),
+	};
+	const tools = registerTools(
+		fixtureBinary,
+		resolutionService(resolution, async () => {
+			throw new Error("snapshot changed during call");
+		}),
+	);
+	await assert.rejects(
+		executeTool(
+			tools,
+			"search_graph",
+			{ project: "@current" },
+			toolContext(async () => true),
+		),
+		/snapshot changed during call/u,
+	);
 });
 
 test("destructive tools require observable confirmation before spawning", async () => {
@@ -326,6 +501,8 @@ test("bundled skill enforces graph-first evidence and valid project-scoped calls
 		/Verify \(Tier 2, default\)/,
 		/Auditor \(Tier 3\)/,
 		/check_index_coverage` once with every evidence path/,
+		/project="@current"/,
+		/borrowed_canonical_base/,
 		/Do not assume subagents inherit MCP access/i,
 	]) {
 		assert.match(skill, evidence);
@@ -348,8 +525,8 @@ test("bundled skill enforces graph-first evidence and valid project-scoped calls
 		const calls = documentedCalls(tool);
 		assert.ok(calls.length > 0, `expected at least one documented ${tool} call`);
 		assert.ok(
-			calls.every((call) => call[1]?.includes('project="<name>"')),
-			`expected every documented ${tool} call to include project`,
+			calls.every((call) => /project="(?:<name>|@current)"/u.test(call[1] ?? "")),
+			`expected every documented ${tool} call to include an exact project or @current`,
 		);
 	}
 	assert.ok(
@@ -362,15 +539,32 @@ test("bundled skill enforces graph-first evidence and valid project-scoped calls
 	);
 });
 
-function registerTools(binary: string): ToolDefinition[] {
+function registerTools(
+	binary: string,
+	projectResolutionService?: ProjectResolutionService,
+): ToolDefinition[] {
 	const tools: ToolDefinition[] = [];
 	const api = {
 		registerTool(tool: ToolDefinition) {
 			tools.push(tool);
 		},
 	} as unknown as ExtensionAPI;
-	cbmem(api, binary);
+	cbmem(api, binary, projectResolutionService);
 	return tools;
+}
+
+function resolutionService(
+	resolution: ProjectResolution,
+	revalidate: ProjectResolutionService["revalidate"] = async () => {},
+	onResolve: () => void = () => {},
+): ProjectResolutionService {
+	return {
+		async resolve() {
+			onResolve();
+			return resolution;
+		},
+		revalidate,
+	};
 }
 
 function toolContext(
@@ -397,9 +591,10 @@ async function executeTool(
 	return await tool.execute("test-call", params, signal, undefined, ctx);
 }
 
-function resultText(result: Awaited<ReturnType<typeof callCodebaseMemory>>): string {
-	const content = result.content[0];
+function resultText(result: { content: readonly unknown[] }): string {
+	const content = result.content[0] as { type?: unknown; text?: unknown } | undefined;
 	assert.equal(content?.type, "text");
+	if (typeof content.text !== "string") throw new Error("expected text tool result");
 	return content.text;
 }
 

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -12,7 +12,12 @@ import {
 	type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { afterAll, beforeAll, test } from "vitest";
-import cbmem, { type CbmemToolDetails, callCodebaseMemory, TOOL_NAMES } from "../src/cbmem.js";
+import cbmem, {
+	type CbmemToolDetails,
+	callCodebaseMemory,
+	readLineRange,
+	TOOL_NAMES,
+} from "../src/cbmem.js";
 import type { ProjectResolution, ProjectResolutionService } from "../src/worktree-project.js";
 
 const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -44,6 +49,9 @@ process.stdin.on("end", () => {
       return;
     case "largeMalformed":
       process.stdout.write("not-json".repeat(10000));
+      return;
+    case "nearLimit":
+      process.stdout.write(JSON.stringify({ payload: "x".repeat(51000) }));
       return;
     case "manyLines":
       process.stdout.write(JSON.stringify({ rows: Array.from({ length: 2500 }, (_, i) => i) }, null, 2));
@@ -203,7 +211,7 @@ test("borrowed snippets are read from and point to the current worktree", async 
 	const sourcePath = path.join(sourceRoot, "example.ts");
 	const currentPath = path.join(currentRoot, "example.ts");
 	await writeFile(sourcePath, "first\nsource copy\nthird\n", "utf8");
-	await writeFile(currentPath, "first\ncurrent copy\nthird\n", "utf8");
+	await writeFile(currentPath, `first\ncurrent copy\n${"x".repeat(4 * 1024 * 1024)}`, "utf8");
 	const resolution: ProjectResolution = {
 		kind: "borrowed",
 		project: "source-project",
@@ -247,6 +255,34 @@ test("borrowed snippets are read from and point to the current worktree", async 
 		),
 		/escapes the canonical project root/u,
 	);
+});
+
+test("project resolution refuses to corrupt JSON when metadata exceeds output bounds", async () => {
+	const resolution: ProjectResolution = {
+		kind: "current",
+		project: "current-project",
+		currentRoot: fixtureDirectory,
+		sourceRoot: fixtureDirectory,
+		headSha: "a".repeat(40),
+	};
+	const tools = registerTools(fixtureBinary, resolutionService(resolution));
+	await assert.rejects(
+		executeTool(
+			tools,
+			"search_graph",
+			{ project: "@current", testMode: "nearLimit" },
+			toolContext(async () => true),
+		),
+		/project-resolved output exceeded.*refusing to return truncated structured data/u,
+	);
+});
+
+test("borrowed snippet range reads honor cancellation", async () => {
+	const path = await makeLargeSnippetFile("cancel-range-", "x".repeat(8 * 1024 * 1024));
+	const controller = new AbortController();
+	const pending = readLineRange(path, 2, 2, controller.signal);
+	controller.abort();
+	await assert.rejects(pending, (error: Error) => error.name === "AbortError");
 });
 
 test("borrowed results are discarded when post-call revalidation fails", async () => {
@@ -601,6 +637,13 @@ function resultText(result: { content: readonly unknown[] }): string {
 function countLines(text: string): number {
 	if (!text) return 0;
 	return text.split("\n").length - (text.endsWith("\n") ? 1 : 0);
+}
+
+async function makeLargeSnippetFile(prefix: string, content: string): Promise<string> {
+	const directory = await mkdtemp(path.join(fixtureDirectory, prefix));
+	const file = path.join(directory, "example.ts");
+	await writeFile(file, content, "utf8");
+	return file;
 }
 
 async function waitForProcessExit(pid: number): Promise<void> {

--- a/packages/pi-cbmem/test/worktree-project.test.ts
+++ b/packages/pi-cbmem/test/worktree-project.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, beforeEach, test } from "vitest";
+import type { ToolName } from "../src/tool-definitions.js";
+import {
+	type CbmemJsonQuery,
+	defaultProjectResolutionService,
+	resolveCurrentProject,
+} from "../src/worktree-project.js";
+
+const execFileAsync = promisify(execFile);
+let fixtureRoot: string;
+let sourceRoot: string;
+let worktreeRoot: string;
+let headSha: string;
+
+beforeAll(async () => {
+	fixtureRoot = await mkdtemp(path.join(tmpdir(), "pi-cbmem-worktree-test-"));
+	sourceRoot = path.join(fixtureRoot, "source");
+	worktreeRoot = path.join(fixtureRoot, "worktree");
+	await git(fixtureRoot, "init", "--initial-branch=main", sourceRoot);
+	await writeFile(path.join(sourceRoot, "example.ts"), "export const answer = 42;\n", "utf8");
+	await git(sourceRoot, "add", "example.ts");
+	await git(
+		sourceRoot,
+		"-c",
+		"commit.gpgsign=false",
+		"-c",
+		"user.name=Pi Test",
+		"-c",
+		"user.email=pi@example.invalid",
+		"commit",
+		"-m",
+		"test fixture",
+	);
+	headSha = await git(sourceRoot, "rev-parse", "HEAD");
+	await git(sourceRoot, "worktree", "add", "-b", "feature", worktreeRoot, "HEAD");
+});
+
+beforeEach(async () => {
+	await git(worktreeRoot, "reset", "--hard", headSha);
+	await git(worktreeRoot, "clean", "-fd");
+	await git(sourceRoot, "reset", "--hard", headSha);
+	await git(sourceRoot, "clean", "-fd");
+});
+
+afterAll(async () => {
+	await rm(fixtureRoot, { force: true, recursive: true });
+});
+
+test("current project resolution prefers an exact worktree index", async () => {
+	await writeFile(path.join(worktreeRoot, "example.ts"), "dirty\n", "utf8");
+	const query = fixtureQuery({ includeWorktree: true });
+	const resolution = await resolveCurrentProject(worktreeRoot, undefined, query);
+
+	assert.deepEqual(resolution, {
+		kind: "current",
+		project: "worktree-project",
+		currentRoot: worktreeRoot,
+		sourceRoot: worktreeRoot,
+		headSha,
+	});
+});
+
+test("unindexed clean linked worktree borrows the matching canonical index", async () => {
+	const query = fixtureQuery({ decoyCount: 100 });
+	const resolution = await resolveCurrentProject(worktreeRoot, undefined, query);
+
+	assert.deepEqual(resolution, {
+		kind: "borrowed",
+		project: "source-project",
+		currentRoot: worktreeRoot,
+		sourceRoot,
+		headSha,
+	});
+	await defaultProjectResolutionService.revalidate(resolution, undefined, query);
+});
+
+test("borrowed resolution fails closed for dirty, divergent, stale, and ambiguous contexts", async () => {
+	await writeFile(path.join(worktreeRoot, "example.ts"), "dirty\n", "utf8");
+	await assert.rejects(
+		resolveCurrentProject(worktreeRoot, undefined, fixtureQuery()),
+		/must be clean before borrowing/u,
+	);
+
+	await git(worktreeRoot, "reset", "--hard", headSha);
+	await writeFile(path.join(sourceRoot, "example.ts"), "dirty source\n", "utf8");
+	await assert.rejects(
+		resolveCurrentProject(worktreeRoot, undefined, fixtureQuery()),
+		/must be clean before borrowing/u,
+	);
+
+	await git(sourceRoot, "reset", "--hard", headSha);
+	await writeFile(path.join(worktreeRoot, "next.ts"), "export const next = true;\n", "utf8");
+	await git(worktreeRoot, "add", "next.ts");
+	await git(
+		worktreeRoot,
+		"-c",
+		"commit.gpgsign=false",
+		"-c",
+		"user.name=Pi Test",
+		"-c",
+		"user.email=pi@example.invalid",
+		"commit",
+		"-m",
+		"diverge",
+	);
+	await assert.rejects(
+		resolveCurrentProject(worktreeRoot, undefined, fixtureQuery()),
+		/at different Git HEADs/u,
+	);
+
+	await git(worktreeRoot, "reset", "--hard", headSha);
+	await assert.rejects(
+		resolveCurrentProject(worktreeRoot, undefined, fixtureQuery({ indexedHead: "0".repeat(40) })),
+		/does not match this worktree's clean HEAD/u,
+	);
+
+	await assert.rejects(
+		resolveCurrentProject(worktreeRoot, undefined, fixtureQuery({ duplicateSource: true })),
+		/Multiple Codebase Memory projects/u,
+	);
+});
+
+test("borrowed resolution is invalidated when the worktree changes", async () => {
+	const query = fixtureQuery();
+	const resolution = await resolveCurrentProject(worktreeRoot, undefined, query);
+	await writeFile(path.join(worktreeRoot, "example.ts"), "dirty during call\n", "utf8");
+
+	await assert.rejects(
+		defaultProjectResolutionService.revalidate(resolution, undefined, query),
+		/must be clean before borrowing/u,
+	);
+});
+
+test("project resolution honors cancellation before Git or backend work", async () => {
+	const controller = new AbortController();
+	controller.abort();
+	let queried = false;
+	await assert.rejects(
+		resolveCurrentProject(worktreeRoot, controller.signal, async () => {
+			queried = true;
+			return {};
+		}),
+		(error: Error) => error.name === "AbortError",
+	);
+	assert.equal(queried, false);
+});
+
+function fixtureQuery(
+	options: {
+		decoyCount?: number;
+		duplicateSource?: boolean;
+		includeWorktree?: boolean;
+		indexedHead?: string;
+	} = {},
+): CbmemJsonQuery {
+	const decoys = Array.from({ length: options.decoyCount ?? 0 }, (_, index) => ({
+		name: `decoy-${index}`,
+		root_path: path.join(fixtureRoot, `decoy-${index}`),
+	}));
+	const projects = [
+		...decoys,
+		{ name: "source-project", root_path: sourceRoot },
+		...(options.duplicateSource
+			? [{ name: "duplicate-source-project", root_path: sourceRoot }]
+			: []),
+		...(options.includeWorktree ? [{ name: "worktree-project", root_path: worktreeRoot }] : []),
+	];
+	return async (tool: ToolName, args: Record<string, unknown>) => {
+		if (tool === "list_projects") {
+			const offset = typeof args.offset === "number" ? args.offset : 0;
+			const limit = typeof args.limit === "number" ? args.limit : 100;
+			const page = projects.slice(offset, offset + limit);
+			return {
+				projects: page,
+				total: projects.length,
+				offset,
+				limit,
+				returned: page.length,
+				has_more: offset + page.length < projects.length,
+			};
+		}
+		if (tool === "index_status") {
+			return {
+				project: args.project,
+				status: "ready",
+				root_path: args.project === "worktree-project" ? worktreeRoot : sourceRoot,
+			};
+		}
+		if (tool === "search_graph") {
+			return {
+				total: 1,
+				count: 1,
+				cols: [
+					"name",
+					"label",
+					"lines",
+					"in",
+					"out",
+					"head_sha",
+					"canonical_root",
+					"worktree_root",
+					"is_worktree",
+				],
+				groups: [
+					{
+						rows: [
+							[
+								"main",
+								"Branch",
+								"",
+								0,
+								0,
+								options.indexedHead ?? headSha,
+								sourceRoot,
+								sourceRoot,
+								false,
+							],
+						],
+					},
+				],
+				has_more: false,
+			};
+		}
+		throw new Error(`Unexpected fixture tool: ${tool}`);
+	};
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+	const result = await execFileAsync("git", ["-C", cwd, ...args], {
+		encoding: "utf8",
+	});
+	return result.stdout.trim();
+}

--- a/packages/pi-cbmem/test/worktree-project.test.ts
+++ b/packages/pi-cbmem/test/worktree-project.test.ts
@@ -8,6 +8,7 @@ import { afterAll, beforeAll, beforeEach, test } from "vitest";
 import type { ToolName } from "../src/tool-definitions.js";
 import {
 	type CbmemJsonQuery,
+	currentRelativePath,
 	defaultProjectResolutionService,
 	resolveCurrentProject,
 } from "../src/worktree-project.js";
@@ -64,6 +65,15 @@ test("current project resolution prefers an exact worktree index", async () => {
 		sourceRoot: worktreeRoot,
 		headSha,
 	});
+	await defaultProjectResolutionService.revalidate(resolution, undefined, query);
+	await assert.rejects(
+		defaultProjectResolutionService.revalidate(
+			resolution,
+			undefined,
+			fixtureQuery({ currentStatusRoot: sourceRoot, includeWorktree: true }),
+		),
+		/project root changed while resolving/u,
+	);
 });
 
 test("unindexed clean linked worktree borrows the matching canonical index", async () => {
@@ -137,6 +147,80 @@ test("borrowed resolution is invalidated when the worktree changes", async () =>
 	);
 });
 
+test("linked worktrees resolve canonical indexes with a separate Git directory", async () => {
+	const root = await mkdtemp(path.join(tmpdir(), "pi-cbmem-separate-git-test-"));
+	const separateSource = path.join(root, "source");
+	const separateMetadata = path.join(root, "metadata.git");
+	const separateWorktree = path.join(root, "worktree");
+	try {
+		await git(
+			root,
+			"init",
+			"--initial-branch=main",
+			`--separate-git-dir=${separateMetadata}`,
+			separateSource,
+		);
+		await writeFile(path.join(separateSource, "example.ts"), "export const value = 1;\n", "utf8");
+		await git(separateSource, "add", "example.ts");
+		await git(
+			separateSource,
+			"-c",
+			"commit.gpgsign=false",
+			"-c",
+			"user.name=Pi Test",
+			"-c",
+			"user.email=pi@example.invalid",
+			"commit",
+			"-m",
+			"separate fixture",
+		);
+		const separateHead = await git(separateSource, "rev-parse", "HEAD");
+		await git(
+			separateSource,
+			"worktree",
+			"add",
+			"-b",
+			"separate-feature",
+			separateWorktree,
+			"HEAD",
+		);
+		const query = fixtureQuery({
+			indexedGitCommonDir: separateMetadata,
+			indexedHead: separateHead,
+			sourceRoot: separateSource,
+			worktreeRoot: separateWorktree,
+		});
+
+		assert.deepEqual(await resolveCurrentProject(separateWorktree, undefined, query), {
+			kind: "borrowed",
+			project: "source-project",
+			currentRoot: separateWorktree,
+			sourceRoot: separateSource,
+			headSha: separateHead,
+		});
+	} finally {
+		await rm(root, { force: true, recursive: true });
+	}
+});
+
+test("borrowed paths allow legal two-dot names but reject parent traversal", () => {
+	const resolution = {
+		kind: "borrowed" as const,
+		project: "source-project",
+		currentRoot: worktreeRoot,
+		sourceRoot,
+		headSha,
+	};
+	assert.equal(
+		currentRelativePath(resolution, path.join(sourceRoot, "..foo.ts")),
+		path.join(worktreeRoot, "..foo.ts"),
+	);
+	assert.throws(
+		() => currentRelativePath(resolution, path.join(sourceRoot, "..", "outside.ts")),
+		/escapes the canonical project root/u,
+	);
+});
+
 test("project resolution honors cancellation before Git or backend work", async () => {
 	const controller = new AbortController();
 	controller.abort();
@@ -153,23 +237,29 @@ test("project resolution honors cancellation before Git or backend work", async 
 
 function fixtureQuery(
 	options: {
+		currentStatusRoot?: string;
 		decoyCount?: number;
 		duplicateSource?: boolean;
 		includeWorktree?: boolean;
+		indexedGitCommonDir?: string;
 		indexedHead?: string;
+		sourceRoot?: string;
+		worktreeRoot?: string;
 	} = {},
 ): CbmemJsonQuery {
+	const sourcePath = options.sourceRoot ?? sourceRoot;
+	const worktreePath = options.worktreeRoot ?? worktreeRoot;
 	const decoys = Array.from({ length: options.decoyCount ?? 0 }, (_, index) => ({
 		name: `decoy-${index}`,
 		root_path: path.join(fixtureRoot, `decoy-${index}`),
 	}));
 	const projects = [
 		...decoys,
-		{ name: "source-project", root_path: sourceRoot },
+		{ name: "source-project", root_path: sourcePath },
 		...(options.duplicateSource
-			? [{ name: "duplicate-source-project", root_path: sourceRoot }]
+			? [{ name: "duplicate-source-project", root_path: sourcePath }]
 			: []),
-		...(options.includeWorktree ? [{ name: "worktree-project", root_path: worktreeRoot }] : []),
+		...(options.includeWorktree ? [{ name: "worktree-project", root_path: worktreePath }] : []),
 	];
 	return async (tool: ToolName, args: Record<string, unknown>) => {
 		if (tool === "list_projects") {
@@ -189,7 +279,10 @@ function fixtureQuery(
 			return {
 				project: args.project,
 				status: "ready",
-				root_path: args.project === "worktree-project" ? worktreeRoot : sourceRoot,
+				root_path:
+					args.project === "worktree-project"
+						? (options.currentStatusRoot ?? worktreePath)
+						: sourcePath,
 			};
 		}
 		if (tool === "search_graph") {
@@ -203,7 +296,7 @@ function fixtureQuery(
 					"in",
 					"out",
 					"head_sha",
-					"canonical_root",
+					"git_common_dir",
 					"worktree_root",
 					"is_worktree",
 				],
@@ -217,8 +310,8 @@ function fixtureQuery(
 								0,
 								0,
 								options.indexedHead ?? headSha,
-								sourceRoot,
-								sourceRoot,
+								options.indexedGitCommonDir ?? ".git",
+								sourcePath,
 								false,
 							],
 						],


### PR DESCRIPTION
## Summary

- add `project="@current"` resolution for exact current-root indexes and matching canonical checkout graphs
- keep borrowed access read-only, validate clean matching Git snapshots before and after each call, and discard stale results
- read borrowed snippets from the current worktree while blocking root-sensitive and mutating tools
- document the worktree behavior, update the bundled skill, add deterministic coverage, and record the package change

## Safety and limitations

Borrowing requires the same Git common directory and `HEAD`, clean current and canonical worktrees, a ready source project, and matching graph-recorded Branch metadata.
The alias does not provide project forking, artifact bootstrap, change detection, mutations, or overlays.
Codebase Memory does not expose an immutable generation lease or complete semantic-input comparison, so the documented fallback remains conservative and best-effort.
Follow-up work is tracked in #1124 and the backend overlay design remains tracked upstream in DeusData/codebase-memory-mcp#573.

## Verification

- `npm run check`
- `npm test` — 3,271 tests passed
- `just pack cbmem` — expected 11 package files
- package-directory Pi load smoke via `pi --no-extensions -e ./packages/pi-cbmem --list-models`
