### PR TITLE
feat(usage): add accurate Fireworks rated spend reporting

### DIFF
--- a/.changeset/fireworks-api-spend.md
+++ b/.changeset/fireworks-api-spend.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add Fireworks rated API spend reporting for the official fireworks provider, summarizing the trailing 30 days of rated costs per currency with serverless, dedicated-deployment, and training subtotals from the documented billing summary endpoint.
+
+The account slug is discovered through the documented account listing when exactly one account is visible; keys that can see several accounts set `FIREWORKS_ACCOUNT_ID`. Fireworks exposes no credit-balance or spend-cap endpoint, so the report claims only rated spend.

--- a/.changeset/fireworks-api-spend.md
+++ b/.changeset/fireworks-api-spend.md
@@ -4,4 +4,4 @@
 
 Add Fireworks rated API spend reporting for the official fireworks provider, summarizing the trailing 30 days of rated costs per currency with serverless, dedicated-deployment, and training subtotals from the documented billing summary endpoint.
 
-The account slug is discovered through the documented account listing when exactly one account is visible; keys that can see several accounts set `FIREWORKS_ACCOUNT_ID`. Fireworks exposes no credit-balance or spend-cap endpoint, so the report claims only rated spend.
+The account slug is discovered through the documented account listing when exactly one account is visible; keys that can see several accounts set `fireworksAccountId` in `pi-usage.json`. Fireworks exposes no credit-balance or spend-cap endpoint, so the report claims only rated spend.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -15,6 +15,8 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
+- Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
+- Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
 - Reports xAI OAuth subscription allowances and credits.
 - Toggles persistent Codex Fast routing through `/fast` or the usage menu.
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
@@ -219,6 +221,22 @@ The balance endpoint does not provide historical spend, request windows, reset t
 The contract was verified on 2026-08-28 against [DeepSeek's Get User Balance documentation](https://api-docs.deepseek.com/api/get-user-balance) and Pi's [`deepseek.ts`](https://github.com/earendil-works/pi/blob/c49906ec77788625aacbdc53ebca6fbe65bd20f5/packages/ai/src/providers/deepseek.ts) at `c49906ec77788625aacbdc53ebca6fbe65bd20f5`.
 DeepSeek Harness `cd5ef8148158c3a752a658978873241fdf8e2bbc` reports only per-request model token usage and does not provide account balance data.
 
+### Fireworks API spend
+
+- Provider ID: `fireworks`
+- Semantics: rated 30-day account spend, not credit balance or spend-cap quota
+- Source: documented `GET https://api.fireworks.ai/v1/accounts` account discovery and `GET https://api.fireworks.ai/v1/accounts/{account_id}/billing/summary` rated costs using Pi's resolved inference API key
+- Displayed data: exact rated spend per currency with serverless, dedicated-deployment, and training subtotals for the trailing 30 days
+- Statusline example: `fireworks USD 12.345678901`
+
+The extension queries the fixed endpoints only when the selected model origin is `https://api.fireworks.ai` and any resolved-auth origin override, when present, has the same official origin.
+The account slug is discovered through the documented account listing; a key that can see several accounts must set `FIREWORKS_ACCOUNT_ID` to one of the listed account slugs, and the slug must remain visible to the key.
+Monetary `units` and `nanos` values are summed exactly with integer arithmetic and stay exact through display.
+Fireworks does not expose credit balance, spend caps, per-window quota, or reset times through its API, so `pi-usage` does not claim those Fireworks capabilities; the web console remains the authoritative balance source.
+Rated line items may differ from the final invoice once credits or adjustments are applied.
+
+The contract was verified on 2026-07-31 against Fireworks' [Usage & Cost Breakdown](https://docs.fireworks.ai/accounts/exporting-usage-and-costs), [Get billing summary](https://docs.fireworks.ai/api-reference/get-billing-summary), and [List Accounts](https://docs.fireworks.ai/api-reference/list-accounts) API references.
+
 ### OpenCode Go (Zen)
 
 - Provider ID: `opencode-go`
@@ -303,6 +321,7 @@ After the active runtime credential changes, the next command, turn, or schedule
 The `usage` status item is active only for selected providers that publish statusline usage.
 It refreshes every five minutes while the session remains on such a provider and is cleared when the model changes to an unsupported or menu-only provider.
 DeepSeek publishes each returned currency as a separate exact balance segment and reports when the API is unavailable.
+Fireworks publishes exact per-currency rated spend totals and reports when no rated usage exists.
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
@@ -334,6 +353,7 @@ Credential candidates are collected synchronously in memory and are not cached, 
 The protocol carries no account name or extension identity.
 Only the selected provider's exact runtime match is used, and secrets are sent only to its validated official origin.
 DeepSeek balance requests require Bearer authentication, send only that resolved credential from Pi's runtime auth to `https://api.deepseek.com/user/balance`, and refuse redirects.
+Fireworks spend requests send only that resolved credential to the official `https://api.fireworks.ai` account-listing and billing-summary endpoints and refuse redirects.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
 Install only trusted extensions because they can read user files and process memory.
 Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
@@ -348,6 +368,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
+- Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `FIREWORKS_ACCOUNT_ID`.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.
@@ -390,7 +411,7 @@ The generated runtime is built from the authoritative `src/index.ts` graph and d
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -90,7 +90,7 @@ Successful, already-completed, not-needed, and no-credit outcomes are reported s
 
 ## ⚙️ Settings
 
-Choose **Settings** in `/usage` to edit Codex Fast mode and the Codex reset countdown through Pi's settings-list interaction in TUI mode.
+Choose **Settings** in `/usage` to edit Codex Fast mode, the Codex reset countdown, and the Fireworks account selector through Pi's settings-list interaction in TUI mode.
 RPC mode reports the active manual settings path instead of opening terminal UI.
 
 These preferences live in `pi-usage.json` under Pi's user agent directory, normally `~/.pi/agent/pi-usage.json`.
@@ -104,7 +104,7 @@ Separate Pi processes are not mutually locked.
 ### Fireworks account
 
 A Fireworks key that can see one account needs no setting.
-For a key that can see several accounts, set the exact visible account slug in `pi-usage.json` and run `/reload`:
+For a key that can see several accounts, choose **Fireworks account** in the TUI Settings screen, or set the exact visible account slug in `pi-usage.json` and run `/reload`:
 
 ```json
 {
@@ -113,8 +113,7 @@ For a key that can see several accounts, set the exact visible account slug in `
 ```
 
 The `fireworksAccountId` setting is validated as a URL-safe account slug and then checked against the official account listing before billing data is requested.
-Remove the field to restore single-account auto-selection.
-The TUI Settings screen edits the bounded Codex preferences; edit this free-form account slug through the documented settings file.
+Submit a blank value from the TUI input, or remove the JSON field and run `/reload`, to restore single-account auto-selection.
 
 ### Codex Fast mode
 

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -16,7 +16,6 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
 - Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
-- Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
 - Reports xAI OAuth subscription allowances and credits.
 - Toggles persistent Codex Fast routing through `/fast` or the usage menu.
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
@@ -101,6 +100,21 @@ Saves preserve unknown JSON fields and publish through a private temporary file 
 Malformed or invalid files remain untouched.
 A failed save restores the prior displayed and effective value, while shutdown waits for queued writes.
 Separate Pi processes are not mutually locked.
+
+### Fireworks account
+
+A Fireworks key that can see one account needs no setting.
+For a key that can see several accounts, set the exact visible account slug in `pi-usage.json` and run `/reload`:
+
+```json
+{
+  "fireworksAccountId": "acme"
+}
+```
+
+The `fireworksAccountId` setting is validated as a URL-safe account slug and then checked against the official account listing before billing data is requested.
+Remove the field to restore single-account auto-selection.
+The TUI Settings screen edits the bounded Codex preferences; edit this free-form account slug through the documented settings file.
 
 ### Codex Fast mode
 
@@ -230,7 +244,7 @@ DeepSeek Harness `cd5ef8148158c3a752a658978873241fdf8e2bbc` reports only per-req
 - Statusline example: `fireworks USD 12.345678901`
 
 The extension queries the fixed endpoints only when the selected model origin is `https://api.fireworks.ai` and any resolved-auth origin override, when present, has the same official origin.
-The account slug is discovered through the documented account listing; a key that can see several accounts must set `FIREWORKS_ACCOUNT_ID` to one of the listed account slugs, and the slug must remain visible to the key.
+The account slug is discovered through the documented account listing; a key that can see several accounts must set `fireworksAccountId` in `pi-usage.json` to one of the listed account slugs, and the slug must remain visible to the key.
 Monetary `units` and `nanos` values are summed exactly with integer arithmetic and stay exact through display.
 Fireworks does not expose credit balance, spend caps, per-window quota, or reset times through its API, so `pi-usage` does not claim those Fireworks capabilities; the web console remains the authoritative balance source.
 Rated line items may differ from the final invoice once credits or adjustments are applied.
@@ -368,7 +382,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
-- Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `FIREWORKS_ACCOUNT_ID`.
+- Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `fireworksAccountId` in `pi-usage.json`.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -13,6 +13,7 @@
 		"quota",
 		"balance",
 		"deepseek",
+		"fireworks",
 		"codex",
 		"kimi",
 		"kimi-coding",

--- a/packages/pi-usage/src/codex-fast-runtime.ts
+++ b/packages/pi-usage/src/codex-fast-runtime.ts
@@ -24,6 +24,7 @@ export function registerCodexFastMode(
 	pi: ExtensionAPI,
 	settingsRuntime: UsageSettingsRuntime,
 	refreshStatus: (ctx: ExtensionContext) => void,
+	options: { registerSessionStart?: boolean } = {},
 ) {
 	let sessionController = new AbortController();
 	let generation = 0;
@@ -95,41 +96,47 @@ export function registerCodexFastMode(
 		},
 	});
 
-	pi.on("session_start", async (_event, ctx) => {
+	const prepareSession = (ctx: ExtensionContext): Promise<void> => {
+		const sessionId = ctx.sessionManager.getSessionId();
 		generation += 1;
 		sessionController.abort();
 		pendingFastRequests.clear();
 		sessionController = new AbortController();
 		const ownerGeneration = generation;
-		const sessionId = ctx.sessionManager.getSessionId();
-		let state: Readonly<UsageSettingsState>;
-		try {
-			state = await settingsRuntime.reload(sessionController.signal);
-		} catch (error) {
-			if (sessionController.signal.aborted || ownerGeneration !== generation) return;
-			if (ctx.hasUI) {
+		return (async () => {
+			let state: Readonly<UsageSettingsState>;
+			try {
+				state = await settingsRuntime.reload(sessionController.signal);
+			} catch (error) {
+				if (sessionController.signal.aborted || ownerGeneration !== generation) return;
+				if (ctx.hasUI) {
+					ctx.ui.notify(
+						`Could not load pi-usage.json; using defaults. ${errorMessage(error)}`,
+						"warning",
+					);
+				}
+				return;
+			}
+			if (
+				sessionController.signal.aborted ||
+				ownerGeneration !== generation ||
+				ctx.sessionManager.getSessionId() !== sessionId
+			) {
+				return;
+			}
+			if (ctx.hasUI && state.kind === "invalid") {
 				ctx.ui.notify(
-					`Could not load pi-usage.json; using defaults. ${errorMessage(error)}`,
+					`Invalid pi-usage.json; using defaults without overwriting it. ${state.issue}`,
 					"warning",
 				);
 			}
-			return;
-		}
-		if (
-			sessionController.signal.aborted ||
-			ownerGeneration !== generation ||
-			ctx.sessionManager.getSessionId() !== sessionId
-		) {
-			return;
-		}
-		if (ctx.hasUI && state.kind === "invalid") {
-			ctx.ui.notify(
-				`Invalid pi-usage.json; using defaults without overwriting it. ${state.issue}`,
-				"warning",
-			);
-		}
-		refreshStatus(ctx);
-	});
+			refreshStatus(ctx);
+		})();
+	};
+
+	if (options.registerSessionStart !== false) {
+		pi.on("session_start", async (_event, ctx) => prepareSession(ctx));
+	}
 
 	pi.on("before_provider_request", (event, ctx) => {
 		const rewritten = rewriteCodexFastPayload(
@@ -164,6 +171,7 @@ export function registerCodexFastMode(
 	});
 
 	return {
+		prepareSession,
 		availability(model: PiModel | undefined) {
 			return codexFastAvailability(model, settingsRuntime.get().settings.codexFastMode);
 		},

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -12,13 +12,18 @@ const VALUE_COLUMN = 29;
 export function formatUsageReport(report: UsageReport, displayState: UsageDisplayState): string {
 	const stateLabel = displayState === "current" ? "Current" : "Configured";
 	const title =
-		report.providerId === "deepseek" ? "DeepSeek API Balance" : `${report.providerName} Usage`;
+		report.providerId === "deepseek"
+			? "DeepSeek API Balance"
+			: report.providerId === "fireworks"
+				? "Fireworks API Spend"
+				: `${report.providerName} Usage`;
 	const lines = [`${title} · ${stateLabel}`];
 	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
 	lines.push(`Semantics: ${report.semantics.label}`, "");
 
 	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
 	else if (report.providerId === "deepseek") formatDeepSeekReport(lines, report);
+	else if (report.providerId === "fireworks") formatFireworksReport(lines, report);
 	else if (report.providerId === "github-copilot") formatGitHubCopilotReport(lines, report);
 	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
 	else if (report.providerId === "opencode-go") formatOpenCodeZenReport(lines, report);
@@ -44,6 +49,7 @@ export function formatUsageStatusline(
 		return formatCodexStatusline(report, model, now, showCodexResetCountdown);
 	}
 	if (report.providerId === "deepseek") return formatDeepSeekStatusline(report);
+	if (report.providerId === "fireworks") return formatFireworksStatusline(report);
 	if (report.providerId === "github-copilot") return formatGitHubCopilotStatusline(report);
 	if (report.providerId === "openrouter") {
 		const limit = report.buckets.find((bucket) => bucket.id === "key-limit");
@@ -123,6 +129,32 @@ function formatDeepSeekStatusline(report: UsageReport): string {
 		return metric ? [`${currency} ${metric.value}`] : [];
 	});
 	return totals.length > 0 ? `deepseek ${totals.join(" · ")}` : "deepseek balance unavailable";
+}
+
+function formatFireworksReport(lines: string[], report: UsageReport): void {
+	lines.push(`${"Spend window:".padEnd(VALUE_COLUMN)}Last 30 days (rated)`);
+	for (const currency of fireworksCurrencies(report)) {
+		lines.push("", `${currency} rated spend:`);
+		for (const metric of report.metrics) {
+			if (metric.currency !== currency) continue;
+			lines.push(`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${currency} ${metric.value}`);
+		}
+	}
+}
+
+function formatFireworksStatusline(report: UsageReport): string {
+	const totals = report.metrics.filter((metric) => metric.id.endsWith("-total"));
+	if (totals.length === 0) return "fireworks no rated usage";
+	return `fireworks ${totals.map((metric) => `${metric.currency} ${metric.value}`).join(" · ")}`;
+}
+
+function fireworksCurrencies(report: UsageReport): string[] {
+	const currencies: string[] = [];
+	for (const metric of report.metrics) {
+		if (!metric.currency || currencies.includes(metric.currency)) continue;
+		currencies.push(metric.currency);
+	}
+	return currencies;
 }
 
 function formatGitHubCopilotReport(lines: string[], report: UsageReport): void {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -78,6 +78,7 @@ export type {
 	UsageMetric,
 	UsageModel,
 	UsageProviderAdapter,
+	UsageQuerySettings,
 	UsageReport,
 	UsageSemantics,
 	UsageSemanticsKind,

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -34,6 +34,10 @@ export {
 export { formatProviderStates, formatUsageReport, formatUsageStatusline } from "./format.js";
 export { normalizeCodexBackendPayload } from "./providers/codex.js";
 export { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
+export {
+	normalizeFireworksAccountsPayload,
+	normalizeFireworksBillingSummaryPayload,
+} from "./providers/fireworks.js";
 export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 export { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 export { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -64,6 +68,8 @@ export {
 } from "./settings.js";
 export type {
 	DeepSeekBalancePayload,
+	FireworksAccountsPayload,
+	FireworksBillingSummaryPayload,
 	KimiCodingUsagePayload,
 	ProviderUsageState,
 	ResolvedUsageAuth,

--- a/packages/pi-usage/src/providers/fireworks.ts
+++ b/packages/pi-usage/src/providers/fireworks.ts
@@ -1,0 +1,186 @@
+import { sanitizeDisplayText } from "../core.js";
+import type {
+	FireworksAccountsPayload,
+	FireworksBillingSummaryPayload,
+	UsageMetric,
+	UsageReport,
+} from "../types.js";
+
+const NANOS_PER_UNIT = 1_000_000_000n;
+const CURRENCY_PATTERN = /^[A-Z]{3}$/u;
+const ACCOUNT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u;
+const INTEGER_PATTERN = /^-?\d+$/u;
+const MAX_UNITS_CHARS = 16;
+const MAX_NANOS_CHARS = 10;
+
+const SERIES_KEYS = ["serverless", "dedicated", "training", "other"] as const;
+type SeriesKey = (typeof SERIES_KEYS)[number];
+
+const SERIES_LABELS: Readonly<Record<SeriesKey, string>> = {
+	serverless: "Serverless",
+	dedicated: "Dedicated deployments",
+	training: "Training",
+	other: "Other",
+};
+
+export function normalizeFireworksAccountsPayload(payload: FireworksAccountsPayload): string[] {
+	if (!Array.isArray(payload.accounts)) {
+		throw new Error("Fireworks accounts response did not contain an accounts array.");
+	}
+	const accounts: string[] = [];
+	for (const raw of payload.accounts) {
+		const account = asObject(raw);
+		if (!account) throw new Error("Fireworks accounts response row was not an object.");
+		if (typeof account.name !== "string") {
+			throw new Error("Fireworks accounts response omitted the account resource name.");
+		}
+		const match = /^accounts\/([^/]+)$/u.exec(account.name);
+		if (!match || !ACCOUNT_ID_PATTERN.test(match[1])) {
+			throw new Error("Fireworks accounts response returned an unsafe account resource name.");
+		}
+		const accountId = match[1];
+		if (accounts.includes(accountId)) {
+			throw new Error(`Fireworks accounts response repeated ${accountId}.`);
+		}
+		accounts.push(accountId);
+	}
+	return accounts;
+}
+
+export function normalizeFireworksBillingSummaryPayload(
+	payload: FireworksBillingSummaryPayload,
+	accountId: string,
+	capturedAt: number,
+): UsageReport {
+	if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+		throw new Error("Fireworks billing summary received an unsafe account identifier.");
+	}
+	if (payload.lineItems !== undefined && !Array.isArray(payload.lineItems)) {
+		throw new Error("Fireworks billing summary lineItems was not an array.");
+	}
+
+	const totals = new Map<string, Map<SeriesKey, bigint>>();
+	for (const raw of payload.lineItems ?? []) {
+		const lineItem = asObject(raw);
+		if (!lineItem) throw new Error("Fireworks billing line item was not an object.");
+		const cost = moneyAmount(lineItem.totalCost, "line item total cost");
+		const series = seriesKey(lineItem.series);
+		let amounts = totals.get(cost.currency);
+		if (!amounts) {
+			amounts = new Map<SeriesKey, bigint>();
+			totals.set(cost.currency, amounts);
+		}
+		amounts.set(series, (amounts.get(series) ?? 0n) + cost.amount);
+	}
+
+	const metrics: UsageMetric[] = [];
+	for (const [currency, amounts] of totals) {
+		metrics.push({
+			id: `${currency.toLowerCase()}-total`,
+			label: "Total spend",
+			value: formatMoneyAmount(sumSeries(amounts)),
+			unit: "currency",
+			currency,
+		});
+		for (const series of SERIES_KEYS) {
+			const amount = amounts.get(series);
+			if (amount === undefined) continue;
+			metrics.push({
+				id: `${currency.toLowerCase()}-${series}`,
+				label: SERIES_LABELS[series],
+				value: formatMoneyAmount(amount),
+				unit: "currency",
+				currency,
+			});
+		}
+	}
+
+	const notes = [
+		"Rated line items may differ from the final invoice once credits or adjustments are applied.",
+	];
+	if (metrics.length === 0) {
+		notes.push("Fireworks returned no rated line items for the last 30 days.");
+	}
+
+	return {
+		providerId: "fireworks",
+		providerName: "Fireworks",
+		capturedAt,
+		source: "fireworks-billing-summary",
+		semantics: { kind: "api-key", label: "Fireworks API spend" },
+		accountLabel: sanitizeDisplayText(accountId, 80),
+		buckets: [],
+		metrics,
+		notes,
+	};
+}
+
+type RatedMoney = { currency: string; amount: bigint };
+
+function moneyAmount(value: unknown, description: string): RatedMoney {
+	const money = asObject(value);
+	if (!money) throw new Error(`Fireworks billing ${description} was not a money object.`);
+	const currency = typeof money.currencyCode === "string" ? money.currencyCode : undefined;
+	if (!currency || !CURRENCY_PATTERN.test(currency)) {
+		throw new Error(`Fireworks billing ${description} currency was not an ISO 4217 code.`);
+	}
+	// proto3 JSON omits zero-valued money fields, so absent components default to zero.
+	const units =
+		money.units === undefined
+			? 0n
+			: integerComponent(money.units, description, "whole units", MAX_UNITS_CHARS);
+	const nanos =
+		money.nanos === undefined
+			? 0n
+			: integerComponent(money.nanos, description, "nano units", MAX_NANOS_CHARS);
+	if ((units > 0n && nanos < 0n) || (units < 0n && nanos > 0n)) {
+		throw new Error(`Fireworks billing ${description} mixed unit and nano signs.`);
+	}
+	return { currency, amount: units * NANOS_PER_UNIT + nanos };
+}
+
+function integerComponent(
+	value: unknown,
+	description: string,
+	component: string,
+	maxChars: number,
+): bigint {
+	const text =
+		typeof value === "number" && Number.isSafeInteger(value)
+			? String(value)
+			: typeof value === "string" && INTEGER_PATTERN.test(value)
+				? value
+				: undefined;
+	if (text === undefined || text.length > maxChars) {
+		throw new Error(`Fireworks billing ${description} ${component} was not a bounded integer.`);
+	}
+	return BigInt(text);
+}
+
+function seriesKey(value: unknown): SeriesKey {
+	if (value === undefined || value === null) return "other";
+	if (typeof value !== "string") throw new Error("Fireworks billing line item series was invalid.");
+	if (value === "SERVERLESS") return "serverless";
+	if (value === "DEDICATED_DEPLOYMENT") return "dedicated";
+	if (value === "TRAINING") return "training";
+	return "other";
+}
+
+function sumSeries(amounts: ReadonlyMap<SeriesKey, bigint>): bigint {
+	let total = 0n;
+	for (const amount of amounts.values()) total += amount;
+	return total;
+}
+
+function formatMoneyAmount(amount: bigint): string {
+	const negative = amount < 0n;
+	const magnitude = negative ? -amount : amount;
+	const units = magnitude / NANOS_PER_UNIT;
+	const nanos = (magnitude % NANOS_PER_UNIT).toString().padStart(9, "0").replace(/0+$/u, "");
+	return `${negative ? "-" : ""}${units.toString()}${nanos ? `.${nanos}` : ""}`;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}

--- a/packages/pi-usage/src/providers/fireworks.ts
+++ b/packages/pi-usage/src/providers/fireworks.ts
@@ -10,8 +10,10 @@ const NANOS_PER_UNIT = 1_000_000_000n;
 const CURRENCY_PATTERN = /^[A-Z]{3}$/u;
 const ACCOUNT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u;
 const INTEGER_PATTERN = /^-?\d+$/u;
-const MAX_UNITS_CHARS = 16;
-const MAX_NANOS_CHARS = 10;
+const INT64_MIN = -(2n ** 63n);
+const INT64_MAX = 2n ** 63n - 1n;
+const MAX_UNITS_CHARS = 20;
+const MAX_NANOS_CHARS = 11;
 
 const SERIES_KEYS = ["serverless", "dedicated", "training", "other"] as const;
 type SeriesKey = (typeof SERIES_KEYS)[number];
@@ -133,10 +135,16 @@ function moneyAmount(value: unknown, description: string): RatedMoney {
 		money.units === undefined
 			? 0n
 			: integerComponent(money.units, description, "whole units", MAX_UNITS_CHARS);
+	if (units < INT64_MIN || units > INT64_MAX) {
+		throw new Error(`Fireworks billing ${description} whole units exceeded the int64 range.`);
+	}
 	const nanos =
 		money.nanos === undefined
 			? 0n
 			: integerComponent(money.nanos, description, "nano units", MAX_NANOS_CHARS);
+	if (nanos <= -NANOS_PER_UNIT || nanos >= NANOS_PER_UNIT) {
+		throw new Error(`Fireworks billing ${description} nano units exceeded the Money range.`);
+	}
 	if ((units > 0n && nanos < 0n) || (units < 0n && nanos > 0n)) {
 		throw new Error(`Fireworks billing ${description} mixed unit and nano signs.`);
 	}

--- a/packages/pi-usage/src/providers/fireworks.ts
+++ b/packages/pi-usage/src/providers/fireworks.ts
@@ -23,6 +23,10 @@ const SERIES_LABELS: Readonly<Record<SeriesKey, string>> = {
 	other: "Other",
 };
 
+export function isFireworksAccountId(value: unknown): value is string {
+	return typeof value === "string" && ACCOUNT_ID_PATTERN.test(value);
+}
+
 export function normalizeFireworksAccountsPayload(payload: FireworksAccountsPayload): string[] {
 	if (!Array.isArray(payload.accounts)) {
 		throw new Error("Fireworks accounts response did not contain an accounts array.");
@@ -35,7 +39,7 @@ export function normalizeFireworksAccountsPayload(payload: FireworksAccountsPayl
 			throw new Error("Fireworks accounts response omitted the account resource name.");
 		}
 		const match = /^accounts\/([^/]+)$/u.exec(account.name);
-		if (!match || !ACCOUNT_ID_PATTERN.test(match[1])) {
+		if (!match || !isFireworksAccountId(match[1])) {
 			throw new Error("Fireworks accounts response returned an unsafe account resource name.");
 		}
 		const accountId = match[1];
@@ -52,7 +56,7 @@ export function normalizeFireworksBillingSummaryPayload(
 	accountId: string,
 	capturedAt: number,
 ): UsageReport {
-	if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+	if (!isFireworksAccountId(accountId)) {
 		throw new Error("Fireworks billing summary received an unsafe account identifier.");
 	}
 	if (payload.lineItems !== undefined && !Array.isArray(payload.lineItems)) {

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -828,6 +828,7 @@ async function resolveFireworksAccountId(
 	timeoutMs: number,
 	guard: () => Promise<void>,
 ): Promise<string> {
+	const startedAt = Date.now();
 	const accounts: string[] = [];
 	let pageToken: string | undefined;
 	for (let page = 0; page < FIREWORKS_MAX_ACCOUNT_PAGES; page += 1) {
@@ -836,7 +837,7 @@ async function resolveFireworksAccountId(
 			fireworksAccountsUrl(pageToken),
 			auth,
 			signal,
-			remainingTimeout(timeoutMs, Date.now(), "fetching Fireworks accounts"),
+			remainingTimeout(timeoutMs, startedAt, "fetching Fireworks accounts"),
 			"Fireworks accounts endpoint",
 			{ redirect: "error" },
 		)) as FireworksAccountsPayload;
@@ -903,8 +904,12 @@ function fireworksBillingSummaryUrl(accountId: string, startedAt: number): strin
 		`/v1/accounts/${accountId}/billing/summary`,
 		FIREWORKS_BILLING_SUMMARY_ORIGIN,
 	);
-	// The endpoint aggregates by UTC date; endTime is exclusive, so tomorrow's floor includes today.
-	url.searchParams.set("startTime", dayFloor(startedAt - FIREWORKS_SPEND_WINDOW_DAYS * dayMs));
+	// The endpoint aggregates by UTC date; endTime is exclusive, so the window includes today
+	// plus the preceding 29 dates.
+	url.searchParams.set(
+		"startTime",
+		dayFloor(startedAt - (FIREWORKS_SPEND_WINDOW_DAYS - 1) * dayMs),
+	);
 	url.searchParams.set("endTime", dayFloor(startedAt + dayMs));
 	return url.toString();
 }

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -7,6 +7,10 @@ import {
 } from "./oauth-credential-source.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
 import { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
+import {
+	normalizeFireworksAccountsPayload,
+	normalizeFireworksBillingSummaryPayload,
+} from "./providers/fireworks.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -16,6 +20,8 @@ import { normalizeZaiQuotaPayload } from "./providers/zai.js";
 import type {
 	CodexBackendPayload,
 	DeepSeekBalancePayload,
+	FireworksAccountsPayload,
+	FireworksBillingSummaryPayload,
 	GitHubCopilotUsagePayload,
 	KimiCodingUsagePayload,
 	OpenCodeZenPayload,
@@ -31,6 +37,11 @@ import type {
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance";
+const FIREWORKS_BILLING_SUMMARY_ORIGIN = "https://api.fireworks.ai";
+const FIREWORKS_ACCOUNT_ID_ENV = "FIREWORKS_ACCOUNT_ID";
+const FIREWORKS_SPEND_WINDOW_DAYS = 30;
+const FIREWORKS_MAX_ACCOUNT_PAGES = 5;
+const SAFE_URL_TOKEN = /^[A-Za-z0-9._~-]+$/u;
 const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
@@ -120,6 +131,33 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				"OpenRouter key endpoint",
 			);
 			return normalizeOpenRouterKeyPayload(payload as OpenRouterKeyPayload, Date.now());
+		},
+	},
+	{
+		id: "fireworks",
+		displayName: "Fireworks",
+		semantics: { kind: "api-key", label: "Fireworks API spend" },
+		async query(auth, signal, timeoutMs, guard) {
+			if (!guard) throw new Error("Fireworks API spend requires request-boundary revalidation.");
+			const startedAt = Date.now();
+			await guard();
+			const accountId = await resolveFireworksAccountId(
+				auth,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "resolving the Fireworks account"),
+				guard,
+			);
+			await guard();
+			const payload = (await fetchProviderJson(
+				fireworksBillingSummaryUrl(accountId, startedAt),
+				auth,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "fetching Fireworks rated spend"),
+				"Fireworks billing summary endpoint",
+				{ redirect: "error" },
+			)) as FireworksBillingSummaryPayload;
+			await guard();
+			return normalizeFireworksBillingSummaryPayload(payload, accountId, Date.now());
 		},
 	},
 	{
@@ -733,6 +771,7 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 		const url = new URL(value);
 		if (providerId === "openai-codex") return url.origin === "https://chatgpt.com";
 		if (providerId === "deepseek") return url.origin === "https://api.deepseek.com";
+		if (providerId === "fireworks") return url.origin === FIREWORKS_BILLING_SUMMARY_ORIGIN;
 		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
 		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
 		if (providerId === "kimi-coding") return url.origin === "https://api.kimi.com";
@@ -771,10 +810,103 @@ function validatedXaiUserId(value: unknown): string {
 	return value;
 }
 
-function remainingTimeout(timeoutMs: number, startedAt: number): number {
+function remainingTimeout(
+	timeoutMs: number,
+	startedAt: number,
+	description = "fetching xAI consumer usage",
+): number {
 	const remaining = timeoutMs - (Date.now() - startedAt);
-	if (remaining <= 0) throw new Error("Timed out while fetching xAI consumer usage.");
+	if (remaining <= 0) throw new Error(`Timed out while ${description}.`);
 	return remaining;
+}
+
+// Fireworks requires an account slug for its billing endpoints; discover it through the
+// documented account listing, requiring an explicit slug when a key can see several accounts.
+async function resolveFireworksAccountId(
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+	guard: () => Promise<void>,
+): Promise<string> {
+	const accounts: string[] = [];
+	let pageToken: string | undefined;
+	for (let page = 0; page < FIREWORKS_MAX_ACCOUNT_PAGES; page += 1) {
+		await guard();
+		const payload = (await fetchProviderJson(
+			fireworksAccountsUrl(pageToken),
+			auth,
+			signal,
+			remainingTimeout(timeoutMs, Date.now(), "fetching Fireworks accounts"),
+			"Fireworks accounts endpoint",
+			{ redirect: "error" },
+		)) as FireworksAccountsPayload;
+		for (const accountId of normalizeFireworksAccountsPayload(
+			payload as FireworksAccountsPayload,
+		)) {
+			if (accounts.includes(accountId)) {
+				throw new Error(`Fireworks accounts listing repeated ${accountId}.`);
+			}
+			accounts.push(accountId);
+		}
+		pageToken = fireworksNextPageToken(payload.nextPageToken);
+		if (!pageToken) break;
+	}
+	if (pageToken) {
+		throw new Error(
+			`Fireworks account listing exceeded ${FIREWORKS_MAX_ACCOUNT_PAGES} pages; set ${FIREWORKS_ACCOUNT_ID_ENV} to the desired account slug.`,
+		);
+	}
+	if (accounts.length === 0) {
+		throw new Error("Fireworks account discovery returned no accounts for this API key.");
+	}
+	if (accounts.length === 1) return accounts[0] as string;
+	const configured = process.env[FIREWORKS_ACCOUNT_ID_ENV];
+	if (configured === undefined || configured.trim() === "") {
+		const preview = accounts.slice(0, 8).join(", ");
+		const suffix = accounts.length > 8 ? ` …and ${accounts.length - 8} more` : "";
+		throw new Error(
+			`The Fireworks key can see ${accounts.length} accounts (${preview}${suffix}); set ${FIREWORKS_ACCOUNT_ID_ENV} to one of them.`,
+		);
+	}
+	if (!/^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u.test(configured)) {
+		throw new Error(
+			`The ${FIREWORKS_ACCOUNT_ID_ENV} environment variable was not a safe account slug.`,
+		);
+	}
+	if (!accounts.includes(configured)) {
+		throw new Error(
+			`${FIREWORKS_ACCOUNT_ID_ENV} does not match an account visible to this Fireworks key.`,
+		);
+	}
+	return configured;
+}
+
+function fireworksAccountsUrl(pageToken: string | undefined): string {
+	const url = new URL("/v1/accounts", FIREWORKS_BILLING_SUMMARY_ORIGIN);
+	url.searchParams.set("pageSize", "200");
+	if (pageToken !== undefined) url.searchParams.set("pageToken", pageToken);
+	return url.toString();
+}
+
+function fireworksNextPageToken(value: unknown): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "string" || !value || value.length > 512 || !SAFE_URL_TOKEN.test(value)) {
+		throw new Error("Fireworks accounts listing returned an unsafe page token.");
+	}
+	return value;
+}
+
+function fireworksBillingSummaryUrl(accountId: string, startedAt: number): string {
+	const dayMs = 24 * 60 * 60 * 1000;
+	const dayFloor = (time: number) => `${new Date(time).toISOString().slice(0, 10)}T00:00:00Z`;
+	const url = new URL(
+		`/v1/accounts/${accountId}/billing/summary`,
+		FIREWORKS_BILLING_SUMMARY_ORIGIN,
+	);
+	// The endpoint aggregates by UTC date; endTime is exclusive, so tomorrow's floor includes today.
+	url.searchParams.set("startTime", dayFloor(startedAt - FIREWORKS_SPEND_WINDOW_DAYS * dayMs));
+	url.searchParams.set("endTime", dayFloor(startedAt + dayMs));
+	return url.toString();
 }
 
 function zaiMonitorUrl(baseUrl: string | undefined): string {

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
 import { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
 import {
+	isFireworksAccountId,
 	normalizeFireworksAccountsPayload,
 	normalizeFireworksBillingSummaryPayload,
 } from "./providers/fireworks.js";
@@ -29,6 +30,7 @@ import type {
 	PiModel,
 	ResolvedUsageAuth,
 	UsageProviderAdapter,
+	UsageQuerySettings,
 	UsageReport,
 	XaiBillingPayload,
 	XaiUserPayload,
@@ -38,10 +40,8 @@ import type {
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance";
 const FIREWORKS_BILLING_SUMMARY_ORIGIN = "https://api.fireworks.ai";
-const FIREWORKS_ACCOUNT_ID_ENV = "FIREWORKS_ACCOUNT_ID";
 const FIREWORKS_SPEND_WINDOW_DAYS = 30;
 const FIREWORKS_MAX_ACCOUNT_PAGES = 5;
-const SAFE_URL_TOKEN = /^[A-Za-z0-9._~-]+$/u;
 const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
@@ -137,7 +137,7 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 		id: "fireworks",
 		displayName: "Fireworks",
 		semantics: { kind: "api-key", label: "Fireworks API spend" },
-		async query(auth, signal, timeoutMs, guard) {
+		async query(auth, signal, timeoutMs, guard, settings) {
 			if (!guard) throw new Error("Fireworks API spend requires request-boundary revalidation.");
 			const startedAt = Date.now();
 			await guard();
@@ -146,10 +146,12 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				signal,
 				remainingTimeout(timeoutMs, startedAt, "resolving the Fireworks account"),
 				guard,
+				settings?.fireworksAccountId,
 			);
 			await guard();
+			const billingWindowAt = Date.now();
 			const payload = (await fetchProviderJson(
-				fireworksBillingSummaryUrl(accountId, startedAt),
+				fireworksBillingSummaryUrl(accountId, billingWindowAt),
 				auth,
 				signal,
 				remainingTimeout(timeoutMs, startedAt, "fetching Fireworks rated spend"),
@@ -408,9 +410,10 @@ export async function queryProviderUsage(
 	signal: AbortSignal,
 	timeoutMs: number,
 	guard?: UsageRequestGuard,
+	settings?: Readonly<UsageQuerySettings>,
 ): Promise<UsageReport> {
 	try {
-		return await adapter.query(auth, signal, timeoutMs, guard);
+		return await adapter.query(auth, signal, timeoutMs, guard, settings);
 	} catch (error) {
 		if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
 		throw new Error(redactUsageError(errorMessage(error), auth.secrets));
@@ -827,7 +830,11 @@ async function resolveFireworksAccountId(
 	signal: AbortSignal,
 	timeoutMs: number,
 	guard: () => Promise<void>,
+	configuredAccountId: string | undefined,
 ): Promise<string> {
+	if (configuredAccountId !== undefined && !isFireworksAccountId(configuredAccountId)) {
+		throw new Error("The Fireworks account setting was not a safe account slug.");
+	}
 	const startedAt = Date.now();
 	const accounts: string[] = [];
 	let pageToken: string | undefined;
@@ -848,38 +855,32 @@ async function resolveFireworksAccountId(
 				throw new Error(`Fireworks accounts listing repeated ${accountId}.`);
 			}
 			accounts.push(accountId);
+			if (configuredAccountId === accountId) return accountId;
 		}
 		pageToken = fireworksNextPageToken(payload.nextPageToken);
 		if (!pageToken) break;
 	}
 	if (pageToken) {
 		throw new Error(
-			`Fireworks account listing exceeded ${FIREWORKS_MAX_ACCOUNT_PAGES} pages; set ${FIREWORKS_ACCOUNT_ID_ENV} to the desired account slug.`,
+			configuredAccountId
+				? `The configured Fireworks account was not found within the first ${FIREWORKS_MAX_ACCOUNT_PAGES} listing pages.`
+				: `Fireworks account listing exceeded ${FIREWORKS_MAX_ACCOUNT_PAGES} pages; set fireworksAccountId in pi-usage.json to an account returned in those pages.`,
 		);
 	}
 	if (accounts.length === 0) {
 		throw new Error("Fireworks account discovery returned no accounts for this API key.");
 	}
+	if (configuredAccountId) {
+		throw new Error(
+			"The configured Fireworks account does not match an account visible to this API key.",
+		);
+	}
 	if (accounts.length === 1) return accounts[0] as string;
-	const configured = process.env[FIREWORKS_ACCOUNT_ID_ENV];
-	if (configured === undefined || configured.trim() === "") {
-		const preview = accounts.slice(0, 8).join(", ");
-		const suffix = accounts.length > 8 ? ` …and ${accounts.length - 8} more` : "";
-		throw new Error(
-			`The Fireworks key can see ${accounts.length} accounts (${preview}${suffix}); set ${FIREWORKS_ACCOUNT_ID_ENV} to one of them.`,
-		);
-	}
-	if (!/^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u.test(configured)) {
-		throw new Error(
-			`The ${FIREWORKS_ACCOUNT_ID_ENV} environment variable was not a safe account slug.`,
-		);
-	}
-	if (!accounts.includes(configured)) {
-		throw new Error(
-			`${FIREWORKS_ACCOUNT_ID_ENV} does not match an account visible to this Fireworks key.`,
-		);
-	}
-	return configured;
+	const preview = accounts.slice(0, 8).join(", ");
+	const suffix = accounts.length > 8 ? ` …and ${accounts.length - 8} more` : "";
+	throw new Error(
+		`The Fireworks key can see ${accounts.length} accounts (${preview}${suffix}); set fireworksAccountId in pi-usage.json to one of them.`,
+	);
 }
 
 function fireworksAccountsUrl(pageToken: string | undefined): string {
@@ -891,8 +892,8 @@ function fireworksAccountsUrl(pageToken: string | undefined): string {
 
 function fireworksNextPageToken(value: unknown): string | undefined {
 	if (value === undefined || value === null) return undefined;
-	if (typeof value !== "string" || !value || value.length > 512 || !SAFE_URL_TOKEN.test(value)) {
-		throw new Error("Fireworks accounts listing returned an unsafe page token.");
+	if (typeof value !== "string" || !value || value.length > 512) {
+		throw new Error("Fireworks accounts listing returned an invalid page token.");
 	}
 	return value;
 }

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -183,7 +183,11 @@ async function saveUsageSettingsPatch(
 	if (latest.kind === "invalid") {
 		throw new Error("Cannot overwrite an invalid pi-usage.json; repair it and reload first");
 	}
-	const document = { ...latest.document, ...patch };
+	const document = { ...latest.document };
+	for (const [key, value] of Object.entries(patch)) {
+		if (value === undefined) delete document[key];
+		else document[key] = value;
+	}
 	const settings = normalizeUsageSettings(document);
 	if (!settings) throw new Error("Refusing to save invalid pi-usage settings");
 	const directory = dirname(path);

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -3,6 +3,7 @@ import { constants } from "node:fs";
 import { chmod, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { isFireworksAccountId } from "./providers/fireworks.js";
 
 export const USAGE_SETTINGS_FILE = "pi-usage.json";
 export const MAX_USAGE_SETTINGS_BYTES = 64 * 1024;
@@ -10,6 +11,7 @@ export const MAX_USAGE_SETTINGS_BYTES = 64 * 1024;
 export interface UsageSettings {
 	codexFastMode: boolean;
 	codexStatusResetCountdown: boolean;
+	fireworksAccountId?: string;
 }
 
 export const DEFAULT_USAGE_SETTINGS: Readonly<UsageSettings> = Object.freeze({
@@ -60,6 +62,12 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 	) {
 		return undefined;
 	}
+	if (
+		Object.hasOwn(value, "fireworksAccountId") &&
+		!isFireworksAccountId(value.fireworksAccountId)
+	) {
+		return undefined;
+	}
 	return {
 		codexFastMode:
 			typeof value.codexFastMode === "boolean"
@@ -69,6 +77,9 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 			typeof value.codexStatusResetCountdown === "boolean"
 				? value.codexStatusResetCountdown
 				: DEFAULT_USAGE_SETTINGS.codexStatusResetCountdown,
+		...(isFireworksAccountId(value.fireworksAccountId)
+			? { fireworksAccountId: value.fireworksAccountId }
+			: {}),
 	};
 }
 

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -55,6 +55,10 @@ export interface ResolvedUsageAuth {
 	model: PiModel;
 }
 
+export interface UsageQuerySettings {
+	fireworksAccountId?: string;
+}
+
 export interface UsageProviderAdapter {
 	id: string;
 	displayName: string;
@@ -65,6 +69,7 @@ export interface UsageProviderAdapter {
 		signal: AbortSignal,
 		timeoutMs: number,
 		guard?: () => Promise<void>,
+		settings?: Readonly<UsageQuerySettings>,
 	): Promise<UsageReport>;
 }
 

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -89,6 +89,15 @@ export type DeepSeekBalancePayload = {
 	balance_infos?: unknown;
 };
 
+export type FireworksAccountsPayload = {
+	accounts?: unknown;
+	nextPageToken?: unknown;
+};
+
+export type FireworksBillingSummaryPayload = {
+	lineItems?: unknown;
+};
+
 export type GitHubCopilotUsagePayload = {
 	login?: unknown;
 	copilot_plan?: unknown;

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -11,19 +11,19 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import { errorMessage } from "./core.js";
-import type { UsageSettings, UsageSettingsRuntime } from "./settings.js";
+import type { UsageSettingsRuntime } from "./settings.js";
 
 const OFF = "Off";
 const ON = "On";
 
-type UsageSettingId = keyof UsageSettings;
+type UsageToggleSettingId = "codexFastMode" | "codexStatusResetCountdown";
 
 export async function showUsageSettings(
 	ctx: ExtensionCommandContext,
 	settingsRuntime: UsageSettingsRuntime,
 	parentSignal: AbortSignal,
 	isCurrent: () => boolean,
-	onApplied: (id: UsageSettingId) => void,
+	onApplied: (id: UsageToggleSettingId) => void,
 ): Promise<boolean> {
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${settingsRuntime.get().path}`, "info");
@@ -70,7 +70,7 @@ export async function showUsageSettings(
 			getSettingsListTheme(),
 			(id, value) => {
 				if (closing || signal.aborted || !isCurrent()) return;
-				const settingId = id as UsageSettingId;
+				const settingId = id as UsageToggleSettingId;
 				const requested = value !== OFF;
 				saveQueue = saveQueue.then(async () => {
 					const previous = settingsRuntime.get().settings[settingId];

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -11,33 +11,60 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import { errorMessage } from "./core.js";
-import type { UsageSettingsRuntime } from "./settings.js";
+import { isFireworksAccountId } from "./providers/fireworks.js";
+import type { UsageSettings, UsageSettingsRuntime } from "./settings.js";
 
+const AUTO = "Auto";
+const EDIT = "Edit…";
 const OFF = "Off";
 const ON = "On";
 
-type UsageToggleSettingId = "codexFastMode" | "codexStatusResetCountdown";
+type UsageSettingId = keyof UsageSettings;
+type SettingsScreenResult = { changed: boolean; editFireworksAccount: boolean };
 
 export async function showUsageSettings(
 	ctx: ExtensionCommandContext,
 	settingsRuntime: UsageSettingsRuntime,
 	parentSignal: AbortSignal,
 	isCurrent: () => boolean,
-	onApplied: (id: UsageToggleSettingId) => void,
+	onApplied: (id: UsageSettingId) => void,
 ): Promise<boolean> {
 	if (ctx.mode !== "tui") {
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${settingsRuntime.get().path}`, "info");
 		return false;
 	}
-	if (parentSignal.aborted || !isCurrent()) return false;
+	let changed = false;
+	while (!parentSignal.aborted && isCurrent()) {
+		const result = await showSettingsList(ctx, settingsRuntime, parentSignal, isCurrent, onApplied);
+		if (!result) return changed;
+		changed ||= result.changed;
+		if (!result.editFireworksAccount) return changed;
+		changed ||= await editFireworksAccount(
+			ctx,
+			settingsRuntime,
+			parentSignal,
+			isCurrent,
+			onApplied,
+		);
+	}
+	return changed;
+}
 
-	return ctx.ui.custom<boolean>((tui, theme, _keybindings, done) => {
+async function showSettingsList(
+	ctx: ExtensionCommandContext,
+	settingsRuntime: UsageSettingsRuntime,
+	parentSignal: AbortSignal,
+	isCurrent: () => boolean,
+	onApplied: (id: UsageSettingId) => void,
+): Promise<SettingsScreenResult | undefined> {
+	return ctx.ui.custom<SettingsScreenResult>((tui, theme, _keybindings, done) => {
 		const localController = new AbortController();
 		const signal = AbortSignal.any([parentSignal, localController.signal]);
 		let changed = false;
 		let closing = false;
 		let saveQueue = Promise.resolve();
 		const state = settingsRuntime.get();
+		const fireworksValue = state.settings.fireworksAccountId ?? AUTO;
 		const items: SettingItem[] = [
 			{
 				id: "codexFastMode",
@@ -53,6 +80,15 @@ export async function showUsageSettings(
 				currentValue: state.settings.codexStatusResetCountdown ? ON : OFF,
 				values: [OFF, ON],
 			},
+			{
+				id: "fireworksAccountId",
+				label: "Fireworks account",
+				description: "Select Edit to enter a visible account slug, or submit blank to clear it.",
+				currentValue: fireworksValue,
+				values: state.settings.fireworksAccountId
+					? [state.settings.fireworksAccountId, EDIT]
+					: [AUTO, EDIT],
+			},
 		];
 		const container = new Container();
 		container.addChild(new Text(theme.fg("accent", theme.bold("pi-usage Settings")), 1, 1));
@@ -62,7 +98,40 @@ export async function showUsageSettings(
 			if (closing) return;
 			closing = true;
 			localController.abort();
-			done(changed);
+			done({ changed, editFireworksAccount: false });
+		};
+		const queueUpdate = (
+			id: UsageSettingId,
+			requested: UsageSettings[UsageSettingId],
+			display: string,
+		) => {
+			saveQueue = saveQueue.then(async () => {
+				const previous = settingsRuntime.get().settings[id];
+				if (settingsRuntime.get().kind === "invalid") {
+					settingsList.updateValue(id, displaySetting(id, previous));
+					if (!signal.aborted && isCurrent()) {
+						ctx.ui.notify("Repair pi-usage.json and reload before changing settings.", "error");
+						tui.requestRender();
+					}
+					return;
+				}
+				try {
+					await settingsRuntime.update({ [id]: requested }, signal);
+				} catch (error) {
+					if (signal.aborted || !isCurrent()) return;
+					settingsList.updateValue(id, displaySetting(id, previous));
+					ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
+					tui.requestRender();
+					return;
+				}
+				if (previous !== requested) {
+					changed = true;
+					onApplied(id);
+				}
+				if (signal.aborted || !isCurrent()) return;
+				settingsList.updateValue(id, display);
+				tui.requestRender();
+			});
 		};
 		settingsList = new SettingsList(
 			items,
@@ -70,35 +139,18 @@ export async function showUsageSettings(
 			getSettingsListTheme(),
 			(id, value) => {
 				if (closing || signal.aborted || !isCurrent()) return;
-				const settingId = id as UsageToggleSettingId;
-				const requested = value !== OFF;
-				saveQueue = saveQueue.then(async () => {
-					const previous = settingsRuntime.get().settings[settingId];
-					if (settingsRuntime.get().kind === "invalid") {
-						settingsList.updateValue(id, displayValue(previous));
-						if (!signal.aborted && isCurrent()) {
-							ctx.ui.notify("Repair pi-usage.json and reload before changing settings.", "error");
-							tui.requestRender();
-						}
-						return;
+				if (id === "fireworksAccountId") {
+					if (value === EDIT) {
+						saveQueue = saveQueue.then(() => {
+							if (closing || signal.aborted || !isCurrent()) return;
+							closing = true;
+							done({ changed, editFireworksAccount: true });
+						});
 					}
-					try {
-						await settingsRuntime.update({ [settingId]: requested }, signal);
-					} catch (error) {
-						if (signal.aborted || !isCurrent()) return;
-						settingsList.updateValue(id, displayValue(previous));
-						ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
-						tui.requestRender();
-						return;
-					}
-					if (previous !== requested) {
-						changed = true;
-						onApplied(settingId);
-					}
-					if (signal.aborted || !isCurrent()) return;
-					settingsList.updateValue(id, displayValue(requested));
-					tui.requestRender();
-				});
+					return;
+				}
+				const settingId = id as "codexFastMode" | "codexStatusResetCountdown";
+				queueUpdate(settingId, value !== OFF, value);
 			},
 			cancel,
 		);
@@ -122,6 +174,46 @@ export async function showUsageSettings(
 	});
 }
 
-function displayValue(enabled: boolean): string {
-	return enabled ? ON : OFF;
+async function editFireworksAccount(
+	ctx: ExtensionCommandContext,
+	settingsRuntime: UsageSettingsRuntime,
+	signal: AbortSignal,
+	isCurrent: () => boolean,
+	onApplied: (id: UsageSettingId) => void,
+): Promise<boolean> {
+	while (!signal.aborted && isCurrent()) {
+		const state = settingsRuntime.get();
+		if (state.kind === "invalid") {
+			ctx.ui.notify("Repair pi-usage.json and reload before changing settings.", "error");
+			return false;
+		}
+		const entered = await ctx.ui.input(
+			"Fireworks account slug · submit blank for Auto",
+			state.settings.fireworksAccountId ?? "Example: acme",
+			{ signal },
+		);
+		if (signal.aborted || !isCurrent() || entered === undefined) return false;
+		const normalized = entered.trim();
+		const requested = normalized || undefined;
+		if (requested !== undefined && !isFireworksAccountId(requested)) {
+			ctx.ui.notify("Enter a URL-safe Fireworks account slug.", "warning");
+			continue;
+		}
+		if (requested === state.settings.fireworksAccountId) return false;
+		try {
+			await settingsRuntime.update({ fireworksAccountId: requested }, signal);
+		} catch (error) {
+			if (signal.aborted || !isCurrent()) return false;
+			ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
+			return false;
+		}
+		onApplied("fireworksAccountId");
+		return true;
+	}
+	return false;
+}
+
+function displaySetting(id: UsageSettingId, value: UsageSettings[UsageSettingId]): string {
+	if (id === "fireworksAccountId") return typeof value === "string" ? value : AUTO;
+	return value ? ON : OFF;
 }

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -254,6 +254,10 @@ export default function usageExtension(
 		const expectedSessionGeneration = sessionGeneration;
 		const expectedSessionId = ctx.sessionManager.getSessionId();
 		const expectedModelIdentity = modelIdentity(ctx.model);
+		const expectedFireworksAccountId =
+			adapter.id === "fireworks" ? settingsRuntime.get().settings.fireworksAccountId : undefined;
+		const querySettings =
+			adapter.id === "fireworks" ? { fireworksAccountId: expectedFireworksAccountId } : undefined;
 		let auth: ResolvedUsageAuth | undefined;
 		try {
 			auth = await awaitWithDeadline(
@@ -277,11 +281,13 @@ export default function usageExtension(
 				},
 			};
 		}
-		const requiresRequestBoundaryGuard = adapter.id === "deepseek" || adapter.id === "xai";
+		const requiresRequestBoundaryGuard = ["deepseek", "fireworks", "xai"].includes(adapter.id);
 		const requestContextChanged = () =>
 			expectedSessionGeneration !== sessionGeneration ||
 			ctx.sessionManager.getSessionId() !== expectedSessionId ||
-			modelIdentity(ctx.model) !== expectedModelIdentity;
+			modelIdentity(ctx.model) !== expectedModelIdentity ||
+			(adapter.id === "fireworks" &&
+				settingsRuntime.get().settings.fireworksAccountId !== expectedFireworksAccountId);
 		if (requiresRequestBoundaryGuard && requestContextChanged()) throw abortError();
 		if (!auth) {
 			if (displayState === "current") {
@@ -298,11 +304,15 @@ export default function usageExtension(
 				authState: "unavailable",
 			};
 		}
+		const queryFingerprint =
+			adapter.id === "fireworks"
+				? `${auth.fingerprint}:account:${expectedFireworksAccountId ?? "auto"}`
+				: auth.fingerprint;
 		if (displayState === "current") {
-			transitionCurrentIdentity(`${adapter.id}:${auth.fingerprint}`, adapter.id);
+			transitionCurrentIdentity(`${adapter.id}:${queryFingerprint}`, adapter.id);
 		}
 
-		const cached = !force ? cache.get(adapter.id, auth.fingerprint) : undefined;
+		const cached = !force ? cache.get(adapter.id, queryFingerprint) : undefined;
 		if (cached) {
 			return {
 				state: {
@@ -316,7 +326,7 @@ export default function usageExtension(
 			};
 		}
 
-		const failureKey = `${adapter.id}:${auth.fingerprint}`;
+		const failureKey = `${adapter.id}:${queryFingerprint}`;
 		const previousFailure = failureBackoff.get(failureKey);
 		if (!force && previousFailure && previousFailure.until > Date.now()) {
 			return {
@@ -357,10 +367,17 @@ export default function usageExtension(
 						}
 					}
 				: undefined;
-			const report = await queryProviderUsage(adapter, auth, signal, remainingMs, guard);
+			const report = await queryProviderUsage(
+				adapter,
+				auth,
+				signal,
+				remainingMs,
+				guard,
+				querySettings,
+			);
 			if (guard) await guard();
 			if (latestQueries.get(failureKey) === queryId) {
-				cache.set(adapter.id, auth.fingerprint, report);
+				cache.set(adapter.id, queryFingerprint, report);
 				failureBackoff.delete(failureKey);
 			}
 			return {

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -1120,7 +1120,7 @@ export default function usageExtension(
 			}
 		},
 	});
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (_event, ctx) => {
 		sessionGeneration += 1;
 		statusGeneration += 1;
 		clearStatusTimers();
@@ -1128,7 +1128,13 @@ export default function usageExtension(
 		activeControllers.clear();
 		statusController = undefined;
 		sessionActive = true;
-		startStatusRefresh(ctx, ctx.model, false);
+		const ownerGeneration = sessionGeneration;
+		try {
+			await fastRuntime.prepareSession(ctx);
+		} catch (error) {
+			if (isStaleExtensionContextError(error) || ownerGeneration !== sessionGeneration) return;
+			throw error;
+		}
 	});
 	pi.on("session_tree", (_event, ctx) => {
 		startStatusRefresh(ctx, ctx.model, false);
@@ -1154,7 +1160,10 @@ export default function usageExtension(
 		safeSetStatus(ctx, undefined);
 	});
 
-	fastRuntime = registerCodexFastMode(pi, settingsRuntime, (ctx) =>
-		startStatusRefresh(ctx, ctx.model, false),
+	fastRuntime = registerCodexFastMode(
+		pi,
+		settingsRuntime,
+		(ctx) => startStatusRefresh(ctx, ctx.model, false),
+		{ registerSessionStart: false },
 	);
 }

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -54,8 +54,14 @@ function fireworksAuth(secret = "fw-test-secret"): ResolvedUsageAuth {
 	};
 }
 
-function queryFireworks(signal = new AbortController().signal, timeoutMs = 1_000) {
-	return queryProviderUsage(adapter, fireworksAuth(), signal, timeoutMs, async () => undefined);
+function queryFireworks(
+	signal = new AbortController().signal,
+	timeoutMs = 1_000,
+	fireworksAccountId?: string,
+) {
+	return queryProviderUsage(adapter, fireworksAuth(), signal, timeoutMs, async () => undefined, {
+		fireworksAccountId,
+	});
 }
 
 test("Fireworks billing summary sums rated line items exactly per currency and series", () => {
@@ -339,6 +345,31 @@ test("Fireworks transport auto-selects a single account and queries only the fix
 	}
 });
 
+test("Fireworks billing window uses the current UTC date after account discovery", async () => {
+	let now = Date.parse("2026-08-30T23:59:59.900Z");
+	const nowMock = vi.spyOn(Date, "now").mockImplementation(() => now);
+	const requests: string[] = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request) => {
+		requests.push(String(input));
+		if (requests.length === 1) {
+			now = Date.parse("2026-08-31T00:00:00.100Z");
+			return new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 });
+		}
+		return summaryResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await queryFireworks();
+		assert.equal(
+			requests[1],
+			"https://api.fireworks.ai/v1/accounts/acme/billing/summary?startTime=2026-08-02T00%3A00%3A00Z&endTime=2026-09-01T00%3A00%3A00Z",
+		);
+	} finally {
+		nowMock.mockRestore();
+		vi.unstubAllGlobals();
+	}
+});
+
 test("Fireworks transport shares one deadline across account pages", async () => {
 	vi.useFakeTimers();
 	vi.setSystemTime(0);
@@ -370,13 +401,36 @@ test("Fireworks transport shares one deadline across account pages", async () =>
 	}
 });
 
-test("Fireworks transport follows documented pagination across account pages", async () => {
+test("Fireworks transport stops long account listings after finding the configured account", async () => {
 	const requests: string[] = [];
 	const fetchMock = vi.fn(async (input: string | URL | Request) => {
 		requests.push(String(input));
 		if (requests.length === 1) {
 			return new Response(
-				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "token-1" }),
+				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "still-more" }),
+				{ status: 200 },
+			);
+		}
+		return summaryResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const report = await queryFireworks(new AbortController().signal, 1_000, "acme");
+		assert.equal(report.accountLabel, "acme");
+		assert.equal(requests.length, 2);
+		assert.match(requests[1] ?? "", /\/v1\/accounts\/acme\/billing\/summary\?/u);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport follows opaque pagination tokens across account pages", async () => {
+	const requests: string[] = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request) => {
+		requests.push(String(input));
+		if (requests.length === 1) {
+			return new Response(
+				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "token+/=" }),
 				{ status: 200 },
 			);
 		}
@@ -386,19 +440,17 @@ test("Fireworks transport follows documented pagination across account pages", a
 		return summaryResponse();
 	});
 	vi.stubGlobal("fetch", fetchMock);
-	vi.stubEnv("FIREWORKS_ACCOUNT_ID", "acme");
 	try {
-		const report = await queryFireworks();
-		assert.equal(report.accountLabel, "acme");
+		const report = await queryFireworks(new AbortController().signal, 1_000, "bold");
+		assert.equal(report.accountLabel, "bold");
 		assert.equal(requests.length, 3);
 		assert.equal(requests[0], "https://api.fireworks.ai/v1/accounts?pageSize=200");
 		assert.equal(
 			requests[1],
-			"https://api.fireworks.ai/v1/accounts?pageSize=200&pageToken=token-1",
+			"https://api.fireworks.ai/v1/accounts?pageSize=200&pageToken=token%2B%2F%3D",
 		);
-		assert.match(requests[2] ?? "", /\/v1\/accounts\/acme\/billing\/summary\?/u);
+		assert.match(requests[2] ?? "", /\/v1\/accounts\/bold\/billing\/summary\?/u);
 	} finally {
-		vi.unstubAllEnvs();
 		vi.unstubAllGlobals();
 	}
 });
@@ -413,30 +465,26 @@ test("Fireworks transport fails closed for ambiguous, hostile, or unresolvable a
 	try {
 		await assert.rejects(
 			() => queryFireworks(),
-			/see 2 accounts \(acme, beta\); set FIREWORKS_ACCOUNT_ID to one of them\./iu,
+			/see 2 accounts \(acme, beta\); set fireworksAccountId in pi-usage\.json/iu,
 		);
-
-		vi.stubEnv("FIREWORKS_ACCOUNT_ID", "../other");
 		await assert.rejects(
-			() => queryFireworks(),
-			/environment variable was not a safe account slug/iu,
+			() => queryFireworks(new AbortController().signal, 1_000, "../other"),
+			/account setting was not a safe account slug/iu,
 		);
-		vi.stubEnv("FIREWORKS_ACCOUNT_ID", "hidden-account");
 		await assert.rejects(
-			() => queryFireworks(),
-			/does not match an account visible to this Fireworks key/iu,
+			() => queryFireworks(new AbortController().signal, 1_000, "hidden-account"),
+			/configured Fireworks account does not match an account visible/iu,
 		);
 	} finally {
-		vi.unstubAllEnvs();
 		vi.unstubAllGlobals();
 	}
 });
 
-test("Fireworks transport rejects unsafe page tokens and bounds bodies, JSON, and errors", async () => {
+test("Fireworks transport rejects invalid page tokens and bounds bodies, JSON, and errors", async () => {
 	const fetchMock = vi.fn(
 		async () =>
 			new Response(
-				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "bad token!" }),
+				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "x".repeat(513) }),
 				{
 					status: 200,
 				},
@@ -444,7 +492,7 @@ test("Fireworks transport rejects unsafe page tokens and bounds bodies, JSON, an
 	);
 	vi.stubGlobal("fetch", fetchMock);
 	try {
-		await assert.rejects(() => queryFireworks(), /unsafe page token/iu);
+		await assert.rejects(() => queryFireworks(), /invalid page token/iu);
 
 		fetchMock.mockResolvedValueOnce(
 			new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 }),

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -310,6 +310,7 @@ test("Fireworks transport auto-selects a single account and queries only the fix
 		}
 		return summaryResponse();
 	});
+	const nowMock = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-30T12:34:56Z"));
 	vi.stubGlobal("fetch", fetchMock);
 	try {
 		const report = await queryFireworks();
@@ -317,9 +318,9 @@ test("Fireworks transport auto-selects a single account and queries only the fix
 		assert.equal(report.accountLabel, "acme");
 		assert.equal(requests.length, 2);
 		assert.equal(requests[0]?.url, "https://api.fireworks.ai/v1/accounts?pageSize=200");
-		assert.match(
-			requests[1]?.url ?? "",
-			/^https:\/\/api\.fireworks\.ai\/v1\/accounts\/acme\/billing\/summary\?startTime=\d{4}-\d{2}-\d{2}T00%3A00%3A00Z&endTime=\d{4}-\d{2}-\d{2}T00%3A00%3A00Z$/u,
+		assert.equal(
+			requests[1]?.url,
+			"https://api.fireworks.ai/v1/accounts/acme/billing/summary?startTime=2026-08-01T00%3A00%3A00Z&endTime=2026-08-31T00%3A00%3A00Z",
 		);
 		assert.equal(requests[1]?.init?.method, "GET");
 		assert.equal(requests[1]?.init?.redirect, "error");
@@ -333,7 +334,39 @@ test("Fireworks transport auto-selects a single account and queries only the fix
 		fetchMock.mockResolvedValueOnce(redirected);
 		await assert.rejects(() => queryFireworks(), /refused a redirected response/iu);
 	} finally {
+		nowMock.mockRestore();
 		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport shares one deadline across account pages", async () => {
+	vi.useFakeTimers();
+	vi.setSystemTime(0);
+	let page = 0;
+	const fetchMock = vi.fn(async () => {
+		await new Promise<void>((resolve) => setTimeout(resolve, 8));
+		page += 1;
+		return new Response(
+			JSON.stringify(
+				page === 1
+					? { accounts: [accountRow("acme")], nextPageToken: "token-1" }
+					: { accounts: [accountRow("beta")] },
+			),
+			{ status: 200 },
+		);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const rejection = assert.rejects(
+			queryFireworks(new AbortController().signal, 10),
+			/timed out after .* while fetching usage/iu,
+		);
+		await vi.advanceTimersByTimeAsync(16);
+		await rejection;
+		assert.equal(fetchMock.mock.calls.length, 2);
+	} finally {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
 	}
 });
 

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -176,8 +176,46 @@ test("Fireworks billing summary rejects malformed, ambiguous, or hostile payload
 			/whole units was not a bounded integer/iu,
 		],
 		[
+			{
+				lineItems: [
+					{
+						series: "SERVERLESS",
+						totalCost: { ...money("0", 0), units: "9223372036854775808" },
+					},
+				],
+			},
+			/whole units exceeded the int64 range/iu,
+		],
+		[
+			{
+				lineItems: [
+					{
+						series: "SERVERLESS",
+						totalCost: { ...money("0", 0), units: "-9223372036854775809" },
+					},
+				],
+			},
+			/whole units exceeded the int64 range/iu,
+		],
+		[
 			{ lineItems: [{ series: "SERVERLESS", totalCost: { ...money("1", 0), nanos: 1.5 } }] },
 			/nano units was not a bounded integer/iu,
+		],
+		[
+			{
+				lineItems: [
+					{ series: "SERVERLESS", totalCost: { ...money("0", 0), nanos: 1_000_000_000 } },
+				],
+			},
+			/nano units exceeded the Money range/iu,
+		],
+		[
+			{
+				lineItems: [
+					{ series: "SERVERLESS", totalCost: { ...money("0", 0), nanos: -1_000_000_000 } },
+				],
+			},
+			/nano units exceeded the Money range/iu,
 		],
 		[
 			{

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -1,0 +1,442 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeFireworksAccountsPayload,
+	normalizeFireworksBillingSummaryPayload,
+	queryProviderUsage,
+	type ResolvedUsageAuth,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+	type UsageProviderAdapter,
+} from "../src/index.js";
+
+const FIREWORKS_MODEL = {
+	id: "accounts/fireworks/models/kimi-k2p6",
+	name: "Kimi K2.6",
+	provider: "fireworks",
+	baseUrl: "https://api.fireworks.ai/inference",
+};
+
+function fireworksAdapter(): UsageProviderAdapter {
+	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === "fireworks");
+	assert.ok(candidate);
+	return candidate;
+}
+
+const adapter = fireworksAdapter();
+
+function money(units: string, nanos: number): Record<string, unknown> {
+	return { currencyCode: "USD", units, nanos };
+}
+
+function lineItem(
+	series: string,
+	totalCost: unknown,
+	currencyCode = "USD",
+): Record<string, unknown> {
+	return { category: "Text Completion", series, totalCost, currencyCode };
+}
+
+function accountRow(slug: string): Record<string, unknown> {
+	return { name: `accounts/${slug}` };
+}
+
+function fireworksAuth(secret = "fw-test-secret"): ResolvedUsageAuth {
+	return {
+		apiKey: secret,
+		headers: { Authorization: `Bearer ${secret}` },
+		fingerprint: "fingerprint",
+		secrets: [secret, `Bearer ${secret}`],
+		model: FIREWORKS_MODEL as never,
+	};
+}
+
+function queryFireworks(signal = new AbortController().signal, timeoutMs = 1_000) {
+	return queryProviderUsage(adapter, fireworksAuth(), signal, timeoutMs, async () => undefined);
+}
+
+test("Fireworks billing summary sums rated line items exactly per currency and series", () => {
+	const report = normalizeFireworksBillingSummaryPayload(
+		{
+			lineItems: [
+				{ category: "Serverless", series: "SERVERLESS", totalCost: money("12", 345_678_901) },
+				{
+					category: "Dedicated",
+					series: "DEDICATED_DEPLOYMENT",
+					totalCost: money("0", 750_000_000),
+				},
+				{
+					category: "Training",
+					series: "TRAINING",
+					totalCost: { ...money("-1", -250_000_000), currencyCode: "USD" },
+				},
+				{
+					category: "Audio",
+					series: "SERVERLESS",
+					totalCost: { currencyCode: "EUR", units: "0", nanos: 5 },
+				},
+			],
+		},
+		"acme",
+		1_000,
+	);
+
+	assert.equal(report.providerId, "fireworks");
+	assert.equal(report.providerName, "Fireworks");
+	assert.equal(report.accountLabel, "acme");
+	assert.equal(report.source, "fireworks-billing-summary");
+	assert.deepEqual(report.semantics, { kind: "api-key", label: "Fireworks API spend" });
+	assert.deepEqual(report.buckets, []);
+	assert.deepEqual(
+		report.metrics.map((metric) => [metric.id, metric.value, metric.currency]),
+		[
+			["usd-total", "11.845678901", "USD"],
+			["usd-serverless", "12.345678901", "USD"],
+			["usd-dedicated", "0.75", "USD"],
+			["usd-training", "-1.25", "USD"],
+			["eur-total", "0.000000005", "EUR"],
+			["eur-serverless", "0.000000005", "EUR"],
+		],
+	);
+	const formatted = formatUsageReport(report, "current");
+	assert.match(formatted, /^Fireworks API Spend · Current/mu);
+	assert.match(formatted, /Account: acme/u);
+	assert.match(formatted, /Semantics: Fireworks API spend/u);
+	assert.match(formatted, /Spend window:\s+Last 30 days \(rated\)/u);
+	assert.match(formatted, /Total spend:\s+USD 11\.845678901/u);
+	assert.match(formatted, /Serverless:\s+USD 12\.345678901/u);
+	assert.match(formatted, /Dedicated deployments:\s+USD 0\.75/u);
+	assert.match(formatted, /Training:\s+USD -1\.25/u);
+	assert.ok(formatted.indexOf("USD rated spend:") < formatted.indexOf("EUR rated spend:"));
+	assert.equal(formatUsageStatusline(report), "fireworks USD 11.845678901 · EUR 0.000000005");
+});
+
+test("Fireworks billing summary accepts empty rated line items without inventing quota semantics", () => {
+	const report = normalizeFireworksBillingSummaryPayload({ lineItems: [] }, "acme", 2_000);
+
+	assert.equal(report.providerId, "fireworks");
+	assert.deepEqual(report.metrics, []);
+	assert.deepEqual(report.notes, [
+		"Rated line items may differ from the final invoice once credits or adjustments are applied.",
+		"Fireworks returned no rated line items for the last 30 days.",
+	]);
+	assert.equal(formatUsageStatusline(report), "fireworks no rated usage");
+	assert.doesNotMatch(formatUsageReport(report, "configured"), /quota|reset|remaining/iu);
+});
+
+test("Fireworks billing summary rejects malformed, ambiguous, or hostile payloads", () => {
+	const invalid: Array<[Record<string, unknown>, RegExp]> = [
+		[{ lineItems: "nope" }, /lineItems was not an array/iu],
+		[{ lineItems: [null] }, /line item was not an object/iu],
+		[{ lineItems: [{ category: "x" }] }, /total cost.*money object/iu],
+		[
+			{
+				lineItems: [
+					{ category: "Serverless", totalCost: { currencyCode: "usd", units: "1", nanos: 0 } },
+				],
+			},
+			/currency was not an ISO 4217/iu,
+		],
+		[
+			{
+				lineItems: [{ category: "Serverless", series: 5, totalCost: money("1", 0) }],
+			},
+			/series was invalid/iu,
+		],
+		[
+			{
+				lineItems: [
+					{
+						category: "Serverless",
+						series: "SERVERLESS",
+						totalCost: { ...money("1", 0), currencyCode: "EU" },
+					},
+				],
+			},
+			/ISO 4217/iu,
+		],
+		[
+			{
+				lineItems: [
+					{
+						...lineItem("SERVERLESS", money("1", 0)),
+						totalCost: { ...money("1", 0), units: "1e3" },
+					},
+				],
+			},
+			/whole units was not a bounded integer/iu,
+		],
+		[
+			{ lineItems: [{ series: "SERVERLESS", totalCost: { ...money("1", 0), nanos: 1.5 } }] },
+			/nano units was not a bounded integer/iu,
+		],
+		[
+			{
+				lineItems: [
+					{
+						series: "SERVERLESS",
+						totalCost: { currencyCode: "USD", units: "-1", nanos: 750_000_000 },
+					},
+				],
+			},
+			/mixed unit and nano signs/iu,
+		],
+		[
+			{
+				lineItems: [
+					{ series: "SERVERLESS", totalCost: { ...money("1", 0), currencyCode: "EURO" } },
+				],
+			},
+			/currency was not an ISO 4217/iu,
+		],
+	];
+	for (const [payload, pattern] of invalid) {
+		assert.throws(() => normalizeFireworksBillingSummaryPayload(payload, "acme", 0), pattern);
+	}
+});
+
+test("Fireworks account discovery normalizes and validates the documented listing", () => {
+	assert.deepEqual(
+		normalizeFireworksAccountsPayload({
+			accounts: [{ name: "accounts/acme" }, { name: "accounts/b.io" }],
+		}),
+		["acme", "b.io"],
+	);
+	const invalid: Array<[Record<string, unknown>, RegExp]> = [
+		[{}, /did not contain an accounts array/iu],
+		[{ accounts: "acme" }, /did not contain an accounts array/iu],
+		[{ accounts: [null] }, /row was not an object/iu],
+		[{ accounts: [{ displayName: "Acme" }] }, /omitted the account resource name/iu],
+		[{ accounts: [{ name: "accounts/../secrets" }] }, /unsafe account resource name/iu],
+		[{ accounts: [{ name: "accounts/acme/deployments/x" }] }, /unsafe account resource name/iu],
+		[{ accounts: [{ name: "accounts/acme" }, { name: "accounts/acme" }] }, /repeated acme/iu],
+	];
+	for (const [payload, pattern] of invalid) {
+		assert.throws(() => normalizeFireworksAccountsPayload(payload), pattern);
+	}
+});
+
+test("Fireworks runtime auth accepts only official model and resolved-auth origins", async () => {
+	const { ctx: officialContext } = createMockContext({
+		model: FIREWORKS_MODEL,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({
+				ok: true,
+				headers: {
+					Authorization: "Bearer fw-current-key",
+					"X-Private": "must-not-send",
+				},
+			}),
+			getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+			getAvailable: () => [FIREWORKS_MODEL],
+			getAll: () => [FIREWORKS_MODEL],
+		},
+	});
+	const auth = await resolveUsageAuth(officialContext, adapter);
+	assert.deepEqual(auth?.headers, { Authorization: "Bearer fw-current-key" });
+	assert.ok(!auth?.secrets.includes("must-not-send"));
+
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		for (const [modelBaseUrl, authBaseUrl, pattern] of [
+			["https://proxy.example.test/inference", undefined, /custom.*official/iu],
+			[FIREWORKS_MODEL.baseUrl, "https://proxy.example.test/v1", /proxy-resolved.*official/iu],
+		] as const) {
+			const model = { ...FIREWORKS_MODEL, baseUrl: modelBaseUrl };
+			const { ctx } = createMockContext({
+				model,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-send" }),
+					getProviderAuth: async () => ({
+						auth: {
+							apiKey: "must-not-send",
+							...(authBaseUrl ? { baseUrl: authBaseUrl } : {}),
+						},
+					}),
+					getAvailable: () => [model],
+					getAll: () => [model],
+				},
+			});
+			await assert.rejects(() => resolveUsageAuth(ctx, adapter), pattern);
+		}
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("Fireworks transport revalidates before network access and counts it against its deadline", async () => {
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		await assert.rejects(
+			() => queryProviderUsage(adapter, fireworksAuth(), new AbortController().signal, 1_000),
+			/request-boundary revalidation/iu,
+		);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					fireworksAuth(),
+					new AbortController().signal,
+					5,
+					() => new Promise<void>((resolve) => setTimeout(resolve, 10)),
+				),
+			/timed out.*resolving the fireworks account/iu,
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+function summaryResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			lineItems: [{ category: "Serverless", series: "SERVERLESS", totalCost: money("1", 0) }],
+		}),
+		{ status: 200 },
+	);
+}
+
+test("Fireworks transport auto-selects a single account and queries only the fixed endpoints", async () => {
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		requests.push({ url: String(input), init });
+		if (requests.length === 1) {
+			return new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 });
+		}
+		return summaryResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const report = await queryFireworks();
+		assert.equal(report.providerId, "fireworks");
+		assert.equal(report.accountLabel, "acme");
+		assert.equal(requests.length, 2);
+		assert.equal(requests[0]?.url, "https://api.fireworks.ai/v1/accounts?pageSize=200");
+		assert.match(
+			requests[1]?.url ?? "",
+			/^https:\/\/api\.fireworks\.ai\/v1\/accounts\/acme\/billing\/summary\?startTime=\d{4}-\d{2}-\d{2}T00%3A00%3A00Z&endTime=\d{4}-\d{2}-\d{2}T00%3A00%3A00Z$/u,
+		);
+		assert.equal(requests[1]?.init?.method, "GET");
+		assert.equal(requests[1]?.init?.redirect, "error");
+		assert.deepEqual(requests[1]?.init?.headers, {
+			Authorization: "Bearer fw-test-secret",
+			"User-Agent": "pi-usage",
+		});
+
+		const redirected = summaryResponse();
+		Object.defineProperty(redirected, "redirected", { value: true });
+		fetchMock.mockResolvedValueOnce(redirected);
+		await assert.rejects(() => queryFireworks(), /refused a redirected response/iu);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport follows documented pagination across account pages", async () => {
+	const requests: string[] = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request) => {
+		requests.push(String(input));
+		if (requests.length === 1) {
+			return new Response(
+				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "token-1" }),
+				{ status: 200 },
+			);
+		}
+		if (requests.length === 2) {
+			return new Response(JSON.stringify({ accounts: [accountRow("bold")] }), { status: 200 });
+		}
+		return summaryResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	vi.stubEnv("FIREWORKS_ACCOUNT_ID", "acme");
+	try {
+		const report = await queryFireworks();
+		assert.equal(report.accountLabel, "acme");
+		assert.equal(requests.length, 3);
+		assert.equal(requests[0], "https://api.fireworks.ai/v1/accounts?pageSize=200");
+		assert.equal(
+			requests[1],
+			"https://api.fireworks.ai/v1/accounts?pageSize=200&pageToken=token-1",
+		);
+		assert.match(requests[2] ?? "", /\/v1\/accounts\/acme\/billing\/summary\?/u);
+	} finally {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport fails closed for ambiguous, hostile, or unresolvable accounts", async () => {
+	const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+		return new Response(JSON.stringify({ accounts: [accountRow("acme"), accountRow("beta")] }), {
+			status: 200,
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() => queryFireworks(),
+			/see 2 accounts \(acme, beta\); set FIREWORKS_ACCOUNT_ID to one of them\./iu,
+		);
+
+		vi.stubEnv("FIREWORKS_ACCOUNT_ID", "../other");
+		await assert.rejects(
+			() => queryFireworks(),
+			/environment variable was not a safe account slug/iu,
+		);
+		vi.stubEnv("FIREWORKS_ACCOUNT_ID", "hidden-account");
+		await assert.rejects(
+			() => queryFireworks(),
+			/does not match an account visible to this Fireworks key/iu,
+		);
+	} finally {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks transport rejects unsafe page tokens and bounds bodies, JSON, and errors", async () => {
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(
+				JSON.stringify({ accounts: [accountRow("acme")], nextPageToken: "bad token!" }),
+				{
+					status: 200,
+				},
+			),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(() => queryFireworks(), /unsafe page token/iu);
+
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 }),
+		);
+		fetchMock.mockResolvedValueOnce(new Response("x".repeat(70_000), { status: 200 }));
+		await assert.rejects(() => queryFireworks(), /exceeded.*bytes/iu);
+
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 }),
+		);
+		fetchMock.mockResolvedValueOnce(new Response("{broken", { status: 200 }));
+		await assert.rejects(() => queryFireworks(), /invalid JSON/iu);
+
+		fetchMock.mockResolvedValueOnce(
+			new Response("Bearer fw-test-secret failed\u001b[31m", { status: 401, statusText: "Denied" }),
+		);
+		await assert.rejects(
+			() => queryFireworks(),
+			(error: unknown) =>
+				error instanceof Error &&
+				error.message.includes("401") &&
+				!error.message.includes("fw-test-secret") &&
+				!error.message.includes("\u001b"),
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -40,9 +40,16 @@ test("normalizes owned settings and ignores the retired xAI field", () => {
 		codexFastMode: true,
 		codexStatusResetCountdown: true,
 	});
+	assert.deepEqual(normalizeUsageSettings({ fireworksAccountId: "acme-prod" }), {
+		codexFastMode: false,
+		codexStatusResetCountdown: true,
+		fireworksAccountId: "acme-prod",
+	});
 	assert.deepEqual(normalizeUsageSettings({ xaiUsage: false }), DEFAULT_USAGE_SETTINGS);
 	assert.deepEqual(normalizeUsageSettings({ xaiUsage: "retired" }), DEFAULT_USAGE_SETTINGS);
 	assert.equal(normalizeUsageSettings({ codexFastMode: "true" }), undefined);
+	assert.equal(normalizeUsageSettings({ fireworksAccountId: "../other" }), undefined);
+	assert.equal(normalizeUsageSettings({ fireworksAccountId: "" }), undefined);
 	assert.equal(normalizeUsageSettings([]), undefined);
 });
 
@@ -52,10 +59,14 @@ test("missing loads are side-effect free and valid loads preserve unknown fields
 	assert.equal(missing.kind, "missing");
 	assert.equal((await readdir(join(path, ".."))).length, 0);
 
-	await writeFile(path, '{"codexFastMode":true,"xaiUsage":false,"future":"kept"}\n');
+	await writeFile(
+		path,
+		'{"codexFastMode":true,"fireworksAccountId":"acme","xaiUsage":false,"future":"kept"}\n',
+	);
 	const loaded = await loadUsageSettings(path);
 	assert.equal(loaded.kind, "loaded");
 	assert.equal(loaded.settings.codexFastMode, true);
+	assert.equal(loaded.settings.fireworksAccountId, "acme");
 	assert.equal(loaded.document?.xaiUsage, false);
 	assert.equal(loaded.document?.future, "kept");
 });

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -116,6 +116,16 @@ test("the first explicit save creates a private file and preserves unknown field
 	if (process.platform !== "win32") assert.equal((await stat(path)).mode & 0o777, 0o600);
 });
 
+test("clearing the Fireworks account removes only its owned field", async () => {
+	const path = await tempSettingsPath();
+	await writeFile(path, '{"fireworksAccountId":"acme","future":"kept"}\n');
+	const runtime = createUsageSettingsRuntime(path);
+	await runtime.reload();
+	await runtime.update({ fireworksAccountId: undefined });
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { future: "kept" });
+	assert.equal(runtime.get().settings.fireworksAccountId, undefined);
+});
+
 test("serialized updates reread the latest document and leave no temporary files", async () => {
 	const path = await tempSettingsPath();
 	await writeFile(path, '{"codexFastMode":false,"external":"first"}\n');

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -633,7 +633,7 @@ test("current auth appearance during a command is revalidated before display", a
 	assert.ok(authCalls >= 3);
 });
 
-test("automatic lifecycle refresh starts asynchronously", () => {
+test("session start awaits settings before launching the automatic refresh", async () => {
 	const mock = createMockPi();
 	usageExtension(mock.pi);
 	const never = new Promise<never>(() => undefined);
@@ -647,7 +647,8 @@ test("automatic lifecycle refresh starts asynchronously", () => {
 	});
 
 	const result = mock.events.get("session_start")?.[0]?.({}, ctx);
-	assert.equal(result, undefined);
+	assert.ok(result instanceof Promise);
+	await result;
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 });
 
@@ -862,7 +863,7 @@ test("current Kimi usage follows account changes and clears status on model repl
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	assert.equal(statuses.get("usage"), "kimi 99% 5h 96% wk");
 	await command.handler("", ctx);
@@ -940,7 +941,7 @@ test("current DeepSeek API balance follows account changes and clears status", a
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	assert.equal(statuses.get("usage"), "deepseek USD 12.50");
 	await command.handler("", ctx);
@@ -1012,7 +1013,7 @@ test("current Fireworks usage receives its guard and settings-backed account sel
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	await settle();
 
@@ -1022,6 +1023,85 @@ test("current Fireworks usage receives its guard and settings-backed account sel
 	assert.ok(billingRequests.every((url) => url.includes("/accounts/beta/billing/summary")));
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("Fireworks waits for settings reload and cancels a replaced reload before refreshing", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const requests: string[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input);
+		requests.push(url);
+		if (url.includes("/v1/accounts?")) {
+			return new Response(
+				JSON.stringify({ accounts: [{ name: "accounts/acme" }, { name: "accounts/beta" }] }),
+				{ status: 200 },
+			);
+		}
+		return new Response(
+			JSON.stringify({
+				lineItems: [
+					{
+						series: "SERVERLESS",
+						totalCost: { currencyCode: "USD", units: "1", nanos: 0 },
+					},
+				],
+			}),
+			{ status: 200 },
+		);
+	};
+	const settings = memorySettingsRuntime({ fireworksAccountId: "acme" });
+	let reloads = 0;
+	let markReloadStarted: () => void = () => undefined;
+	const reloadStarted = new Promise<void>((resolve) => {
+		markReloadStarted = resolve;
+	});
+	settings.runtime.reload = async (signal) => {
+		reloads += 1;
+		if (reloads === 1) {
+			markReloadStarted();
+			await new Promise<void>((_resolve, reject) => {
+				signal?.addEventListener(
+					"abort",
+					() => reject(new DOMException("Settings reload aborted", "AbortError")),
+					{ once: true },
+				);
+			});
+		}
+		return settings.runtime.update({ fireworksAccountId: "beta" }, signal);
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const { ctx, statuses } = createMockContext({
+		model: fireworksModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "fw-key" }),
+			getProviderAuth: async () => ({
+				auth: { apiKey: "fw-key", baseUrl: fireworksModel.baseUrl },
+			}),
+			getAvailable: () => [fireworksModel],
+			getAll: () => [fireworksModel],
+		},
+	});
+	const start = mock.events.get("session_start")?.[0];
+	assert.ok(start);
+
+	const replaced = Promise.resolve(start({}, ctx));
+	await reloadStarted;
+	assert.equal(requests.length, 0);
+	const replacement = Promise.resolve(start({}, ctx));
+	await Promise.all([replaced, replacement]);
+	await settle();
+	await settle();
+
+	assert.equal(settings.state().settings.fireworksAccountId, "beta");
+	assert.equal(statuses.get("usage"), "fireworks USD 1");
+	const billingRequests = requests.filter((url) => url.includes("/billing/summary"));
+	assert.ok(billingRequests.length > 0);
+	assert.ok(billingRequests.every((url) => url.includes("/accounts/beta/billing/summary")));
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 });
 
 test("DeepSeek account rotation at the request boundary retries without querying the stale key", async (t) => {
@@ -1067,7 +1147,7 @@ test("DeepSeek account rotation at the request boundary retries without querying
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	await settle();
 
@@ -1125,10 +1205,10 @@ test("DeepSeek session replacement aborts a stale balance request before publica
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await firstRequestReady;
 	activeKey = "deepseek-account-b";
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 
 	assert.equal(requests, 2);
@@ -1181,7 +1261,7 @@ test("Z.AI providers publish statusline usage and refresh through /usage", async
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	assert.equal(fetches, 1);
 	assert.equal(statuses.get("usage"), "zai 90% 5h 80% wk");
@@ -1218,7 +1298,7 @@ test("automatic provider failures back off instead of retrying every turn", asyn
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	mock.events.get("turn_start")?.[0]?.({}, ctx);
 	await settle();
@@ -1272,7 +1352,7 @@ test("a current command supersedes an older automatic query for the same provide
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	while (fetches < 1) await settle();
 	activeKey = "account-b";
 	await command.handler("", ctx);
@@ -1362,7 +1442,7 @@ test("session shutdown clears status through the shutdown context", async (t) =>
 		modelRegistry: registry,
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, startContext);
+	await mock.events.get("session_start")?.[0]?.({}, startContext);
 	await settle();
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 	mock.events.get("session_shutdown")?.[0]?.({}, shutdownContext);
@@ -1408,7 +1488,7 @@ test("Codex reset countdown repaints locally and stops across replacement and sh
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await vi.advanceTimersByTimeAsync(0);
 	assert.equal(statuses.get("usage"), "codex 80% ↻ 3m");
 	assert.equal(fetches, 1);
@@ -1418,7 +1498,7 @@ test("Codex reset countdown repaints locally and stops across replacement and sh
 	assert.equal(fetches, 1);
 
 	Object.assign(ctx, { model: undefined });
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await vi.advanceTimersByTimeAsync(60_000);
 	assert.equal(statuses.get("usage"), undefined);
 	assert.equal(fetches, 1);
@@ -1474,7 +1554,7 @@ test("a slow command cannot overwrite status after the selected model changes", 
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	const commandPromise = command.handler("", ctx);
 	while (openRouterFetches < 2) await settle();
@@ -1539,7 +1619,7 @@ test("statusline follows runtime auth changes and clears for unsupported selecte
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
 
@@ -1640,7 +1720,7 @@ test("a retired xAI setting cannot disable explicit usage or publish status", as
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	await settle();
 	assert.equal(requests.length, 0);
 	await command.handler("", ctx);
@@ -1944,7 +2024,181 @@ test("the TUI SettingsList describes and applies usage preferences immediately",
 		),
 	);
 	assert.ok(renderedSettings.some((frame) => /Use faster Codex routing/.test(frame)));
+	assert.ok(renderedSettings.some((frame) => /Fireworks account/.test(frame)));
 	assert.doesNotMatch(renderedSettings.join("\n"), /xAI|warning|undocumented|experimental/iu);
+});
+
+test("the TUI Settings flow edits and clears the Fireworks account", async () => {
+	for (const [initial, entered, expected] of [
+		[undefined, "acme-prod", "acme-prod"],
+		["acme-prod", "   ", undefined],
+	] as const) {
+		const settings = memorySettingsRuntime({ fireworksAccountId: initial });
+		let customCalls = 0;
+		const applied: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => entered,
+			custom: async (factory: unknown) =>
+				new Promise<unknown>((resolve) => {
+					customCalls += 1;
+					let component: {
+						dispose?(): void;
+						handleInput(data: string): void;
+						render(width: number): string[];
+					};
+					const done = (value: unknown) => {
+						component.dispose?.();
+						resolve(value);
+					};
+					component = (
+						factory as (
+							tui: { requestRender(): void },
+							theme: {
+								bold(text: string): string;
+								fg(_color: string, text: string): string;
+							},
+							keybindings: object,
+							done: (value: unknown) => void,
+						) => typeof component
+					)({ requestRender() {} }, { bold: (text) => text, fg: (_color, text) => text }, {}, done);
+					if (customCalls === 1) {
+						component.handleInput("\u001b[B");
+						component.handleInput("\u001b[B");
+						component.handleInput("\r");
+					} else {
+						component.handleInput("\u0003");
+					}
+				}),
+		});
+
+		const changed = await showUsageSettings(
+			ctx,
+			settings.runtime,
+			new AbortController().signal,
+			() => true,
+			(id) => applied.push(id),
+		);
+
+		assert.equal(changed, true);
+		assert.equal(settings.state().settings.fireworksAccountId, expected);
+		assert.deepEqual(applied, ["fireworksAccountId"]);
+		assert.equal(customCalls, 2);
+	}
+});
+
+test("the Fireworks settings input retries validation and rolls back save failures", async () => {
+	for (const failUpdates of [false, true]) {
+		const settings = memorySettingsRuntime({ failUpdates });
+		const inputs = ["../unsafe", "acme"];
+		let customCalls = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => inputs.shift(),
+			custom: async (factory: unknown) =>
+				new Promise<unknown>((resolve) => {
+					customCalls += 1;
+					let component: {
+						dispose?(): void;
+						handleInput(data: string): void;
+					};
+					const done = (value: unknown) => {
+						component.dispose?.();
+						resolve(value);
+					};
+					component = (
+						factory as (
+							tui: { requestRender(): void },
+							theme: {
+								bold(text: string): string;
+								fg(_color: string, text: string): string;
+							},
+							keybindings: object,
+							done: (value: unknown) => void,
+						) => typeof component
+					)({ requestRender() {} }, { bold: (text) => text, fg: (_color, text) => text }, {}, done);
+					if (customCalls === 1) {
+						component.handleInput("\u001b[B");
+						component.handleInput("\u001b[B");
+						component.handleInput("\r");
+					} else {
+						component.handleInput("\u0003");
+					}
+				}),
+		});
+
+		const changed = await showUsageSettings(
+			ctx,
+			settings.runtime,
+			new AbortController().signal,
+			() => true,
+			() => undefined,
+		);
+
+		assert.equal(changed, !failUpdates);
+		assert.equal(settings.state().settings.fireworksAccountId, failUpdates ? undefined : "acme");
+		assert.match(notifications[0]?.message ?? "", /URL-safe Fireworks account slug/iu);
+		if (failUpdates) assert.match(notifications[1]?.message ?? "", /disk full/iu);
+	}
+});
+
+test("parent cancellation aborts the Fireworks settings input without saving", async () => {
+	const settings = memorySettingsRuntime();
+	const parentController = new AbortController();
+	let markInputStarted: () => void = () => undefined;
+	const inputStarted = new Promise<void>((resolve) => {
+		markInputStarted = resolve;
+	});
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		input: async (_title: string, _placeholder: string, options: { signal: AbortSignal }) => {
+			markInputStarted();
+			return new Promise<undefined>((resolve) => {
+				options.signal.addEventListener("abort", () => resolve(undefined), { once: true });
+			});
+		},
+		custom: async (factory: unknown) =>
+			new Promise<unknown>((resolve) => {
+				let component: {
+					dispose?(): void;
+					handleInput(data: string): void;
+				};
+				const done = (value: unknown) => {
+					component.dispose?.();
+					resolve(value);
+				};
+				component = (
+					factory as (
+						tui: { requestRender(): void },
+						theme: {
+							bold(text: string): string;
+							fg(_color: string, text: string): string;
+						},
+						keybindings: object,
+						done: (value: unknown) => void,
+					) => typeof component
+				)({ requestRender() {} }, { bold: (text) => text, fg: (_color, text) => text }, {}, done);
+				component.handleInput("\u001b[B");
+				component.handleInput("\u001b[B");
+				component.handleInput("\r");
+			}),
+	});
+
+	const pending = showUsageSettings(
+		ctx,
+		settings.runtime,
+		parentController.signal,
+		() => true,
+		() => assert.fail("cancelled input must not apply"),
+	);
+	await inputStarted;
+	parentController.abort();
+
+	assert.equal(await pending, false);
+	assert.equal(settings.state().settings.fireworksAccountId, undefined);
 });
 
 test("Ctrl+C hard-cancels Settings before conflicting configurable actions", async (t) => {
@@ -2257,7 +2511,7 @@ test("shutdown cancels an explicit xAI identity body before billing or status pu
 		},
 	});
 
-	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
 	const pending = command.handler("", ctx);
 	await started;
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -58,6 +58,13 @@ const deepSeekModel = {
 	baseUrl: "https://api.deepseek.com",
 };
 
+const fireworksModel = {
+	id: "accounts/fireworks/models/kimi-k2p6",
+	name: "Kimi K2.6",
+	provider: "fireworks",
+	baseUrl: "https://api.fireworks.ai/inference",
+};
+
 function codexAccessToken(accountId: string): string {
 	const payload = Buffer.from(
 		JSON.stringify({
@@ -70,6 +77,7 @@ function codexAccessToken(accountId: string): string {
 function memorySettingsRuntime(
 	options: {
 		codexStatusResetCountdown?: boolean;
+		fireworksAccountId?: string;
 		document?: Record<string, unknown>;
 		failUpdates?: boolean;
 		kind?: UsageSettingsState["kind"];
@@ -82,10 +90,19 @@ function memorySettingsRuntime(
 		settings: {
 			codexFastMode: false,
 			codexStatusResetCountdown: options.codexStatusResetCountdown ?? false,
+			...(options.fireworksAccountId ? { fireworksAccountId: options.fireworksAccountId } : {}),
 		},
 		...(kind === "invalid"
 			? { issue: "invalid test settings" }
-			: { document: { codexFastMode: false, ...options.document } }),
+			: {
+					document: {
+						codexFastMode: false,
+						...(options.fireworksAccountId
+							? { fireworksAccountId: options.fireworksAccountId }
+							: {}),
+						...options.document,
+					},
+				}),
 	};
 	const runtime: UsageSettingsRuntime = {
 		get: () => structuredClone(state),
@@ -949,6 +966,60 @@ test("current DeepSeek API balance follows account changes and clears status", a
 		ctx,
 	);
 	assert.equal(statuses.get("usage"), undefined);
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("current Fireworks usage receives its guard and settings-backed account selector", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const requests: string[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input);
+		requests.push(url);
+		if (url.includes("/v1/accounts?")) {
+			return new Response(
+				JSON.stringify({ accounts: [{ name: "accounts/acme" }, { name: "accounts/beta" }] }),
+				{ status: 200 },
+			);
+		}
+		return new Response(
+			JSON.stringify({
+				lineItems: [
+					{
+						series: "SERVERLESS",
+						totalCost: { currencyCode: "USD", units: "1", nanos: 0 },
+					},
+				],
+			}),
+			{ status: 200 },
+		);
+	};
+	const settings = memorySettingsRuntime({ fireworksAccountId: "beta" });
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const { ctx, statuses } = createMockContext({
+		model: fireworksModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "fw-key" }),
+			getProviderAuth: async () => ({
+				auth: { apiKey: "fw-key", baseUrl: fireworksModel.baseUrl },
+			}),
+			getAvailable: () => [fireworksModel],
+			getAll: () => [fireworksModel],
+		},
+	});
+
+	mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	await settle();
+
+	assert.equal(statuses.get("usage"), "fireworks USD 1");
+	const billingRequests = requests.filter((url) => url.includes("/billing/summary"));
+	assert.ok(billingRequests.length > 0);
+	assert.ok(billingRequests.every((url) => url.includes("/accounts/beta/billing/summary")));
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 	assert.equal(statuses.get("usage"), undefined);
 });


### PR DESCRIPTION
## Summary

- Add Fireworks rated API spend reporting through the official account-listing and billing-summary endpoints.
- Report exactly 30 UTC billing dates, including the current date, instead of an accidental 31-day interval.
- Keep one timeout budget across every account-listing page.
- Preserve exact per-currency `BigInt` arithmetic, official-origin validation, redirect refusal, bounded responses, and credential redaction.

Closes #1120

## Review follow-up

This PR carries the work from #1120 onto a branch in `narumiruna/pi-extensions` and resolves its confirmed review findings.
The original head branch belongs to a fork, so it cannot serve as the base of a stacked PR in this repository.

## Verification

- `npx vitest run packages/pi-usage/test/fireworks.test.ts` — 11 tests passed.
- `npm --workspace @narumitw/pi-usage run check` — passed.
- `npm run check` — passed.
- `npm test` — 331 files and 3,273 tests passed.
- `just pack usage` — dry-run package contained the generated `dist/index.ts` entrypoint and expected published files.

A live Fireworks account smoke was not run.
