### PR TITLE
feat(usage): add Vercel AI Gateway credits

### DIFF
--- a/.changeset/calm-vercel-credits.md
+++ b/.changeset/calm-vercel-credits.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add Vercel AI Gateway credit reporting with exact remaining balance and lifetime spend from the official credits endpoint.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -16,6 +16,7 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
 - Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
+- Reports Vercel AI Gateway credit balance and lifetime spend.
 - Reports xAI OAuth subscription allowances and credits.
 - Toggles persistent Codex Fast routing through `/fast` or the usage menu.
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
@@ -250,6 +251,21 @@ Rated line items may differ from the final invoice once credits or adjustments a
 
 The contract was verified on 2026-07-31 against Fireworks' [Usage & Cost Breakdown](https://docs.fireworks.ai/accounts/exporting-usage-and-costs), [Get billing summary](https://docs.fireworks.ai/api-reference/get-billing-summary), and [List Accounts](https://docs.fireworks.ai/api-reference/list-accounts) API references.
 
+### Vercel AI Gateway credits
+
+- Provider ID: `vercel-ai-gateway`
+- Semantics: current team credit balance and lifetime spend, not rate-limit quota
+- Source: documented `GET https://ai-gateway.vercel.sh/v1/credits` using Pi's resolved AI Gateway API key
+- Displayed data: exact decimal-string credit balance and lifetime spend in USD
+- Statusline example: `vercel USD 95.50 left`
+
+The extension queries the fixed endpoint only when the selected model origin and any resolved-auth origin are `https://ai-gateway.vercel.sh`.
+Custom and proxy origins fail before network access, redirects are rejected, and only the resolved Bearer credential is forwarded.
+The credits endpoint does not provide reset times, request-rate counters, or date-window usage, so `pi-usage` does not claim those capabilities.
+Vercel's separate Custom Reporting API is limited to eligible paid plans and is intentionally outside this first integration.
+
+The contract was verified on 2026-08-30 against Vercel's [REST API Reference](https://vercel.com/docs/ai-gateway/sdks-and-apis/rest-api#check-credit-balance) and the first-party [`vercel/ai` Gateway implementation](https://github.com/vercel/ai/blob/69428b1f8b037e4d118fb4853428d5c4e620493c/packages/gateway/src/gateway-fetch-metadata.ts).
+
 ### OpenCode Go (Zen)
 
 - Provider ID: `opencode-go`
@@ -335,6 +351,7 @@ The `usage` status item is active only for selected providers that publish statu
 It refreshes every five minutes while the session remains on such a provider and is cleared when the model changes to an unsupported or menu-only provider.
 DeepSeek publishes each returned currency as a separate exact balance segment and reports when the API is unavailable.
 Fireworks publishes exact per-currency rated spend totals and reports when no rated usage exists.
+Vercel AI Gateway publishes the exact current USD credit balance.
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
@@ -367,6 +384,7 @@ The protocol carries no account name or extension identity.
 Only the selected provider's exact runtime match is used, and secrets are sent only to its validated official origin.
 DeepSeek balance requests require Bearer authentication, send only that resolved credential from Pi's runtime auth to `https://api.deepseek.com/user/balance`, and refuse redirects.
 Fireworks spend requests send only that resolved credential to the official `https://api.fireworks.ai` account-listing and billing-summary endpoints and refuse redirects.
+Vercel AI Gateway credit requests send only the resolved Bearer credential to `https://ai-gateway.vercel.sh/v1/credits` and refuse redirects.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
 Install only trusted extensions because they can read user files and process memory.
 Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
@@ -382,6 +400,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
 - Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `fireworksAccountId` in `pi-usage.json`.
+- Vercel AI Gateway reports current team credits and lifetime spend only; Custom Reporting and request-rate counters are not queried.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.
@@ -424,7 +443,7 @@ The generated runtime is built from the authoritative `src/index.ts` graph and d
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, Vercel AI Gateway credits, Vercel AI Gateway usage, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -14,6 +14,7 @@
 		"balance",
 		"deepseek",
 		"fireworks",
+		"vercel-ai-gateway",
 		"codex",
 		"kimi",
 		"kimi-coding",

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -16,7 +16,9 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 			? "DeepSeek API Balance"
 			: report.providerId === "fireworks"
 				? "Fireworks API Spend"
