### PR TITLE
feat(herdr): bundle integration and skill

### DIFF
--- a/.changeset/tidy-herdr-sheep.md
+++ b/.changeset/tidy-herdr-sheep.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-herdr": minor
+---
+
+Bundle Herdr's Pi agent-state integration with the `herdr` operating skill in one installable package.
+
+Report interactive Pi session and lifecycle state to Herdr with bounded local socket retries and shutdown cancellation.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The deprecated combined `pi-workflow` package has no atomic Plan-to-Goal replace
 | --- | --- | --- |
 | [`pi-chat`](./packages/pi-chat) | Join ephemeral peer-to-peer chat rooms that stay separate from Pi sessions, prompts, and model context. | `pi install npm:@narumitw/pi-chat` |
 | [`pi-fleet`](./packages/pi-fleet) | Start a separate Pi process in a terminal split and connect explicit local Pi sessions for bounded messages and one-turn requests. | `pi install npm:@narumitw/pi-fleet` |
+| [`pi-herdr`](./packages/pi-herdr) | Report Pi lifecycle state to Herdr and bundle safe Herdr terminal-orchestration guidance. | `pi install npm:@narumitw/pi-herdr` |
 
 ### Accounts and data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,6 +1968,10 @@
 			"resolved": "packages/pi-goal",
 			"link": true
 		},
+		"node_modules/@narumitw/pi-herdr": {
+			"resolved": "packages/pi-herdr",
+			"link": true
+		},
 		"node_modules/@narumitw/pi-langfuse": {
 			"resolved": "packages/pi-langfuse",
 			"link": true
@@ -7371,6 +7375,20 @@
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*",
 				"typebox": "*"
+			}
+		},
+		"packages/pi-herdr": {
+			"name": "@narumitw/pi-herdr",
+			"version": "0.0.1",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.5.11",
+				"@earendil-works/pi-coding-agent": "0.84.4",
+				"@types/node": "26.4.0",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*"
 			}
 		},
 		"packages/pi-langfuse": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 			"./packages/pi-fleet/src/index.ts",
 			"./packages/pi-github-pr/src/index.ts",
 			"./packages/pi-goal/src/index.ts",
+			"./packages/pi-herdr/src/index.ts",
 			"./packages/pi-langfuse/src/index.ts",
 			"./packages/pi-lsp/src/index.ts",
 			"./packages/pi-plan-mode/src/index.ts",
