### PR TITLE
feat(herdr): add sibling agent widget

### DIFF
--- a/.changeset/tidy-herdr-sheep.md
+++ b/.changeset/tidy-herdr-sheep.md
@@ -6,4 +6,4 @@ Bundle Herdr's Pi agent-state integration with the `herdr` operating skill in on
 
 Report interactive Pi session and lifecycle state to Herdr with bounded local socket retries and shutdown cancellation.
 
-Show recognized sibling agents from the current Herdr workspace in a terminal-safe, event-driven widget above Pi's editor.
+Show recognized sibling agents from the current Herdr workspace in a terminal-safe, event-driven widget above Pi's editor, with distinct state, renamed agent, pane, and workspace identities.

--- a/.changeset/tidy-herdr-sheep.md
+++ b/.changeset/tidy-herdr-sheep.md
@@ -5,3 +5,5 @@
 Bundle Herdr's Pi agent-state integration with the `herdr` operating skill in one installable package.
 
 Report interactive Pi session and lifecycle state to Herdr with bounded local socket retries and shutdown cancellation.
+
+Show recognized sibling agents from the current Herdr workspace in a terminal-safe, event-driven widget above Pi's editor.

--- a/docs/roadmaps/2026-08-30_pi-herdr-bidirectional-integration-roadmap.md
+++ b/docs/roadmaps/2026-08-30_pi-herdr-bidirectional-integration-roadmap.md
@@ -18,7 +18,7 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 - `packages/pi-herdr/src/herdr-agent-state.ts` reports the current interactive Pi session plus `working`, `blocked`, and `idle` state to the Herdr socket.
 - The extension coalesces state changes, retries bounded delivery failures, guards session generations, and aborts reporting during shutdown.
 - The bundled `herdr` skill provides explicit, on-demand CLI guidance for inspecting and controlling workspaces, tabs, panes, agents, commands, and notifications.
-- The extension now renders a terminal-safe, event-driven widget for recognized sibling agents in the current workspace and maintains pane-scoped status subscriptions with bounded failure recovery.
+- The extension now renders a terminal-safe, event-driven widget with one state, agent, pane, and workspace row per recognized sibling and maintains pane-scoped status subscriptions with bounded failure recovery.
 - The extension still has no footer status, `/herdr` command, pane metadata publication, autocomplete, or watch notification.
 - The installed Herdr 0.8.2 API exposes `pane.current`, `pane.list`, `events.subscribe`, pane lifecycle and agent-status events, `pane.report_metadata`, and protocol metadata through its public schema.
 - The bundled skill currently lists `herdr terminal` as a discovery group even though that group is absent from the installed Herdr 0.8.2 CLI.
@@ -37,7 +37,7 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 
 ### Phase 1: Establish trustworthy ambient awareness
 
-- [x] A Pi widget above the editor presents a bounded, responsive view of relevant sibling agents in the current Herdr workspace, excludes the current pane, distinguishes `blocked`, `done`, `working`, `idle`, and `unknown`, and hides when there is nothing useful to show.
+- [x] A Pi widget above the editor presents one bounded state, agent, pane, and workspace row per relevant sibling, excludes the current pane, distinguishes `blocked`, `done`, `working`, `idle`, and `unknown`, and hides when there is nothing useful to show.
   Evidence: focused model and rendering tests plus a Herdr-managed TUI smoke cover every state, five-row overflow, empty state, and narrow rendering.
 - [x] Widget state initializes from authoritative `pane.current` and `pane.list` reads and remains current through topology plus pane-scoped status subscriptions without steady-state CLI polling, while disconnects and unsupported responses degrade without interrupting Pi.
   Evidence: protocol, client, observer, replay, reconnect, and live moved-pane tests pass.
@@ -97,7 +97,7 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 | Persistent widgets consume scarce terminal rows | Ambient status could distract more than it helps | Default to current-workspace siblings, bound rows, collapse overflow, and hide when no useful state exists. |
 | Herdr-derived terminal text is untrusted | Titles, paths, or state labels could inject controls or break layout | Sanitize at the display boundary before presentation sorting or truncation while preserving raw protocol data internally. |
 | Herdr `done` depends on unseen background completion | Reading state from Pi could accidentally change user-visible semantics | Use read-only APIs that do not focus panes or mark tabs seen, and test that widget inspection preserves `done`. |
-| Agent names or display labels may be absent or non-unique | Widget rows and actions could target the wrong pane | Display friendly labels with stable pane IDs as fallback and resolve every action through returned Herdr identifiers. |
+| Agent names or display labels may be absent or non-unique | Widget rows and actions could become ambiguous | Keep agent identity primary, show pane and workspace labels with short stable IDs in separate visual roles, and resolve future actions through raw Herdr identifiers. |
 | A command dashboard can drift into a second Herdr TUI | Maintenance and safety scope could expand rapidly | Keep Phase 3 current-context and menu-first, and require a separate go/no-go decision for each mutating action. |
 | New settings would introduce persistence and precedence obligations | Early delivery could become dominated by configuration complexity | Use a useful zero-configuration default first and adopt extension settings only after a concrete user need is established. |
 
@@ -107,6 +107,7 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 - **2026-08-30 — Prefer a widget over editor replacement:** `ctx.ui.setWidget()` preserves editor composition, keybindings, paste behavior, and compatibility with other editor extensions.
 - **2026-08-30 — Prefer subscription over polling:** authoritative workspace reads plus topology and pane-scoped status subscriptions provide a lower-overhead and more truthful source than recurring `herdr agent list` subprocesses.
 - **2026-08-30 — Reconcile replayed topology:** Herdr replays retained topology events, so the widget coalesces them into fresh workspace reads and rebuilds status subscriptions only when the recognized pane set changes.
+- **2026-08-30 — Keep one agent per row:** each row uses theme roles to present state, agent name, pane label and short ID, then workspace label and short ID without misclassifying terminal titles as agent identity.
 - **2026-08-30 — Defer broad model tools:** the bundled skill and installed CLI remain authoritative until a narrow typed tool proves additional safety or reliability.
 
 ## Non-Goals

--- a/docs/roadmaps/2026-08-30_pi-herdr-bidirectional-integration-roadmap.md
+++ b/docs/roadmaps/2026-08-30_pi-herdr-bidirectional-integration-roadmap.md
@@ -1,0 +1,130 @@
+# pi-herdr Bidirectional Integration Roadmap
+
+## Vision
+
+Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context in both directions without replacing Herdr's TUI, duplicating its CLI, or distracting users when no coordination needs attention.
+
+**Current roadmap status:** The Phase 1 agent widget is delivered and verified, while the optional footer summary and Phases 2–4 remain planned.
+
+## Objectives
+
+- **Make nearby agent activity visible in Pi** — Success after Phase 1: a responsive editor widget accurately reflects relevant sibling-agent state from Herdr, starts no steady-state CLI polling, and leaves no UI or socket resource after session shutdown.
+- **Give Herdr useful Pi context** — Success after Phase 2: Herdr can display bounded, current Pi session and model metadata without exposing conversation content or allowing stale sessions to publish updates.
+- **Make inspection and coordination deliberate** — Success after Phase 3: users can inspect current Herdr context and invoke a small set of explicit, accurately labelled actions without requiring model interpretation.
+- **Keep the skill and runtime compatible** — Success throughout: unsupported Herdr protocols degrade without interrupting Pi, and every documented CLI discovery path is valid for the supported Herdr surface.
+
+## Current State
+
+- `packages/pi-herdr/src/herdr-agent-state.ts` reports the current interactive Pi session plus `working`, `blocked`, and `idle` state to the Herdr socket.
+- The extension coalesces state changes, retries bounded delivery failures, guards session generations, and aborts reporting during shutdown.
+- The bundled `herdr` skill provides explicit, on-demand CLI guidance for inspecting and controlling workspaces, tabs, panes, agents, commands, and notifications.
+- The extension now renders a terminal-safe, event-driven widget for recognized sibling agents in the current workspace and maintains pane-scoped status subscriptions with bounded failure recovery.
+- The extension still has no footer status, `/herdr` command, pane metadata publication, autocomplete, or watch notification.
+- The installed Herdr 0.8.2 API exposes `pane.current`, `pane.list`, `events.subscribe`, pane lifecycle and agent-status events, `pane.report_metadata`, and protocol metadata through its public schema.
+- The bundled skill currently lists `herdr terminal` as a discovery group even though that group is absent from the installed Herdr 0.8.2 CLI.
+- The repository has no telemetry or grounded adoption baseline, so usage and delivery targets remain unknown.
+
+## Guiding Principles
+
+- **Ambient before interactive:** establish trustworthy read-only awareness before adding coordination actions.
+- **Attention over noise:** show blocked, completed, or active work prominently and hide permanent ready-state decoration.
+- **Event-driven by default:** use Herdr snapshot and subscription APIs instead of recurring CLI subprocesses.
+- **Graceful degradation:** preserve existing outbound lifecycle reporting when reverse integration is unavailable or incompatible.
+- **One authority per concern:** let Herdr own workspace state and control semantics while Pi owns its widget, status, lifecycle, and session metadata.
+- **Public surfaces only:** rely on Pi extension APIs and Herdr's published CLI or socket schema rather than screen scraping or private implementation details.
+
+## Roadmap
+
+### Phase 1: Establish trustworthy ambient awareness
+
+- [x] A Pi widget above the editor presents a bounded, responsive view of relevant sibling agents in the current Herdr workspace, excludes the current pane, distinguishes `blocked`, `done`, `working`, `idle`, and `unknown`, and hides when there is nothing useful to show.
+  Evidence: focused model and rendering tests plus a Herdr-managed TUI smoke cover every state, five-row overflow, empty state, and narrow rendering.
+- [x] Widget state initializes from authoritative `pane.current` and `pane.list` reads and remains current through topology plus pane-scoped status subscriptions without steady-state CLI polling, while disconnects and unsupported responses degrade without interrupting Pi.
+  Evidence: protocol, client, observer, replay, reconnect, and live moved-pane tests pass.
+- [ ] An activity-only `herdr` footer status summarizes conditions needing attention and remains absent when there is no blocked, completed, or active sibling work.
+- [x] Session replacement, reload, shutdown, failed initialization, and reconnect exhaustion leave no open subscription, retry task, widget, or status owned by the old session.
+  Evidence: lifecycle tests cover delayed stale work, replacement during shutdown, repeated shutdown, one bounded reconnect, and exhaustion.
+- [x] Every displayed Herdr-derived label, title, path, and state label is terminal-safe, width-bounded, and tested under narrow rendering.
+  Evidence: hostile ANSI, OSC, bidi, newline, Unicode, zero-width, narrow-width, and theme-invalidation tests pass.
+
+**Outcome:** Pi users can understand nearby Herdr activity at a glance without switching views, paying a polling cost, or risking stale lifecycle resources.
+
+### Phase 2: Enrich Herdr with bounded Pi context
+
+- [ ] Herdr pane metadata exposes a stable Pi display identity and useful session title when available without replacing user-owned pane labels or leaking message content.
+- [ ] Model, provider, thinking level, and bounded context-usage metadata remain current through Pi lifecycle events and use a publication cadence that avoids volatile socket traffic.
+- [ ] Metadata ownership, sequence ordering, replacement, and shutdown behavior prevent an older Pi session from overwriting newer pane state.
+- [ ] The integration documents exactly which environment, session, model, and prompt-label fields cross the Herdr socket boundary.
+
+**Outcome:** Herdr can explain which Pi session and model occupy a pane while preserving privacy and source ownership.
+
+### Phase 3: Add a deliberate Pi-native Herdr dashboard
+
+- [ ] `/herdr` provides a current-state TUI dashboard for relevant agents and panes, with an explicit non-TUI behavior decision and no silent fallback into terminal-only UI.
+- [ ] Read-only inspection exposes bounded recent output, lifecycle state, blocked reason, and stable target identifiers without marking background completion as seen.
+- [ ] A documented go/no-go decision approves only frequent, unambiguous actions such as focus, prompt, wait, or watch when their cancellation, targeting, and safety semantics can match the Herdr CLI.
+- [ ] Every approved action is labelled with its workspace or pane effect, preserves user focus unless requested, and reports CLI or socket failures observably.
+
+**Outcome:** Users gain a predictable Pi-native path from awareness to intentional coordination without reproducing the full Herdr TUI or CLI.
+
+### Phase 4: Improve discovery without expanding ambient complexity
+
+- [ ] Agent or pane autocomplete is delivered only if a stable insertion syntax and target identity improve a demonstrated workflow without intercepting ordinary `@` or path completion.
+- [ ] Opt-in watch notifications distinguish `blocked` from unseen `done`, avoid notifying for every idle transition, and can be cancelled or cleared with the owning session.
+- [ ] A documented decision either retains skill-plus-`bash` as the model control surface or introduces a narrowly scoped typed tool only when it provides measurable safety or reliability beyond the CLI guidance.
+- [ ] Bundled skill discovery commands and examples are verified against the supported Herdr CLI surface, with version-sensitive behavior delegated to installed `herdr --help` output.
+
+**Outcome:** Higher-frequency workflows become easier to discover while model prompt weight, notification noise, and duplicated command semantics remain controlled.
+
+## Success Metrics
+
+| Indicator | Baseline | Target or invariant | Measurement source |
+| --- | --- | --- | --- |
+| Herdr state visible inside Pi | Current-workspace widget delivered | Every accepted relevant status event or authoritative topology refresh is reflected by the next widget publication | State-model, observer, and live TUI tests |
+| Steady-state CLI subprocesses for widget updates | 0 | 0 | Source review and live smoke |
+| Rendered widget lines exceeding available width | 0 in deterministic coverage | 0 | Narrow-width and untrusted-input tests |
+| Session-owned resources remaining after shutdown | 0 in deterministic coverage | 0 subscriptions, retry tasks, widgets, or statuses | Lifecycle tests |
+| Stale session metadata accepted after replacement | Existing outbound generation guards only | 0 | Sequence and replacement tests |
+| Invalid documented CLI discovery groups | At least 1 against installed Herdr 0.8.2 | 0 for the supported CLI fixture | Skill/CLI contract check |
+| Adoption and coordination task completion | Unknown | TBD if privacy-compatible evidence becomes available | No current measurement source |
+
+## Risks and Dependencies
+
+| Risk or dependency | Impact | Mitigation or decision |
+| --- | --- | --- |
+| Herdr socket protocol or event schemas change across versions | Reverse state could fail or become misleading | Structurally validate narrow workspace reads and events, reject invalid frames, test supported fixtures, and preserve outbound reporting when reverse features are disabled. |
+| A long-lived subscription adds reconnect and shutdown complexity | Reloads or replacement sessions could leak work or repaint stale UI | Give each session one abortable owner, use bounded backoff, revalidate generation after every await, and clear exact UI keys during all teardown paths. |
+| Persistent widgets consume scarce terminal rows | Ambient status could distract more than it helps | Default to current-workspace siblings, bound rows, collapse overflow, and hide when no useful state exists. |
+| Herdr-derived terminal text is untrusted | Titles, paths, or state labels could inject controls or break layout | Sanitize at the display boundary before presentation sorting or truncation while preserving raw protocol data internally. |
+| Herdr `done` depends on unseen background completion | Reading state from Pi could accidentally change user-visible semantics | Use read-only APIs that do not focus panes or mark tabs seen, and test that widget inspection preserves `done`. |
+| Agent names or display labels may be absent or non-unique | Widget rows and actions could target the wrong pane | Display friendly labels with stable pane IDs as fallback and resolve every action through returned Herdr identifiers. |
+| A command dashboard can drift into a second Herdr TUI | Maintenance and safety scope could expand rapidly | Keep Phase 3 current-context and menu-first, and require a separate go/no-go decision for each mutating action. |
+| New settings would introduce persistence and precedence obligations | Early delivery could become dominated by configuration complexity | Use a useful zero-configuration default first and adopt extension settings only after a concrete user need is established. |
+
+## Decisions and Changes
+
+- **2026-08-30 — Put the widget first:** reverse ambient observability closes the largest gap between the existing outbound extension and on-demand skill.
+- **2026-08-30 — Prefer a widget over editor replacement:** `ctx.ui.setWidget()` preserves editor composition, keybindings, paste behavior, and compatibility with other editor extensions.
+- **2026-08-30 — Prefer subscription over polling:** authoritative workspace reads plus topology and pane-scoped status subscriptions provide a lower-overhead and more truthful source than recurring `herdr agent list` subprocesses.
+- **2026-08-30 — Reconcile replayed topology:** Herdr replays retained topology events, so the widget coalesces them into fresh workspace reads and rebuilds status subscriptions only when the recognized pane set changes.
+- **2026-08-30 — Defer broad model tools:** the bundled skill and installed CLI remain authoritative until a narrow typed tool proves additional safety or reliability.
+
+## Non-Goals
+
+- Replace the Herdr TUI, sidebar, workspace manager, or terminal layout controls.
+- Mirror every Herdr CLI command as a Pi slash command or model tool.
+- Start agents, create worktrees, move panes, or send prompts autonomously without explicit user intent.
+- Replace Pi's editor component solely to display Herdr state.
+- Show permanent `ready`, `connected`, or `on` decoration when no coordination state needs attention.
+- Poll the Herdr CLI continuously for widget updates.
+- Enable notifications for every agent transition by default.
+- Claim interactive widget or dashboard support in JSON or print mode.
+- Authorize a package version bump, npm publication, tag, or release workflow.
+
+## Assumptions and Unknowns
+
+- This roadmap is for maintainers and contributors, and no delivery dates, owners, capacity commitments, or planning horizon were supplied.
+- Current-workspace sibling agents are assumed to be the most useful default scope, but user demand for current-tab or all-workspace views is unknown.
+- A zero-configuration widget is assumed to be preferable initially, while demand for placement, visibility, filtering, or row-limit settings is unknown.
+- Herdr's public socket schema is assumed to remain available to managed panes, but the minimum supported protocol and compatibility window require an explicit implementation decision.
+- Demand for autocomplete, watch notifications, direct actions, and typed model tools is unknown and remains gated behind demonstrated workflows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7669,14 +7669,19 @@
 			"name": "@narumitw/pi-herdr",
 			"version": "0.0.1",
 			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.60.0"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.11",
 				"@earendil-works/pi-coding-agent": "0.84.4",
