### PR TITLE
fix(herdr): align agent status symbols

### DIFF
--- a/.changeset/bright-herdr-symbols.md
+++ b/.changeset/bright-herdr-symbols.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-herdr": patch
+---
+
+Align the sibling-agent widget's state icons with Herdr's distinct static status symbols.

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -69,6 +69,7 @@ Session shutdown aborts in-flight reporting and prevents stale session work from
 
 The widget lists only recognized agents in the current Herdr workspace and excludes the pane running the current Pi session.
 Each row presents state, agent, pane, and workspace in that order, using theme hierarchy instead of repeating field labels.
+State icons follow Herdr's distinct static symbols: `×` blocked, `◐` working, `✓` done, `○` idle, and `·` unknown.
 Agent identity prefers the name assigned by `herdr agent rename`, then Herdr display metadata, and finally the detected agent kind.
 Pane identity uses its label or metadata title with a short pane ID, while workspace identity uses its label with a short workspace ID.
 Terminal titles are not used as agent identity.

--- a/packages/pi-herdr/src/herdr-widget.ts
+++ b/packages/pi-herdr/src/herdr-widget.ts
@@ -240,15 +240,15 @@ function stateStyle(theme: Theme, state: HerdrAgentStatus, text: string): string
 function stateSymbol(state: HerdrAgentStatus): string {
 	switch (state) {
 		case "blocked":
-			return "!";
+			return "×";
 		case "done":
 			return "✓";
 		case "working":
-			return "●";
+			return "◐";
 		case "idle":
 			return "○";
 		case "unknown":
-			return "?";
+			return "·";
 	}
 }
 

--- a/packages/pi-herdr/test/herdr-widget.test.ts
+++ b/packages/pi-herdr/test/herdr-widget.test.ts
@@ -204,6 +204,53 @@ test("tracks moved current panes plus agent detection, release, and exit", () =>
 	assert.equal(model.snapshot(), undefined);
 });
 
+test("renders Herdr's distinct static symbol for every agent state", () => {
+	const theme = {
+		bold: (text: string) => text,
+		fg: (_role: string, text: string) => text,
+	} as Theme;
+	const widget = createHerdrWidget(
+		{
+			totalAgents: 5,
+			hiddenAgents: 0,
+			rows: [
+				{
+					agent: "a",
+					pane: "p1",
+					paneId: "w1:p1",
+					space: "w1",
+					state: "blocked",
+					stateLabel: "blocked",
+				},
+				{
+					agent: "b",
+					pane: "p2",
+					paneId: "w1:p2",
+					space: "w1",
+					state: "working",
+					stateLabel: "working",
+				},
+				{ agent: "c", pane: "p3", paneId: "w1:p3", space: "w1", state: "done", stateLabel: "done" },
+				{ agent: "d", pane: "p4", paneId: "w1:p4", space: "w1", state: "idle", stateLabel: "idle" },
+				{
+					agent: "e",
+					pane: "p5",
+					paneId: "w1:p5",
+					space: "w1",
+					state: "unknown",
+					stateLabel: "unknown",
+				},
+			],
+		},
+		theme,
+	);
+
+	const rendered = widget.render(80).join("\n");
+	for (const state of ["× blocked", "◐ working", "✓ done", "○ idle", "· unknown"]) {
+		assert.ok(rendered.includes(state), `missing ${state}`);
+	}
+});
+
 test("sanitizes before sorting and renders terminal-width-safe themed rows", () => {
 	const model = new HerdrWidgetModel();
 	model.reset(


### PR DESCRIPTION
## Summary

- align the Pi sibling-agent widget with Herdr v0.8.2's distinct static status symbols
- render `×` blocked, `◐` working, `✓` done, `○` idle, and `·` unknown while retaining Pi theme roles
- document the mapping and cover every lifecycle state with a deterministic rendering regression test

## Verification

- `npm exec -- vitest run packages/pi-herdr/test/herdr-widget.test.ts packages/pi-herdr/test/herdr-observer.test.ts packages/pi-herdr/test/herdr-agent-state.test.ts packages/pi-herdr/test/herdr-client.test.ts` — 4 files and 26 tests passed
- `npm run check` — passed
- `npm test` — 336 files and 3,343 tests passed
- `npm exec -- changeset status` — includes the intended `@narumitw/pi-herdr` release

## Risks and unverified paths

- the symbols mirror Herdr v0.8.2's `ui.status_indicators = "symbols"` design but do not read or alter the user's Herdr configuration
- no lifecycle, socket, or runtime-loading behavior changed; rendering is covered deterministically rather than with another live TUI smoke
- no package was published and no release workflow was dispatched
