### PR TITLE
feat(cbmem): start codebase memory daemon automatically

### DIFF
--- a/.changeset/warm-cbmem-daemon.md
+++ b/.changeset/warm-cbmem-daemon.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-cbmem": minor
+---
+
+Detect the account-scoped Codebase Memory daemon at Pi session startup and start a permanent daemon when none is active.
+
+Cancel stale daemon control commands during session replacement without stopping the persistent daemon.

--- a/.changeset/warm-cbmem-daemon.md
+++ b/.changeset/warm-cbmem-daemon.md
@@ -4,4 +4,4 @@
 
 Detect the account-scoped Codebase Memory daemon at Pi session startup and start a permanent daemon when none is active.
 
-Cancel stale daemon control commands during session replacement without stopping the persistent daemon.
+Cancel and await stale daemon control commands during session replacement or shutdown without stopping the persistent daemon.

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -7,6 +7,7 @@ Connect Pi to the local Codebase Memory CLI and give the model graph-first opera
 ## ✨ Features
 
 - Registers 15 Codebase Memory tools for graph queries, search, indexing, coverage, tracing, and architecture.
+- Detects the local Codebase Memory daemon when a Pi session starts and starts a permanent daemon when needed.
 - Runs the local `codebase-memory-mcp` CLI with cancellation, failure reporting, and bounded output.
 - Bundles the `codebase-memory` skill for graph-first, evidence-tier workflows.
 - Resolves `@current` to an exact current-root index or a matching clean canonical-checkout graph for approved read tools.
@@ -40,7 +41,9 @@ Install only trusted packages, and review the source before loading this extensi
 
 ## 🚀 Quick start
 
-Install `codebase-memory-mcp` at `~/.local/bin/codebase-memory-mcp`, load pi-cbmem, and ask Pi a structural codebase question.
+Install a current `codebase-memory-mcp` with the `daemon status` and `daemon start` commands at `~/.local/bin/codebase-memory-mcp`, then load pi-cbmem.
+At session startup, pi-cbmem keeps an existing daemon or starts a permanent daemon that survives Pi session shutdown.
+Then ask Pi a structural codebase question.
 The bundled skill directs Pi to identify the active graph project before exploration and verify material claims with snippets and index-coverage evidence.
 
 ## 🌳 Worktree base reuse
@@ -90,13 +93,17 @@ Tool calls can read and index repositories, inspect source, persist graph data, 
 Deleting a project or replacing all Architecture Decision Records requires explicit confirmation in TUI or RPC mode and is rejected in other modes.
 Repository content returned by graph tools can be sent to the selected model provider as tool output.
 Terminal controls are removed at the TUI display boundary, while the validated raw result remains available to the model.
-Each tool call starts one local CLI child process in the active session directory; extension loading starts no background work.
+Extension factory loading starts no background work.
+Session startup runs bounded `daemon status` and, when needed, `daemon start` control processes in the active session directory.
+The permanent account-scoped daemon survives Pi session replacement and shutdown until the user runs `codebase-memory-mcp daemon stop`.
+Session shutdown cancels an in-flight daemon control process but does not stop the permanent daemon.
+Each tool call starts one local CLI child process in the active session directory.
 Cancelling the tool call terminates that child process.
 
 ## 🚧 Limitations
 
-- The package requires `~/.local/bin/codebase-memory-mcp` for the current user.
-- It does not install or update the Codebase Memory binary.
+- The package requires a current `~/.local/bin/codebase-memory-mcp` with the public daemon control commands for the current user.
+- It does not install or update the Codebase Memory binary, and it does not stop the permanent daemon.
 - Static tool schemas match the bundled skill, while the installed CLI performs final argument validation.
 - Worktree base reuse requires an exact clean snapshot and does not cover branch changes, dirty files, source-code search, change detection, index mutation, project forking, or overlays.
 
@@ -110,6 +117,7 @@ packages/pi-cbmem/
 ├── src/
 │   ├── index.ts                    # Thin Pi entrypoint
 │   ├── cbmem.ts                    # Bounded Codebase Memory CLI runner
+│   ├── daemon.ts                   # Session-start daemon detection and startup
 │   ├── render-result.ts            # Terminal-safe result rendering
 │   ├── tool-definitions.ts         # Pi tool metadata and TypeBox schemas
 │   └── worktree-project.ts         # Safe current-worktree project resolution