+				"@earendil-works/pi-tui": "0.84.4",
 				"@types/node": "26.4.0",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": "*"
+				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*"
 			}
 		},
 		"packages/pi-langfuse": {

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -7,6 +7,8 @@ Connect Pi's interactive lifecycle to Herdr and bundle the operating guidance ne
 ## ✨ Features
 
 - Reports Pi session identity and `working`, `blocked`, and `idle` lifecycle states to the current Herdr pane.
+- Shows recognized sibling agents from the current Herdr workspace in a passive widget above Pi's editor.
+- Updates the widget from Herdr pane lifecycle and agent-status events without polling the CLI.
 - Coalesces rapid state changes and retries short-lived local socket failures without interrupting Pi.
 - Derives blocked state from Pi's public `ui_prompt_start` and `ui_prompt_end` lifecycle events.
 - Bundles the `herdr` skill for explicit Herdr inspection and control requests.
@@ -39,6 +41,7 @@ Install only trusted packages, and review the source and bundled instructions be
 
 Start Pi inside a Herdr-managed pane after installing the package.
 The extension activates automatically when `HERDR_ENV=1`, `HERDR_SOCKET_PATH`, and `HERDR_PANE_ID` are present.
+When the current Herdr workspace contains another recognized agent, Pi shows its state in a widget above the editor.
 Ask Pi to use Herdr, or invoke `/skill:herdr`, when you want it to inspect or control the current Herdr session.
 
 If the standalone integration and skill are already installed, remove them after installing this package to avoid duplicate state reports and skill-name collisions:
@@ -62,10 +65,26 @@ Local socket delivery is best-effort.
 A failed request is retried once with bounded timeouts, and reporting failures never stop Pi.
 Session shutdown aborts in-flight reporting and prevents stale session work from publishing later state.
 
+## 🐑 Agent widget
+
+The widget lists only recognized agents in the current Herdr workspace and excludes the pane running the current Pi session.
+It orders agents by `blocked`, `done`, `working`, `idle`, and `unknown`, shows at most five rows, and reports any remaining count.
+A state label published through Herdr metadata can replace the raw state name.
+Herdr's public pane responses do not expose the blocked prompt message, so the widget cannot show that reason.
+The widget is read-only and does not focus panes, read terminal output, send prompts, or mark a background `done` state as seen.
+The extension discovers the current workspace, opens pane-scoped status subscriptions plus topology subscriptions, and then reloads the pane list to reconcile changes made during initialization.
+Expected pane creation, movement, or agent detection rebuilds the pane-scoped subscriptions without consuming the bounded failure retry.
+Unexpected disconnection clears the widget before one bounded reconnect attempt, and a second failure leaves it hidden until the next Pi session or `/reload`.
+Session replacement and shutdown abort the subscription, pending requests, reconnect delay, and stale widget publication.
+
 ## 🔒 Security and privacy
 
 The extension connects only to the Unix socket or Windows named pipe provided by `HERDR_SOCKET_PATH`.
 It sends the current Herdr pane ID, Pi session path or ID, lifecycle state, session start reason, and blocked label to that endpoint.
+For the widget, it reads the canonical current pane and pane list for the current workspace, then subscribes to pane creation, closure, movement, exit, agent detection, and agent-status events.
+Widget fields can include workspace, tab, pane, terminal, agent, display, title, label, state-label, and lifecycle identifiers supplied by Herdr.
+The subscription can deliver matching pane events from other workspaces in the same Herdr session, and the extension ignores them after resolving the current workspace.
+The extension filters presentation to the current workspace, strips terminal controls at the display boundary, and never reads sibling terminal output for the widget.
 The package does not authenticate the endpoint, so trust the environment that launches Pi and controls these variables.
 
 The bundled skill can direct Pi to inspect terminals, create panes, start agents, send input, and run commands through the local `herdr` CLI.
@@ -74,8 +93,10 @@ The skill requires an explicit user request involving Herdr and stops when `HERD
 
 ## 🚧 Limitations
 
-- State reporting is disabled in RPC, JSON, and print modes.
-- State reporting requires a running Herdr session and valid injected environment variables.
+- State reporting and the agent widget are disabled in RPC, JSON, and print modes.
+- The widget has no settings for placement, workspace scope, visibility, or row count.
+- The widget cannot show blocked prompt text because Herdr does not expose it through public pane responses.
+- Integration requires a running compatible Herdr session and valid injected environment variables.
 - Socket failures are intentionally silent after the bounded retry.
 - The package does not install, start, update, or configure Herdr itself.
 
@@ -87,9 +108,16 @@ packages/pi-herdr/
 │   └── SKILL.md              # Herdr control workflow and safety rules
 ├── src/
 │   ├── index.ts              # Thin Pi entrypoint
-│   └── herdr-agent-state.ts  # Herdr socket and Pi lifecycle integration
+│   ├── herdr-agent-state.ts  # Pi lifecycle and integration ownership
+│   ├── herdr-client.ts       # Bounded Herdr socket transport
+│   ├── herdr-observer.ts     # Read-only event subscription lifecycle
+│   ├── herdr-protocol.ts     # Narrow response and event validation
+│   └── herdr-widget.ts       # Agent state model and presentation
 ├── test/
-│   └── herdr-agent-state.test.ts
+│   ├── herdr-agent-state.test.ts
+│   ├── herdr-client.test.ts
+│   ├── herdr-observer.test.ts
+│   └── herdr-widget.test.ts
 ├── package.json              # Pi extension and skill declarations
 ├── tsconfig.json
 ├── README.md

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -68,11 +68,15 @@ Session shutdown aborts in-flight reporting and prevents stale session work from
 ## 🐑 Agent widget
 
 The widget lists only recognized agents in the current Herdr workspace and excludes the pane running the current Pi session.
-It orders agents by `blocked`, `done`, `working`, `idle`, and `unknown`, shows at most five rows, and reports any remaining count.
+Each row presents state, agent, pane, and workspace in that order, using theme hierarchy instead of repeating field labels.
+Agent identity prefers the name assigned by `herdr agent rename`, then Herdr display metadata, and finally the detected agent kind.
+Pane identity uses its label or metadata title with a short pane ID, while workspace identity uses its label with a short workspace ID.
+Terminal titles are not used as agent identity.
+The widget orders agents by `blocked`, `done`, `working`, `idle`, and `unknown`, shows at most five rows, and reports any remaining count.
 A state label published through Herdr metadata can replace the raw state name.
 Herdr's public pane responses do not expose the blocked prompt message, so the widget cannot show that reason.
 The widget is read-only and does not focus panes, read terminal output, send prompts, or mark a background `done` state as seen.
-The extension discovers the current workspace, opens pane-scoped status subscriptions plus topology subscriptions, and then reloads the pane list to reconcile changes made during initialization.
+The extension discovers the current workspace, pane list, and agent names, opens pane-scoped status subscriptions plus topology subscriptions, and then reloads those identities to reconcile changes made during initialization.
 Expected pane creation, movement, or agent detection rebuilds the pane-scoped subscriptions without consuming the bounded failure retry.
 Unexpected disconnection clears the widget before one bounded reconnect attempt, and a second failure leaves it hidden until the next Pi session or `/reload`.
 Session replacement and shutdown abort the subscription, pending requests, reconnect delay, and stale widget publication.
@@ -81,8 +85,9 @@ Session replacement and shutdown abort the subscription, pending requests, recon
 
 The extension connects only to the Unix socket or Windows named pipe provided by `HERDR_SOCKET_PATH`.
 It sends the current Herdr pane ID, Pi session path or ID, lifecycle state, session start reason, and blocked label to that endpoint.
-For the widget, it reads the canonical current pane and pane list for the current workspace, then subscribes to pane creation, closure, movement, exit, agent detection, and agent-status events.
-Widget fields can include workspace, tab, pane, terminal, agent, display, title, label, state-label, and lifecycle identifiers supplied by Herdr.
+For the widget, it reads the canonical current pane, current workspace metadata, current workspace pane list, and session agent list, then subscribes to pane creation, closure, movement, exit, agent detection, and agent-status events.
+The session agent list can contain agent metadata from other workspaces, but the extension retains names only for panes in the current workspace list.
+Widget fields can include workspace, tab, pane, terminal, agent, display, name, title, label, state-label, and lifecycle identifiers supplied by Herdr.
 The subscription can deliver matching pane events from other workspaces in the same Herdr session, and the extension ignores them after resolving the current workspace.
 The extension filters presentation to the current workspace, strips terminal controls at the display boundary, and never reads sibling terminal output for the widget.
 The package does not authenticate the endpoint, so trust the environment that launches Pi and controls these variables.
@@ -96,6 +101,7 @@ The skill requires an explicit user request involving Herdr and stops when `HERD
 - State reporting and the agent widget are disabled in RPC, JSON, and print modes.
 - The widget has no settings for placement, workspace scope, visibility, or row count.
 - The widget cannot show blocked prompt text because Herdr does not expose it through public pane responses.
+- Herdr exposes no rename event, so agent and pane renames appear after the next topology refresh, reconnect, Pi `/reload`, or session start rather than immediately.
 - Integration requires a running compatible Herdr session and valid injected environment variables.
 - Socket failures are intentionally silent after the bounded retry.
 - The package does not install, start, update, or configure Herdr itself.

--- a/packages/pi-herdr/package.json
+++ b/packages/pi-herdr/package.json
@@ -32,12 +32,17 @@
 		"format": "biome check --write .",
 		"typecheck": "tsc --noEmit"
 	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.60.0"
+	},
 	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": "*"
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.11",
 		"@earendil-works/pi-coding-agent": "0.84.4",
+		"@earendil-works/pi-tui": "0.84.4",
 		"@types/node": "26.4.0",
 		"typescript": "7.0.2"
 	},

--- a/packages/pi-herdr/src/herdr-agent-state.ts
+++ b/packages/pi-herdr/src/herdr-agent-state.ts
@@ -1,6 +1,7 @@
-import net from "node:net";
 import path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createBestEffortSender, type HerdrRequest } from "./herdr-client.js";
+import { createHerdrWidgetObserver, type HerdrWidgetObserver } from "./herdr-observer.js";
 
 const SOURCE = "herdr:pi";
 
@@ -10,12 +11,6 @@ interface HerdrEnvironment {
 	enabled: boolean;
 	paneId: string;
 	socketEndpoint: string;
-}
-
-interface HerdrRequest {
-	id: string;
-	method: "pane.report_agent" | "pane.report_agent_session";
-	params: Record<string, unknown>;
 }
 
 interface QueuedState {
@@ -30,6 +25,7 @@ export interface HerdrAgentStateOptions {
 	now?: () => number;
 	random?: () => number;
 	sendRequest?: (request: HerdrRequest, signal: AbortSignal) => Promise<void>;
+	widgetObserver?: HerdrWidgetObserver;
 }
 
 let reportSeq = Date.now() * 1000;
@@ -61,54 +57,20 @@ function readEnvironment(environment: NodeJS.ProcessEnv = process.env): HerdrEnv
 	};
 }
 