@@ -39,7 +40,8 @@
 			"./packages/pi-worktree/src/index.ts"
 		],
 		"skills": [
-			"./packages/pi-cbmem/skills"
+			"./packages/pi-cbmem/skills",
+			"./packages/pi-herdr/skills"
 		]
 	},
 	"scripts": {

--- a/packages/pi-herdr/LICENSE
+++ b/packages/pi-herdr/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -1,0 +1,105 @@
+# 🐑 pi-herdr — Herdr Integration for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-herdr)](https://www.npmjs.com/package/@narumitw/pi-herdr) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+Connect Pi's interactive lifecycle to Herdr and bundle the operating guidance needed to control Herdr safely.
+
+## ✨ Features
+
+- Reports Pi session identity and `working`, `blocked`, and `idle` lifecycle states to the current Herdr pane.
+- Coalesces rapid state changes and retries short-lived local socket failures without interrupting Pi.
+- Listens for `herdr:blocked` events from approval or question integrations.
+- Bundles the `herdr` skill for explicit Herdr inspection and control requests.
+- Keeps extension and skill installation in one Pi package.
+
+## 📦 Install
+
+Install persistently from npm:
+
+```bash
+pi install npm:@narumitw/pi-herdr
+```
+
+Try from npm without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-herdr
+```
+
+Load a local checkout from the repository root:
+
+```bash
+pi --no-extensions -e ./packages/pi-herdr
+```
+
+Pi extensions and skills run with your user permissions.
+Install only trusted packages, and review the source and bundled instructions before loading this package.
+
+## 🚀 Quick start
+
+Start Pi inside a Herdr-managed pane after installing the package.
+The extension activates automatically when `HERDR_ENV=1`, `HERDR_SOCKET_PATH`, and `HERDR_PANE_ID` are present.
+Ask Pi to use Herdr, or invoke `/skill:herdr`, when you want it to inspect or control the current Herdr session.
+
+If the standalone integration and skill are already installed, remove them after installing this package to avoid duplicate state reports and skill-name collisions:
+
+```bash
+rm ~/.pi/agent/extensions/herdr-agent-state.ts
+rm -rf ~/.agents/skills/herdr
+```
+
+Run `/reload` or restart Pi after changing the installed resources.
+
+## 🔄 Lifecycle reporting
+
+The extension reports only interactive TUI sessions because Herdr displays agents attached to terminal panes.
+A session report contains the Herdr pane ID, the integration source, Pi's agent kind, a monotonic sequence, the session start reason, and an absolute Pi session path when available.
+It falls back to Pi's session ID when no absolute session path is available.
+Agent reports contain the same ownership fields plus the current lifecycle state and optional blocked label.
+
+Local socket delivery is best-effort.
+A failed request is retried once with bounded timeouts, and reporting failures never stop Pi.
+Session shutdown aborts in-flight reporting and prevents stale session work from publishing later state.
+
+## 🔒 Security and privacy
+
+The extension connects only to the Unix socket or Windows named pipe provided by `HERDR_SOCKET_PATH`.
+It sends the current Herdr pane ID, Pi session path or ID, lifecycle state, session start reason, and blocked label to that endpoint.
+The package does not authenticate the endpoint, so trust the environment that launches Pi and controls these variables.
+
+The bundled skill can direct Pi to inspect terminals, create panes, start agents, send input, and run commands through the local `herdr` CLI.
+Those commands execute with the same user permissions as Pi and can affect live terminal sessions.
+The skill requires an explicit user request involving Herdr and stops when `HERDR_ENV` is not `1`.
+
+## 🚧 Limitations
+
+- State reporting is disabled in RPC, JSON, and print modes.
+- State reporting requires a running Herdr session and valid injected environment variables.
+- Socket failures are intentionally silent after the bounded retry.
+- The package does not install, start, update, or configure Herdr itself.
+
+## 🗂️ Package layout
+
+```text
+packages/pi-herdr/
+├── skills/herdr/
+│   └── SKILL.md              # Herdr control workflow and safety rules
+├── src/
+│   ├── index.ts              # Thin Pi entrypoint
+│   └── herdr-agent-state.ts  # Herdr socket and Pi lifecycle integration
+├── test/
+│   └── herdr-agent-state.test.ts
+├── package.json              # Pi extension and skill declarations
+├── tsconfig.json
+├── README.md
+└── LICENSE
+```
+
+## 🔎 Keywords
+
+Pi, Herdr, terminal multiplexer, coding agents, agent orchestration, lifecycle state.
+
+## 📄 License
+
+MIT.
+See [`LICENSE`](./LICENSE).

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -8,7 +8,7 @@ Connect Pi's interactive lifecycle to Herdr and bundle the operating guidance ne
 
 - Reports Pi session identity and `working`, `blocked`, and `idle` lifecycle states to the current Herdr pane.
 - Coalesces rapid state changes and retries short-lived local socket failures without interrupting Pi.
-- Listens for `herdr:blocked` events from approval or question integrations.
+- Derives blocked state from Pi's public `ui_prompt_start` and `ui_prompt_end` lifecycle events.
 - Bundles the `herdr` skill for explicit Herdr inspection and control requests.
 - Keeps extension and skill installation in one Pi package.
 
@@ -56,6 +56,7 @@ The extension reports only interactive TUI sessions because Herdr displays agent
 A session report contains the Herdr pane ID, the integration source, Pi's agent kind, a monotonic sequence, the session start reason, and an absolute Pi session path when available.
 It falls back to Pi's session ID when no absolute session path is available.
 Agent reports contain the same ownership fields plus the current lifecycle state and optional blocked label.
+Blocking extension prompts use their Pi-provided title as the label and fall back to the prompt kind.
 
 Local socket delivery is best-effort.
 A failed request is retried once with bounded timeouts, and reporting failures never stop Pi.

--- a/packages/pi-herdr/package.json
+++ b/packages/pi-herdr/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@narumitw/pi-herdr",
+	"version": "0.0.1",
+	"description": "Herdr agent-state integration and operating skill for Pi.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"herdr",
+		"terminal-multiplexer",
+		"agent-orchestration"
+	],
+	"files": [
+		"src",
+		"skills",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		],
+		"skills": [
+			"./skills"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.11",
+		"@earendil-works/pi-coding-agent": "0.84.4",
+		"@types/node": "26.4.0",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "packages/pi-herdr"
+	}
+}

--- a/packages/pi-herdr/skills/herdr/SKILL.md
+++ b/packages/pi-herdr/skills/herdr/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: herdr
+description: "Control Herdr, a terminal multiplexer for coding agents. Use only when the user explicitly mentions Herdr or asks to use Herdr to inspect or control panes, tabs, workspaces, commands, or another agent. Do not use merely because a task could benefit from a background terminal, delegation, or parallel work. Requires HERDR_ENV=1."
+---
+
+# Herdr
+
+Herdr organizes terminals into workspaces, tabs, and panes, recognizes coding agents running inside panes, and exposes the current session through the `herdr` CLI.
+
+Before issuing any control command, verify that this agent is running inside a Herdr-managed pane:
+
+```bash
+test "${HERDR_ENV:-}" = 1
+```
+
+If the check fails, say that you are not running inside Herdr and stop. Do not inspect or control the focused Herdr session from outside Herdr.
+
+When the check passes, the `herdr` binary in `PATH` talks to the current session. Use it to inspect neighboring work, create terminal layout, start agents and commands, read output, and wait for state changes.
+
+## Learn the current CLI
+
+The installed binary is the authority for command syntax. Start with:
+
+```bash
+herdr --help
+```
+
+Then print the relevant command group by running the group without a subcommand:
+
+```bash
+herdr agent
+herdr pane
+herdr workspace
+herdr tab
+herdr worktree
+herdr terminal
+herdr notification
+herdr integration
+herdr session
+```
+
+Do not run bare `herdr` for discovery; it launches or attaches the TUI. Do not probe a mutating nested command by omitting arguments. Commands such as `herdr workspace create` are valid with defaults and will execute.
+
+Most control commands return JSON. Read identifiers and state from those responses instead of predicting them.
+
+## Understand layout, panes, and agents
+
+Choose the primitive that matches the job:
+
+- Workspace, tab, and pane topology organize terminal locations.
+- Pane commands control raw terminals, shells, tests, servers, input, and output.
+- Agent commands control the recognized coding agent currently occupying a pane.
+
+A pane exists whether or not it contains an agent. `agent start` requires an existing available shell pane and never creates, splits, or moves layout. Use pane commands for ordinary processes. Use agent commands when Herdr must validate agent identity or interpret `idle`, `working`, `blocked`, `done`, and `unknown` lifecycle states.
+
+Agent commands accept either a unique live agent name or the pane ID currently hosting that agent. They do not accept terminal IDs or bare agent-kind labels. Names must match `[a-z][a-z0-9_-]{0,31}` and be unique among live agents. A name follows the current pane occupant and is cleared when that agent exits, is released, or is replaced.
+
+`idle` means the agent is ready for input and its tab has been seen in the focused Herdr UI. `done` is the same underlying idle state after unseen background work finishes. Focusing the tab or targeting the pane or agent with a focus command marks it seen. CLI reads do not mark it seen. `blocked` means Herdr recognized an approval or question UI. `unknown` means an agent is present but Herdr cannot classify it confidently; it does not prove completion.
+
+## Use IDs and caller context
+
+Public IDs are opaque stable handles:
+
+- workspace: `w1`
+- tab: `w1:t1`
+- pane: `w1:p1`
+
+Closed tab and pane IDs are not reused. A pane moved into another workspace receives a new workspace-qualified pane ID. After `pane move`, continue with `.result.move_result.pane.pane_id` or the live agent name. The old value is reported as `.result.move_result.previous_pane_id`; only the moved process's inherited caller context keeps resolving that old ID, so do not use it as a general agent target.
+
+Herdr injects the caller's context into each managed pane:
+
+```bash
+printf '%s\n' "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" "$HERDR_PANE_ID"
+```
+
+Prefer `--current` when a pane command should target the calling pane. Omitting a target may use the UI-focused pane, which can belong to the user or another client.
+
+Discover live state with:
+
+```bash
+herdr workspace list
+herdr tab list --workspace "$HERDR_WORKSPACE_ID"
+herdr pane current --current
+herdr pane list --workspace "$HERDR_WORKSPACE_ID"
+herdr agent list
+```
+
+Creation responses expose the IDs to use next. `workspace create` returns `.result.workspace`, `.result.tab`, and `.result.root_pane`. `tab create` returns `.result.tab` and `.result.root_pane`. `pane split` returns the new pane as `.result.pane`.
+
+## Start and coordinate an agent
+
+Default to a sibling pane in the current tab and the current working directory. Do not create a workspace, tab, worktree, or different cwd unless the user explicitly requests that topology or location.
+
+Honor a direction requested by the user. Otherwise inspect the caller pane:
+
+```bash
+herdr pane layout --pane "$HERDR_PANE_ID"
+```
+
+Split a wide pane to the right and a narrow or tall pane down. Avoid repeated same-direction splits that create unusably narrow columns or short rows. Keep the user's focus in the calling pane and explicitly preserve the caller's working directory:
+
+```bash
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+```
+
+Replace `right` with `down` when appropriate. Read the new pane ID from `.result.pane.pane_id`.
+
+An available shell pane must be at its interactive prompt, with the shell itself in the foreground and no foreground command, editor, or agent running. Start a supported agent in that pane with a useful unique name:
+
+```bash
+herdr agent start reviewer --kind codex --pane <returned-pane-id>
+```
+
+Use the kind requested by the user. Run `herdr agent` to inspect the installed kind list and options. Pass native agent arguments only after `--`:
+
+```bash
+herdr agent start reviewer --kind codex --pane <returned-pane-id> -- <agent-args...>
+```
+
+`agent start` returns only after Herdr detects the expected agent in the same pane and considers it ready for interactive input. It defaults to a 30-second startup timeout.
+
+Submit work through the agent surface:
+
+```bash
+herdr agent prompt reviewer "Review the current diff and report only actionable findings." --wait --timeout 120000
+```
+
+`agent prompt` atomically submits text and encoded Enter while honoring the pane's live bracketed-paste mode. For normal agent work, `--wait` is enough: it waits for the first settled `idle`, `done`, or `blocked` state. Do not repeat those defaults with `--until`.
+
+A prompt sent from a non-working state must produce an observed lifecycle change within five seconds. Otherwise Herdr returns `agent_prompt_stalled` instead of waiting indefinitely. This wait tracks lifecycle state, not an individual turn; if the agent is already working, completion of the active turn may satisfy it.
+
+Use `--until` only for a state-specific workflow, such as waiting for an already-running agent to request input:
+
+```bash
+herdr agent wait reviewer --until blocked --timeout 120000
+```
+
+Without `--until`, standalone `agent wait` uses the same settled-state defaults as `agent prompt --wait`.
+
+Use logical keys for interactive agent UI controls:
+
+```bash
+herdr agent send-keys reviewer esc
+herdr agent send-keys reviewer ctrl+c
+```
+
+Herdr validates all keys before writing any bytes. Read the result through the resolved agent:
+
+```bash
+herdr agent get reviewer
+herdr agent read reviewer --source recent-unwrapped --lines 120
+```
+
+If a wait fails or returns `blocked`, inspect `agent get` and `agent read` before deciding what input to send. Use the pane surface only when raw terminal control is intentional.
+
+## Run an ordinary command in another pane
+
+Create a sibling pane with the same geometry rule, preserve the caller's working directory, and keep user focus unchanged:
+
+```bash
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+```
+
+Read the new pane ID from `.result.pane.pane_id`, then run and inspect the command:
+
+```bash
+herdr pane run <returned-pane-id> "just test"
+herdr pane wait-output <returned-pane-id> --match "test result" --timeout 120000
+herdr pane read <returned-pane-id> --source recent-unwrapped --lines 120
+```
+
+`pane run` atomically sends command text and Enter. `pane wait-output` searches the selected snapshot immediately, so output that already exists can match. Use `--match <text>` for a literal substring or `--regex <pattern>` for a Rust regular expression. Omitting `--timeout` allows an indefinite wait.
+
+Use the read source that matches the task:
+
+- `visible`: the currently rendered viewport.
+- `recent`: recent rendered output, including soft wraps.
+- `recent-unwrapped`: recent output with soft wraps joined; prefer it for logs and transcripts.
+- `detection`: the plain-text bottom-buffer snapshot used for agent detection.
+
+Use `--format ansi` when colors and terminal styling are evidence. Otherwise use text.
+
+`--lines` asks Herdr for more rows from the pane's available screen and host scrollback. If increasing it does not reveal more of a completed response, the pane is probably running the agent on the terminal's alternate screen. Rows that leave the alternate screen do not enter Herdr's host scrollback, so a larger line count cannot recover them.
+
+After that failed read, ask the agent to write its complete response as Markdown in a temporary directory and reply only with the file path, then read the file directly. Use this only as a fallback; do not request file output in the initial prompt.
+
+## Safety and coordination rules
+
+- Use `--no-focus` for background work unless the user asked to switch context.
+- Use `--current`, an explicit pane ID, or a unique agent name. Do not rely on another client's focused pane.
+- Parse IDs from JSON responses. Do not derive them from sidebar order or examples.
+- Do not close workspaces, tabs, panes, or sessions you did not create unless the user explicitly asked.
+- Never run `herdr server stop` from an active session unless the user explicitly intends to stop the server and its pane processes.
+- Never kill the main Herdr process. Use named test sessions for experiments that need an isolated server.
+- CLI server errors are JSON on stderr with exit status 1. CLI syntax errors exit with status 2.

--- a/packages/pi-herdr/src/herdr-agent-state.ts
+++ b/packages/pi-herdr/src/herdr-agent-state.ts
@@ -39,16 +39,25 @@ function nextReportSeq(): number {
 	return reportSeq;
 }
 
+export function resolveSocketEndpoint(
+	socketPath: string | undefined,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	if (!socketPath || platform !== "win32") return socketPath ?? "";
+	const normalized = socketPath.toLowerCase();
+	if (normalized.startsWith("\\\\.\\pipe\\") || normalized.startsWith("\\\\?\\pipe\\")) {
+		return socketPath;
+	}
+	return `\\\\.\\pipe\\${socketPath}`;
+}
+
 function readEnvironment(environment: NodeJS.ProcessEnv = process.env): HerdrEnvironment {
 	const socketPath = environment.HERDR_SOCKET_PATH;
 	const paneId = environment.HERDR_PANE_ID;
 	return {
 		enabled: environment.HERDR_ENV === "1" && !!socketPath && !!paneId,
 		paneId: paneId ?? "",
-		socketEndpoint:
-			process.platform === "win32" && socketPath
-				? `\\\\.\\pipe\\${socketPath}`
-				: (socketPath ?? ""),
+		socketEndpoint: resolveSocketEndpoint(socketPath),
 	};
 }
 

--- a/packages/pi-herdr/src/herdr-agent-state.ts
+++ b/packages/pi-herdr/src/herdr-agent-state.ts
@@ -1,0 +1,309 @@
+import net from "node:net";
+import path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+const SOURCE = "herdr:pi";
+
+export type AgentState = "working" | "blocked" | "idle";
+
+interface HerdrEnvironment {
+	enabled: boolean;
+	paneId: string;
+	socketEndpoint: string;
+}
+
+interface HerdrRequest {
+	id: string;
+	method: "pane.report_agent" | "pane.report_agent_session";
+	params: Record<string, unknown>;
+}
+
+interface QueuedState {
+	state: AgentState;
+	message?: string;
+	seq: number;
+	signal: AbortSignal;
+}
+
+interface HerdrBlockedEvent {
+	active: boolean;
+	label?: string;
+}
+
+export interface HerdrAgentStateOptions {
+	environment?: HerdrEnvironment;
+	now?: () => number;
+	random?: () => number;
+	sendRequest?: (request: HerdrRequest, signal: AbortSignal) => Promise<void>;
+}
+
+let reportSeq = Date.now() * 1000;
+
+function nextReportSeq(): number {
+	reportSeq += 1;
+	return reportSeq;
+}
+
+function readEnvironment(environment: NodeJS.ProcessEnv = process.env): HerdrEnvironment {
+	const socketPath = environment.HERDR_SOCKET_PATH;
+	const paneId = environment.HERDR_PANE_ID;
+	return {
+		enabled: environment.HERDR_ENV === "1" && !!socketPath && !!paneId,
+		paneId: paneId ?? "",
+		socketEndpoint:
+			process.platform === "win32" && socketPath
+				? `\\\\.\\pipe\\${socketPath}`
+				: (socketPath ?? ""),
+	};
+}
+
+function sendRequestAttempt(
+	socketEndpoint: string,
+	request: HerdrRequest,
+	timeoutMs: number,
+	signal: AbortSignal,
+): Promise<boolean> {
+	if (signal.aborted) return Promise.resolve(false);
+
+	return new Promise((resolve) => {
+		let finished = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		const socket = net.createConnection(socketEndpoint);
+
+		const finish = (delivered: boolean) => {
+			if (finished) return;
+			finished = true;
+			if (timeout) clearTimeout(timeout);
+			signal.removeEventListener("abort", abort);
+			socket.destroy();
+			resolve(delivered);
+		};
+		const abort = () => finish(false);
+
+		signal.addEventListener("abort", abort, { once: true });
+		socket.on("error", () => finish(false));
+		socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+		socket.on("data", () => finish(true));
+		socket.on("end", () => finish(false));
+		timeout = setTimeout(() => finish(false), timeoutMs);
+		timeout.unref?.();
+	});
+}
+
+function createSocketSender(socketEndpoint: string) {
+	return async (request: HerdrRequest, signal: AbortSignal): Promise<void> => {
+		if (await sendRequestAttempt(socketEndpoint, request, 500, signal)) return;
+		if (signal.aborted) return;
+		await sendRequestAttempt(socketEndpoint, request, 1500, signal);
+	};
+}
+
+function isHerdrBlockedEvent(data: unknown): data is HerdrBlockedEvent {
+	if (!data || typeof data !== "object") return false;
+	const event = data as { active?: unknown; label?: unknown };
+	return (
+		typeof event.active === "boolean" &&
+		(event.label === undefined || typeof event.label === "string")
+	);
+}
+
+export function createHerdrAgentStateExtension(
+	options: HerdrAgentStateOptions = {},
+): (pi: ExtensionAPI) => void {
+	const environment = options.environment ?? readEnvironment();
+	const now = options.now ?? Date.now;
+	const random = options.random ?? Math.random;
+	const sendRequest = options.sendRequest ?? createSocketSender(environment.socketEndpoint);
+
+	return function herdrAgentState(pi: ExtensionAPI): void {
+		if (!environment.enabled) return;
+
+		let sessionGeneration = 0;
+		let sessionController = new AbortController();
+		let currentAgentSessionId: string | undefined;
+		let currentAgentSessionPath: string | undefined;
+		let agentActive = false;
+		let blockedCount = 0;
+		let blockedMessage: string | undefined;
+		let lastState: AgentState | undefined;
+		let lastMessage: string | undefined;
+		let rootSession = false;
+		let queuedState: QueuedState | undefined;
+		let drainTask: Promise<void> | undefined;
+
+		function requestId(kind?: "session"): string {
+			const segment = kind ? `${kind}:` : "";
+			return `${SOURCE}:${segment}${now()}:${random().toString(36).slice(2)}`;
+		}
+
+		function updateSessionRef(ctx: ExtensionContext): void {
+			try {
+				const file = ctx.sessionManager.getSessionFile();
+				currentAgentSessionPath =
+					typeof file === "string" && path.isAbsolute(file) ? file : undefined;
+			} catch {
+				currentAgentSessionPath = undefined;
+			}
+
+			try {
+				const id = ctx.sessionManager.getSessionId();
+				currentAgentSessionId = typeof id === "string" && id.length > 0 ? id : undefined;
+			} catch {
+				currentAgentSessionId = undefined;
+			}
+		}
+
+		function currentSessionRef(): Record<string, unknown> | undefined {
+			if (currentAgentSessionPath) return { agent_session_path: currentAgentSessionPath };
+			if (currentAgentSessionId) return { agent_session_id: currentAgentSessionId };
+			return undefined;
+		}
+
+		function withSessionRef(params: Record<string, unknown>): Record<string, unknown> {
+			return { ...params, ...currentSessionRef() };
+		}
+
+		async function safeSend(request: HerdrRequest, signal: AbortSignal): Promise<void> {
+			try {
+				await sendRequest(request, signal);
+			} catch {
+				// Herdr reporting is best-effort and must not interrupt Pi.
+			}
+		}
+
+		function reportSession(sessionStartSource?: string): Promise<void> {
+			const sessionRef = currentSessionRef();
+			if (!sessionRef) return Promise.resolve();
+			return safeSend(
+				{
+					id: requestId("session"),
+					method: "pane.report_agent_session",
+					params: {
+						pane_id: environment.paneId,
+						source: SOURCE,
+						agent: "pi",
+						seq: nextReportSeq(),
+						session_start_source: sessionStartSource,
+						...sessionRef,
+					},
+				},
+				sessionController.signal,
+			);
+		}
+
+		function stateRequest(state: QueuedState): HerdrRequest {
+			return {
+				id: requestId(),
+				method: "pane.report_agent",
+				params: withSessionRef({
+					pane_id: environment.paneId,
+					source: SOURCE,
+					agent: "pi",
+					state: state.state,
+					message: state.message,
+					seq: state.seq,
+				}),
+			};
+		}
+
+		async function drainStateQueue(): Promise<void> {
+			while (queuedState) {
+				const next = queuedState;
+				queuedState = undefined;
+				if (!next.signal.aborted) await safeSend(stateRequest(next), next.signal);
+			}
+		}
+
+		function queueState(state: AgentState, message?: string): void {
+			queuedState = {
+				state,
+				message,
+				seq: nextReportSeq(),
+				signal: sessionController.signal,
+			};
+			if (drainTask) return;
+			drainTask = drainStateQueue().finally(() => {
+				drainTask = undefined;
+				if (queuedState) queueState(queuedState.state, queuedState.message);
+			});
+		}
+
+		function desiredState(): { state: AgentState; message?: string } {
+			if (blockedCount > 0) return { state: "blocked", message: blockedMessage };
+			if (agentActive) return { state: "working" };
+			return { state: "idle" };
+		}
+
+		function publishState(force = false): void {
+			const next = desiredState();
+			if (!force && next.state === lastState && next.message === lastMessage) return;
+			lastState = next.state;
+			lastMessage = next.message;
+			queueState(next.state, next.message);
+		}
+
+		const unsubscribeBlocked = pi.events.on("herdr:blocked", (data) => {
+			if (!rootSession || !isHerdrBlockedEvent(data)) return;
+			if (!data.active) {
+				blockedCount = Math.max(0, blockedCount - 1);
+				if (blockedCount === 0) blockedMessage = undefined;
+				publishState();
+				return;
+			}
+
+			blockedCount += 1;
+			blockedMessage = data.label;
+			publishState();
+		});
+
+		pi.on("session_start", async (event, ctx) => {
+			const generation = ++sessionGeneration;
+			sessionController.abort(new DOMException("Herdr session replaced", "AbortError"));
+			sessionController = new AbortController();
+			rootSession = ctx.mode === "tui";
+			agentActive = false;
+			blockedCount = 0;
+			blockedMessage = undefined;
+			lastState = undefined;
+			lastMessage = undefined;
+			if (!rootSession) return;
+
+			updateSessionRef(ctx);
+			await reportSession(event.reason);
+			if (generation !== sessionGeneration || sessionController.signal.aborted || !rootSession) {
+				return;
+			}
+			agentActive = !ctx.isIdle();
+			publishState(true);
+		});
+
+		pi.on("agent_start", (_event, ctx) => {
+			if (!rootSession) return;
+			updateSessionRef(ctx);
+			void reportSession();
+			agentActive = true;
+			publishState();
+		});
+
+		pi.on("agent_settled", (_event, ctx) => {
+			if (!rootSession || !ctx.isIdle()) return;
+			agentActive = false;
+			publishState();
+		});
+
+		pi.on("session_shutdown", async () => {
+			++sessionGeneration;
+			rootSession = false;
+			sessionController.abort(new DOMException("Herdr session shut down", "AbortError"));
+			queuedState = undefined;
+			unsubscribeBlocked();
+			await drainTask;
+			currentAgentSessionId = undefined;
+			currentAgentSessionPath = undefined;
+		});
+	};
+}
+
+export default function herdrAgentState(pi: ExtensionAPI): void {
+	createHerdrAgentStateExtension()(pi);
+}

--- a/packages/pi-herdr/src/herdr-agent-state.ts
+++ b/packages/pi-herdr/src/herdr-agent-state.ts
@@ -25,11 +25,6 @@ interface QueuedState {
 	signal: AbortSignal;
 }
 
-interface HerdrBlockedEvent {
-	active: boolean;
-	label?: string;
-}
-
 export interface HerdrAgentStateOptions {
 	environment?: HerdrEnvironment;
 	now?: () => number;
@@ -96,15 +91,6 @@ function createSocketSender(socketEndpoint: string) {
 		if (signal.aborted) return;
 		await sendRequestAttempt(socketEndpoint, request, 1500, signal);
 	};
-}
-
-function isHerdrBlockedEvent(data: unknown): data is HerdrBlockedEvent {
-	if (!data || typeof data !== "object") return false;
-	const event = data as { active?: unknown; label?: unknown };
-	return (
-		typeof event.active === "boolean" &&
-		(event.label === undefined || typeof event.label === "string")
-	);
 }
 
 export function createHerdrAgentStateExtension(
@@ -242,17 +228,17 @@ export function createHerdrAgentStateExtension(
 			queueState(next.state, next.message);
 		}
 
-		const unsubscribeBlocked = pi.events.on("herdr:blocked", (data) => {
-			if (!rootSession || !isHerdrBlockedEvent(data)) return;
-			if (!data.active) {
-				blockedCount = Math.max(0, blockedCount - 1);
-				if (blockedCount === 0) blockedMessage = undefined;
-				publishState();
-				return;
-			}
-
+		pi.on("ui_prompt_start", (event) => {
+			if (!rootSession) return;
 			blockedCount += 1;
-			blockedMessage = data.label;
+			blockedMessage = event.title?.trim() || event.kind;
+			publishState();
+		});
+
+		pi.on("ui_prompt_end", () => {
+			if (!rootSession) return;
+			blockedCount = Math.max(0, blockedCount - 1);
+			if (blockedCount === 0) blockedMessage = undefined;
 			publishState();
 		});
 
@@ -296,7 +282,6 @@ export function createHerdrAgentStateExtension(
 			rootSession = false;
 			sessionController.abort(new DOMException("Herdr session shut down", "AbortError"));
 			queuedState = undefined;
-			unsubscribeBlocked();
 			await drainTask;
 			currentAgentSessionId = undefined;
 			currentAgentSessionPath = undefined;

--- a/packages/pi-herdr/src/index.ts
+++ b/packages/pi-herdr/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./herdr-agent-state.js";

--- a/packages/pi-herdr/test/herdr-agent-state.test.ts
+++ b/packages/pi-herdr/test/herdr-agent-state.test.ts
@@ -117,17 +117,37 @@ test("blocked events override working state until every blocker clears", async (
 	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
 	await flushReporting();
 
-	mock.eventBus.emit("herdr:blocked", { active: true, label: "Approval" });
+	await emit(
+		mock,
+		"ui_prompt_start",
+		{ reason: "ui_prompt", kind: "confirm", title: "Approval" },
+		started.ctx,
+	);
 	await flushReporting();
 	assert.equal(stateRequests(requests).at(-1)?.params.state, "blocked");
 	assert.equal(stateRequests(requests).at(-1)?.params.message, "Approval");
 
-	mock.eventBus.emit("herdr:blocked", { active: true, label: "Question" });
-	mock.eventBus.emit("herdr:blocked", { active: false });
+	await emit(
+		mock,
+		"ui_prompt_start",
+		{ reason: "ui_prompt", kind: "input", title: "Question" },
+		started.ctx,
+	);
+	await emit(
+		mock,
+		"ui_prompt_end",
+		{ reason: "ui_prompt", kind: "confirm", title: "Approval" },
+		started.ctx,
+	);
 	await flushReporting();
 	assert.equal(stateRequests(requests).at(-1)?.params.state, "blocked");
 
-	mock.eventBus.emit("herdr:blocked", { active: false });
+	await emit(
+		mock,
+		"ui_prompt_end",
+		{ reason: "ui_prompt", kind: "input", title: "Question" },
+		started.ctx,
+	);
 	await flushReporting();
 	assert.equal(stateRequests(requests).at(-1)?.params.state, "working");
 });
@@ -140,7 +160,12 @@ test("non-TUI sessions never report state", async () => {
 	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
 	await emit(mock, "agent_start", {}, started.ctx);
 	await emit(mock, "agent_settled", {}, started.ctx);
-	mock.eventBus.emit("herdr:blocked", { active: true, label: "Hidden" });
+	await emit(
+		mock,
+		"ui_prompt_start",
+		{ reason: "ui_prompt", kind: "confirm", title: "Hidden" },
+		started.ctx,
+	);
 	await flushReporting();
 	assert.deepEqual(requests, []);
 });
@@ -224,7 +249,12 @@ test("shutdown aborts a delayed session report before it can publish state", asy
 	await flushReporting();
 	assert.equal(stateRequests(requests).length, 0);
 
-	mock.eventBus.emit("herdr:blocked", { active: true, label: "Stale" });
+	await emit(
+		mock,
+		"ui_prompt_start",
+		{ reason: "ui_prompt", kind: "confirm", title: "Stale" },
+		started.ctx,
+	);
 	await flushReporting();
 	assert.equal(requests.length, 1);
 });

--- a/packages/pi-herdr/test/herdr-agent-state.test.ts
+++ b/packages/pi-herdr/test/herdr-agent-state.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { DefaultResourceLoader, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { afterAll, beforeAll, test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import type { HerdrAgentStateOptions } from "../src/herdr-agent-state.js";
+
+type HerdrModule = typeof import("../src/herdr-agent-state.js");
+type HerdrRequest = Parameters<NonNullable<HerdrAgentStateOptions["sendRequest"]>>[0];
+
+const packageRoot = resolve("packages/pi-herdr");
+let agentDir: string;
+let previousAgentDir: string | undefined;
+let herdrModule: HerdrModule;
+
+beforeAll(async () => {
+	agentDir = await mkdtemp(join(tmpdir(), "pi-herdr-agent-"));
+	previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	herdrModule = await import("../src/herdr-agent-state.js");
+});
+
+afterAll(async () => {
+	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	await rm(agentDir, { force: true, recursive: true });
+});
+
+function enabledOptions(requests: HerdrRequest[]): HerdrAgentStateOptions {
+	return {
+		environment: {
+			enabled: true,
+			paneId: "w1:p2",
+			socketEndpoint: "/tmp/herdr.sock",
+		},
+		now: () => 1234,
+		random: () => 0.5,
+		sendRequest: async (request) => {
+			requests.push(request);
+		},
+	};
+}
+
+async function emit(
+	mock: ReturnType<typeof createMockPi>,
+	name: string,
+	event: Record<string, unknown>,
+	ctx: unknown,
+): Promise<void> {
+	for (const handler of mock.events.get(name) ?? []) await handler(event, ctx);
+}
+
+async function flushReporting(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function tuiContext(idle = true) {
+	return createMockContext({
+		mode: "tui",
+		hasUI: true,
+		isIdle: () => idle,
+		sessionManager: {
+			getSessionFile: () => "/sessions/pi.jsonl",
+			getSessionId: () => "session-id",
+		},
+	});
+}
+
+function stateRequests(requests: HerdrRequest[]) {
+	return requests.filter(({ method }) => method === "pane.report_agent");
+}
+
+test("disabled factory registers no lifecycle work", () => {
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension({
+		environment: { enabled: false, paneId: "", socketEndpoint: "" },
+	})(mock.pi);
+	assert.deepEqual([...mock.events.keys()], []);
+});
+
+test("TUI lifecycle reports the session and coalesced agent states", async () => {
+	const requests: HerdrRequest[] = [];
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension(enabledOptions(requests))(mock.pi);
+	const started = tuiContext();
+
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await flushReporting();
+	assert.equal(requests[0]?.method, "pane.report_agent_session");
+	assert.deepEqual(requests[0]?.params, {
+		pane_id: "w1:p2",
+		source: "herdr:pi",
+		agent: "pi",
+		seq: requests[0]?.params.seq,
+		session_start_source: "startup",
+		agent_session_path: "/sessions/pi.jsonl",
+	});
+	assert.equal(stateRequests(requests).at(-1)?.params.state, "idle");
+
+	await emit(mock, "agent_start", {}, started.ctx);
+	await flushReporting();
+	assert.equal(stateRequests(requests).at(-1)?.params.state, "working");
+
+	await emit(mock, "agent_settled", {}, started.ctx);
+	await flushReporting();
+	assert.equal(stateRequests(requests).at(-1)?.params.state, "idle");
+});
+
+test("blocked events override working state until every blocker clears", async () => {
+	const requests: HerdrRequest[] = [];
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension(enabledOptions(requests))(mock.pi);
+	const started = tuiContext(false);
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await flushReporting();
+
+	mock.eventBus.emit("herdr:blocked", { active: true, label: "Approval" });
+	await flushReporting();
+	assert.equal(stateRequests(requests).at(-1)?.params.state, "blocked");
+	assert.equal(stateRequests(requests).at(-1)?.params.message, "Approval");
+
+	mock.eventBus.emit("herdr:blocked", { active: true, label: "Question" });
+	mock.eventBus.emit("herdr:blocked", { active: false });
+	await flushReporting();
+	assert.equal(stateRequests(requests).at(-1)?.params.state, "blocked");
+
+	mock.eventBus.emit("herdr:blocked", { active: false });
+	await flushReporting();
+	assert.equal(stateRequests(requests).at(-1)?.params.state, "working");
+});
+
+test("non-TUI sessions never report state", async () => {
+	const requests: HerdrRequest[] = [];
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension(enabledOptions(requests))(mock.pi);
+	const started = createMockContext({ mode: "rpc", hasUI: true });
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await emit(mock, "agent_start", {}, started.ctx);
+	await emit(mock, "agent_settled", {}, started.ctx);
+	mock.eventBus.emit("herdr:blocked", { active: true, label: "Hidden" });
+	await flushReporting();
+	assert.deepEqual(requests, []);
+});
+
+test("socket transport retries one failed delivery and preserves the request", async () => {
+	const socketPath = join(agentDir, "herdr-test.sock");
+	const received: HerdrRequest[] = [];
+	let connectionCount = 0;
+	let reportState!: () => void;
+	const stateReceived = new Promise<void>((resolve) => {
+		reportState = resolve;
+	});
+	const server = net.createServer((socket) => {
+		connectionCount += 1;
+		let input = "";
+		socket.on("error", () => {
+			// The client closes immediately after Herdr acknowledges delivery.
+		});
+		socket.on("data", (chunk) => {
+			input += chunk.toString();
+			const newline = input.indexOf("\n");
+			if (newline < 0) return;
+			const request = JSON.parse(input.slice(0, newline)) as HerdrRequest;
+			received.push(request);
+			if (connectionCount === 1) socket.end();
+			else socket.write("{}\n");
+			if (request.method === "pane.report_agent") reportState();
+		});
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(socketPath, resolve);
+	});
+
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension({
+		environment: { enabled: true, paneId: "w1:p2", socketEndpoint: socketPath },
+	})(mock.pi);
+	const started = tuiContext();
+	try {
+		await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+		await stateReceived;
+		assert.equal(connectionCount, 3);
+		assert.equal(received[0]?.id, received[1]?.id);
+		assert.equal(received[0]?.method, "pane.report_agent_session");
+		assert.equal(received[2]?.params.state, "idle");
+	} finally {
+		await emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+		await rm(socketPath, { force: true });
+	}
+});
+
+test("shutdown aborts a delayed session report before it can publish state", async () => {
+	const requests: HerdrRequest[] = [];
+	let release!: () => void;
+	const delayed = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let firstSignal: AbortSignal | undefined;
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions(requests),
+		sendRequest: async (request, signal) => {
+			requests.push(request);
+			firstSignal ??= signal;
+			await delayed;
+		},
+	})(mock.pi);
+	const started = tuiContext();
+
+	const starting = emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await flushReporting();
+	assert.equal(requests.length, 1);
+	const shuttingDown = emit(mock, "session_shutdown", { reason: "reload" }, started.ctx);
+	assert.equal(firstSignal?.aborted, true);
+	release();
+	await Promise.all([starting, shuttingDown]);
+	await flushReporting();
+	assert.equal(stateRequests(requests).length, 0);
+
+	mock.eventBus.emit("herdr:blocked", { active: true, label: "Stale" });
+	await flushReporting();
+	assert.equal(requests.length, 1);
+});
+
+test("package resources load one extension and the bundled herdr skill", async () => {
+	const loader = new DefaultResourceLoader({
+		cwd: agentDir,
+		agentDir,
+		settingsManager: SettingsManager.inMemory({ packages: [packageRoot] }),
+		additionalSkillPaths: [join(packageRoot, "skills", "herdr", "SKILL.md")],
+		noSkills: true,
+		noContextFiles: true,
+	});
+	await loader.reload();
+
+	const extensions = loader.getExtensions();
+	assert.deepEqual(extensions.errors, []);
+	assert.equal(extensions.extensions.length, 1);
+	const skills = loader.getSkills();
+	assert.deepEqual(skills.diagnostics, []);
+	assert.deepEqual(
+		skills.skills.map(({ name }) => name),
+		["herdr"],
+	);
+});

--- a/packages/pi-herdr/test/herdr-agent-state.test.ts
+++ b/packages/pi-herdr/test/herdr-agent-state.test.ts
@@ -73,6 +73,19 @@ function stateRequests(requests: HerdrRequest[]) {
 	return requests.filter(({ method }) => method === "pane.report_agent");
 }
 
+test("Windows socket endpoints preserve qualified pipes and qualify bare names", () => {
+	assert.equal(herdrModule.resolveSocketEndpoint("herdr", "win32"), "\\\\.\\pipe\\herdr");
+	assert.equal(
+		herdrModule.resolveSocketEndpoint("\\\\.\\pipe\\herdr", "win32"),
+		"\\\\.\\pipe\\herdr",
+	);
+	assert.equal(
+		herdrModule.resolveSocketEndpoint("\\\\?\\PIPE\\herdr", "win32"),
+		"\\\\?\\PIPE\\herdr",
+	);
+	assert.equal(herdrModule.resolveSocketEndpoint("/tmp/herdr.sock", "linux"), "/tmp/herdr.sock");
+});
+
 test("disabled factory registers no lifecycle work", () => {
 	const mock = createMockPi();
 	herdrModule.createHerdrAgentStateExtension({

--- a/packages/pi-herdr/tsconfig.json
+++ b/packages/pi-herdr/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"types": ["node"],
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add the independently installable `@narumitw/pi-herdr` package.
- Bundle Herdr's Pi lifecycle-state integration with the `herdr` operating skill.
- Add bounded socket retries, state coalescing, TUI-only activation, and shutdown cancellation.
- Register the package resources in the repository manifest and add release metadata.

## Verification

- `npm run check`
- `npm test` — 3,363 tests passed.
- `npm --workspace @narumitw/pi-herdr pack --dry-run --json`
- `pi --no-extensions --no-skills -e ./packages/pi-herdr --list-models`
- README heading audit and exact bundled-skill comparison.

## Notes

- Deterministic tests exercise the Unix socket protocol and retry path.
- Live Herdr TUI reporting was not manually exercised to avoid disrupting the active session.