--- a/packages/pi-cbmem/README.md
+++ b/packages/pi-cbmem/README.md
@@ -96,7 +96,7 @@ Terminal controls are removed at the TUI display boundary, while the validated r
 Extension factory loading starts no background work.
 Session startup runs bounded `daemon status` and, when needed, `daemon start` control processes in the active session directory.
 The permanent account-scoped daemon survives Pi session replacement and shutdown until the user runs `codebase-memory-mcp daemon stop`.
-Session shutdown cancels an in-flight daemon control process but does not stop the permanent daemon.
+Session replacement and shutdown cancel and await any in-flight daemon control process but do not stop the permanent daemon.
 Each tool call starts one local CLI child process in the active session directory.
 Cancelling the tool call terminates that child process.
 

--- a/packages/pi-cbmem/src/cbmem.ts
+++ b/packages/pi-cbmem/src/cbmem.ts
@@ -10,6 +10,11 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+import {
+	type DaemonEnsurer,
+	ensureCodebaseMemoryDaemon,
+	registerDaemonLifecycle,
+} from "./daemon.js";
 import { renderCodebaseMemoryResult } from "./render-result.js";
 import { type BridgeToolDefinition, TOOL_DEFINITIONS, type ToolName } from "./tool-definitions.js";
 import {
@@ -193,7 +198,9 @@ export default function cbmem(
 	pi: ExtensionAPI,
 	binary = BIN,
 	projectResolutionService = defaultProjectResolutionService,
+	ensureDaemon: DaemonEnsurer = ensureCodebaseMemoryDaemon,
 ): void {
+	registerDaemonLifecycle(pi, binary, ensureDaemon);
 	for (const definition of TOOL_DEFINITIONS) {
 		registerBridgeTool(pi, definition, binary, projectResolutionService);
 	}

--- a/packages/pi-cbmem/src/daemon.ts
+++ b/packages/pi-cbmem/src/daemon.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 
 const COMMAND_TIMEOUT_MS = 15_000;
@@ -10,6 +10,12 @@ interface CommandResult {
 	code: number;
 	stdout: string;
 	stderr: string;
+}
+
+interface DaemonSessionLifecycle {
+	generation: number;
+	controller?: AbortController;
+	startup?: Promise<void>;
 }
 
 export interface DaemonEnsureResult {
@@ -43,37 +49,63 @@ export function registerDaemonLifecycle(
 	binary: string,
 	ensureDaemon: DaemonEnsurer = ensureCodebaseMemoryDaemon,
 ): void {
-	let generation = 0;
-	let startupController: AbortController | undefined;
+	const sessions = new WeakMap<ExtensionContext["sessionManager"], DaemonSessionLifecycle>();
 
 	pi.on("session_start", async (_event, ctx) => {
-		const currentGeneration = ++generation;
-		startupController?.abort(abortError("Codebase Memory session replaced"));
-		const controller = new AbortController();
-		startupController = controller;
-
-		try {
-			const result = await ensureDaemon(binary, ctx.cwd, controller.signal);
-			if (controller.signal.aborted || currentGeneration !== generation) return;
-			if (result.started && ctx.hasUI) {
-				ctx.ui.notify("Started the Codebase Memory daemon.", "info");
-			}
-		} catch (error) {
-			if (controller.signal.aborted || currentGeneration !== generation) return;
-			const failure = daemonStartupFailure(error);
-			if (!ctx.hasUI) throw failure;
-			ctx.ui.notify(failure.message, "warning");
-		} finally {
-			if (currentGeneration === generation && startupController === controller) {
-				startupController = undefined;
-			}
+		const sessionManager = ctx.sessionManager;
+		const lifecycle = sessions.get(sessionManager) ?? { generation: 0 };
+		sessions.set(sessionManager, lifecycle);
+		const currentGeneration = ++lifecycle.generation;
+		const previousStartup = lifecycle.startup;
+		lifecycle.controller?.abort(abortError("Codebase Memory session replaced"));
+		if (previousStartup) await previousStartup.catch(() => undefined);
+		if (sessions.get(sessionManager) !== lifecycle || currentGeneration !== lifecycle.generation) {
+			return;
 		}
+
+		const controller = new AbortController();
+		lifecycle.controller = controller;
+		let startup!: Promise<void>;
+		startup = (async () => {
+			try {
+				const result = await ensureDaemon(binary, ctx.cwd, controller.signal);
+				if (controller.signal.aborted || currentGeneration !== lifecycle.generation) return;
+				if (result.started && ctx.hasUI) {
+					ctx.ui.notify("Started the Codebase Memory daemon.", "info");
+				}
+			} catch (error) {
+				if (controller.signal.aborted || currentGeneration !== lifecycle.generation) return;
+				const failure = daemonStartupFailure(error);
+				if (!ctx.hasUI) throw failure;
+				ctx.ui.notify(failure.message, "warning");
+			} finally {
+				if (
+					currentGeneration === lifecycle.generation &&
+					lifecycle.controller === controller &&
+					lifecycle.startup === startup
+				) {
+					lifecycle.controller = undefined;
+					lifecycle.startup = undefined;
+				}
+			}
+		})();
+		lifecycle.startup = startup;
+		await startup;
 	});
 
-	pi.on("session_shutdown", () => {
-		generation += 1;
-		startupController?.abort(abortError("Codebase Memory session shut down"));
-		startupController = undefined;
+	pi.on("session_shutdown", async (_event, ctx) => {
+		const sessionManager = ctx.sessionManager;
+		const lifecycle = sessions.get(sessionManager);
+		if (!lifecycle) return;
+		const shutdownGeneration = ++lifecycle.generation;
+		const startup = lifecycle.startup;
+		lifecycle.controller?.abort(abortError("Codebase Memory session shut down"));
+		if (startup) await startup.catch(() => undefined);
+		if (sessions.get(sessionManager) === lifecycle && shutdownGeneration === lifecycle.generation) {
+			sessions.delete(sessionManager);
+			lifecycle.controller = undefined;
+			lifecycle.startup = undefined;
+		}
 	});
 }
 

--- a/packages/pi-cbmem/src/daemon.ts
+++ b/packages/pi-cbmem/src/daemon.ts
@@ -1,0 +1,169 @@
+import { execFile } from "node:child_process";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+
+const COMMAND_TIMEOUT_MS = 15_000;
+const FORCE_KILL_DELAY_MS = 250;
+const MAX_OUTPUT_BYTES = 16 * 1024;
+
+interface CommandResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+export interface DaemonEnsureResult {
+	started: boolean;
+}
+
+export type DaemonEnsurer = (
+	binary: string,
+	cwd: string,
+	signal: AbortSignal,
+) => Promise<DaemonEnsureResult>;
+
+export async function ensureCodebaseMemoryDaemon(
+	binary: string,
+	cwd: string,
+	signal: AbortSignal,
+): Promise<DaemonEnsureResult> {
+	signal.throwIfAborted();
+	const status = await runDaemonCommand(binary, ["daemon", "status"], cwd, signal);
+	signal.throwIfAborted();
+	if (status.code === 0) return { started: false };
+
+	const started = await runDaemonCommand(binary, ["daemon", "start"], cwd, signal);
+	signal.throwIfAborted();
+	if (started.code !== 0) throw commandFailure("start", started);
+	return { started: true };
+}
+
+export function registerDaemonLifecycle(
+	pi: ExtensionAPI,
+	binary: string,
+	ensureDaemon: DaemonEnsurer = ensureCodebaseMemoryDaemon,
+): void {
+	let generation = 0;
+	let startupController: AbortController | undefined;
+
+	pi.on("session_start", async (_event, ctx) => {
+		const currentGeneration = ++generation;
+		startupController?.abort(abortError("Codebase Memory session replaced"));
+		const controller = new AbortController();
+		startupController = controller;
+
+		try {
+			const result = await ensureDaemon(binary, ctx.cwd, controller.signal);
+			if (controller.signal.aborted || currentGeneration !== generation) return;
+			if (result.started && ctx.hasUI) {
+				ctx.ui.notify("Started the Codebase Memory daemon.", "info");
+			}
+		} catch (error) {
+			if (controller.signal.aborted || currentGeneration !== generation) return;
+			const failure = daemonStartupFailure(error);
+			if (!ctx.hasUI) throw failure;
+			ctx.ui.notify(failure.message, "warning");
+		} finally {
+			if (currentGeneration === generation && startupController === controller) {
+				startupController = undefined;
+			}
+		}
+	});
+
+	pi.on("session_shutdown", () => {
+		generation += 1;
+		startupController?.abort(abortError("Codebase Memory session shut down"));
+		startupController = undefined;
+	});
+}
+
+function runDaemonCommand(
+	binary: string,
+	args: string[],
+	cwd: string,
+	signal: AbortSignal,
+): Promise<CommandResult> {
+	signal.throwIfAborted();
+
+	return new Promise((resolve, reject) => {
+		let timedOut = false;
+		let forceKillTimer: NodeJS.Timeout | undefined;
+		const child = execFile(
+			binary,
+			args,
+			{
+				cwd,
+				env: { ...process.env, CBM_LOG_LEVEL: "error" },
+				encoding: "utf8",
+				maxBuffer: MAX_OUTPUT_BYTES,
+			},
+			(error, stdout, stderr) => {
+				cleanup();
+				if (signal.aborted) {
+					reject(abortReason(signal));
+					return;
+				}
+				if (timedOut) {
+					reject(new Error(`codebase-memory-mcp ${args.join(" ")} timed out`));
+					return;
+				}
+				if (!error) {
+					resolve({ code: 0, stdout, stderr });
+					return;
+				}
+				if (typeof error.code === "number") {
+					resolve({ code: error.code, stdout, stderr });
+					return;
+				}
+				reject(error);
+			},
+		);
+
+		const forceKill = () => {
+			if (child.exitCode !== null || child.signalCode !== null) return;
+			child.kill("SIGTERM");
+			forceKillTimer = setTimeout(() => {
+				if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+			}, FORCE_KILL_DELAY_MS);
+			forceKillTimer.unref();
+		};
+		const onAbort = () => forceKill();
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			forceKill();
+		}, COMMAND_TIMEOUT_MS);
+		timeout.unref();
+
+		function cleanup() {
+			clearTimeout(timeout);
+			if (forceKillTimer) clearTimeout(forceKillTimer);
+			signal.removeEventListener("abort", onAbort);
+		}
+
+		signal.addEventListener("abort", onAbort, { once: true });
+		if (signal.aborted) onAbort();
+	});
+}
+
+function commandFailure(command: string, result: CommandResult): Error {
+	const diagnostic = sanitizeTerminalText(result.stderr.trim() || result.stdout.trim());
+	const suffix = diagnostic ? `: ${diagnostic}` : "";
+	return new Error(
+		`codebase-memory-mcp daemon ${command} exited with code ${result.code}${suffix}`,
+	);
+}
+
+function daemonStartupFailure(error: unknown): Error {
+	const detail = sanitizeTerminalText(error instanceof Error ? error.message : String(error));
+	return new Error(`Could not start the Codebase Memory daemon: ${detail}`, { cause: error });
+}
+
+function abortError(message: string): DOMException {
+	return new DOMException(message, "AbortError");
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason instanceof Error
+		? signal.reason
+		: abortError("Codebase Memory daemon command was aborted");
+}

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -240,17 +240,83 @@ test("daemon lifecycle notifies only when it starts the permanent daemon", async
 	assert.deepEqual(existingContext.notifications, []);
 });
 
-test("daemon lifecycle cancels stale startup work without stopping the daemon", async () => {
+test("daemon lifecycle waits for stale startup cleanup during replacement", async () => {
+	let callCount = 0;
+	let firstSignal: AbortSignal | undefined;
+	let releaseFirstCleanup: (() => void) | undefined;
+	let resolveFirstReady: (() => void) | undefined;
+	let resolveFirstAbort: (() => void) | undefined;
+	const firstReady = new Promise<void>((resolve) => {
+		resolveFirstReady = resolve;
+	});
+	const firstAbort = new Promise<void>((resolve) => {
+		resolveFirstAbort = resolve;
+	});
+	const ensureDaemon: DaemonEnsurer = async (_binary, _cwd, signal) => {
+		callCount += 1;
+		if (callCount > 1) return { started: false };
+		firstSignal = signal;
+		resolveFirstReady?.();
+		return await new Promise((_resolve, reject) => {
+			signal.addEventListener(
+				"abort",
+				() => {
+					resolveFirstAbort?.();
+					releaseFirstCleanup = () => reject(signal.reason);
+				},
+				{ once: true },
+			);
+		});
+	};
+	const harness = createLifecycleHarness(ensureDaemon);
+	const sessionManager = {};
+	const first = lifecycleContext("tui", sessionManager);
+	const replacementContext = lifecycleContext("tui", sessionManager);
+	const firstStartup = harness.emit("session_start", first.ctx);
+	await firstReady;
+
+	let replacementSettled = false;
+	const replacement = harness.emit("session_start", replacementContext.ctx).then(() => {
+		replacementSettled = true;
+	});
+	await firstAbort;
+	await Promise.resolve();
+	assert.equal(firstSignal?.aborted, true);
+	assert.equal(callCount, 1);
+	assert.equal(replacementSettled, false);
+
+	releaseFirstCleanup?.();
+	await firstStartup;
+	await replacement;
+
+	assert.equal(callCount, 2);
+	assert.deepEqual(first.notifications, []);
+	assert.deepEqual(replacementContext.notifications, []);
+});
+
+test("daemon lifecycle waits for startup cleanup during shutdown", async () => {
 	let startupSignal: AbortSignal | undefined;
-	let signalReady: (() => void) | undefined;
+	let releaseCleanup: (() => void) | undefined;
+	let resolveReady: (() => void) | undefined;
+	let resolveAbort: (() => void) | undefined;
 	const ready = new Promise<void>((resolve) => {
-		signalReady = resolve;
+		resolveReady = resolve;
+	});
+	const aborted = new Promise<void>((resolve) => {
+		resolveAbort = resolve;
 	});
 	const ensureDaemon: DaemonEnsurer = async (_binary, _cwd, signal) => {
 		startupSignal = signal;
-		signalReady?.();
+		resolveReady?.();
 		return await new Promise((_resolve, reject) => {
-			signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+			signal.addEventListener(
+				"abort",
+				() => {
+					resolveAbort?.();
+					releaseCleanup = () => reject(signal.reason);
+				},
+				{ once: true },
+			);
 		});
 	};
 	const harness = createLifecycleHarness(ensureDaemon);
@@ -258,11 +324,58 @@ test("daemon lifecycle cancels stale startup work without stopping the daemon", 
 	const startup = harness.emit("session_start", context.ctx);
 	await ready;
 
-	await harness.emit("session_shutdown", context.ctx);
+	let shutdownSettled = false;
+	const shutdown = harness.emit("session_shutdown", context.ctx).then(() => {
+		shutdownSettled = true;
+	});
+	await aborted;
+	await Promise.resolve();
+	assert.equal(startupSignal?.aborted, true);
+	assert.equal(shutdownSettled, false);
+
+	releaseCleanup?.();
+	await shutdown;
 	await startup;
 
-	assert.equal(startupSignal?.aborted, true);
+	assert.equal(shutdownSettled, true);
 	assert.deepEqual(context.notifications, []);
+});
+
+test("daemon lifecycle isolates startup work by session manager", async () => {
+	const signals: AbortSignal[] = [];
+	let resolveFirstReady: (() => void) | undefined;
+	let resolveSecondReady: (() => void) | undefined;
+	const firstReady = new Promise<void>((resolve) => {
+		resolveFirstReady = resolve;
+	});
+	const secondReady = new Promise<void>((resolve) => {
+		resolveSecondReady = resolve;
+	});
+	const ensureDaemon: DaemonEnsurer = async (_binary, _cwd, signal) => {
+		signals.push(signal);
+		if (signals.length === 1) resolveFirstReady?.();
+		if (signals.length === 2) resolveSecondReady?.();
+		return await new Promise((_resolve, reject) => {
+			signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+		});
+	};
+	const harness = createLifecycleHarness(ensureDaemon);
+	const first = lifecycleContext("print", {});
+	const second = lifecycleContext("print", {});
+	const firstStartup = harness.emit("session_start", first.ctx);
+	await firstReady;
+	const secondStartup = harness.emit("session_start", second.ctx);
+	await secondReady;
+
+	assert.equal(signals[0]?.aborted, false);
+	assert.equal(signals[1]?.aborted, false);
+	await harness.emit("session_shutdown", second.ctx);
+	await harness.emit("session_shutdown", second.ctx);
+	assert.equal(signals[0]?.aborted, false);
+	assert.equal(signals[1]?.aborted, true);
+	await harness.emit("session_shutdown", first.ctx);
+	await Promise.all([firstStartup, secondStartup]);
+	assert.equal(signals[0]?.aborted, true);
 });
 
 test("daemon lifecycle exposes startup failures safely in UI and non-UI modes", async () => {
@@ -741,12 +854,13 @@ function createLifecycleHarness(ensureDaemon: DaemonEnsurer) {
 	};
 }
 
-function lifecycleContext(mode: ExtensionContext["mode"]) {
+function lifecycleContext(mode: ExtensionContext["mode"], sessionManager: object = {}) {
 	const notifications: Array<[string, string | undefined]> = [];
 	const ctx = {
 		cwd: fixtureDirectory,
 		mode,
 		hasUI: mode === "tui" || mode === "rpc",
+		sessionManager,
 		ui: {
 			notify(message: string, level?: string) {
 				notifications.push([message, level]);

--- a/packages/pi-cbmem/test/cbmem.test.ts
+++ b/packages/pi-cbmem/test/cbmem.test.ts
@@ -18,11 +18,14 @@ import cbmem, {
 	readLineRange,
 	TOOL_NAMES,
 } from "../src/cbmem.js";
+import { type DaemonEnsurer, ensureCodebaseMemoryDaemon } from "../src/daemon.js";
 import type { ProjectResolution, ProjectResolutionService } from "../src/worktree-project.js";
 
 const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 let fixtureDirectory: string;
 let fixtureBinary: string;
+
+type LifecycleHandler = (event: never, ctx: ExtensionContext) => Promise<void> | void;
 
 beforeAll(async () => {
 	fixtureDirectory = await mkdtemp(path.join(tmpdir(), "pi-cbmem-test-"));
@@ -31,6 +34,33 @@ beforeAll(async () => {
 		fixtureBinary,
 		`#!/usr/bin/env node
 const fs = require("node:fs");
+if (process.argv[2] === "daemon") {
+  const command = process.argv[3];
+  const statePath = process.env.CBMEM_TEST_DAEMON_STATE;
+  const logPath = process.env.CBMEM_TEST_DAEMON_LOG;
+  if (logPath) fs.appendFileSync(logPath, command + "\\n");
+  if (command === "status") {
+    const waitReadyPath = process.env.CBMEM_TEST_DAEMON_WAIT_READY;
+    if (waitReadyPath) {
+      fs.writeFileSync(waitReadyPath + ".tmp", String(process.pid));
+      fs.renameSync(waitReadyPath + ".tmp", waitReadyPath);
+      setInterval(() => {}, 1000);
+    } else if (statePath && fs.existsSync(statePath)) {
+      process.stdout.write("daemon: active (permanent)\\n");
+    } else {
+      process.stdout.write("daemon: not running\\n");
+      process.exitCode = 1;
+    }
+  } else if (command === "start") {
+    if (process.env.CBMEM_TEST_DAEMON_START_FAIL === "1") {
+      process.stderr.write("daemon startup failed\\n");
+      process.exitCode = 9;
+    } else {
+      if (statePath) fs.writeFileSync(statePath, String(process.pid));
+      process.stdout.write("daemon: started (permanent)\\n");
+    }
+  }
+} else {
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => { input += chunk; });
@@ -86,6 +116,7 @@ process.stdin.on("end", () => {
       process.stdout.write(JSON.stringify({ ok: true, args, tool: process.argv[3] }));
   }
 });
+}
 `,
 		{ mode: 0o700 },
 	);
@@ -96,15 +127,21 @@ afterAll(async () => {
 	await rm(fixtureDirectory, { recursive: true, force: true });
 });
 
-test("cbmem registers complete Pi tool definitions", () => {
+test("cbmem registers complete Pi tool definitions and daemon lifecycle", () => {
 	const registered: ToolDefinition[] = [];
+	const events: string[] = [];
 	const api = {
+		on(event: string) {
+			events.push(event);
+		},
 		registerTool(tool: ToolDefinition) {
 			registered.push(tool);
 		},
 	} as unknown as ExtensionAPI;
 
 	cbmem(api);
+
+	assert.deepEqual(events, ["session_start", "session_shutdown"]);
 
 	assert.deepEqual(
 		registered.map((tool) => tool.name),
@@ -131,6 +168,119 @@ test("cbmem registers complete Pi tool definitions", () => {
 		if (aliasTools.has(tool.name)) assert.match(projectDescription ?? "", /@current/u);
 		else assert.doesNotMatch(projectDescription ?? "", /@current/u);
 	}
+});
+
+test("daemon controller starts only when status reports no active daemon", async () => {
+	const statePath = path.join(fixtureDirectory, `daemon-state-${Date.now()}`);
+	const logPath = path.join(fixtureDirectory, `daemon-log-${Date.now()}`);
+	await withDaemonFixture(statePath, logPath, async () => {
+		const controller = new AbortController();
+		assert.deepEqual(
+			await ensureCodebaseMemoryDaemon(fixtureBinary, fixtureDirectory, controller.signal),
+			{ started: true },
+		);
+		assert.deepEqual(
+			await ensureCodebaseMemoryDaemon(fixtureBinary, fixtureDirectory, controller.signal),
+			{ started: false },
+		);
+	});
+
+	assert.deepEqual((await readFile(logPath, "utf8")).trim().split("\n"), [
+		"status",
+		"start",
+		"status",
+	]);
+});
+
+test("daemon controller cancellation terminates its status process", async () => {
+	const statePath = path.join(fixtureDirectory, `daemon-cancel-state-${Date.now()}`);
+	const logPath = path.join(fixtureDirectory, `daemon-cancel-log-${Date.now()}`);
+	const readyPath = path.join(fixtureDirectory, `daemon-cancel-ready-${Date.now()}`);
+	await withDaemonFixture(statePath, logPath, async () => {
+		process.env.CBMEM_TEST_DAEMON_WAIT_READY = readyPath;
+		const watcher = watch(fixtureDirectory);
+		const ready = new Promise<void>((resolve) => {
+			watcher.on("change", (_event, filename) => {
+				if (filename === path.basename(readyPath)) resolve();
+			});
+		});
+		const controller = new AbortController();
+		const pending = ensureCodebaseMemoryDaemon(fixtureBinary, fixtureDirectory, controller.signal);
+
+		await ready;
+		watcher.close();
+		const pid = Number(await readFile(readyPath, "utf8"));
+		controller.abort();
+		await assert.rejects(pending, (error: Error) => error.name === "AbortError");
+		await waitForProcessExit(pid);
+	});
+});
+
+test("daemon controller reports bounded start failures", async () => {
+	const statePath = path.join(fixtureDirectory, `daemon-failure-state-${Date.now()}`);
+	const logPath = path.join(fixtureDirectory, `daemon-failure-log-${Date.now()}`);
+	await withDaemonFixture(statePath, logPath, async () => {
+		process.env.CBMEM_TEST_DAEMON_START_FAIL = "1";
+		await assert.rejects(
+			ensureCodebaseMemoryDaemon(fixtureBinary, fixtureDirectory, new AbortController().signal),
+			/daemon start exited with code 9: daemon startup failed/u,
+		);
+	});
+});
+
+test("daemon lifecycle notifies only when it starts the permanent daemon", async () => {
+	const started = createLifecycleHarness(async () => ({ started: true }));
+	const startedContext = lifecycleContext("tui");
+	await started.emit("session_start", startedContext.ctx);
+	assert.deepEqual(startedContext.notifications, [["Started the Codebase Memory daemon.", "info"]]);
+
+	const existing = createLifecycleHarness(async () => ({ started: false }));
+	const existingContext = lifecycleContext("rpc");
+	await existing.emit("session_start", existingContext.ctx);
+	assert.deepEqual(existingContext.notifications, []);
+});
+
+test("daemon lifecycle cancels stale startup work without stopping the daemon", async () => {
+	let startupSignal: AbortSignal | undefined;
+	let signalReady: (() => void) | undefined;
+	const ready = new Promise<void>((resolve) => {
+		signalReady = resolve;
+	});
+	const ensureDaemon: DaemonEnsurer = async (_binary, _cwd, signal) => {
+		startupSignal = signal;
+		signalReady?.();
+		return await new Promise((_resolve, reject) => {
+			signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+		});
+	};
+	const harness = createLifecycleHarness(ensureDaemon);
+	const context = lifecycleContext("tui");
+	const startup = harness.emit("session_start", context.ctx);
+	await ready;
+
+	await harness.emit("session_shutdown", context.ctx);
+	await startup;
+
+	assert.equal(startupSignal?.aborted, true);
+	assert.deepEqual(context.notifications, []);
+});
+
+test("daemon lifecycle exposes startup failures safely in UI and non-UI modes", async () => {
+	const harness = createLifecycleHarness(async () => {
+		throw new Error("failed\u001b[31m badly");
+	});
+	const tui = lifecycleContext("tui");
+	await harness.emit("session_start", tui.ctx);
+	assert.deepEqual(tui.notifications, [
+		["Could not start the Codebase Memory daemon: failed badly", "warning"],
+	]);
+
+	const print = lifecycleContext("print");
+	await assert.rejects(
+		harness.emit("session_start", print.ctx),
+		/Could not start the Codebase Memory daemon: failed badly/u,
+	);
+	assert.deepEqual(print.notifications, []);
 });
 
 test("@current routes read-only graph tools and annotates the resolved project", async () => {
@@ -575,12 +725,71 @@ test("bundled skill enforces graph-first evidence and valid project-scoped calls
 	);
 });
 
+function createLifecycleHarness(ensureDaemon: DaemonEnsurer) {
+	const handlers = new Map<string, LifecycleHandler[]>();
+	const api = {
+		on(event: string, handler: LifecycleHandler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+	cbmem(api, fixtureBinary, undefined, ensureDaemon);
+	return {
+		async emit(event: string, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) await handler({} as never, ctx);
+		},
+	};
+}
+
+function lifecycleContext(mode: ExtensionContext["mode"]) {
+	const notifications: Array<[string, string | undefined]> = [];
+	const ctx = {
+		cwd: fixtureDirectory,
+		mode,
+		hasUI: mode === "tui" || mode === "rpc",
+		ui: {
+			notify(message: string, level?: string) {
+				notifications.push([message, level]);
+			},
+		},
+	} as unknown as ExtensionContext;
+	return { ctx, notifications };
+}
+
+async function withDaemonFixture(
+	statePath: string,
+	logPath: string,
+	callback: () => Promise<void>,
+): Promise<void> {
+	const previousState = process.env.CBMEM_TEST_DAEMON_STATE;
+	const previousLog = process.env.CBMEM_TEST_DAEMON_LOG;
+	const previousFailure = process.env.CBMEM_TEST_DAEMON_START_FAIL;
+	const previousWaitReady = process.env.CBMEM_TEST_DAEMON_WAIT_READY;
+	process.env.CBMEM_TEST_DAEMON_STATE = statePath;
+	process.env.CBMEM_TEST_DAEMON_LOG = logPath;
+	delete process.env.CBMEM_TEST_DAEMON_START_FAIL;
+	delete process.env.CBMEM_TEST_DAEMON_WAIT_READY;
+	try {
+		await callback();
+	} finally {
+		if (previousState === undefined) delete process.env.CBMEM_TEST_DAEMON_STATE;
+		else process.env.CBMEM_TEST_DAEMON_STATE = previousState;
+		if (previousLog === undefined) delete process.env.CBMEM_TEST_DAEMON_LOG;
+		else process.env.CBMEM_TEST_DAEMON_LOG = previousLog;
+		if (previousFailure === undefined) delete process.env.CBMEM_TEST_DAEMON_START_FAIL;
+		else process.env.CBMEM_TEST_DAEMON_START_FAIL = previousFailure;
+		if (previousWaitReady === undefined) delete process.env.CBMEM_TEST_DAEMON_WAIT_READY;
+		else process.env.CBMEM_TEST_DAEMON_WAIT_READY = previousWaitReady;
+	}
+}
+
 function registerTools(
 	binary: string,
 	projectResolutionService?: ProjectResolutionService,
 ): ToolDefinition[] {
 	const tools: ToolDefinition[] = [];
 	const api = {
+		on() {},
 		registerTool(tool: ToolDefinition) {
 			tools.push(tool);
 		},


### PR DESCRIPTION
## Summary

- detect the account-scoped `codebase-memory-mcp` daemon during `session_start`
- start a permanent daemon only when `daemon status` reports none active
- cancel stale daemon control commands during session replacement without stopping the persistent daemon
- document the lifecycle and add deterministic startup, cancellation, mode, and failure coverage

## Verification

- `npm run check`
- `npm test` — 3,281 tests passed
- focused `pi-cbmem` tests — 34 tests passed
- README heading audit
- `npm pack --workspace @narumitw/pi-cbmem --dry-run --json`
- Pi RPC package-load smoke with the existing permanent daemon left unchanged