-function sendRequestAttempt(
-	socketEndpoint: string,
-	request: HerdrRequest,
-	timeoutMs: number,
-	signal: AbortSignal,
-): Promise<boolean> {
-	if (signal.aborted) return Promise.resolve(false);
-
-	return new Promise((resolve) => {
-		let finished = false;
-		let timeout: ReturnType<typeof setTimeout> | undefined;
-		const socket = net.createConnection(socketEndpoint);
-
-		const finish = (delivered: boolean) => {
-			if (finished) return;
-			finished = true;
-			if (timeout) clearTimeout(timeout);
-			signal.removeEventListener("abort", abort);
-			socket.destroy();
-			resolve(delivered);
-		};
-		const abort = () => finish(false);
-
-		signal.addEventListener("abort", abort, { once: true });
-		socket.on("error", () => finish(false));
-		socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
-		socket.on("data", () => finish(true));
-		socket.on("end", () => finish(false));
-		timeout = setTimeout(() => finish(false), timeoutMs);
-		timeout.unref?.();
-	});
-}
-
-function createSocketSender(socketEndpoint: string) {
-	return async (request: HerdrRequest, signal: AbortSignal): Promise<void> => {
-		if (await sendRequestAttempt(socketEndpoint, request, 500, signal)) return;
-		if (signal.aborted) return;
-		await sendRequestAttempt(socketEndpoint, request, 1500, signal);
-	};
-}
-
 export function createHerdrAgentStateExtension(
 	options: HerdrAgentStateOptions = {},
 ): (pi: ExtensionAPI) => void {
 	const environment = options.environment ?? readEnvironment();
 	const now = options.now ?? Date.now;
 	const random = options.random ?? Math.random;
-	const sendRequest = options.sendRequest ?? createSocketSender(environment.socketEndpoint);
+	const sendRequest = options.sendRequest ?? createBestEffortSender(environment.socketEndpoint);
+	const widgetObserver =
+		options.widgetObserver ??
+		createHerdrWidgetObserver({
+			environment,
+			now,
+			random,
+		});
 
 	return function herdrAgentState(pi: ExtensionAPI): void {
 		if (!environment.enabled) return;
@@ -256,6 +218,7 @@ export function createHerdrAgentStateExtension(
 			sessionController.abort(new DOMException("Herdr session replaced", "AbortError"));
 			sessionController = new AbortController();
 			rootSession = ctx.mode === "tui";
+			if (rootSession) widgetObserver.start(ctx);
 			agentActive = false;
 			blockedCount = 0;
 			blockedMessage = undefined;
@@ -286,12 +249,12 @@ export function createHerdrAgentStateExtension(
 			publishState();
 		});
 
-		pi.on("session_shutdown", async () => {
+		pi.on("session_shutdown", async (_event, ctx) => {
 			++sessionGeneration;
 			rootSession = false;
 			sessionController.abort(new DOMException("Herdr session shut down", "AbortError"));
 			queuedState = undefined;
-			await drainTask;
+			await Promise.all([drainTask, widgetObserver.shutdown(ctx)]);
 			currentAgentSessionId = undefined;
 			currentAgentSessionPath = undefined;
 		});

--- a/packages/pi-herdr/src/herdr-client.ts
+++ b/packages/pi-herdr/src/herdr-client.ts
@@ -1,0 +1,287 @@
+import net from "node:net";
+
+export const MAX_HERDR_FRAME_BYTES = 1024 * 1024;
+const MAX_PENDING_SUBSCRIPTION_EVENTS = 1024;
+
+export interface HerdrRequest {
+	id: string;
+	method: string;
+	params: Record<string, unknown>;
+}
+
+export interface HerdrSubscription {
+	closed: Promise<void>;
+	close(): void;
+}
+
+class NdjsonFrames {
+	private buffer = Buffer.alloc(0);
+
+	push(chunk: Buffer): unknown[] {
+		this.buffer = Buffer.concat([this.buffer, chunk]);
+		if (this.buffer.length > MAX_HERDR_FRAME_BYTES && this.buffer.indexOf(0x0a) < 0) {
+			throw new Error("Herdr response frame exceeded the size limit");
+		}
+
+		const frames: unknown[] = [];
+		while (true) {
+			const newline = this.buffer.indexOf(0x0a);
+			if (newline < 0) break;
+			if (newline > MAX_HERDR_FRAME_BYTES) {
+				throw new Error("Herdr response frame exceeded the size limit");
+			}
+			const line = this.buffer.subarray(0, newline);
+			this.buffer = this.buffer.subarray(newline + 1);
+			if (line.length === 0) continue;
+			try {
+				frames.push(JSON.parse(line.toString("utf8")));
+			} catch {
+				throw new Error("Herdr returned invalid JSON");
+			}
+		}
+		return frames;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function abortReason(signal: AbortSignal): Error {
+	return signal.reason instanceof Error
+		? signal.reason
+		: new DOMException("Herdr request aborted", "AbortError");
+}
+
+function responseError(frame: Record<string, unknown>): Error | undefined {
+	if (!isRecord(frame.error)) return undefined;
+	const message = typeof frame.error.message === "string" ? frame.error.message : "request failed";
+	return new Error(`Herdr ${message}`);
+}
+
+function sendRequestAttempt(
+	socketEndpoint: string,
+	request: HerdrRequest,
+	timeoutMs: number,
+	signal: AbortSignal,
+): Promise<boolean> {
+	if (signal.aborted) return Promise.resolve(false);
+
+	return new Promise((resolve) => {
+		let finished = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		const socket = net.createConnection(socketEndpoint);
+
+		const finish = (delivered: boolean) => {
+			if (finished) return;
+			finished = true;
+			if (timeout) clearTimeout(timeout);
+			signal.removeEventListener("abort", abort);
+			socket.destroy();
+			resolve(delivered);
+		};
+		const abort = () => finish(false);
+
+		signal.addEventListener("abort", abort, { once: true });
+		socket.on("error", () => finish(false));
+		socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+		socket.on("data", () => finish(true));
+		socket.on("end", () => finish(false));
+		socket.on("close", () => finish(false));
+		timeout = setTimeout(() => finish(false), timeoutMs);
+		timeout.unref?.();
+	});
+}
+
+export function createBestEffortSender(socketEndpoint: string) {
+	return async (request: HerdrRequest, signal: AbortSignal): Promise<void> => {
+		if (await sendRequestAttempt(socketEndpoint, request, 500, signal)) return;
+		if (signal.aborted) return;
+		await sendRequestAttempt(socketEndpoint, request, 1500, signal);
+	};
+}
+
+export function requestHerdr(
+	socketEndpoint: string,
+	request: HerdrRequest,
+	signal: AbortSignal,
+	timeoutMs = 1500,
+): Promise<unknown> {
+	if (signal.aborted) return Promise.reject(abortReason(signal));
+
+	return new Promise((resolve, reject) => {
+		const socket = net.createConnection(socketEndpoint);
+		const parser = new NdjsonFrames();
+		let finished = false;
+		const timeout = setTimeout(() => finish(new Error("Herdr request timed out")), timeoutMs);
+		timeout.unref?.();
+
+		const cleanup = () => {
+			clearTimeout(timeout);
+			signal.removeEventListener("abort", abort);
+			socket.destroy();
+		};
+		const finish = (error?: Error, result?: unknown) => {
+			if (finished) return;
+			finished = true;
+			cleanup();
+			if (error) reject(error);
+			else resolve(result);
+		};
+		const abort = () => finish(abortReason(signal));
+
+		signal.addEventListener("abort", abort, { once: true });
+		socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+		socket.on("error", (error) => finish(error));
+		socket.on("end", () => finish(new Error("Herdr closed the request before responding")));
+		socket.on("close", () => finish(new Error("Herdr request socket closed")));
+		socket.on("data", (chunk: Buffer) => {
+			try {
+				for (const value of parser.push(chunk)) {
+					if (!isRecord(value)) continue;
+					const uncorrelatedError = responseError(value);
+					if (uncorrelatedError && (value.id === "" || value.id === undefined)) {
+						finish(uncorrelatedError);
+						return;
+					}
+					if (value.id !== request.id) continue;
+					const error = responseError(value);
+					if (error) {
+						finish(error);
+						return;
+					}
+					if (!("result" in value)) {
+						finish(new Error("Herdr response did not include a result"));
+						return;
+					}
+					finish(undefined, value.result);
+					return;
+				}
+			} catch (error) {
+				finish(error instanceof Error ? error : new Error(String(error)));
+			}
+		});
+	});
+}
+
+export async function openHerdrSubscription(
+	socketEndpoint: string,
+	request: HerdrRequest,
+	signal: AbortSignal,
+	onEvent: (frame: unknown) => void,
+	timeoutMs = 1500,
+): Promise<HerdrSubscription> {
+	if (signal.aborted) throw abortReason(signal);
+
+	const socket = net.createConnection(socketEndpoint);
+	const parser = new NdjsonFrames();
+	const pendingEvents: unknown[] = [];
+	let ready = false;
+	let finished = false;
+	let intentionalClose = false;
+	let resolveReady!: () => void;
+	let rejectReady!: (error: Error) => void;
+	let resolveClosed!: () => void;
+	let rejectClosed!: (error: Error) => void;
+	const readyPromise = new Promise<void>((resolve, reject) => {
+		resolveReady = resolve;
+		rejectReady = reject;
+	});
+	const closed = new Promise<void>((resolve, reject) => {
+		resolveClosed = resolve;
+		rejectClosed = reject;
+	});
+	void closed.catch(() => undefined);
+	const timeout = setTimeout(() => finish(new Error("Herdr subscription timed out")), timeoutMs);
+	timeout.unref?.();
+
+	const cleanup = () => {
+		clearTimeout(timeout);
+		signal.removeEventListener("abort", abort);
+		socket.destroy();
+	};
+	const finish = (error?: Error) => {
+		if (finished) return;
+		finished = true;
+		cleanup();
+		if (!ready) {
+			if (error && !intentionalClose) rejectReady(error);
+			else rejectReady(abortReason(signal));
+			resolveClosed();
+			return;
+		}
+		if (error && !intentionalClose) rejectClosed(error);
+		else resolveClosed();
+	};
+	const deliver = (frame: unknown) => {
+		try {
+			onEvent(frame);
+		} catch (error) {
+			finish(error instanceof Error ? error : new Error(String(error)));
+		}
+	};
+	const abort = () => {
+		intentionalClose = true;
+		finish();
+	};
+
+	signal.addEventListener("abort", abort, { once: true });
+	socket.on("connect", () => socket.write(`${JSON.stringify(request)}\n`));
+	socket.on("error", (error) => finish(error));
+	socket.on("end", () => finish(new Error("Herdr subscription closed")));
+	socket.on("close", () => finish(new Error("Herdr subscription socket closed")));
+	socket.on("data", (chunk: Buffer) => {
+		try {
+			for (const value of parser.push(chunk)) {
+				if (!ready) {
+					if (isRecord(value)) {
+						const uncorrelatedError = responseError(value);
+						if (uncorrelatedError && (value.id === "" || value.id === undefined)) {
+							finish(uncorrelatedError);
+							return;
+						}
+					}
+					if (isRecord(value) && value.id === request.id) {
+						const error = responseError(value);
+						if (error) {
+							finish(error);
+							return;
+						}
+						if (!isRecord(value.result) || value.result.type !== "subscription_started") {
+							finish(new Error("Herdr returned an invalid subscription acknowledgement"));
+							return;
+						}
+						ready = true;
+						clearTimeout(timeout);
+						resolveReady();
+						for (const event of pendingEvents.splice(0)) deliver(event);
+						continue;
+					}
+					if (pendingEvents.length >= MAX_PENDING_SUBSCRIPTION_EVENTS) {
+						finish(new Error("Too many Herdr events arrived before subscription acknowledgement"));
+						return;
+					}
+					pendingEvents.push(value);
+					continue;
+				}
+				deliver(value);
+			}
+		} catch (error) {
+			finish(error instanceof Error ? error : new Error(String(error)));
+		}
+	});
+
+	await readyPromise;
+	if (signal.aborted) {
+		intentionalClose = true;
+		finish();
+		throw abortReason(signal);
+	}
+	return {
+		closed,
+		close() {
+			intentionalClose = true;
+			finish();
+		},
+	};
+}

--- a/packages/pi-herdr/src/herdr-observer.ts
+++ b/packages/pi-herdr/src/herdr-observer.ts
@@ -1,0 +1,379 @@
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	type HerdrRequest,
+	type HerdrSubscription,
+	openHerdrSubscription,
+	requestHerdr,
+} from "./herdr-client.js";
+import {
+	type HerdrPane,
+	type HerdrPaneEvent,
+	herdrWidgetSubscriptions,
+	parseHerdrPaneEvent,
+	parsePaneCurrentResult,
+	parsePaneListResult,
+} from "./herdr-protocol.js";
+import {
+	createHerdrWidget,
+	HERDR_WIDGET_KEY,
+	HerdrWidgetModel,
+	herdrWidgetFingerprint,
+} from "./herdr-widget.js";
+
+export interface HerdrObserverEnvironment {
+	paneId: string;
+	socketEndpoint: string;
+}
+
+export interface HerdrObserverOptions {
+	environment: HerdrObserverEnvironment;
+	now?: () => number;
+	random?: () => number;
+	request?: (
+		socketEndpoint: string,
+		request: HerdrRequest,
+		signal: AbortSignal,
+	) => Promise<unknown>;
+	subscribe?: (
+		socketEndpoint: string,
+		request: HerdrRequest,
+		signal: AbortSignal,
+		onEvent: (frame: unknown) => void,
+	) => Promise<HerdrSubscription>;
+	retryDelayMs?: number;
+}
+
+export interface HerdrWidgetObserver {
+	start(ctx: ExtensionContext): void;
+	shutdown(ctx: ExtensionContext): Promise<void>;
+}
+
+const MAX_PENDING_EVENTS = 1024;
+
+class HerdrTopologyChangedError extends Error {}
+
+function requiresResubscribe(event: HerdrPaneEvent): boolean {
+	return event.type === "created" || event.type === "moved" || event.type === "agent_detected";
+}
+
+function isRelevantEvent(model: HerdrWidgetModel, event: HerdrPaneEvent): boolean {
+	if (event.type === "created") return model.isCurrentWorkspace(event.pane.workspaceId);
+	if (event.type === "moved") {
+		return (
+			model.isCurrentPane(event.previousPaneId) ||
+			model.isCurrentWorkspace(event.previousWorkspaceId) ||
+			model.isCurrentWorkspace(event.pane.workspaceId)
+		);
+	}
+	return model.isCurrentWorkspace(event.workspaceId);
+}
+
+function subscriptionFingerprint(currentPane: HerdrPane, panes: readonly HerdrPane[]): string {
+	const agentPaneIds = panes
+		.filter((pane) => pane.agent !== undefined)
+		.map((pane) => pane.paneId)
+		.sort();
+	return JSON.stringify([currentPane.paneId, currentPane.workspaceId, agentPaneIds]);
+}
+
+function waitForRetry(delayMs: number, signal: AbortSignal): Promise<void> {
+	if (signal.aborted) return Promise.reject(signal.reason);
+	if (delayMs <= 0) return Promise.resolve();
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			signal.removeEventListener("abort", abort);
+			resolve();
+		}, delayMs);
+		timer.unref?.();
+		const abort = () => {
+			clearTimeout(timer);
+			reject(signal.reason);
+		};
+		signal.addEventListener("abort", abort, { once: true });
+	});
+}
+
+export function createHerdrWidgetObserver(options: HerdrObserverOptions): HerdrWidgetObserver {
+	const now = options.now ?? Date.now;
+	const random = options.random ?? Math.random;
+	const request = options.request ?? requestHerdr;
+	const subscribe = options.subscribe ?? openHerdrSubscription;
+	const retryDelayMs = options.retryDelayMs ?? 200;
+	let generation = 0;
+	let activeContext: ExtensionContext | undefined;
+	let activeSession: ExtensionContext["sessionManager"] | undefined;
+	let controller: AbortController | undefined;
+	const ownedTasks = new Set<Promise<void>>();
+	let publishedFingerprint: string | undefined;
+	let hasPublished = false;
+
+	const owns = (ctx: ExtensionContext, expectedGeneration = generation) =>
+		ctx.sessionManager === activeSession && expectedGeneration === generation;
+
+	const requestId = (kind: string) =>
+		`herdr:pi:widget:${kind}:${now()}:${random().toString(36).slice(2)}`;
+
+	const clearWidget = (ctx: ExtensionContext) => {
+		if (ctx.mode === "tui") ctx.ui.setWidget(HERDR_WIDGET_KEY, undefined);
+		publishedFingerprint = undefined;
+		hasPublished = false;
+	};
+
+	const publish = (ctx: ExtensionContext, model: HerdrWidgetModel, expectedGeneration: number) => {
+		if (!owns(ctx, expectedGeneration) || ctx.mode !== "tui") return;
+		const snapshot = model.snapshot();
+		const fingerprint = herdrWidgetFingerprint(snapshot);
+		if (hasPublished && fingerprint === publishedFingerprint) return;
+		if (!snapshot) {
+			ctx.ui.setWidget(HERDR_WIDGET_KEY, undefined);
+		} else {
+			ctx.ui.setWidget(
+				HERDR_WIDGET_KEY,
+				(_tui: unknown, theme: Theme) => createHerdrWidget(snapshot, theme),
+				{ placement: "aboveEditor" },
+			);
+		}
+		publishedFingerprint = fingerprint;
+		hasPublished = true;
+	};
+
+	const loadPaneSet = async (
+		ctx: ExtensionContext,
+		expectedGeneration: number,
+		signal: AbortSignal,
+	): Promise<{ currentPane: HerdrPane; panes: HerdrPane[] } | undefined> => {
+		const currentResult = await request(
+			options.environment.socketEndpoint,
+			{
+				id: requestId("current"),
+				method: "pane.current",
+				params: { caller_pane_id: options.environment.paneId },
+			},
+			signal,
+		);
+		if (!owns(ctx, expectedGeneration) || signal.aborted) return undefined;
+		const currentPane = parsePaneCurrentResult(currentResult);
+		const listResult = await request(
+			options.environment.socketEndpoint,
+			{
+				id: requestId("list"),
+				method: "pane.list",
+				params: { workspace_id: currentPane.workspaceId },
+			},
+			signal,
+		);
+		if (!owns(ctx, expectedGeneration) || signal.aborted) return undefined;
+		return { currentPane, panes: parsePaneListResult(listResult) };
+	};
+
+	const runAttempt = async (
+		ctx: ExtensionContext,
+		expectedGeneration: number,
+		sessionSignal: AbortSignal,
+	): Promise<void> => {
+		const attemptController = new AbortController();
+		const abortAttempt = () => attemptController.abort(sessionSignal.reason);
+		if (sessionSignal.aborted) abortAttempt();
+		else sessionSignal.addEventListener("abort", abortAttempt, { once: true });
+		const signal = attemptController.signal;
+		let attemptActive = true;
+		let subscription: HerdrSubscription | undefined;
+		let refreshTask: Promise<void> | undefined;
+		try {
+			const discovered = await loadPaneSet(ctx, expectedGeneration, signal);
+			if (!discovered) return;
+			const subscribedFingerprint = subscriptionFingerprint(
+				discovered.currentPane,
+				discovered.panes,
+			);
+			const model = new HerdrWidgetModel();
+			model.reset(discovered.currentPane, discovered.panes);
+			const pendingEvents: HerdrPaneEvent[] = [];
+			const pendingStatusEvents: HerdrPaneEvent[] = [];
+			let initialized = false;
+			let topologyPending = false;
+			let refreshingTopology = false;
+			let refreshAgain = false;
+			let rejectReconfigure!: (error: Error) => void;
+			let reconfigureSettled = false;
+			const reconfigure = new Promise<never>((_resolve, reject) => {
+				rejectReconfigure = reject;
+			});
+			void reconfigure.catch(() => undefined);
+			const failAttempt = (error: Error) => {
+				if (reconfigureSettled) return;
+				reconfigureSettled = true;
+				rejectReconfigure(error);
+			};
+			const scheduleTopologyRefresh = () => {
+				if (!initialized || !attemptActive || signal.aborted) return;
+				if (refreshTask) {
+					refreshAgain = true;
+					return;
+				}
+				refreshTask = (async () => {
+					do {
+						refreshAgain = false;
+						refreshingTopology = true;
+						const refreshed = await loadPaneSet(ctx, expectedGeneration, signal);
+						if (!refreshed || !attemptActive || signal.aborted) return;
+						model.reset(refreshed.currentPane, refreshed.panes);
+						for (const event of pendingStatusEvents.splice(0)) {
+							if (isRelevantEvent(model, event)) model.apply(event);
+						}
+						refreshingTopology = false;
+						publish(ctx, model, expectedGeneration);
+						if (
+							subscriptionFingerprint(refreshed.currentPane, refreshed.panes) !==
+							subscribedFingerprint
+						) {
+							failAttempt(new HerdrTopologyChangedError());
+							return;
+						}
+					} while (refreshAgain && attemptActive && !signal.aborted);
+				})()
+					.catch((error) => {
+						failAttempt(error instanceof Error ? error : new Error(String(error)));
+					})
+					.finally(() => {
+						refreshingTopology = false;
+						refreshTask = undefined;
+					});
+			};
+
+			subscription = await subscribe(
+				options.environment.socketEndpoint,
+				{
+					id: requestId("subscribe"),
+					method: "events.subscribe",
+					params: { subscriptions: herdrWidgetSubscriptions(discovered.panes) },
+				},
+				signal,
+				(frame) => {
+					const event = parseHerdrPaneEvent(frame);
+					if (!initialized) {
+						if (!event || !isRelevantEvent(model, event)) return;
+						if (requiresResubscribe(event)) {
+							topologyPending = true;
+							return;
+						}
+						if (pendingEvents.length >= MAX_PENDING_EVENTS) {
+							throw new Error("Too many Herdr events arrived during initialization");
+						}
+						pendingEvents.push(event);
+						return;
+					}
+
+					if (
+						!event ||
+						!owns(ctx, expectedGeneration) ||
+						signal.aborted ||
+						!isRelevantEvent(model, event)
+					) {
+						return;
+					}
+					if (requiresResubscribe(event)) {
+						scheduleTopologyRefresh();
+						return;
+					}
+					if (refreshingTopology) {
+						if (pendingStatusEvents.length >= MAX_PENDING_EVENTS) {
+							throw new Error("Too many Herdr status events arrived during refresh");
+						}
+						pendingStatusEvents.push(event);
+						return;
+					}
+					model.apply(event);
+					publish(ctx, model, expectedGeneration);
+				},
+			);
+			if (!owns(ctx, expectedGeneration) || signal.aborted) return;
+
+			const reconciled = await loadPaneSet(ctx, expectedGeneration, signal);
+			if (!reconciled) return;
+			model.reset(reconciled.currentPane, reconciled.panes);
+			for (const event of pendingEvents.splice(0)) {
+				if (isRelevantEvent(model, event)) model.apply(event);
+			}
+			if (
+				subscriptionFingerprint(reconciled.currentPane, reconciled.panes) !== subscribedFingerprint
+			) {
+				throw new HerdrTopologyChangedError();
+			}
+			initialized = true;
+			publish(ctx, model, expectedGeneration);
+			if (topologyPending) scheduleTopologyRefresh();
+			await Promise.race([
+				subscription.closed.then(() => {
+					if (!signal.aborted) throw new Error("Herdr subscription ended");
+				}),
+				reconfigure,
+			]);
+		} finally {
+			attemptActive = false;
+			attemptController.abort(new DOMException("Herdr widget attempt ended", "AbortError"));
+			sessionSignal.removeEventListener("abort", abortAttempt);
+			subscription?.close();
+			await Promise.allSettled(refreshTask ? [refreshTask] : []);
+		}
+	};
+
+	const run = async (
+		ctx: ExtensionContext,
+		expectedGeneration: number,
+		signal: AbortSignal,
+	): Promise<void> => {
+		let failures = 0;
+		while (owns(ctx, expectedGeneration) && !signal.aborted) {
+			try {
+				await runAttempt(ctx, expectedGeneration, signal);
+				return;
+			} catch (error) {
+				if (!owns(ctx, expectedGeneration) || signal.aborted) return;
+				clearWidget(ctx);
+				if (error instanceof HerdrTopologyChangedError) continue;
+				failures += 1;
+				if (failures >= 2) return;
+				try {
+					await waitForRetry(retryDelayMs, signal);
+				} catch {
+					return;
+				}
+				if (!owns(ctx, expectedGeneration) || signal.aborted) return;
+			}
+		}
+	};
+
+	return {
+		start(ctx) {
+			generation += 1;
+			controller?.abort(new DOMException("Herdr widget session replaced", "AbortError"));
+			if (activeContext) clearWidget(activeContext);
+			activeContext = undefined;
+			activeSession = undefined;
+			controller = undefined;
+			if (ctx.mode !== "tui") return;
+
+			activeContext = ctx;
+			activeSession = ctx.sessionManager;
+			controller = new AbortController();
+			const expectedGeneration = generation;
+			clearWidget(ctx);
+			const task = run(ctx, expectedGeneration, controller.signal).finally(() => {
+				ownedTasks.delete(task);
+			});
+			ownedTasks.add(task);
+		},
+		async shutdown(ctx) {
+			if (!owns(ctx)) return;
+			const shutdownGeneration = ++generation;
+			controller?.abort(new DOMException("Herdr widget session shut down", "AbortError"));
+			clearWidget(ctx);
+			await Promise.allSettled([...ownedTasks]);
+			if (generation !== shutdownGeneration) return;
+			activeContext = undefined;
+			activeSession = undefined;
+			controller = undefined;
+		},
+	};
+}

--- a/packages/pi-herdr/src/herdr-observer.ts
+++ b/packages/pi-herdr/src/herdr-observer.ts
@@ -8,10 +8,13 @@ import {
 import {
 	type HerdrPane,
 	type HerdrPaneEvent,
+	type HerdrWorkspace,
 	herdrWidgetSubscriptions,
+	parseAgentListResult,
 	parseHerdrPaneEvent,
 	parsePaneCurrentResult,
 	parsePaneListResult,
+	parseWorkspaceGetResult,
 } from "./herdr-protocol.js";
 import {
 	createHerdrWidget,
@@ -141,7 +144,9 @@ export function createHerdrWidgetObserver(options: HerdrObserverOptions): HerdrW
 		ctx: ExtensionContext,
 		expectedGeneration: number,
 		signal: AbortSignal,
-	): Promise<{ currentPane: HerdrPane; panes: HerdrPane[] } | undefined> => {
+	): Promise<
+		{ currentPane: HerdrPane; panes: HerdrPane[]; workspace: HerdrWorkspace } | undefined
+	> => {
 		const currentResult = await request(
 			options.environment.socketEndpoint,
 			{
@@ -153,17 +158,48 @@ export function createHerdrWidgetObserver(options: HerdrObserverOptions): HerdrW
 		);
 		if (!owns(ctx, expectedGeneration) || signal.aborted) return undefined;
 		const currentPane = parsePaneCurrentResult(currentResult);
-		const listResult = await request(
-			options.environment.socketEndpoint,
-			{
-				id: requestId("list"),
-				method: "pane.list",
-				params: { workspace_id: currentPane.workspaceId },
-			},
-			signal,
-		);
+		const [listResult, agentResult, workspaceResult] = await Promise.all([
+			request(
+				options.environment.socketEndpoint,
+				{
+					id: requestId("list"),
+					method: "pane.list",
+					params: { workspace_id: currentPane.workspaceId },
+				},
+				signal,
+			),
+			request(
+				options.environment.socketEndpoint,
+				{ id: requestId("agents"), method: "agent.list", params: {} },
+				signal,
+			),
+			request(
+				options.environment.socketEndpoint,
+				{
+					id: requestId("workspace"),
+					method: "workspace.get",
+					params: { workspace_id: currentPane.workspaceId },
+				},
+				signal,
+			),
+		]);
 		if (!owns(ctx, expectedGeneration) || signal.aborted) return undefined;
-		return { currentPane, panes: parsePaneListResult(listResult) };
+		const namesByPane = new Map(
+			parseAgentListResult(agentResult).map((pane) => [pane.paneId, pane.agentName]),
+		);
+		const withAgentName = (pane: HerdrPane): HerdrPane => ({
+			...pane,
+			agentName: namesByPane.get(pane.paneId) ?? pane.agentName,
+		});
+		const workspace = parseWorkspaceGetResult(workspaceResult);
+		if (workspace.workspaceId !== currentPane.workspaceId) {
+			throw new Error("Herdr returned a mismatched workspace");
+		}
+		return {
+			currentPane: withAgentName(currentPane),
+			panes: parsePaneListResult(listResult).map(withAgentName),
+			workspace,
+		};
 	};
 
 	const runAttempt = async (
@@ -187,7 +223,7 @@ export function createHerdrWidgetObserver(options: HerdrObserverOptions): HerdrW
 				discovered.panes,
 			);
 			const model = new HerdrWidgetModel();
-			model.reset(discovered.currentPane, discovered.panes);
+			model.reset(discovered.currentPane, discovered.panes, discovered.workspace);
 			const pendingEvents: HerdrPaneEvent[] = [];
 			const pendingStatusEvents: HerdrPaneEvent[] = [];
 			let initialized = false;
@@ -217,7 +253,7 @@ export function createHerdrWidgetObserver(options: HerdrObserverOptions): HerdrW
 						refreshingTopology = true;
 						const refreshed = await loadPaneSet(ctx, expectedGeneration, signal);
 						if (!refreshed || !attemptActive || signal.aborted) return;
-						model.reset(refreshed.currentPane, refreshed.panes);
+						model.reset(refreshed.currentPane, refreshed.panes, refreshed.workspace);
 						for (const event of pendingStatusEvents.splice(0)) {
 							if (isRelevantEvent(model, event)) model.apply(event);
 						}
@@ -291,7 +327,7 @@ export function createHerdrWidgetObserver(options: HerdrObserverOptions): HerdrW
 
 			const reconciled = await loadPaneSet(ctx, expectedGeneration, signal);
 			if (!reconciled) return;
-			model.reset(reconciled.currentPane, reconciled.panes);
+			model.reset(reconciled.currentPane, reconciled.panes, reconciled.workspace);
 			for (const event of pendingEvents.splice(0)) {
 				if (isRelevantEvent(model, event)) model.apply(event);
 			}

--- a/packages/pi-herdr/src/herdr-protocol.ts
+++ b/packages/pi-herdr/src/herdr-protocol.ts
@@ -10,12 +10,18 @@ export interface HerdrPane {
 	focused: boolean;
 	revision: number;
 	agent?: string;
+	agentName?: string;
 	agentStatus: HerdrAgentStatus;
 	displayAgent?: string;
 	label?: string;
 	stateLabels: Record<string, string>;
 	terminalTitle?: string;
 	title?: string;
+}
+
+export interface HerdrWorkspace {
+	workspaceId: string;
+	label?: string;
 }
 
 export type HerdrPaneEvent =
@@ -117,6 +123,7 @@ export function parseHerdrPane(value: unknown): HerdrPane | undefined {
 		focused: value.focused,
 		revision,
 		agent: optionalString(value.agent),
+		agentName: optionalString(value.name),
 		agentStatus: status,
 		displayAgent: optionalString(value.display_agent),
 		label: optionalString(value.label),
@@ -145,6 +152,25 @@ export function parsePaneListResult(value: unknown): HerdrPane[] {
 		throw new Error("Herdr returned an invalid pane in the pane list");
 	}
 	return panes as HerdrPane[];
+}
+
+export function parseAgentListResult(value: unknown): HerdrPane[] {
+	if (!isRecord(value) || value.type !== "agent_list" || !Array.isArray(value.agents)) {
+		throw new Error("Herdr returned an invalid agent-list response");
+	}
+	return value.agents.flatMap((entry) => {
+		const pane = parseHerdrPane(entry);
+		return pane ? [pane] : [];
+	});
+}
+
+export function parseWorkspaceGetResult(value: unknown): HerdrWorkspace {
+	if (!isRecord(value) || value.type !== "workspace_info" || !isRecord(value.workspace)) {
+		throw new Error("Herdr returned an invalid workspace response");
+	}
+	const workspaceId = requiredString(value.workspace.workspace_id);
+	if (!workspaceId) throw new Error("Herdr returned an invalid workspace identity");
+	return { workspaceId, label: optionalString(value.workspace.label) };
 }
 
 export function parseHerdrPaneEvent(value: unknown): HerdrPaneEvent | undefined {

--- a/packages/pi-herdr/src/herdr-protocol.ts
+++ b/packages/pi-herdr/src/herdr-protocol.ts
@@ -1,0 +1,211 @@
+export const HERDR_AGENT_STATUSES = ["idle", "working", "blocked", "done", "unknown"] as const;
+
+export type HerdrAgentStatus = (typeof HERDR_AGENT_STATUSES)[number];
+
+export interface HerdrPane {
+	paneId: string;
+	workspaceId: string;
+	tabId: string;
+	terminalId: string;
+	focused: boolean;
+	revision: number;
+	agent?: string;
+	agentStatus: HerdrAgentStatus;
+	displayAgent?: string;
+	label?: string;
+	stateLabels: Record<string, string>;
+	terminalTitle?: string;
+	title?: string;
+}
+
+export type HerdrPaneEvent =
+	| { type: "created"; pane: HerdrPane }
+	| { type: "closed" | "exited"; paneId: string; workspaceId: string }
+	| {
+			type: "moved";
+			pane: HerdrPane;
+			previousPaneId: string;
+			previousWorkspaceId: string;
+	  }
+	| {
+			type: "agent_detected";
+			paneId: string;
+			workspaceId: string;
+			agent?: string;
+			finalStatus?: HerdrAgentStatus;
+			released: boolean;
+	  }
+	| {
+			type: "agent_status_changed";
+			paneId: string;
+			workspaceId: string;
+			agent?: string;
+			agentStatus: HerdrAgentStatus;
+			displayAgent?: string;
+			stateLabels?: Record<string, string>;
+			title?: string;
+	  };
+
+const HERDR_WIDGET_TOPOLOGY_SUBSCRIPTIONS = [
+	{ type: "pane.created" },
+	{ type: "pane.closed" },
+	{ type: "pane.moved" },
+	{ type: "pane.exited" },
+	{ type: "pane.agent_detected" },
+] as const;
+
+export function herdrWidgetSubscriptions(panes: readonly HerdrPane[]) {
+	return [
+		...HERDR_WIDGET_TOPOLOGY_SUBSCRIPTIONS.map((entry) => ({ ...entry })),
+		...panes
+			.filter((pane) => pane.agent !== undefined)
+			.map((pane) => ({ type: "pane.agent_status_changed", pane_id: pane.paneId })),
+	];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function agentStatus(value: unknown): HerdrAgentStatus | undefined {
+	return typeof value === "string" && HERDR_AGENT_STATUSES.includes(value as HerdrAgentStatus)
+		? (value as HerdrAgentStatus)
+		: undefined;
+}
+
+function stringRecord(value: unknown): Record<string, string> | undefined {
+	if (!isRecord(value)) return undefined;
+	const entries = Object.entries(value);
+	if (!entries.every(([, entry]) => typeof entry === "string")) return undefined;
+	return Object.fromEntries(entries) as Record<string, string>;
+}
+
+export function parseHerdrPane(value: unknown): HerdrPane | undefined {
+	if (!isRecord(value)) return undefined;
+	const paneId = requiredString(value.pane_id);
+	const workspaceId = requiredString(value.workspace_id);
+	const tabId = requiredString(value.tab_id);
+	const terminalId = requiredString(value.terminal_id);
+	const status = agentStatus(value.agent_status);
+	const revision = value.revision;
+	if (
+		!paneId ||
+		!workspaceId ||
+		!tabId ||
+		!terminalId ||
+		!status ||
+		typeof value.focused !== "boolean" ||
+		typeof revision !== "number" ||
+		!Number.isSafeInteger(revision) ||
+		revision < 0
+	) {
+		return undefined;
+	}
+	return {
+		paneId,
+		workspaceId,
+		tabId,
+		terminalId,
+		focused: value.focused,
+		revision,
+		agent: optionalString(value.agent),
+		agentStatus: status,
+		displayAgent: optionalString(value.display_agent),
+		label: optionalString(value.label),
+		stateLabels: stringRecord(value.state_labels) ?? {},
+		terminalTitle:
+			optionalString(value.terminal_title_stripped) ?? optionalString(value.terminal_title),
+		title: optionalString(value.title),
+	};
+}
+
+export function parsePaneCurrentResult(value: unknown): HerdrPane {
+	if (!isRecord(value) || value.type !== "pane_current") {
+		throw new Error("Herdr returned an invalid current-pane response");
+	}
+	const pane = parseHerdrPane(value.pane);
+	if (!pane) throw new Error("Herdr returned an invalid current pane");
+	return pane;
+}
+
+export function parsePaneListResult(value: unknown): HerdrPane[] {
+	if (!isRecord(value) || value.type !== "pane_list" || !Array.isArray(value.panes)) {
+		throw new Error("Herdr returned an invalid pane-list response");
+	}
+	const panes = value.panes.map(parseHerdrPane);
+	if (panes.some((pane) => pane === undefined)) {
+		throw new Error("Herdr returned an invalid pane in the pane list");
+	}
+	return panes as HerdrPane[];
+}
+
+export function parseHerdrPaneEvent(value: unknown): HerdrPaneEvent | undefined {
+	if (!isRecord(value) || typeof value.event !== "string" || !isRecord(value.data)) {
+		return undefined;
+	}
+	const data = value.data;
+
+	if (value.event === "pane.agent_status_changed") {
+		const paneId = requiredString(data.pane_id);
+		const workspaceId = requiredString(data.workspace_id);
+		const status = agentStatus(data.agent_status);
+		if (!paneId || !workspaceId || !status) return undefined;
+		return {
+			type: "agent_status_changed",
+			paneId,
+			workspaceId,
+			agent: optionalString(data.agent),
+			agentStatus: status,
+			displayAgent: optionalString(data.display_agent),
+			stateLabels: stringRecord(data.state_labels),
+			title: optionalString(data.title),
+		};
+	}
+
+	if (value.event === "pane_created") {
+		const pane = parseHerdrPane(data.pane);
+		return pane ? { type: "created", pane } : undefined;
+	}
+	if (value.event === "pane_closed" || value.event === "pane_exited") {
+		const paneId = requiredString(data.pane_id);
+		const workspaceId = requiredString(data.workspace_id);
+		if (!paneId || !workspaceId) return undefined;
+		return {
+			type: value.event === "pane_closed" ? "closed" : "exited",
+			paneId,
+			workspaceId,
+		};
+	}
+	if (value.event === "pane_moved") {
+		const pane = parseHerdrPane(data.pane);
+		const previousPaneId = requiredString(data.previous_pane_id);
+		const previousWorkspaceId = requiredString(data.previous_workspace_id);
+		if (!pane || !previousPaneId || !previousWorkspaceId) return undefined;
+		return { type: "moved", pane, previousPaneId, previousWorkspaceId };
+	}
+	if (value.event === "pane_agent_detected") {
+		const paneId = requiredString(data.pane_id);
+		const workspaceId = requiredString(data.workspace_id);
+		if (!paneId || !workspaceId || typeof data.released !== "boolean") return undefined;
+		const finalStatus = data.final_status === null ? undefined : agentStatus(data.final_status);
+		if (data.final_status !== undefined && data.final_status !== null && !finalStatus)
+			return undefined;
+		return {
+			type: "agent_detected",
+			paneId,
+			workspaceId,
+			agent: optionalString(data.agent),
+			finalStatus,
+			released: data.released,
+		};
+	}
+	return undefined;
+}

--- a/packages/pi-herdr/src/herdr-widget.ts
+++ b/packages/pi-herdr/src/herdr-widget.ts
@@ -1,7 +1,12 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { EditorStatusWidget } from "@narumitw/pi-tui-kit/editor-status-widget";
 import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
-import type { HerdrAgentStatus, HerdrPane, HerdrPaneEvent } from "./herdr-protocol.js";
+import type {
+	HerdrAgentStatus,
+	HerdrPane,
+	HerdrPaneEvent,
+	HerdrWorkspace,
+} from "./herdr-protocol.js";
 
 export const HERDR_WIDGET_KEY = "herdr:agents";
 export const MAX_HERDR_WIDGET_AGENTS = 5;
@@ -10,17 +15,19 @@ interface ObservedPane {
 	paneId: string;
 	workspaceId: string;
 	agent?: string;
+	agentName?: string;
 	agentStatus: HerdrAgentStatus;
 	displayAgent?: string;
 	label?: string;
 	stateLabels: Record<string, string>;
-	terminalTitle?: string;
 	title?: string;
 }
 
 export interface HerdrWidgetRow {
-	name: string;
+	agent: string;
+	pane: string;
 	paneId: string;
+	space: string;
 	state: HerdrAgentStatus;
 	stateLabel: string;
 }
@@ -44,11 +51,11 @@ function observedPane(pane: HerdrPane): ObservedPane {
 		paneId: pane.paneId,
 		workspaceId: pane.workspaceId,
 		agent: pane.agent,
+		agentName: pane.agentName,
 		agentStatus: pane.agentStatus,
 		displayAgent: pane.displayAgent,
 		label: pane.label,
 		stateLabels: { ...pane.stateLabels },
-		terminalTitle: pane.terminalTitle,
 		title: pane.title,
 	};
 }
@@ -59,22 +66,39 @@ function safeDisplay(value: string | undefined): string | undefined {
 	return safe.length > 0 ? safe : undefined;
 }
 
-function displayName(pane: ObservedPane): string {
+function shortIdentity(value: string, fallback: string): string {
+	const safe = safeDisplay(value);
+	if (!safe) return fallback;
+	return safe.split(":").at(-1) || fallback;
+}
+
+function agentDisplay(pane: ObservedPane): string {
 	return (
-		safeDisplay(pane.label) ??
-		safeDisplay(pane.title) ??
+		safeDisplay(pane.agentName) ??
 		safeDisplay(pane.displayAgent) ??
-		safeDisplay(pane.terminalTitle) ??
 		safeDisplay(pane.agent) ??
-		safeDisplay(pane.paneId) ??
 		"agent"
 	);
 }
 
-function rowForPane(pane: ObservedPane): HerdrWidgetRow {
+function paneDisplay(pane: ObservedPane): string {
+	const id = shortIdentity(pane.paneId, "pane");
+	const label = safeDisplay(pane.label) ?? safeDisplay(pane.title);
+	return label ? `${label}/${id}` : id;
+}
+
+function spaceDisplay(workspace: HerdrWorkspace): string {
+	const id = shortIdentity(workspace.workspaceId, "space");
+	const label = safeDisplay(workspace.label);
+	return label ? `${label}/${id}` : id;
+}
+
+function rowForPane(pane: ObservedPane, workspace: HerdrWorkspace): HerdrWidgetRow {
 	return {
-		name: displayName(pane),
+		agent: agentDisplay(pane),
+		pane: paneDisplay(pane),
 		paneId: safeDisplay(pane.paneId) ?? "pane",
+		space: spaceDisplay(workspace),
 		state: pane.agentStatus,
 		stateLabel:
 			safeDisplay(pane.stateLabels[pane.agentStatus]) ?? safeDisplay(pane.agentStatus) ?? "unknown",
@@ -94,17 +118,24 @@ function immutableSnapshot(rows: HerdrWidgetRow[]): HerdrWidgetSnapshot | undefi
 export class HerdrWidgetModel {
 	private currentPaneId: string | undefined;
 	private currentWorkspaceId: string | undefined;
+	private workspace: HerdrWorkspace | undefined;
 	private panes = new Map<string, ObservedPane>();
 
-	reset(currentPane: HerdrPane, panes: readonly HerdrPane[]): void {
+	reset(
+		currentPane: HerdrPane,
+		panes: readonly HerdrPane[],
+		workspace: HerdrWorkspace = { workspaceId: currentPane.workspaceId },
+	): void {
 		this.currentPaneId = currentPane.paneId;
 		this.currentWorkspaceId = currentPane.workspaceId;
+		this.workspace = { ...workspace };
 		this.panes = new Map(panes.map((pane) => [pane.paneId, observedPane(pane)]));
 	}
 
 	clear(): void {
 		this.currentPaneId = undefined;
 		this.currentWorkspaceId = undefined;
+		this.workspace = undefined;
 		this.panes.clear();
 	}
 
@@ -131,6 +162,7 @@ export class HerdrWidgetModel {
 			if (this.currentPaneId === event.previousPaneId) {
 				this.currentPaneId = event.pane.paneId;
 				this.currentWorkspaceId = event.pane.workspaceId;
+				this.workspace = { workspaceId: event.pane.workspaceId };
 			}
 			return;
 		}
@@ -170,7 +202,7 @@ export class HerdrWidgetModel {
 	}
 
 	snapshot(): HerdrWidgetSnapshot | undefined {
-		if (!this.currentPaneId || !this.currentWorkspaceId) return undefined;
+		if (!this.currentPaneId || !this.currentWorkspaceId || !this.workspace) return undefined;
 		const rows = [...this.panes.values()]
 			.filter(
 				(pane) =>
@@ -178,16 +210,12 @@ export class HerdrWidgetModel {
 					pane.paneId !== this.currentPaneId &&
 					pane.agent !== undefined,
 			)
-			.map(rowForPane);
-		const duplicateNames = new Map<string, number>();
-		for (const row of rows) duplicateNames.set(row.name, (duplicateNames.get(row.name) ?? 0) + 1);
-		for (const row of rows) {
-			if ((duplicateNames.get(row.name) ?? 0) > 1) row.name = `${row.name} · ${row.paneId}`;
-		}
+			.map((pane) => rowForPane(pane, this.workspace as HerdrWorkspace));
 		rows.sort(
 			(left, right) =>
 				STATE_ORDER[left.state] - STATE_ORDER[right.state] ||
-				left.name.localeCompare(right.name) ||
+				left.agent.localeCompare(right.agent) ||
+				left.pane.localeCompare(right.pane) ||
 				left.paneId.localeCompare(right.paneId),
 		);
 		return immutableSnapshot(rows);
@@ -230,9 +258,13 @@ export function createHerdrWidget(snapshot: HerdrWidgetSnapshot, theme: Theme): 
 		renderBody() {
 			const noun = snapshot.totalAgents === 1 ? "agent" : "agents";
 			const lines = [theme.fg("muted", `Herdr · ${snapshot.totalAgents} sibling ${noun}`)];
+			const separator = theme.fg("dim", " · ");
 			for (const row of snapshot.rows) {
 				const state = stateStyle(theme, row.state, `${stateSymbol(row.state)} ${row.stateLabel}`);
-				lines.push(`${state}  ${theme.fg("text", row.name)}  ${theme.fg("dim", row.paneId)}`);
+				const agent = theme.bold(theme.fg("text", row.agent));
+				const pane = theme.fg("muted", row.pane);
+				const space = theme.fg("dim", row.space);
+				lines.push(`${state}  ${agent}${separator}${pane}${separator}${space}`);
 			}
 			if (snapshot.hiddenAgents > 0) {
 				lines.push(theme.fg("dim", `+${snapshot.hiddenAgents} more`));

--- a/packages/pi-herdr/src/herdr-widget.ts
+++ b/packages/pi-herdr/src/herdr-widget.ts
@@ -1,0 +1,249 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { EditorStatusWidget } from "@narumitw/pi-tui-kit/editor-status-widget";
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+import type { HerdrAgentStatus, HerdrPane, HerdrPaneEvent } from "./herdr-protocol.js";
+
+export const HERDR_WIDGET_KEY = "herdr:agents";
+export const MAX_HERDR_WIDGET_AGENTS = 5;
+
+interface ObservedPane {
+	paneId: string;
+	workspaceId: string;
+	agent?: string;
+	agentStatus: HerdrAgentStatus;
+	displayAgent?: string;
+	label?: string;
+	stateLabels: Record<string, string>;
+	terminalTitle?: string;
+	title?: string;
+}
+
+export interface HerdrWidgetRow {
+	name: string;
+	paneId: string;
+	state: HerdrAgentStatus;
+	stateLabel: string;
+}
+
+export interface HerdrWidgetSnapshot {
+	totalAgents: number;
+	hiddenAgents: number;
+	rows: readonly HerdrWidgetRow[];
+}
+
+const STATE_ORDER: Record<HerdrAgentStatus, number> = {
+	blocked: 0,
+	done: 1,
+	working: 2,
+	idle: 3,
+	unknown: 4,
+};
+
+function observedPane(pane: HerdrPane): ObservedPane {
+	return {
+		paneId: pane.paneId,
+		workspaceId: pane.workspaceId,
+		agent: pane.agent,
+		agentStatus: pane.agentStatus,
+		displayAgent: pane.displayAgent,
+		label: pane.label,
+		stateLabels: { ...pane.stateLabels },
+		terminalTitle: pane.terminalTitle,
+		title: pane.title,
+	};
+}
+
+function safeDisplay(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	const safe = sanitizeTerminalText(value).trim();
+	return safe.length > 0 ? safe : undefined;
+}
+
+function displayName(pane: ObservedPane): string {
+	return (
+		safeDisplay(pane.label) ??
+		safeDisplay(pane.title) ??
+		safeDisplay(pane.displayAgent) ??
+		safeDisplay(pane.terminalTitle) ??
+		safeDisplay(pane.agent) ??
+		safeDisplay(pane.paneId) ??
+		"agent"
+	);
+}
+
+function rowForPane(pane: ObservedPane): HerdrWidgetRow {
+	return {
+		name: displayName(pane),
+		paneId: safeDisplay(pane.paneId) ?? "pane",
+		state: pane.agentStatus,
+		stateLabel:
+			safeDisplay(pane.stateLabels[pane.agentStatus]) ?? safeDisplay(pane.agentStatus) ?? "unknown",
+	};
+}
+
+function immutableSnapshot(rows: HerdrWidgetRow[]): HerdrWidgetSnapshot | undefined {
+	if (rows.length === 0) return undefined;
+	const visible = rows.slice(0, MAX_HERDR_WIDGET_AGENTS).map((row) => Object.freeze({ ...row }));
+	return Object.freeze({
+		totalAgents: rows.length,
+		hiddenAgents: Math.max(0, rows.length - visible.length),
+		rows: Object.freeze(visible),
+	});
+}
+
+export class HerdrWidgetModel {
+	private currentPaneId: string | undefined;
+	private currentWorkspaceId: string | undefined;
+	private panes = new Map<string, ObservedPane>();
+
+	reset(currentPane: HerdrPane, panes: readonly HerdrPane[]): void {
+		this.currentPaneId = currentPane.paneId;
+		this.currentWorkspaceId = currentPane.workspaceId;
+		this.panes = new Map(panes.map((pane) => [pane.paneId, observedPane(pane)]));
+	}
+
+	clear(): void {
+		this.currentPaneId = undefined;
+		this.currentWorkspaceId = undefined;
+		this.panes.clear();
+	}
+
+	isCurrentPane(paneId: string): boolean {
+		return this.currentPaneId === paneId;
+	}
+
+	isCurrentWorkspace(workspaceId: string): boolean {
+		return this.currentWorkspaceId === workspaceId;
+	}
+
+	apply(event: HerdrPaneEvent): void {
+		if (event.type === "created") {
+			this.panes.set(event.pane.paneId, observedPane(event.pane));
+			return;
+		}
+		if (event.type === "closed" || event.type === "exited") {
+			this.panes.delete(event.paneId);
+			return;
+		}
+		if (event.type === "moved") {
+			this.panes.delete(event.previousPaneId);
+			this.panes.set(event.pane.paneId, observedPane(event.pane));
+			if (this.currentPaneId === event.previousPaneId) {
+				this.currentPaneId = event.pane.paneId;
+				this.currentWorkspaceId = event.pane.workspaceId;
+			}
+			return;
+		}
+
+		const existing = this.panes.get(event.paneId);
+		if (event.type === "agent_detected") {
+			if (event.released || !event.agent) {
+				if (existing) this.panes.set(event.paneId, { ...existing, agent: undefined });
+				return;
+			}
+			this.panes.set(event.paneId, {
+				...(existing ?? {
+					paneId: event.paneId,
+					workspaceId: event.workspaceId,
+					agentStatus: event.finalStatus ?? "unknown",
+					stateLabels: {},
+				}),
+				agent: event.agent,
+				agentStatus: event.finalStatus ?? existing?.agentStatus ?? "unknown",
+			});
+			return;
+		}
+		if (event.type !== "agent_status_changed") return;
+
+		this.panes.set(event.paneId, {
+			...(existing ?? {
+				paneId: event.paneId,
+				workspaceId: event.workspaceId,
+				stateLabels: {},
+			}),
+			agent: event.agent ?? existing?.agent,
+			agentStatus: event.agentStatus,
+			displayAgent: event.displayAgent ?? existing?.displayAgent,
+			stateLabels: event.stateLabels ?? existing?.stateLabels ?? {},
+			title: event.title ?? existing?.title,
+		});
+	}
+
+	snapshot(): HerdrWidgetSnapshot | undefined {
+		if (!this.currentPaneId || !this.currentWorkspaceId) return undefined;
+		const rows = [...this.panes.values()]
+			.filter(
+				(pane) =>
+					pane.workspaceId === this.currentWorkspaceId &&
+					pane.paneId !== this.currentPaneId &&
+					pane.agent !== undefined,
+			)
+			.map(rowForPane);
+		const duplicateNames = new Map<string, number>();
+		for (const row of rows) duplicateNames.set(row.name, (duplicateNames.get(row.name) ?? 0) + 1);
+		for (const row of rows) {
+			if ((duplicateNames.get(row.name) ?? 0) > 1) row.name = `${row.name} · ${row.paneId}`;
+		}
+		rows.sort(
+			(left, right) =>
+				STATE_ORDER[left.state] - STATE_ORDER[right.state] ||
+				left.name.localeCompare(right.name) ||
+				left.paneId.localeCompare(right.paneId),
+		);
+		return immutableSnapshot(rows);
+	}
+}
+
+function stateStyle(theme: Theme, state: HerdrAgentStatus, text: string): string {
+	switch (state) {
+		case "blocked":
+			return theme.fg("warning", text);
+		case "done":
+			return theme.fg("success", text);
+		case "working":
+			return theme.fg("accent", text);
+		case "idle":
+			return theme.fg("muted", text);
+		case "unknown":
+			return theme.fg("dim", text);
+	}
+}
+
+function stateSymbol(state: HerdrAgentStatus): string {
+	switch (state) {
+		case "blocked":
+			return "!";
+		case "done":
+			return "✓";
+		case "working":
+			return "●";
+		case "idle":
+			return "○";
+		case "unknown":
+			return "?";
+	}
+}
+
+export function createHerdrWidget(snapshot: HerdrWidgetSnapshot, theme: Theme): EditorStatusWidget {
+	return new EditorStatusWidget({
+		theme,
+		renderBody() {
+			const noun = snapshot.totalAgents === 1 ? "agent" : "agents";
+			const lines = [theme.fg("muted", `Herdr · ${snapshot.totalAgents} sibling ${noun}`)];
+			for (const row of snapshot.rows) {
+				const state = stateStyle(theme, row.state, `${stateSymbol(row.state)} ${row.stateLabel}`);
+				lines.push(`${state}  ${theme.fg("text", row.name)}  ${theme.fg("dim", row.paneId)}`);
+			}
+			if (snapshot.hiddenAgents > 0) {
+				lines.push(theme.fg("dim", `+${snapshot.hiddenAgents} more`));
+			}
+			return lines;
+		},
+	});
+}
+
+export function herdrWidgetFingerprint(
+	snapshot: HerdrWidgetSnapshot | undefined,
+): string | undefined {
+	return snapshot ? JSON.stringify(snapshot) : undefined;
+}

--- a/packages/pi-herdr/test/herdr-agent-state.test.ts
+++ b/packages/pi-herdr/test/herdr-agent-state.test.ts
@@ -41,6 +41,10 @@ function enabledOptions(requests: HerdrRequest[]): HerdrAgentStateOptions {
 		sendRequest: async (request) => {
 			requests.push(request);
 		},
+		widgetObserver: {
+			start() {},
+			async shutdown() {},
+		},
 	};
 }
 
@@ -167,8 +171,20 @@ test("blocked events override working state until every blocker clears", async (
 
 test("non-TUI sessions never report state", async () => {
 	const requests: HerdrRequest[] = [];
+	const observerStarts: string[] = [];
+	const observerShutdowns: string[] = [];
 	const mock = createMockPi();
-	herdrModule.createHerdrAgentStateExtension(enabledOptions(requests))(mock.pi);
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions(requests),
+		widgetObserver: {
+			start(ctx) {
+				observerStarts.push(ctx.mode);
+			},
+			async shutdown(ctx) {
+				observerShutdowns.push(ctx.mode);
+			},
+		},
+	})(mock.pi);
 	const started = createMockContext({ mode: "rpc", hasUI: true });
 	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
 	await emit(mock, "agent_start", {}, started.ctx);
@@ -179,8 +195,32 @@ test("non-TUI sessions never report state", async () => {
 		{ reason: "ui_prompt", kind: "confirm", title: "Hidden" },
 		started.ctx,
 	);
+	await emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
 	await flushReporting();
 	assert.deepEqual(requests, []);
+	assert.deepEqual(observerStarts, []);
+	assert.deepEqual(observerShutdowns, ["rpc"]);
+});
+
+test("TUI sessions start and shut down the widget observer", async () => {
+	const requests: HerdrRequest[] = [];
+	const events: string[] = [];
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions(requests),
+		widgetObserver: {
+			start(ctx) {
+				events.push(`start:${ctx.mode}`);
+			},
+			async shutdown(ctx) {
+				events.push(`shutdown:${ctx.mode}`);
+			},
+		},
+	})(mock.pi);
+	const started = tuiContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await emit(mock, "session_shutdown", { reason: "reload" }, started.ctx);
+	assert.deepEqual(events, ["start:tui", "shutdown:tui"]);
 });
 
 test("socket transport retries one failed delivery and preserves the request", async () => {
@@ -216,6 +256,10 @@ test("socket transport retries one failed delivery and preserves the request", a
 	const mock = createMockPi();
 	herdrModule.createHerdrAgentStateExtension({
 		environment: { enabled: true, paneId: "w1:p2", socketEndpoint: socketPath },
+		widgetObserver: {
+			start() {},
+			async shutdown() {},
+		},
 	})(mock.pi);
 	const started = tuiContext();
 	try {

--- a/packages/pi-herdr/test/herdr-client.test.ts
+++ b/packages/pi-herdr/test/herdr-client.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "vitest";
+import { MAX_HERDR_FRAME_BYTES, openHerdrSubscription, requestHerdr } from "../src/herdr-client.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+	await Promise.allSettled(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+async function listen(
+	handle: (socket: net.Socket, request: Record<string, unknown>) => void,
+): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "pi-herdr-client-"));
+	const socketPath = join(directory, "api.sock");
+	const sockets = new Set<net.Socket>();
+	const server = net.createServer((socket) => {
+		sockets.add(socket);
+		socket.on("close", () => sockets.delete(socket));
+		let input = "";
+		socket.on("data", (chunk) => {
+			input += chunk.toString();
+			const newline = input.indexOf("\n");
+			if (newline < 0) return;
+			const request = JSON.parse(input.slice(0, newline)) as Record<string, unknown>;
+			input = input.slice(newline + 1);
+			handle(socket, request);
+		});
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(socketPath, resolve);
+	});
+	cleanups.push(async () => {
+		for (const socket of sockets) socket.destroy();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+		await rm(directory, { force: true, recursive: true });
+	});
+	return socketPath;
+}
+
+function request(id = "request-1") {
+	return { id, method: "pane.list", params: { workspace_id: "w1" } };
+}
+
+test("correlates fragmented request responses and ignores unrelated frames", async () => {
+	const socketPath = await listen((socket, received) => {
+		assert.equal(received.id, "request-1");
+		socket.write(`${JSON.stringify({ id: "other", result: { type: "other" } })}\n`);
+		const response = `${JSON.stringify({ id: "request-1", result: { type: "pane_list", panes: [] } })}\n`;
+		socket.write(response.slice(0, 9));
+		socket.write(response.slice(9));
+	});
+	const result = await requestHerdr(socketPath, request(), new AbortController().signal, 100);
+	assert.deepEqual(result, { type: "pane_list", panes: [] });
+});
+
+test("rejects error, malformed, oversized, and result-less responses", async () => {
+	const cases: Array<{ payload: string | Buffer; message: RegExp }> = [
+		{
+			payload: `${JSON.stringify({ id: "request-1", error: { message: "request failed" } })}\n`,
+			message: /request failed/u,
+		},
+		{
+			payload: `${JSON.stringify({ id: "", error: { message: "invalid request" } })}\n`,
+			message: /invalid request/u,
+		},
+		{ payload: "{nope}\n", message: /invalid JSON/u },
+		{
+			payload: Buffer.concat([Buffer.alloc(MAX_HERDR_FRAME_BYTES + 1, 0x61), Buffer.from("\n")]),
+			message: /size limit/u,
+		},
+		{ payload: `${JSON.stringify({ id: "request-1" })}\n`, message: /include a result/u },
+	];
+	for (const entry of cases) {
+		const socketPath = await listen((socket) => socket.write(entry.payload));
+		await assert.rejects(
+			requestHerdr(socketPath, request(), new AbortController().signal, 100),
+			entry.message,
+		);
+	}
+});
+
+test("bounds request timeout, abort, and early socket close", async () => {
+	const timeoutPath = await listen(() => {});
+	await assert.rejects(
+		requestHerdr(timeoutPath, request(), new AbortController().signal, 20),
+		/timed out/u,
+	);
+
+	const abortController = new AbortController();
+	const abortPath = await listen(() =>
+		abortController.abort(new DOMException("stop", "AbortError")),
+	);
+	await assert.rejects(requestHerdr(abortPath, request(), abortController.signal, 100), /stop/u);
+
+	const closePath = await listen((socket) => socket.end());
+	await assert.rejects(
+		requestHerdr(closePath, request(), new AbortController().signal, 100),
+		/closed the request/u,
+	);
+});
+
+test("starts a subscription and delivers coalesced event frames", async () => {
+	const event = {
+		event: "pane.agent_status_changed",
+		data: { pane_id: "w1:p2", workspace_id: "w1", agent_status: "working" },
+	};
+	const socketPath = await listen((socket, received) => {
+		const response = `${JSON.stringify({ id: received.id, result: { type: "subscription_started" } })}\n${JSON.stringify(event)}\n`;
+		socket.write(response.slice(0, 17));
+		socket.write(response.slice(17));
+	});
+	const controller = new AbortController();
+	const events: unknown[] = [];
+	const subscription = await openHerdrSubscription(
+		socketPath,
+		{ id: "subscribe-1", method: "events.subscribe", params: { subscriptions: [] } },
+		controller.signal,
+		(frame) => events.push(frame),
+		100,
+	);
+	assert.deepEqual(events, [event]);
+	controller.abort();
+	await subscription.closed;
+});
+
+test("rejects invalid subscription acknowledgement and malformed event frames", async () => {
+	const invalidAckPath = await listen((socket, received) => {
+		socket.write(`${JSON.stringify({ id: received.id, result: { type: "wrong" } })}\n`);
+	});
+	await assert.rejects(
+		openHerdrSubscription(
+			invalidAckPath,
+			{ id: "subscribe-1", method: "events.subscribe", params: { subscriptions: [] } },
+			new AbortController().signal,
+			() => {},
+			100,
+		),
+		/invalid subscription acknowledgement/u,
+	);
+
+	const malformedPath = await listen((socket, received) => {
+		socket.write(
+			`${JSON.stringify({ id: received.id, result: { type: "subscription_started" } })}\n`,
+		);
+		setTimeout(() => socket.write("{bad}\n"), 10);
+	});
+	const subscription = await openHerdrSubscription(
+		malformedPath,
+		{ id: "subscribe-2", method: "events.subscribe", params: { subscriptions: [] } },
+		new AbortController().signal,
+		() => {},
+		100,
+	);
+	await assert.rejects(subscription.closed, /invalid JSON/u);
+});

--- a/packages/pi-herdr/test/herdr-observer.test.ts
+++ b/packages/pi-herdr/test/herdr-observer.test.ts
@@ -16,7 +16,12 @@ function deferred<T>() {
 	return { promise, resolve, reject };
 }
 
-function wirePane(paneId: string, status = "idle", agent: string | null = "pi") {
+function wirePane(
+	paneId: string,
+	status = "idle",
+	agent: string | null = "pi",
+	overrides: Record<string, unknown> = {},
+) {
 	return {
 		pane_id: paneId,
 		workspace_id: "w1",
@@ -27,7 +32,16 @@ function wirePane(paneId: string, status = "idle", agent: string | null = "pi") 
 		agent,
 		agent_status: status,
 		label: paneId === "w1:p2" ? "worker" : undefined,
+		...overrides,
 	};
+}
+
+function agentList(panes: ReturnType<typeof wirePane>[]) {
+	return { type: "agent_list", agents: panes };
+}
+
+function workspaceInfo(workspaceId = "w1", label = "space") {
+	return { type: "workspace_info", workspace: { workspace_id: workspaceId, label } };
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {
@@ -42,7 +56,10 @@ function renderWidget(value: unknown): string {
 	assert.equal(typeof value, "function");
 	const component = (value as (tui: unknown, theme: Theme) => { render(width: number): string[] })(
 		{},
-		{ fg: (_role: string, text: string) => text } as Theme,
+		{
+			bold: (text: string) => text,
+			fg: (_role: string, text: string) => text,
+		} as Theme,
 	);
 	return component.render(80).join("\n");
 }
@@ -107,15 +124,23 @@ test("publishes initial siblings and applies live status and exit events", async
 				assert.deepEqual(request.params, { caller_pane_id: "w1:p1" });
 				return { type: "pane_current", pane: wirePane("w1:p1", "working") };
 			}
-			return {
-				type: "pane_list",
-				panes: [wirePane("w1:p1", "working"), wirePane("w1:p2", "idle")],
-			};
+			const panes = [wirePane("w1:p1", "working"), wirePane("w1:p2", "idle")];
+			if (request.method === "agent.list") {
+				return agentList([
+					wirePane("w1:p1", "working", "pi", { name: "current" }),
+					wirePane("w1:p2", "idle", "pi", { name: "reviewer" }),
+				]);
+			}
+			if (request.method === "workspace.get") return workspaceInfo();
+			return { type: "pane_list", panes };
 		},
 	});
 	observer.start(ctx);
 	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function");
-	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /idle.*worker/u);
+	assert.match(
+		renderWidget(widgets.get(HERDR_WIDGET_KEY)),
+		/idle.*reviewer.*worker\/p2.*space\/w1/u,
+	);
 	const initialWidget = widgets.get(HERDR_WIDGET_KEY);
 	onEvent?.({
 		event: "pane.agent_status_changed",
@@ -164,16 +189,20 @@ test("reconciles replayed topology without entering a resubscribe loop", async (
 		},
 		async request(_endpoint, request) {
 			requests += 1;
-			return request.method === "pane.current"
-				? { type: "pane_current", pane: wirePane("w1:p1") }
-				: { type: "pane_list", panes: [wirePane("w1:p1"), wirePane("w1:p2", "idle")] };
+			const panes = [wirePane("w1:p1"), wirePane("w1:p2", "idle")];
+			if (request.method === "pane.current") {
+				return { type: "pane_current", pane: wirePane("w1:p1") };
+			}
+			if (request.method === "agent.list") return agentList(panes);
+			if (request.method === "workspace.get") return workspaceInfo();
+			return { type: "pane_list", panes };
 		},
 	});
 	observer.start(ctx);
-	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function" && requests >= 6);
+	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function" && requests >= 12);
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	assert.equal(subscriptions, 1);
-	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /w1:p2/u);
+	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /worker\/p2.*space\/w1/u);
 	await observer.shutdown(ctx);
 });
 
@@ -196,10 +225,10 @@ test("queues events during initialization and rejects stale delayed publication"
 					? current.promise
 					: { type: "pane_current", pane: wirePane("w1:p1", "working") };
 			}
-			return {
-				type: "pane_list",
-				panes: [wirePane("w1:p1", "working"), wirePane("w1:p2", "idle")],
-			};
+			const panes = [wirePane("w1:p1", "working"), wirePane("w1:p2", "idle")];
+			if (request.method === "agent.list") return agentList(panes);
+			if (request.method === "workspace.get") return workspaceInfo();
+			return { type: "pane_list", panes };
 		},
 	});
 	observer.start(ctx);
@@ -262,10 +291,10 @@ test("clears stale state before one reconnect and stops after exhaustion", async
 				}
 				return { type: "pane_current", pane: wirePane("w1:p1") };
 			}
-			return {
-				type: "pane_list",
-				panes: [wirePane("w1:p1"), wirePane("w1:p2", "working")],
-			};
+			const panes = [wirePane("w1:p1"), wirePane("w1:p2", "working")];
+			if (request.method === "agent.list") return agentList(panes);
+			if (request.method === "workspace.get") return workspaceInfo();
+			return { type: "pane_list", panes };
 		},
 	});
 	observer.start(ctx);
@@ -303,24 +332,23 @@ test("reconnects and reloads the workspace after the current pane moves", async 
 			return harness.subscription;
 		},
 		async request(_endpoint, request) {
+			const panes = moved
+				? [
+						wirePane("w2:p9", "idle", "pi", { workspace_id: "w2" }),
+						wirePane("w2:p2", "done", "pi", {
+							workspace_id: "w2",
+							label: "destination",
+						}),
+					]
+				: [wirePane("w1:p1"), wirePane("w1:p2", "working")];
 			if (request.method === "pane.current") {
-				return {
-					type: "pane_current",
-					pane: moved ? { ...wirePane("w2:p9"), workspace_id: "w2" } : wirePane("w1:p1"),
-				};
+				return { type: "pane_current", pane: panes[0] };
 			}
-			return moved
-				? {
-						type: "pane_list",
-						panes: [
-							{ ...wirePane("w2:p9"), workspace_id: "w2" },
-							{ ...wirePane("w2:p2", "done"), workspace_id: "w2", label: "destination" },
-						],
-					}
-				: {
-						type: "pane_list",
-						panes: [wirePane("w1:p1"), wirePane("w1:p2", "working")],
-					};
+			if (request.method === "agent.list") return agentList(panes);
+			if (request.method === "workspace.get") {
+				return workspaceInfo(moved ? "w2" : "w1", moved ? "destination-space" : "space");
+			}
+			return { type: "pane_list", panes };
 		},
 	});
 	observer.start(ctx);
