### PR TITLE
feat(usage): add Moonshot API balances

### DIFF
--- a/.changeset/fresh-moonshot-balances.md
+++ b/.changeset/fresh-moonshot-balances.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add Moonshot AI Global and China API balance reporting with region-bound credentials and native USD or CNY semantics.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -12,6 +12,7 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Shows active-account usage and next actions through `/usage`.
 - Reports OpenAI Codex subscription windows, credits, resets, and model-specific buckets.
 - Reports Kimi For Coding plan windows, resets, and separately labeled booster-wallet currency.
+- Reports Moonshot AI Global and China API account balances in their native currencies.
 - Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
@@ -188,6 +189,23 @@ It was also revalidated against [Kimi Code `676e4d82240855044fe809fea89ce1dbe8e5
 The pinned Pi source at `e86823096c5bad39e1ca282ec24bc5eb9bec745b` has no changes in either reviewed Kimi file at the selected revision.
 The pinned Kimi managed-usage source at `cd7c97b377a77f7ae1b9d541cafe314e986ec074` is an ancestor of that selected revision and has no changes in the reviewed source or tests.
 
+### Moonshot AI API balance
+
+- Provider IDs: `moonshotai` and `moonshotai-cn`
+- Semantics: current API account balance, not Kimi For Coding subscription usage
+- Global source: `GET https://api.moonshot.ai/v1/users/me/balance`
+- China source: `GET https://api.moonshot.cn/v1/users/me/balance`
+- Displayed data: available, voucher, and cash balance in USD for Global or CNY for China
+- Statusline examples: `moonshot USD 49.58894` or `moonshot CNY 49.58894`
+
+Each endpoint uses Pi's resolved inference Bearer key for the matching region.
+The extension rejects custom, proxy, and cross-region origins before network access and refuses redirects.
+Available and voucher balances must be nonnegative, while cash balance may be negative when the account owes money.
+The endpoint does not provide historical spend, token totals, quota windows, or reset times.
+These API-platform balances are independent from the `kimi-coding` subscription and booster wallet.
+
+The contracts were verified on 2026-08-30 against the official [Global balance reference](https://platform.kimi.ai/docs/api/balance), [China balance reference](https://platform.moonshot.cn/docs/api/balance), and first-party [`MoonshotAI-Cookbook` balance client and DTO](https://github.com/MoonshotAI/MoonshotAI-Cookbook/tree/25a9e46d2391dd4817d28ab980dac69eb59b582c/examples/golang_demo).
+
 ### GitHub Copilot
 
 - Provider ID: `github-copilot`
@@ -335,6 +353,7 @@ The `usage` status item is active only for selected providers that publish statu
 It refreshes every five minutes while the session remains on such a provider and is cleared when the model changes to an unsupported or menu-only provider.
 DeepSeek publishes each returned currency as a separate exact balance segment and reports when the API is unavailable.
 Fireworks publishes exact per-currency rated spend totals and reports when no rated usage exists.
+Moonshot AI publishes the available balance with its region-native currency.
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
@@ -367,6 +386,7 @@ The protocol carries no account name or extension identity.
 Only the selected provider's exact runtime match is used, and secrets are sent only to its validated official origin.
 DeepSeek balance requests require Bearer authentication, send only that resolved credential from Pi's runtime auth to `https://api.deepseek.com/user/balance`, and refuse redirects.
 Fireworks spend requests send only that resolved credential to the official `https://api.fireworks.ai` account-listing and billing-summary endpoints and refuse redirects.
+Moonshot balance requests send only the resolved Bearer credential to the matching official Global or China balance origin and refuse redirects.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
 Install only trusted extensions because they can read user files and process memory.
 Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
@@ -382,6 +402,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
 - Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `fireworksAccountId` in `pi-usage.json`.
+- Moonshot AI reports current API balance only; it does not expose historical spend, aggregate token usage, quota windows, or reset times through the balance endpoint.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.
@@ -424,7 +445,7 @@ The generated runtime is built from the authoritative `src/index.ts` graph and d
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, Moonshot AI balance, Moonshot API balance, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -17,6 +17,8 @@
 		"codex",
 		"kimi",
 		"kimi-coding",
+		"moonshot",
+		"moonshotai",
 		"copilot",
 		"openrouter",
 		"opencode",

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -16,7 +16,9 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 			? "DeepSeek API Balance"
 			: report.providerId === "fireworks"
 				? "Fireworks API Spend"
-				: `${report.providerName} Usage`;
+				: report.providerId === "moonshotai" || report.providerId === "moonshotai-cn"
+					? `${report.providerName} Balance`
+					: `${report.providerName} Usage`;
 	const lines = [`${title} · ${stateLabel}`];
 	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
 	lines.push(`Semantics: ${report.semantics.label}`, "");
@@ -28,7 +30,9 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 	else if (report.providerId === "openrouter") formatOpenRouterReport(lines, report);
 	else if (report.providerId === "opencode-go") formatOpenCodeZenReport(lines, report);
 	else if (report.providerId === "kimi-coding") formatKimiCodingReport(lines, report);
-	else if (report.providerId === "xai") formatXaiReport(lines, report);
+	else if (report.providerId === "moonshotai" || report.providerId === "moonshotai-cn") {
+		formatMoonshotReport(lines, report);
+	} else if (report.providerId === "xai") formatXaiReport(lines, report);
 	else if (report.providerId === "zai" || report.providerId === "zai-coding-cn") {
 		formatZaiReport(lines, report);
 	} else formatGenericReport(lines, report);
@@ -59,6 +63,9 @@ export function formatUsageStatusline(
 	}
 	if (report.providerId === "opencode-go") return formatOpenCodeZenStatusline(report);
 	if (report.providerId === "kimi-coding") return formatKimiCodingStatusline(report);
+	if (report.providerId === "moonshotai" || report.providerId === "moonshotai-cn") {
+		return formatMoonshotStatusline(report);
+	}
 	if (report.providerId === "zai" || report.providerId === "zai-coding-cn") {
 		return formatZaiStatusline(report);
 	}
@@ -284,6 +291,18 @@ function formatKimiCodingStatusline(report: UsageReport): string | undefined {
 		);
 	}
 	return parts.length > 1 ? parts.join(" ") : undefined;
+}
+
+function formatMoonshotReport(lines: string[], report: UsageReport): void {
+	for (const metric of report.metrics) {
+		lines.push(`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${metric.currency} ${metric.value}`);
+	}
+}
+
+function formatMoonshotStatusline(report: UsageReport): string {
+	const available = report.metrics.find((metric) => metric.id === "available-balance");
+	if (!available) return "moonshot balance unavailable";
+	return `moonshot ${available.currency ?? ""} ${available.value}`.replace(/\s+/gu, " ");
 }
 
 function formatZaiStatusline(report: UsageReport): string | undefined {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -40,6 +40,8 @@ export {
 } from "./providers/fireworks.js";
 export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 export { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
+export type { MoonshotProviderId } from "./providers/moonshot.js";
+export { normalizeMoonshotBalancePayload } from "./providers/moonshot.js";
 export { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
 export { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
 export { normalizeXaiBillingPayload } from "./providers/xai.js";
@@ -71,6 +73,7 @@ export type {
 	FireworksAccountsPayload,
 	FireworksBillingSummaryPayload,
 	KimiCodingUsagePayload,
+	MoonshotBalancePayload,
 	ProviderUsageState,
 	ResolvedUsageAuth,
 	UsageBucket,

--- a/packages/pi-usage/src/providers/moonshot.ts
+++ b/packages/pi-usage/src/providers/moonshot.ts
@@ -1,0 +1,64 @@
+import type { MoonshotBalancePayload, UsageMetric, UsageReport } from "../types.js";
+
+export type MoonshotProviderId = "moonshotai" | "moonshotai-cn";
+
+const PROVIDERS = {
+	moonshotai: { name: "Moonshot AI", currency: "USD" },
+	"moonshotai-cn": { name: "Moonshot AI CN", currency: "CNY" },
+} as const;
+
+export function normalizeMoonshotBalancePayload(
+	providerId: MoonshotProviderId,
+	payload: MoonshotBalancePayload,
+	capturedAt: number,
+): UsageReport {
+	if (payload.code !== 0 || payload.status !== true) {
+		throw new Error("Moonshot AI balance response did not report success.");
+	}
+	const data = asObject(payload.data);
+	if (!data) throw new Error("Moonshot AI balance response data was not an object.");
+	const provider = PROVIDERS[providerId];
+	const available = amount(data.available_balance, "available balance", false);
+	const voucher = amount(data.voucher_balance, "voucher balance", false);
+	const cash = amount(data.cash_balance, "cash balance", true);
+	const metrics: UsageMetric[] = [
+		currencyMetric("available-balance", "Available balance", available, provider.currency),
+		currencyMetric("voucher-balance", "Voucher balance", voucher, provider.currency),
+		currencyMetric("cash-balance", "Cash balance", cash, provider.currency),
+	];
+	return {
+		providerId,
+		providerName: provider.name,
+		capturedAt,
+		source: "moonshot-balance",
+		semantics: { kind: "api-key", label: "Moonshot API account balance" },
+		buckets: [],
+		metrics,
+	};
+}
+
+function currencyMetric(
+	id: string,
+	label: string,
+	value: string,
+	currency: "CNY" | "USD",
+): UsageMetric {
+	return { id, label, value, unit: "currency", currency };
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function amount(value: unknown, label: string, allowNegative: boolean): string {
+	if (
+		typeof value !== "number" ||
+		!Number.isFinite(value) ||
+		(!allowNegative && value < 0) ||
+		Math.abs(value) > Number.MAX_SAFE_INTEGER
+	) {
+		throw new Error(`Moonshot AI ${label} was not a valid amount.`);
+	}
+	return String(value);
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -14,6 +14,7 @@ import {
 } from "./providers/fireworks.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
+import { normalizeMoonshotBalancePayload } from "./providers/moonshot.js";
 import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
 import { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
 import { normalizeXaiBillingPayload } from "./providers/xai.js";
@@ -25,6 +26,7 @@ import type {
 	FireworksBillingSummaryPayload,
 	GitHubCopilotUsagePayload,
 	KimiCodingUsagePayload,
+	MoonshotBalancePayload,
 	OpenCodeZenPayload,
 	OpenRouterKeyPayload,
 	PiModel,
@@ -46,6 +48,10 @@ const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
 const KIMI_CODING_USAGE_URL = "https://api.kimi.com/coding/v1/usages";
+const MOONSHOT_BALANCE_URLS = Object.freeze({
+	moonshotai: "https://api.moonshot.ai/v1/users/me/balance",
+	"moonshotai-cn": "https://api.moonshot.cn/v1/users/me/balance",
+});
 const XAI_USER_URL = "https://cli-chat-proxy.grok.com/v1/user?include=subscription";
 const XAI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 const XAI_CLIENT_HEADERS = Object.freeze({
@@ -191,6 +197,22 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				{ redirect: "error" },
 			);
 			return normalizeKimiCodingUsagePayload(payload as KimiCodingUsagePayload, Date.now());
+		},
+	},
+	{
+		id: "moonshotai",
+		displayName: "Moonshot AI",
+		semantics: { kind: "api-key", label: "Moonshot API account balance" },
+		async query(auth, signal, timeoutMs, guard) {
+			return queryMoonshotBalance("moonshotai", auth, signal, timeoutMs, guard);
+		},
+	},
+	{
+		id: "moonshotai-cn",
+		displayName: "Moonshot AI CN",
+		semantics: { kind: "api-key", label: "Moonshot API account balance" },
+		async query(auth, signal, timeoutMs, guard) {
+			return queryMoonshotBalance("moonshotai-cn", auth, signal, timeoutMs, guard);
 		},
 	},
 	{
@@ -778,6 +800,8 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
 		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
 		if (providerId === "kimi-coding") return url.origin === "https://api.kimi.com";
+		if (providerId === "moonshotai") return url.origin === "https://api.moonshot.ai";
+		if (providerId === "moonshotai-cn") return url.origin === "https://api.moonshot.cn";
 		if (providerId === "xai") return url.origin === "https://api.x.ai";
 		if (providerId === "zai") return url.origin === "https://api.z.ai";
 		if (providerId === "zai-coding-cn") return url.origin === "https://open.bigmodel.cn";
@@ -811,6 +835,28 @@ function validatedXaiUserId(value: unknown): string {
 		throw new Error("xAI consumer identity returned an unsafe canonical user ID.");
 	}
 	return value;
+}
+
+async function queryMoonshotBalance(
+	providerId: "moonshotai" | "moonshotai-cn",
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+	guard: UsageRequestGuard | undefined,
+): Promise<UsageReport> {
+	if (!guard) throw new Error("Moonshot AI balance requires request-boundary revalidation.");
+	const startedAt = Date.now();
+	await guard();
+	const payload = (await fetchProviderJson(
+		MOONSHOT_BALANCE_URLS[providerId],
+		auth,
+		signal,
+		remainingTimeout(timeoutMs, startedAt, "fetching Moonshot AI balance"),
+		"Moonshot AI balance endpoint",
+		{ redirect: "error" },
+	)) as MoonshotBalancePayload;
+	await guard();
+	return normalizeMoonshotBalancePayload(providerId, payload, Date.now());
 }
 
 function remainingTimeout(

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -119,6 +119,13 @@ export type OpenRouterKeyPayload = {
 	data?: unknown;
 };
 
+export type MoonshotBalancePayload = {
+	code?: unknown;
+	data?: unknown;
+	scode?: unknown;
+	status?: unknown;
+};
+
 export type OpenCodeZenPayload = {
 	usage?: unknown;
 };

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -281,7 +281,13 @@ export default function usageExtension(
 				},
 			};
 		}
-		const requiresRequestBoundaryGuard = ["deepseek", "fireworks", "xai"].includes(adapter.id);
+		const requiresRequestBoundaryGuard = [
+			"deepseek",
+			"fireworks",
+			"moonshotai",
+			"moonshotai-cn",
+			"xai",
+		].includes(adapter.id);
 		const requestContextChanged = () =>
 			expectedSessionGeneration !== sessionGeneration ||
 			ctx.sessionManager.getSessionId() !== expectedSessionId ||

--- a/packages/pi-usage/test/moonshot.test.ts
+++ b/packages/pi-usage/test/moonshot.test.ts
@@ -1,0 +1,331 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeMoonshotBalancePayload,
+	queryProviderUsage,
+	type ResolvedUsageAuth,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+	type UsageProviderAdapter,
+} from "../src/index.js";
+
+const MODELS = {
+	moonshotai: {
+		id: "kimi-k2.5",
+		name: "Kimi K2.5",
+		provider: "moonshotai",
+		baseUrl: "https://api.moonshot.ai/v1",
+	},
+	"moonshotai-cn": {
+		id: "kimi-k2.5",
+		name: "Kimi K2.5",
+		provider: "moonshotai-cn",
+		baseUrl: "https://api.moonshot.cn/v1",
+	},
+} as const;
+
+type ProviderId = keyof typeof MODELS;
+
+function moonshotAdapter(providerId: ProviderId): UsageProviderAdapter {
+	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === providerId);
+	assert.ok(candidate);
+	return candidate;
+}
+
+function moonshotAuth(providerId: ProviderId, secret = "moonshot-test-secret"): ResolvedUsageAuth {
+	return {
+		apiKey: secret,
+		headers: { Authorization: `Bearer ${secret}` },
+		fingerprint: "fingerprint",
+		secrets: [secret, `Bearer ${secret}`],
+		model: MODELS[providerId] as never,
+	};
+}
+
+function successPayload() {
+	return {
+		code: 0,
+		data: {
+			available_balance: 49.58894,
+			voucher_balance: 46.58893,
+			cash_balance: 3.00001,
+		},
+		scode: "0x0",
+		status: true,
+	};
+}
+
+test("Moonshot balances retain region currency and separate account components", () => {
+	for (const [providerId, currency, title] of [
+		["moonshotai", "USD", "Moonshot AI Balance"],
+		["moonshotai-cn", "CNY", "Moonshot AI CN Balance"],
+	] as const) {
+		const report = normalizeMoonshotBalancePayload(providerId, successPayload(), 1_000);
+		assert.equal(report.providerId, providerId);
+		assert.equal(report.source, "moonshot-balance");
+		assert.deepEqual(report.semantics, {
+			kind: "api-key",
+			label: "Moonshot API account balance",
+		});
+		assert.deepEqual(
+			report.metrics.map((metric) => [metric.id, metric.value, metric.currency]),
+			[
+				["available-balance", "49.58894", currency],
+				["voucher-balance", "46.58893", currency],
+				["cash-balance", "3.00001", currency],
+			],
+		);
+		const formatted = formatUsageReport(report, "current");
+		assert.match(formatted, new RegExp(`^${title} · Current`, "mu"));
+		assert.match(formatted, new RegExp(`Available balance:\\s+${currency} 49\\.58894`, "u"));
+		assert.equal(formatUsageStatusline(report), `moonshot ${currency} 49.58894`);
+	}
+});
+
+test("Moonshot balance preserves a negative cash component without making available credit negative", () => {
+	const report = normalizeMoonshotBalancePayload(
+		"moonshotai",
+		{
+			code: 0,
+			data: { available_balance: 10, voucher_balance: 10, cash_balance: -2.5 },
+			status: true,
+		},
+		2_000,
+	);
+	assert.equal(report.metrics.find((metric) => metric.id === "cash-balance")?.value, "-2.5");
+	assert.match(formatUsageReport(report, "configured"), /Cash balance:\s+USD -2\.5/u);
+});
+
+test("Moonshot balance rejects failed, incomplete, or hostile responses", () => {
+	for (const payload of [
+		{},
+		{ ...successPayload(), code: 1 },
+		{ ...successPayload(), status: false },
+		{ code: 0, status: true, data: null },
+		{ code: 0, status: true, data: { ...successPayload().data, available_balance: -1 } },
+		{ code: 0, status: true, data: { ...successPayload().data, voucher_balance: Number.NaN } },
+		{ code: 0, status: true, data: { ...successPayload().data, cash_balance: "3" } },
+		{
+			code: 0,
+			status: true,
+			data: { ...successPayload().data, cash_balance: Number.MAX_SAFE_INTEGER + 1 },
+		},
+	]) {
+		assert.throws(
+			() => normalizeMoonshotBalancePayload("moonshotai", payload, 0),
+			/not report success|not an object|not a valid amount/iu,
+		);
+	}
+});
+
+test("Moonshot runtime auth keeps Global and China credentials on their official origin", async () => {
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		for (const providerId of ["moonshotai", "moonshotai-cn"] as const) {
+			const model = MODELS[providerId];
+			const adapter = moonshotAdapter(providerId);
+			const { ctx } = createMockContext({
+				model,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({
+						ok: true,
+						headers: {
+							Authorization: `Bearer ${providerId}-key`,
+							"X-Private": "must-not-send",
+						},
+					}),
+					getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+					getAvailable: () => [model],
+					getAll: () => [model],
+				},
+			});
+			const auth = await resolveUsageAuth(ctx, adapter);
+			assert.deepEqual(auth?.headers, { Authorization: `Bearer ${providerId}-key` });
+			assert.ok(!auth?.secrets.includes("must-not-send"));
+
+			for (const [modelBaseUrl, authBaseUrl, pattern] of [
+				["https://proxy.example.test/v1", undefined, /custom.*official/iu],
+				[model.baseUrl, "https://proxy.example.test/v1", /proxy-resolved.*official/iu],
+			] as const) {
+				const rejectedModel = { ...model, baseUrl: modelBaseUrl };
+				const { ctx: rejectedContext } = createMockContext({
+					model: rejectedModel,
+					modelRegistry: {
+						getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-send" }),
+						getProviderAuth: async () => ({
+							auth: {
+								apiKey: "must-not-send",
+								...(authBaseUrl ? { baseUrl: authBaseUrl } : {}),
+							},
+						}),
+						getAvailable: () => [rejectedModel],
+						getAll: () => [rejectedModel],
+					},
+				});
+				await assert.rejects(() => resolveUsageAuth(rejectedContext, adapter), pattern);
+			}
+		}
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("Moonshot transport uses only its region endpoint and revalidates around the request", async () => {
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		requests.push({ url: String(input), init });
+		return new Response(JSON.stringify(successPayload()), { status: 200 });
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		for (const [providerId, expectedUrl] of [
+			["moonshotai", "https://api.moonshot.ai/v1/users/me/balance"],
+			["moonshotai-cn", "https://api.moonshot.cn/v1/users/me/balance"],
+		] as const) {
+			let guardCalls = 0;
+			const report = await queryProviderUsage(
+				moonshotAdapter(providerId),
+				moonshotAuth(providerId),
+				new AbortController().signal,
+				1_000,
+				async () => {
+					guardCalls += 1;
+				},
+			);
+			assert.equal(report.providerId, providerId);
+			assert.equal(guardCalls, 2);
+			const request = requests.at(-1);
+			assert.equal(request?.url, expectedUrl);
+			assert.equal(request?.init?.method, "GET");
+			assert.equal(request?.init?.redirect, "error");
+			assert.deepEqual(request?.init?.headers, {
+				Authorization: "Bearer moonshot-test-secret",
+				"User-Agent": "pi-usage",
+			});
+		}
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Moonshot transport bounds timeout, response bodies, and credential errors", async () => {
+	const adapter = moonshotAdapter("moonshotai");
+	const fetchMock = vi.fn(
+		(_input: string | URL | Request, init?: RequestInit) =>
+			new Promise<Response>((_resolve, reject) => {
+				const rejectAbort = () =>
+					reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+				if (init?.signal?.aborted) rejectAbort();
+				else init?.signal?.addEventListener("abort", rejectAbort, { once: true });
+			}),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					moonshotAuth("moonshotai"),
+					new AbortController().signal,
+					5,
+					async () => undefined,
+				),
+			/Timed out/iu,
+		);
+		fetchMock.mockResolvedValueOnce(new Response("x".repeat(70_000), { status: 200 }));
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					moonshotAuth("moonshotai"),
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			/exceeded.*bytes/iu,
+		);
+		fetchMock.mockResolvedValueOnce(
+			new Response("Bearer moonshot-test-secret failed\u001b[31m", {
+				status: 401,
+				statusText: "Denied",
+			}),
+		);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					moonshotAuth("moonshotai"),
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			(error: unknown) =>
+				error instanceof Error &&
+				error.message.includes("401") &&
+				!error.message.includes("moonshot-test-secret") &&
+				!error.message.includes("\u001b"),
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Moonshot transport requires revalidation and rejects redirects or stale post-response auth", async () => {
+	const adapter = moonshotAdapter("moonshotai");
+	const fetchMock = vi.fn(
+		async () => new Response(JSON.stringify(successPayload()), { status: 200 }),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					moonshotAuth("moonshotai"),
+					new AbortController().signal,
+					1_000,
+				),
+			/request-boundary revalidation/iu,
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+
+		const redirected = new Response(JSON.stringify(successPayload()), { status: 200 });
+		Object.defineProperty(redirected, "redirected", { value: true });
+		fetchMock.mockResolvedValueOnce(redirected);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					moonshotAuth("moonshotai"),
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			/refused a redirected response/iu,
+		);
+
+		let guardCalls = 0;
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					moonshotAuth("moonshotai"),
+					new AbortController().signal,
+					1_000,
+					async () => {
+						guardCalls += 1;
+						if (guardCalls === 2) {
+							throw Object.assign(new Error("stale auth"), { name: "AbortError" });
+						}
+					},
+				),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});


### PR DESCRIPTION
## Summary

- add Global and China Moonshot API account balance reporting
- preserve available, voucher, and cash components with USD or CNY semantics
- bind each resolved credential to its official region endpoint with no redirects and request-boundary revalidation
- publish the current available balance to the usage statusline

## Verification

- `npx vitest run packages/pi-usage/test/moonshot.test.ts` — 7 tests
- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` — 337 files, 3349 tests
- `just pack usage` — expected 28-file tarball with generated runtime and Moonshot provider source
- RPC package-load smoke through `pi --mode rpc --offline --no-extensions -e ./packages/pi-usage`

## Risks and unverified paths

- Live Global and China balance requests were not run because both providers reported `credentials_not_configured` through `pi auth check`.
- Contracts are backed by both official regional API references and the pinned first-party `MoonshotAI-Cookbook` China balance client/DTO.
- The provider returns monetary JSON numbers rather than decimal strings; the adapter validates finite safe-range values and retains their normalized decimal representation.
