### PR TITLE
fix(release): preserve plain internal dependency ranges

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"ignore": [],
-	"bumpVersionsWithWorkspaceProtocolOnly": false,
+	"bumpVersionsWithWorkspaceProtocolOnly": true,
 	"format": false,
 	"privatePackages": {
 		"version": false,

--- a/test/changesets-release.test.ts
+++ b/test/changesets-release.test.ts
@@ -71,7 +71,7 @@ test("Changesets bumps selected packages independently and preserves ordinary in
 		const unchanged = readJson(path.join(fixture, "packages/pi-unchanged/package.json"));
 		assert.equal(kit.version, "0.50.0");
 		assert.equal(consumer.version, "1.2.4");
-		assert.deepEqual(consumer.dependencies, { "@fixture/pi-tui-kit": "^0.50.0" });
+		assert.deepEqual(consumer.dependencies, { "@fixture/pi-tui-kit": "^0.49.1" });
 		assert.equal(unchanged.version, "4.5.6");
 		assert.equal(existsSync(path.join(fixture, "packages/pi-unchanged/CHANGELOG.md")), false);
 		assert.match(


### PR DESCRIPTION
## Summary

- Limit automatic internal dependency range updates to dependencies using the `workspace:` protocol.
- Preserve plain caret ranges so Kit releases do not automatically raise every consumer floor.
- Update the Changesets regression expectation for the restored behavior.

## Verification

- `npx vitest run test/changesets-release.test.ts`
- `npm run check`
- `npm test`

No changeset is included because this only changes repository release tooling and its test.