@@ -339,7 +367,10 @@ test("reconnects and reloads the workspace after the current pane moves", async 
 	});
 	await waitUntil(() => subscriptions === 2);
 	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function");
-	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /destination.*w2:p2/u);
+	assert.match(
+		renderWidget(widgets.get(HERDR_WIDGET_KEY)),
+		/done.*pi.*destination\/p2.*destination-space\/w2/u,
+	);
 	await observer.shutdown(ctx);
 });
 
@@ -357,9 +388,13 @@ test("an older delayed shutdown cannot clear a replacement session", async () =>
 		async request(_endpoint, request) {
 			requests += 1;
 			if (requests === 1) return oldCurrent.promise;
-			return request.method === "pane.current"
-				? { type: "pane_current", pane: wirePane("w1:p1") }
-				: { type: "pane_list", panes: [wirePane("w1:p1"), wirePane("w1:p2", "working")] };
+			const panes = [wirePane("w1:p1"), wirePane("w1:p2", "working")];
+			if (request.method === "pane.current") {
+				return { type: "pane_current", pane: wirePane("w1:p1") };
+			}
+			if (request.method === "agent.list") return agentList(panes);
+			if (request.method === "workspace.get") return workspaceInfo();
+			return { type: "pane_list", panes };
 		},
 	});
 	observer.start(oldContext.ctx);