-				: `${report.providerName} Usage`;
+				: report.providerId === "vercel-ai-gateway"
+					? "Vercel AI Gateway Credits"
+					: `${report.providerName} Usage`;
 	const lines = [`${title} · ${stateLabel}`];
 	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
 	lines.push(`Semantics: ${report.semantics.label}`, "");
@@ -24,6 +26,7 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
 	else if (report.providerId === "deepseek") formatDeepSeekReport(lines, report);
 	else if (report.providerId === "fireworks") formatFireworksReport(lines, report);
+	else if (report.providerId === "vercel-ai-gateway") formatVercelAIGatewayReport(lines, report);
 	else if (report.providerId === "github-copilot") formatGitHubCopilotReport(lines, report);
 	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
 	else if (report.providerId === "opencode-go") formatOpenCodeZenReport(lines, report);
@@ -50,6 +53,7 @@ export function formatUsageStatusline(
 	}
 	if (report.providerId === "deepseek") return formatDeepSeekStatusline(report);
 	if (report.providerId === "fireworks") return formatFireworksStatusline(report);
+	if (report.providerId === "vercel-ai-gateway") return formatVercelAIGatewayStatusline(report);
 	if (report.providerId === "github-copilot") return formatGitHubCopilotStatusline(report);
 	if (report.providerId === "openrouter") {
 		const limit = report.buckets.find((bucket) => bucket.id === "key-limit");
@@ -155,6 +159,17 @@ function fireworksCurrencies(report: UsageReport): string[] {
 		currencies.push(metric.currency);
 	}
 	return currencies;
+}
+
+function formatVercelAIGatewayReport(lines: string[], report: UsageReport): void {
+	for (const metric of report.metrics) {
+		lines.push(`${`${metric.label}:`.padEnd(VALUE_COLUMN)}USD ${metric.value}`);
+	}
+}
+
+function formatVercelAIGatewayStatusline(report: UsageReport): string {
+	const balance = report.metrics.find((metric) => metric.id === "credit-balance");
+	return balance ? `vercel USD ${balance.value} left` : "vercel credits unavailable";
 }
 
 function formatGitHubCopilotReport(lines: string[], report: UsageReport): void {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -42,6 +42,7 @@ export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.j
 export { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 export { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
 export { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
+export { normalizeVercelAIGatewayCreditsPayload } from "./providers/vercel-ai-gateway.js";
 export { normalizeXaiBillingPayload } from "./providers/xai.js";
 export { normalizeZaiQuotaPayload } from "./providers/zai.js";
 export {
@@ -83,6 +84,7 @@ export type {
 	UsageSemantics,
 	UsageSemanticsKind,
 	UsageUnit,
+	VercelAIGatewayCreditsPayload,
 	XaiBillingPayload,
 	XaiUserPayload,
 } from "./types.js";

--- a/packages/pi-usage/src/providers/vercel-ai-gateway.ts
+++ b/packages/pi-usage/src/providers/vercel-ai-gateway.ts
@@ -1,0 +1,43 @@
+import type { UsageMetric, UsageReport, VercelAIGatewayCreditsPayload } from "../types.js";
+
+const DECIMAL_AMOUNT = /^(?:0|[1-9]\d*)(?:\.\d+)?$/u;
+
+export function normalizeVercelAIGatewayCreditsPayload(
+	payload: VercelAIGatewayCreditsPayload,
+	capturedAt: number,
+): UsageReport {
+	const balance = decimalAmount(payload.balance, "balance");
+	const totalUsed = decimalAmount(payload.total_used, "total used");
+	const metrics: UsageMetric[] = [
+		{
+			id: "credit-balance",
+			label: "Credit balance",
+			value: balance,
+			unit: "currency",
+			currency: "USD",
+		},
+		{
+			id: "lifetime-spend",
+			label: "Lifetime spend",
+			value: totalUsed,
+			unit: "currency",
+			currency: "USD",
+		},
+	];
+	return {
+		providerId: "vercel-ai-gateway",
+		providerName: "Vercel AI Gateway",
+		capturedAt,
+		source: "vercel-ai-gateway-credits",
+		semantics: { kind: "api-key", label: "AI Gateway credits and lifetime spend" },
+		buckets: [],
+		metrics,
+	};
+}
+
+function decimalAmount(value: unknown, label: string): string {
+	if (typeof value !== "string" || value.length > 64 || !DECIMAL_AMOUNT.test(value)) {
+		throw new Error(`Vercel AI Gateway ${label} was not a valid nonnegative amount.`);
+	}
+	return value;
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -16,6 +16,7 @@ import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.j
 import { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
 import { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
+import { normalizeVercelAIGatewayCreditsPayload } from "./providers/vercel-ai-gateway.js";
 import { normalizeXaiBillingPayload } from "./providers/xai.js";
 import { normalizeZaiQuotaPayload } from "./providers/zai.js";
 import type {
@@ -32,6 +33,7 @@ import type {
 	UsageProviderAdapter,
 	UsageQuerySettings,
 	UsageReport,
+	VercelAIGatewayCreditsPayload,
 	XaiBillingPayload,
 	XaiUserPayload,
 	ZaiQuotaPayload,
@@ -44,6 +46,7 @@ const FIREWORKS_SPEND_WINDOW_DAYS = 30;
 const FIREWORKS_MAX_ACCOUNT_PAGES = 5;
 const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
+const VERCEL_AI_GATEWAY_CREDITS_URL = "https://ai-gateway.vercel.sh/v1/credits";
 const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
 const KIMI_CODING_USAGE_URL = "https://api.kimi.com/coding/v1/usages";
 const XAI_USER_URL = "https://cli-chat-proxy.grok.com/v1/user?include=subscription";
@@ -131,6 +134,27 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				"OpenRouter key endpoint",
 			);
 			return normalizeOpenRouterKeyPayload(payload as OpenRouterKeyPayload, Date.now());
+		},
+	},
+	{
+		id: "vercel-ai-gateway",
+		displayName: "Vercel AI Gateway",
+		semantics: { kind: "api-key", label: "AI Gateway credits and lifetime spend" },
+		async query(auth, signal, timeoutMs, guard) {
+			if (!guard)
+				throw new Error("Vercel AI Gateway usage requires request-boundary revalidation.");
+			const startedAt = Date.now();
+			await guard();
+			const payload = (await fetchProviderJson(
+				VERCEL_AI_GATEWAY_CREDITS_URL,
+				auth,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "fetching Vercel AI Gateway credits"),
+				"Vercel AI Gateway credits endpoint",
+				{ redirect: "error" },
+			)) as VercelAIGatewayCreditsPayload;
+			await guard();
+			return normalizeVercelAIGatewayCreditsPayload(payload, Date.now());
 		},
 	},
 	{
@@ -776,6 +800,7 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 		if (providerId === "deepseek") return url.origin === "https://api.deepseek.com";
 		if (providerId === "fireworks") return url.origin === FIREWORKS_BILLING_SUMMARY_ORIGIN;
 		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
+		if (providerId === "vercel-ai-gateway") return url.origin === "https://ai-gateway.vercel.sh";
 		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
 		if (providerId === "kimi-coding") return url.origin === "https://api.kimi.com";
 		if (providerId === "xai") return url.origin === "https://api.x.ai";

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -119,6 +119,11 @@ export type OpenRouterKeyPayload = {
 	data?: unknown;
 };
 
+export type VercelAIGatewayCreditsPayload = {
+	balance?: unknown;
+	total_used?: unknown;
+};
+
 export type OpenCodeZenPayload = {
 	usage?: unknown;
 };

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -281,7 +281,12 @@ export default function usageExtension(
 				},
 			};
 		}
-		const requiresRequestBoundaryGuard = ["deepseek", "fireworks", "xai"].includes(adapter.id);
+		const requiresRequestBoundaryGuard = [
+			"deepseek",
+			"fireworks",
+			"vercel-ai-gateway",
+			"xai",
+		].includes(adapter.id);
 		const requestContextChanged = () =>
 			expectedSessionGeneration !== sessionGeneration ||
 			ctx.sessionManager.getSessionId() !== expectedSessionId ||

--- a/packages/pi-usage/test/vercel-ai-gateway.test.ts
+++ b/packages/pi-usage/test/vercel-ai-gateway.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeVercelAIGatewayCreditsPayload,
+	queryProviderUsage,
+	type ResolvedUsageAuth,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+	type UsageProviderAdapter,
+} from "../src/index.js";
+
+const VERCEL_MODEL = {
+	id: "anthropic/claude-sonnet-4.6",
+	name: "Claude Sonnet 4.6",
+	provider: "vercel-ai-gateway",
+	baseUrl: "https://ai-gateway.vercel.sh",
+};
+
+function vercelAdapter(): UsageProviderAdapter {
+	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === "vercel-ai-gateway");
+	assert.ok(candidate);
+	return candidate;
+}
+
+const adapter = vercelAdapter();
+
+function vercelAuth(secret = "vercel-test-secret"): ResolvedUsageAuth {
+	return {
+		apiKey: secret,
+		headers: { Authorization: `Bearer ${secret}` },
+		fingerprint: "fingerprint",
+		secrets: [secret, `Bearer ${secret}`],
+		model: VERCEL_MODEL as never,
+	};
+}
+
+function queryVercel(
+	signal = new AbortController().signal,
+	timeoutMs = 1_000,
+	guard: () => Promise<void> = async () => undefined,
+) {
+	return queryProviderUsage(adapter, vercelAuth(), signal, timeoutMs, guard);
+}
+
+test("Vercel AI Gateway credits preserve decimal strings and native semantics", () => {
+	const report = normalizeVercelAIGatewayCreditsPayload(
+		{ balance: "95.500000000000000001", total_used: "4.499999999999999999" },
+		1_000,
+	);
+
+	assert.equal(report.providerId, "vercel-ai-gateway");
+	assert.equal(report.source, "vercel-ai-gateway-credits");
+	assert.deepEqual(report.semantics, {
+		kind: "api-key",
+		label: "AI Gateway credits and lifetime spend",
+	});
+	assert.deepEqual(
+		report.metrics.map((metric) => [metric.id, metric.value, metric.currency]),
+		[
+			["credit-balance", "95.500000000000000001", "USD"],
+			["lifetime-spend", "4.499999999999999999", "USD"],
+		],
+	);
+	const formatted = formatUsageReport(report, "current");
+	assert.match(formatted, /^Vercel AI Gateway Credits · Current/mu);
+	assert.match(formatted, /Credit balance:\s+USD 95\.500000000000000001/u);
+	assert.match(formatted, /Lifetime spend:\s+USD 4\.499999999999999999/u);
+	assert.equal(formatUsageStatusline(report), "vercel USD 95.500000000000000001 left");
+});
+
+test("Vercel AI Gateway credits reject malformed or ambiguous monetary fields", () => {
+	for (const payload of [
+		{},
+		{ balance: 95.5, total_used: "4.5" },
+		{ balance: "-1", total_used: "4.5" },
+		{ balance: "1e3", total_used: "4.5" },
+		{ balance: "1", total_used: "NaN" },
+		{ balance: "9".repeat(65), total_used: "0" },
+	]) {
+		assert.throws(
+			() => normalizeVercelAIGatewayCreditsPayload(payload, 0),
+			/not a valid nonnegative amount/iu,
+		);
+	}
+});
+
+test("Vercel AI Gateway runtime auth accepts only the official model and auth origin", async () => {
+	const { ctx: officialContext } = createMockContext({
+		model: VERCEL_MODEL,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({
+				ok: true,
+				headers: {
+					Authorization: "Bearer current-vercel-key",
+					"X-Private": "must-not-send",
+				},
+			}),
+			getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+			getAvailable: () => [VERCEL_MODEL],
+			getAll: () => [VERCEL_MODEL],
+		},
+	});
+	const auth = await resolveUsageAuth(officialContext, adapter);
+	assert.deepEqual(auth?.headers, { Authorization: "Bearer current-vercel-key" });
+	assert.ok(!auth?.secrets.includes("must-not-send"));
+
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		for (const [modelBaseUrl, authBaseUrl, pattern] of [
+			["https://proxy.example.test/v1", undefined, /custom.*official/iu],
+			[VERCEL_MODEL.baseUrl, "https://proxy.example.test/v1", /proxy-resolved.*official/iu],
+		] as const) {
+			const model = { ...VERCEL_MODEL, baseUrl: modelBaseUrl };
+			const { ctx } = createMockContext({
+				model,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-send" }),
+					getProviderAuth: async () => ({
+						auth: {
+							apiKey: "must-not-send",
+							...(authBaseUrl ? { baseUrl: authBaseUrl } : {}),
+						},
+					}),
+					getAvailable: () => [model],
+					getAll: () => [model],
+				},
+			});
+			await assert.rejects(() => resolveUsageAuth(ctx, adapter), pattern);
+		}
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("Vercel AI Gateway transport revalidates around the fixed no-redirect request", async () => {
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	let guardCalls = 0;
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		requests.push({ url: String(input), init });
+		return new Response(JSON.stringify({ balance: "95.50", total_used: "4.50" }), {
+			status: 200,
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const report = await queryVercel(undefined, 1_000, async () => {
+			guardCalls += 1;
+		});
+		assert.equal(report.providerId, "vercel-ai-gateway");
+		assert.equal(guardCalls, 2);
+		assert.equal(requests.length, 1);
+		assert.equal(requests[0]?.url, "https://ai-gateway.vercel.sh/v1/credits");
+		assert.equal(requests[0]?.init?.method, "GET");
+		assert.equal(requests[0]?.init?.redirect, "error");
+		assert.deepEqual(requests[0]?.init?.headers, {
+			Authorization: "Bearer vercel-test-secret",
+			"User-Agent": "pi-usage",
+		});
+
+		const redirected = new Response(JSON.stringify({ balance: "1", total_used: "1" }), {
+			status: 200,
+		});
+		Object.defineProperty(redirected, "redirected", { value: true });
+		fetchMock.mockResolvedValueOnce(redirected);
+		await assert.rejects(() => queryVercel(), /refused a redirected response/iu);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Vercel AI Gateway transport fails before or after network access when auth becomes stale", async () => {
+	const fetchMock = vi.fn(
+		async () =>
+			new Response(JSON.stringify({ balance: "95.50", total_used: "4.50" }), { status: 200 }),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() => queryProviderUsage(adapter, vercelAuth(), new AbortController().signal, 1_000),
+			/request-boundary revalidation/iu,
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+
+		let guardCalls = 0;
+		await assert.rejects(
+			() =>
+				queryVercel(undefined, 1_000, async () => {
+					guardCalls += 1;
+					if (guardCalls === 2) {
+						throw Object.assign(new Error("stale auth"), { name: "AbortError" });
+					}
+				}),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+		assert.equal(fetchMock.mock.calls.length, 1);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Vercel AI Gateway transport bounds response bodies and redacts credentials", async () => {
+	const fetchMock = vi.fn(async () => new Response("x".repeat(70_000), { status: 200 }));
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(() => queryVercel(), /exceeded.*bytes/iu);
+		fetchMock.mockResolvedValueOnce(
+			new Response("Bearer vercel-test-secret failed\u001b[31m", {
+				status: 401,
+				statusText: "Denied",
+			}),
+		);
+		await assert.rejects(
+			() => queryVercel(),
+			(error: unknown) =>
+				error instanceof Error &&
+				error.message.includes("401") &&
+				!error.message.includes("vercel-test-secret") &&
+				!error.message.includes("\u001b"),
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});


### PR DESCRIPTION
## Summary

- add Vercel AI Gateway credit balance and lifetime spend reporting
- require official model and resolved-auth origins, no redirects, bounded responses, and request-boundary auth revalidation
- publish exact USD credit balance to the usage statusline
- document provider semantics, security boundaries, and limitations

## Verification

- `npx vitest run packages/pi-usage/test/vercel-ai-gateway.test.ts`
- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` — 337 files, 3348 tests
- `just pack usage` — expected 28-file tarball, including generated runtime and Vercel provider source
- RPC package-load smoke: `pi --mode rpc --offline --no-extensions -e ./packages/pi-usage` with `get_state`

## Risks and unverified paths

- A live Vercel credits request was not run because `pi auth check --provider vercel-ai-gateway --json --no-refresh` reported `credentials_not_configured`.
- The wire contract is backed by Vercel's official REST documentation and pinned first-party `vercel/ai` implementation; deterministic tests cover the fixed endpoint, auth headers, redirects, stale auth, oversized bodies, and redaction.