@@ -369,7 +404,7 @@ test("an older delayed shutdown cannot clear a replacement session", async () =>
 	oldCurrent.resolve({ type: "pane_current", pane: wirePane("w1:p1") });
 	await stoppingOld;
 	await waitUntil(() => typeof replacement.widgets.get(HERDR_WIDGET_KEY) === "function");
-	assert.match(renderWidget(replacement.widgets.get(HERDR_WIDGET_KEY)), /w1:p2/u);
+	assert.match(renderWidget(replacement.widgets.get(HERDR_WIDGET_KEY)), /worker\/p2.*space\/w1/u);
 	await observer.shutdown(replacement.ctx);
 });
 

--- a/packages/pi-herdr/test/herdr-observer.test.ts
+++ b/packages/pi-herdr/test/herdr-observer.test.ts
@@ -1,0 +1,395 @@
+import assert from "node:assert/strict";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import type { HerdrSubscription } from "../src/herdr-client.js";
+import { createHerdrWidgetObserver } from "../src/herdr-observer.js";
+import { HERDR_WIDGET_KEY } from "../src/herdr-widget.js";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (error: Error) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function wirePane(paneId: string, status = "idle", agent: string | null = "pi") {
+	return {
+		pane_id: paneId,
+		workspace_id: "w1",
+		tab_id: `${paneId}:tab`,
+		terminal_id: `${paneId}:term`,
+		focused: false,
+		revision: 1,
+		agent,
+		agent_status: status,
+		label: paneId === "w1:p2" ? "worker" : undefined,
+	};
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (predicate()) return;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	throw new Error("Condition did not become true");
+}
+
+function renderWidget(value: unknown): string {
+	assert.equal(typeof value, "function");
+	const component = (value as (tui: unknown, theme: Theme) => { render(width: number): string[] })(
+		{},
+		{ fg: (_role: string, text: string) => text } as Theme,
+	);
+	return component.render(80).join("\n");
+}
+
+interface SubscriptionHarness {
+	subscription: HerdrSubscription;
+	closeUnexpectedly(error?: Error): void;
+}
+
+function subscriptionHarness(signal: AbortSignal): SubscriptionHarness {
+	const closed = deferred<void>();
+	let finished = false;
+	const finish = (error?: Error) => {
+		if (finished) return;
+		finished = true;
+		if (error) closed.reject(error);
+		else closed.resolve();
+	};
+	const abort = () => finish();
+	if (signal.aborted) finish();
+	else signal.addEventListener("abort", abort, { once: true });
+	return {
+		subscription: {
+			closed: closed.promise,
+			close() {
+				signal.removeEventListener("abort", abort);
+				finish();
+			},
+		},
+		closeUnexpectedly(error = new Error("disconnected")) {
+			finish(error);
+		},
+	};
+}
+
+test("publishes initial siblings and applies live status and exit events", async () => {
+	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+	let onEvent: ((frame: unknown) => void) | undefined;
+	let harness: SubscriptionHarness | undefined;
+	const observer = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		now: () => 1,
+		random: () => 0.5,
+		retryDelayMs: 0,
+		async subscribe(_endpoint, request, signal, nextEvent) {
+			assert.equal(request.method, "events.subscribe");
+			assert.deepEqual(
+				(request.params.subscriptions as Array<Record<string, unknown>>).filter(
+					(entry) => entry.type === "pane.agent_status_changed",
+				),
+				[
+					{ type: "pane.agent_status_changed", pane_id: "w1:p1" },
+					{ type: "pane.agent_status_changed", pane_id: "w1:p2" },
+				],
+			);
+			onEvent = nextEvent;
+			harness = subscriptionHarness(signal);
+			return harness.subscription;
+		},
+		async request(_endpoint, request) {
+			if (request.method === "pane.current") {
+				assert.deepEqual(request.params, { caller_pane_id: "w1:p1" });
+				return { type: "pane_current", pane: wirePane("w1:p1", "working") };
+			}
+			return {
+				type: "pane_list",
+				panes: [wirePane("w1:p1", "working"), wirePane("w1:p2", "idle")],
+			};
+		},
+	});
+	observer.start(ctx);
+	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function");
+	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /idle.*worker/u);
+	const initialWidget = widgets.get(HERDR_WIDGET_KEY);
+	onEvent?.({
+		event: "pane.agent_status_changed",
+		data: {
+			pane_id: "w2:p1",
+			workspace_id: "w2",
+			agent: "pi",
+			agent_status: "blocked",
+		},
+	});
+	assert.equal(widgets.get(HERDR_WIDGET_KEY), initialWidget);
+
+	onEvent?.({
+		event: "pane.agent_status_changed",
+		data: {
+			pane_id: "w1:p2",
+			workspace_id: "w1",
+			agent: "pi",
+			agent_status: "blocked",
+			state_labels: { blocked: "waiting" },
+		},
+	});
+	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /waiting/u);
+	onEvent?.({ event: "pane_exited", data: { pane_id: "w1:p2", workspace_id: "w1" } });
+	assert.equal(widgets.get(HERDR_WIDGET_KEY), undefined);
+
+	await observer.shutdown(ctx);
+	assert.ok(harness);
+	assert.equal(widgets.get(HERDR_WIDGET_KEY), undefined);
+});
+
+test("reconciles replayed topology without entering a resubscribe loop", async () => {
+	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+	let requests = 0;
+	let subscriptions = 0;
+	const observer = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		retryDelayMs: 0,
+		async subscribe(_endpoint, _request, signal, nextEvent) {
+			subscriptions += 1;
+			nextEvent({
+				event: "pane_created",
+				data: { pane: wirePane("w1:old", "unknown", null) },
+			});
+			return subscriptionHarness(signal).subscription;
+		},
+		async request(_endpoint, request) {
+			requests += 1;
+			return request.method === "pane.current"
+				? { type: "pane_current", pane: wirePane("w1:p1") }
+				: { type: "pane_list", panes: [wirePane("w1:p1"), wirePane("w1:p2", "idle")] };
+		},
+	});
+	observer.start(ctx);
+	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function" && requests >= 6);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(subscriptions, 1);
+	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /w1:p2/u);
+	await observer.shutdown(ctx);
+});
+
+test("queues events during initialization and rejects stale delayed publication", async () => {
+	const current = deferred<unknown>();
+	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+	let currentRequests = 0;
+	let onEvent: ((frame: unknown) => void) | undefined;
+	const observer = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		retryDelayMs: 0,
+		async subscribe(_endpoint, _request, signal, nextEvent) {
+			onEvent = nextEvent;
+			return subscriptionHarness(signal).subscription;
+		},
+		async request(_endpoint, request) {
+			if (request.method === "pane.current") {
+				currentRequests += 1;
+				return currentRequests === 2
+					? current.promise
+					: { type: "pane_current", pane: wirePane("w1:p1", "working") };
+			}
+			return {
+				type: "pane_list",
+				panes: [wirePane("w1:p1", "working"), wirePane("w1:p2", "idle")],
+			};
+		},
+	});
+	observer.start(ctx);
+	await waitUntil(() => onEvent !== undefined);
+	onEvent?.({
+		event: "pane.agent_status_changed",
+		data: {
+			pane_id: "w1:p2",
+			workspace_id: "w1",
+			agent: "pi",
+			agent_status: "blocked",
+		},
+	});
+	current.resolve({ type: "pane_current", pane: wirePane("w1:p1", "working") });
+	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function");
+	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /blocked/u);
+
+	const staleCurrent = deferred<unknown>();
+	let requestCount = 0;
+	const replacement = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		retryDelayMs: 0,
+		async subscribe(_endpoint, _request, signal) {
+			return subscriptionHarness(signal).subscription;
+		},
+		async request() {
+			requestCount += 1;
+			return staleCurrent.promise;
+		},
+	});
+	replacement.start(ctx);
+	await waitUntil(() => requestCount === 1);
+	const shuttingDown = replacement.shutdown(ctx);
+	staleCurrent.resolve({ type: "pane_current", pane: wirePane("w1:p1") });
+	await shuttingDown;
+	assert.equal(widgets.get(HERDR_WIDGET_KEY), undefined);
+	await observer.shutdown(ctx);
+});
+
+test("clears stale state before one reconnect and stops after exhaustion", async () => {
+	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+	const harnesses: SubscriptionHarness[] = [];
+	const secondCurrent = deferred<unknown>();
+	let subscriptions = 0;
+	let secondCurrentRequested = false;
+	const observer = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		retryDelayMs: 0,
+		async subscribe(_endpoint, _request, signal) {
+			subscriptions += 1;
+			const harness = subscriptionHarness(signal);
+			harnesses.push(harness);
+			return harness.subscription;
+		},
+		async request(_endpoint, request) {
+			if (request.method === "pane.current") {
+				if (subscriptions === 2) {
+					secondCurrentRequested = true;
+					return secondCurrent.promise;
+				}
+				return { type: "pane_current", pane: wirePane("w1:p1") };
+			}
+			return {
+				type: "pane_list",
+				panes: [wirePane("w1:p1"), wirePane("w1:p2", "working")],
+			};
+		},
+	});
+	observer.start(ctx);
+	await waitUntil(() => subscriptions === 1 && typeof widgets.get(HERDR_WIDGET_KEY) === "function");
+	harnesses[0]?.closeUnexpectedly();
+	await waitUntil(() => subscriptions === 2 && secondCurrentRequested);
+	assert.equal(widgets.get(HERDR_WIDGET_KEY), undefined);
+	secondCurrent.resolve({ type: "pane_current", pane: wirePane("w1:p1") });
+	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function");
+	harnesses[1]?.closeUnexpectedly();
+	await waitUntil(() => widgets.get(HERDR_WIDGET_KEY) === undefined);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(subscriptions, 2);
+	await observer.shutdown(ctx);
+});
+
+test("reconnects and reloads the workspace after the current pane moves", async () => {
+	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+	let subscriptions = 0;
+	let moved = false;
+	let onEvent: ((frame: unknown) => void) | undefined;
+	const observer = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		retryDelayMs: 0,
+		async subscribe(_endpoint, _request, signal, nextEvent) {
+			subscriptions += 1;
+			const harness = subscriptionHarness(signal);
+			onEvent = (frame) => {
+				try {
+					nextEvent(frame);
+				} catch (error) {
+					harness.closeUnexpectedly(error instanceof Error ? error : new Error(String(error)));
+				}
+			};
+			return harness.subscription;
+		},
+		async request(_endpoint, request) {
+			if (request.method === "pane.current") {
+				return {
+					type: "pane_current",
+					pane: moved ? { ...wirePane("w2:p9"), workspace_id: "w2" } : wirePane("w1:p1"),
+				};
+			}
+			return moved
+				? {
+						type: "pane_list",
+						panes: [
+							{ ...wirePane("w2:p9"), workspace_id: "w2" },
+							{ ...wirePane("w2:p2", "done"), workspace_id: "w2", label: "destination" },
+						],
+					}
+				: {
+						type: "pane_list",
+						panes: [wirePane("w1:p1"), wirePane("w1:p2", "working")],
+					};
+		},
+	});
+	observer.start(ctx);
+	await waitUntil(() => subscriptions === 1 && typeof widgets.get(HERDR_WIDGET_KEY) === "function");
+	moved = true;
+	onEvent?.({
+		event: "pane_moved",
+		data: {
+			previous_pane_id: "w1:p1",
+			previous_workspace_id: "w1",
+			pane: {
+				...wirePane("w2:p9", "idle"),
+				workspace_id: "w2",
+			},
+		},
+	});
+	await waitUntil(() => subscriptions === 2);
+	await waitUntil(() => typeof widgets.get(HERDR_WIDGET_KEY) === "function");
+	assert.match(renderWidget(widgets.get(HERDR_WIDGET_KEY)), /destination.*w2:p2/u);
+	await observer.shutdown(ctx);
+});
+
+test("an older delayed shutdown cannot clear a replacement session", async () => {
+	const oldContext = createMockContext({ hasUI: true, mode: "tui" });
+	const replacement = createMockContext({ hasUI: true, mode: "tui" });
+	const oldCurrent = deferred<unknown>();
+	let requests = 0;
+	const observer = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		retryDelayMs: 0,
+		async subscribe(_endpoint, _request, signal) {
+			return subscriptionHarness(signal).subscription;
+		},
+		async request(_endpoint, request) {
+			requests += 1;
+			if (requests === 1) return oldCurrent.promise;
+			return request.method === "pane.current"
+				? { type: "pane_current", pane: wirePane("w1:p1") }
+				: { type: "pane_list", panes: [wirePane("w1:p1"), wirePane("w1:p2", "working")] };
+		},
+	});
+	observer.start(oldContext.ctx);
+	await waitUntil(() => requests === 1);
+	const stoppingOld = observer.shutdown(oldContext.ctx);
+	observer.start(replacement.ctx);
+	oldCurrent.resolve({ type: "pane_current", pane: wirePane("w1:p1") });
+	await stoppingOld;
+	await waitUntil(() => typeof replacement.widgets.get(HERDR_WIDGET_KEY) === "function");
+	assert.match(renderWidget(replacement.widgets.get(HERDR_WIDGET_KEY)), /w1:p2/u);
+	await observer.shutdown(replacement.ctx);
+});
+
+test("opens no resources outside TUI mode and tolerates repeated shutdown", async () => {
+	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "rpc" });
+	let calls = 0;
+	const observer = createHerdrWidgetObserver({
+		environment: { paneId: "w1:p1", socketEndpoint: "/tmp/herdr.sock" },
+		async subscribe() {
+			calls += 1;
+			throw new Error("not expected");
+		},
+		async request() {
+			calls += 1;
+			return undefined;
+		},
+	});
+	observer.start(ctx);
+	await observer.shutdown(ctx);
+	await observer.shutdown(ctx);
+	assert.equal(calls, 0);
+	assert.equal(widgets.size, 0);
+});

--- a/packages/pi-herdr/test/herdr-widget.test.ts
+++ b/packages/pi-herdr/test/herdr-widget.test.ts
@@ -5,9 +5,11 @@ import { test } from "vitest";
 import {
 	type HerdrPane,
 	herdrWidgetSubscriptions,
+	parseAgentListResult,
 	parseHerdrPaneEvent,
 	parsePaneCurrentResult,
 	parsePaneListResult,
+	parseWorkspaceGetResult,
 } from "../src/herdr-protocol.js";
 import {
 	createHerdrWidget,
@@ -64,6 +66,18 @@ test("validates current panes, pane lists, and supported subscription events", (
 	assert.throws(
 		() => parsePaneListResult({ type: "pane_list", panes: [wirePane({ agent_status: "new" })] }),
 		/invalid pane/u,
+	);
+	assert.equal(
+		parseAgentListResult({ type: "agent_list", agents: [wirePane({ name: "reviewer" })] })[0]
+			?.agentName,
+		"reviewer",
+	);
+	assert.deepEqual(
+		parseWorkspaceGetResult({
+			type: "workspace_info",
+			workspace: { workspace_id: "w1", label: "space" },
+		}),
+		{ workspaceId: "w1", label: "space" },
 	);
 
 	assert.deepEqual(
@@ -124,7 +138,7 @@ test("validates current panes, pane lists, and supported subscription events", (
 	);
 });
 
-test("filters siblings, orders every state, resolves duplicate names, and caps rows", () => {
+test("filters siblings, orders every state, distinguishes panes, and caps rows", () => {
 	const model = new HerdrWidgetModel();
 	const current = pane("w1:p1", "working", { title: "current" });
 	model.reset(current, [
@@ -148,7 +162,7 @@ test("filters siblings, orders every state, resolves duplicate names, and caps r
 		snapshot.rows.map(({ state }) => state),
 		["blocked", "done", "working", "idle", "idle"],
 	);
-	assert.ok(snapshot.rows.some(({ name }) => name === "same · w1:p2"));
+	assert.ok(snapshot.rows.some(({ pane }) => pane === "same/p2"));
 	assert.equal(Object.isFrozen(snapshot), true);
 	assert.equal(Object.isFrozen(snapshot.rows), true);
 });
@@ -192,22 +206,30 @@ test("tracks moved current panes plus agent detection, release, and exit", () =>
 
 test("sanitizes before sorting and renders terminal-width-safe themed rows", () => {
 	const model = new HerdrWidgetModel();
-	model.reset(pane("w1:p1"), [
+	model.reset(
 		pane("w1:p1"),
-		pane("w1:p2\u001b]8;;spoof", "blocked", {
-			label: "測試\nagent\u202e\u001b]8;;https://spoof\u0007",
-			stateLabels: { blocked: "wait\rnow" },
-		}),
-	]);
+		[
+			pane("w1:p1"),
+			pane("w1:p2\u001b]8;;spoof", "blocked", {
+				agentName: "reviewer\nname\u202e",
+				label: "測試\nagent\u202e\u001b]8;;https://spoof\u0007",
+				stateLabels: { blocked: "wait\rnow" },
+			}),
+		],
+		{ workspaceId: "w1", label: "space\u001b]8;;spoof" },
+	);
 	const snapshot = model.snapshot();
 	assert.ok(snapshot);
-	assert.equal(snapshot.rows[0]?.name, "測試 agent");
+	assert.equal(snapshot.rows[0]?.agent, "reviewer name");
+	assert.equal(snapshot.rows[0]?.pane, "測試 agent/p2");
+	assert.equal(snapshot.rows[0]?.space, "space/w1");
 	assert.equal(snapshot.rows[0]?.stateLabel, "wait now");
 	assert.equal(snapshot.rows[0]?.paneId.includes("\u001b"), false);
 	assert.equal(herdrWidgetFingerprint(snapshot), herdrWidgetFingerprint(model.snapshot()));
 
 	let color = 31;
 	const theme = {
+		bold: (text: string) => `\u001b[1m${text}\u001b[22m`,
 		fg: (_role: string, text: string) => `\u001b[${color}m${text}\u001b[0m`,
 	} as Theme;
 	const widget = createHerdrWidget(snapshot, theme);

--- a/packages/pi-herdr/test/herdr-widget.test.ts
+++ b/packages/pi-herdr/test/herdr-widget.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import {
+	type HerdrPane,
+	herdrWidgetSubscriptions,
+	parseHerdrPaneEvent,
+	parsePaneCurrentResult,
+	parsePaneListResult,
+} from "../src/herdr-protocol.js";
+import {
+	createHerdrWidget,
+	HerdrWidgetModel,
+	herdrWidgetFingerprint,
+	MAX_HERDR_WIDGET_AGENTS,
+} from "../src/herdr-widget.js";
+
+function pane(
+	paneId: string,
+	agentStatus: HerdrPane["agentStatus"] = "idle",
+	overrides: Partial<HerdrPane> = {},
+): HerdrPane {
+	return {
+		paneId,
+		workspaceId: "w1",
+		tabId: `${paneId}:tab`,
+		terminalId: `${paneId}:term`,
+		focused: false,
+		revision: 1,
+		agent: "pi",
+		agentStatus,
+		stateLabels: {},
+		...overrides,
+	};
+}
+
+function wirePane(overrides: Record<string, unknown> = {}) {
+	return {
+		pane_id: "w1:p1",
+		workspace_id: "w1",
+		tab_id: "w1:t1",
+		terminal_id: "term-1",
+		focused: false,
+		revision: 1,
+		agent: "pi",
+		agent_status: "idle",
+		future_field: true,
+		...overrides,
+	};
+}
+
+test("validates current panes, pane lists, and supported subscription events", () => {
+	assert.equal(parsePaneCurrentResult({ type: "pane_current", pane: wirePane() }).paneId, "w1:p1");
+	assert.equal(
+		parsePaneListResult({ type: "pane_list", panes: [wirePane(), wirePane({ pane_id: "w1:p2" })] })
+			.length,
+		2,
+	);
+	assert.throws(
+		() => parsePaneCurrentResult({ type: "pane_current", pane: wirePane({ pane_id: "" }) }),
+		/invalid current pane/u,
+	);
+	assert.throws(
+		() => parsePaneListResult({ type: "pane_list", panes: [wirePane({ agent_status: "new" })] }),
+		/invalid pane/u,
+	);
+
+	assert.deepEqual(
+		parseHerdrPaneEvent({
+			event: "pane.agent_status_changed",
+			data: {
+				pane_id: "w1:p2",
+				workspace_id: "w1",
+				agent: "pi",
+				agent_status: "blocked",
+				state_labels: { blocked: "waiting" },
+			},
+		}),
+		{
+			type: "agent_status_changed",
+			paneId: "w1:p2",
+			workspaceId: "w1",
+			agent: "pi",
+			agentStatus: "blocked",
+			displayAgent: undefined,
+			stateLabels: { blocked: "waiting" },
+			title: undefined,
+		},
+	);
+	assert.deepEqual(
+		parseHerdrPaneEvent({
+			event: "pane_agent_detected",
+			data: {
+				pane_id: "w1:p2",
+				workspace_id: "w1",
+				agent: "codex",
+				final_status: "done",
+				released: false,
+			},
+		}),
+		{
+			type: "agent_detected",
+			paneId: "w1:p2",
+			workspaceId: "w1",
+			agent: "codex",
+			finalStatus: "done",
+			released: false,
+		},
+	);
+	assert.equal(
+		parseHerdrPaneEvent({
+			event: "pane.agent_status_changed",
+			data: { pane_id: "w1:p2", workspace_id: "w1", agent_status: "invalid" },
+		}),
+		undefined,
+	);
+	assert.deepEqual(
+		herdrWidgetSubscriptions([
+			pane("w1:p1"),
+			pane("w1:shell", "unknown", { agent: undefined }),
+		]).filter((entry) => entry.type === "pane.agent_status_changed"),
+		[{ type: "pane.agent_status_changed", pane_id: "w1:p1" }],
+	);
+});
+
+test("filters siblings, orders every state, resolves duplicate names, and caps rows", () => {
+	const model = new HerdrWidgetModel();
+	const current = pane("w1:p1", "working", { title: "current" });
+	model.reset(current, [
+		current,
+		pane("w1:p2", "idle", { label: "same" }),
+		pane("w1:p3", "blocked", { label: "blocked" }),
+		pane("w1:p4", "done", { label: "done" }),
+		pane("w1:p5", "working", { label: "working" }),
+		pane("w1:p6", "unknown", { label: "unknown" }),
+		pane("w1:p7", "idle", { label: "same" }),
+		pane("w1:p8", "idle", { label: "overflow" }),
+		pane("w2:p1", "blocked", { workspaceId: "w2", label: "other workspace" }),
+		pane("w1:shell", "blocked", { agent: undefined, label: "shell" }),
+	]);
+	const snapshot = model.snapshot();
+	assert.ok(snapshot);
+	assert.equal(snapshot.totalAgents, 7);
+	assert.equal(snapshot.rows.length, MAX_HERDR_WIDGET_AGENTS);
+	assert.equal(snapshot.hiddenAgents, 2);
+	assert.deepEqual(
+		snapshot.rows.map(({ state }) => state),
+		["blocked", "done", "working", "idle", "idle"],
+	);
+	assert.ok(snapshot.rows.some(({ name }) => name === "same · w1:p2"));
+	assert.equal(Object.isFrozen(snapshot), true);
+	assert.equal(Object.isFrozen(snapshot.rows), true);
+});
+
+test("tracks moved current panes plus agent detection, release, and exit", () => {
+	const model = new HerdrWidgetModel();
+	model.reset(pane("w1:p1"), [pane("w1:p1"), pane("w1:p2", "working", { label: "worker" })]);
+	model.apply({
+		type: "moved",
+		previousPaneId: "w1:p1",
+		previousWorkspaceId: "w1",
+		pane: pane("w2:p9", "working", { workspaceId: "w2" }),
+	});
+	model.apply({
+		type: "agent_detected",
+		paneId: "w2:p2",
+		workspaceId: "w2",
+		agent: "codex",
+		finalStatus: "done",
+		released: false,
+	});
+	assert.equal(model.snapshot()?.rows[0]?.paneId, "w2:p2");
+	model.apply({
+		type: "agent_detected",
+		paneId: "w2:p2",
+		workspaceId: "w2",
+		released: true,
+	});
+	assert.equal(model.snapshot(), undefined);
+	model.apply({
+		type: "agent_status_changed",
+		paneId: "w2:p3",
+		workspaceId: "w2",
+		agent: "pi",
+		agentStatus: "blocked",
+	});
+	assert.equal(model.snapshot()?.rows[0]?.paneId, "w2:p3");
+	model.apply({ type: "exited", paneId: "w2:p3", workspaceId: "w2" });
+	assert.equal(model.snapshot(), undefined);
+});
+
+test("sanitizes before sorting and renders terminal-width-safe themed rows", () => {
+	const model = new HerdrWidgetModel();
+	model.reset(pane("w1:p1"), [
+		pane("w1:p1"),
+		pane("w1:p2\u001b]8;;spoof", "blocked", {
+			label: "測試\nagent\u202e\u001b]8;;https://spoof\u0007",
+			stateLabels: { blocked: "wait\rnow" },
+		}),
+	]);
+	const snapshot = model.snapshot();
+	assert.ok(snapshot);
+	assert.equal(snapshot.rows[0]?.name, "測試 agent");
+	assert.equal(snapshot.rows[0]?.stateLabel, "wait now");
+	assert.equal(snapshot.rows[0]?.paneId.includes("\u001b"), false);
+	assert.equal(herdrWidgetFingerprint(snapshot), herdrWidgetFingerprint(model.snapshot()));
+
+	let color = 31;
+	const theme = {
+		fg: (_role: string, text: string) => `\u001b[${color}m${text}\u001b[0m`,
+	} as Theme;
+	const widget = createHerdrWidget(snapshot, theme);
+	for (const width of [0, 1, 12, 32, 80]) {
+		assert.ok(widget.render(width).every((line) => visibleWidth(line) <= width));
+	}
+	const first = widget.render(80).join("\n");
+	assert.equal(first.includes("\u001b]8"), false);
+	assert.equal(first.includes("\u202e"), false);
+	assert.equal(first.includes("> "), false);
+	color = 32;
+	widget.invalidate();
+	assert.notEqual(widget.render(80).join("\n"), first);
+});


### PR DESCRIPTION
## Summary

- add a passive, terminal-safe widget above Pi's editor for recognized sibling agents in the current Herdr workspace
- present one agent per row in `state → agent → pane → workspace` order using theme hierarchy, renamed agent identity, pane labels with short IDs, and workspace labels with short IDs
- initialize from authoritative pane, agent, and workspace reads, subscribe to pane-scoped status events, and reconcile replayed topology without CLI polling
- preserve outbound lifecycle reporting while adding bounded framing, reconnect, replacement, reload, and shutdown cleanup
- document the widget's privacy boundary, rename limitation, package layout, release intent, and remaining roadmap

## Verification

- `npm exec vitest run -- packages/pi-herdr/test/herdr-client.test.ts packages/pi-herdr/test/herdr-widget.test.ts packages/pi-herdr/test/herdr-observer.test.ts packages/pi-herdr/test/herdr-agent-state.test.ts` — 25 passed
- `npm run check` — passed
- `npm test` — 339 files and 3,380 tests passed
- fenced-code-aware package README heading audit — 30 READMEs passed
- `npm exec changeset status` — one minor bump for `@narumitw/pi-herdr`
- `npm ls @narumitw/pi-tui-kit --workspace @narumitw/pi-herdr` — intended published Kit floor resolved
- `just pack herdr` — 10 declared files inspected
- `pi --no-extensions --no-skills -e ./packages/pi-herdr --list-models` — exited 0 without stderr
- Herdr-managed TUI smokes — verified `working`, `blocked`, unseen `done`, `idle`, renamed agent display, state/agent/pane/workspace hierarchy, pane move, agent release/exit, `/reload`, 72-column rendering, focus preservation, and clean shutdown

## Risks and unverified paths

- Herdr replays retained topology events, so the observer treats them as refresh signals and rebuilds pane-scoped status subscriptions only when the authoritative recognized-pane set changes.
- Herdr exposes no rename event, so renamed identities refresh on topology reconciliation, reconnect, Pi `/reload`, or session start rather than immediately.
- Unix-socket behavior received live smokes; Windows named-pipe subscription behavior remains covered by endpoint qualification and deterministic transport tests rather than a live Windows smoke.
- No package was published and no release workflow was dispatched.
