### PR TITLE
feat(usage): add MiniMax plan usage

### DIFF
--- a/.changeset/bright-minimax-usage.md
+++ b/.changeset/bright-minimax-usage.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add MiniMax Global and China Token Plan quota and pay-as-you-go balance reporting with deterministic credential routing.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -13,6 +13,7 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Reports OpenAI Codex subscription windows, credits, resets, and model-specific buckets.
 - Reports Kimi For Coding plan windows, resets, and separately labeled booster-wallet currency.
 - Reports Moonshot AI Global and China API account balances in their native currencies.
+- Reports MiniMax Global and China Token Plan windows or pay-as-you-go API balance.
 - Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
@@ -206,6 +207,22 @@ The endpoint does not provide historical spend, token totals, quota windows, or 
 These API-platform balances are independent from the `kimi-coding` subscription and booster wallet.
 
 The contracts were verified on 2026-08-30 against the official [Global balance reference](https://platform.kimi.ai/docs/api/balance), [China balance reference](https://platform.moonshot.cn/docs/api/balance), and first-party [`MoonshotAI-Cookbook` balance client and DTO](https://github.com/MoonshotAI/MoonshotAI-Cookbook/tree/25a9e46d2391dd4817d28ab980dac69eb59b582c/examples/golang_demo).
+### MiniMax Token Plan and API balance
+
+- Provider IDs: `minimax` and `minimax-cn`
+- Token Plan source: `GET {region-api-root}/v1/token_plan/remains`
+- Pay-as-you-go source: `GET {region-api-root}/account/query_balance`
+- Region API roots: `https://api.minimax.io` and `https://api.minimaxi.com`
+- Statusline examples: `minimax 15% 5h 80% wk` or `minimax USD 98.00001`
+
+Pi's resolved MiniMax API key selects exactly one endpoint before network access.
+Keys with the first-party `sk-api-` prefix query pay-as-you-go balance; other MiniMax API keys query Token Plan quota.
+The extension never probes both endpoints with one credential.
+Token Plan reports preserve provider rows, rolling and weekly windows, counts, reset times, unlimited status, and first-party handling for legacy versus current `*_usage_count` semantics.
+Pay-as-you-go reports keep available, cash, voucher, credit, and owed amounts separate in USD for Global or CNY for China.
+Custom, proxy, and cross-region origins fail before network access, and redirects are rejected.
+
+The contract was verified on 2026-08-30 against MiniMax's [Token Plan FAQ](https://platform.minimax.io/docs/token-plan/faq#how-to-check-token-plan-usage) and the first-party [`MiniMax-AI/cli`](https://github.com/MiniMax-AI/cli/tree/b78eccea80a0f9692e186d98906cff26931464f3), including endpoint selection, response types, quota normalization, and SDK tests.
 
 ### GitHub Copilot
 
@@ -371,6 +388,7 @@ DeepSeek publishes each returned currency as a separate exact balance segment an
 Fireworks publishes exact per-currency rated spend totals and reports when no rated usage exists.
 Moonshot AI publishes the available balance with its region-native currency.
 Vercel AI Gateway publishes the exact current USD credit balance.
+MiniMax publishes Token Plan window percentages or the regional pay-as-you-go available balance.
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
@@ -405,6 +423,7 @@ DeepSeek balance requests require Bearer authentication, send only that resolved
 Fireworks spend requests send only that resolved credential to the official `https://api.fireworks.ai` account-listing and billing-summary endpoints and refuse redirects.
 Moonshot balance requests send only the resolved Bearer credential to the matching official Global or China balance origin and refuse redirects.
 Vercel AI Gateway credit requests send only the resolved Bearer credential to `https://ai-gateway.vercel.sh/v1/credits` and refuse redirects.
+MiniMax usage requests send only the resolved API key to one deterministic endpoint on the matching official Global or China API root and refuse redirects.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
 Install only trusted extensions because they can read user files and process memory.
 Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
@@ -422,6 +441,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `fireworksAccountId` in `pi-usage.json`.
 - Moonshot AI reports current API balance only; it does not expose historical spend, aggregate token usage, quota windows, or reset times through the balance endpoint.
 - Vercel AI Gateway reports current team credits and lifetime spend only; Custom Reporting and request-rate counters are not queried.
+- MiniMax Token Plan field semantics have changed over time; contradictory counts and percentages are reported as unavailable rather than guessed.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.
@@ -464,7 +484,7 @@ The generated runtime is built from the authoritative `src/index.ts` graph and d
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, Vercel AI Gateway credits, Vercel AI Gateway usage, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, Moonshot AI balance, Moonshot API balance, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, Vercel AI Gateway credits, Vercel AI Gateway usage, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, Moonshot AI balance, Moonshot API balance, MiniMax Token Plan, MiniMax API balance, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -20,6 +20,8 @@
 		"kimi-coding",
 		"moonshot",
 		"moonshotai",
+		"minimax",
+		"token-plan",
 		"copilot",
 		"openrouter",
 		"opencode",

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -20,7 +20,11 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 					? "Vercel AI Gateway Credits"
 					: report.providerId === "moonshotai" || report.providerId === "moonshotai-cn"
 						? `${report.providerName} Balance`
-						: `${report.providerName} Usage`;
+						: report.providerId === "minimax" || report.providerId === "minimax-cn"
+							? report.source === "minimax-account-balance"
+								? `${report.providerName} API Balance`
+								: `${report.providerName} Token Plan`
+							: `${report.providerName} Usage`;
 	const lines = [`${title} · ${stateLabel}`];
 	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
 	lines.push(`Semantics: ${report.semantics.label}`, "");
@@ -35,6 +39,8 @@ export function formatUsageReport(report: UsageReport, displayState: UsageDispla
 	else if (report.providerId === "kimi-coding") formatKimiCodingReport(lines, report);
 	else if (report.providerId === "moonshotai" || report.providerId === "moonshotai-cn") {
 		formatMoonshotReport(lines, report);
+	} else if (report.providerId === "minimax" || report.providerId === "minimax-cn") {
+		formatMiniMaxReport(lines, report);
 	} else if (report.providerId === "xai") formatXaiReport(lines, report);
 	else if (report.providerId === "zai" || report.providerId === "zai-coding-cn") {
 		formatZaiReport(lines, report);
@@ -69,6 +75,9 @@ export function formatUsageStatusline(
 	if (report.providerId === "kimi-coding") return formatKimiCodingStatusline(report);
 	if (report.providerId === "moonshotai" || report.providerId === "moonshotai-cn") {
 		return formatMoonshotStatusline(report);
+	}
+	if (report.providerId === "minimax" || report.providerId === "minimax-cn") {
+		return formatMiniMaxStatusline(report);
 	}
 	if (report.providerId === "zai" || report.providerId === "zai-coding-cn") {
 		return formatZaiStatusline(report);
@@ -318,6 +327,48 @@ function formatMoonshotStatusline(report: UsageReport): string {
 	const available = report.metrics.find((metric) => metric.id === "available-balance");
 	if (!available) return "moonshot balance unavailable";
 	return `moonshot ${available.currency ?? ""} ${available.value}`.replace(/\s+/gu, " ");
+}
+
+function formatMiniMaxReport(lines: string[], report: UsageReport): void {
+	if (report.source === "minimax-account-balance") {
+		for (const metric of report.metrics) {
+			lines.push(`${`${metric.label}:`.padEnd(VALUE_COLUMN)}${metric.currency} ${metric.value}`);
+		}
+		return;
+	}
+	let previousGroup: string | undefined;
+	for (const bucket of report.buckets) {
+		if (bucket.groupId !== previousGroup) lines.push(`${bucket.groupLabel ?? "Token Plan"}:`);
+		previousGroup = bucket.groupId;
+		const reset = bucket.resetsAt ? ` (resets ${formatReset(bucket.resetsAt)})` : "";
+		const value =
+			bucket.period === "unlimited"
+				? "unlimited"
+				: bucket.limit && bucket.remaining !== undefined
+					? `${bucket.remaining} of ${bucket.limit} left · ${percentRemaining(bucket)}%${reset}`
+					: "unavailable";
+		lines.push(`${`${bucket.label}:`.padEnd(VALUE_COLUMN)}${value}`);
+	}
+}
+
+function formatMiniMaxStatusline(report: UsageReport): string | undefined {
+	const prefix = report.providerId === "minimax-cn" ? "minimax cn" : "minimax";
+	if (report.source === "minimax-account-balance") {
+		const available = report.metrics.find((metric) => metric.id === "available-balance");
+		return available ? `${prefix} ${available.currency} ${available.value}` : undefined;
+	}
+	const firstGroup = report.buckets[0]?.groupId;
+	const selected = report.buckets.filter((bucket) => bucket.groupId === firstGroup);
+	if (selected.some((bucket) => bucket.period === "unlimited")) return `${prefix} unlimited`;
+	const parts = [prefix];
+	for (const bucket of selected) {
+		if (!bucket.limit || bucket.remaining === undefined) continue;
+		const fallback = bucket.id.endsWith(":weekly") ? "weekly" : "5h";
+		parts.push(
+			`${percentRemaining(bucket)}% ${formatWindowLabel(bucket.windowMinutes, fallback, true)}`,
+		);
+	}
+	return parts.length > 1 ? parts.join(" ") : undefined;
 }
 
 function formatZaiStatusline(report: UsageReport): string | undefined {

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -403,16 +403,23 @@ function selectMiniMaxGroup(report: UsageReport, model?: UsageModel): string | u
 	const modelKeys = [model.id, model.name]
 		.map(normalizeMiniMaxModelKey)
 		.filter((key): key is string => key !== undefined);
-	for (const group of groups) {
+	const candidates = groups.map((group) => {
 		const bucket = report.buckets.find((candidate) => candidate.groupId === group);
 		const patterns = [bucket?.groupLabel, ...(bucket?.modelKeys ?? []), group]
 			.map(normalizeMiniMaxModelKey)
 			.filter((key): key is string => key !== undefined);
-		if (patterns.some((pattern) => modelKeys.some((key) => wildcardKeyMatches(pattern, key)))) {
-			return group;
-		}
-	}
-	return undefined;
+		return { group, patterns };
+	});
+	const exact = candidates.find(({ patterns }) =>
+		patterns.some((pattern) => !pattern.includes("*") && modelKeys.includes(pattern)),
+	);
+	if (exact) return exact.group;
+	return candidates.find(({ patterns }) =>
+		patterns.some(
+			(pattern) =>
+				pattern.includes("*") && modelKeys.some((key) => wildcardKeyMatches(pattern, key)),
+		),
+	)?.group;
 }
 
 function normalizeMiniMaxModelKey(value: string | undefined): string | undefined {

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -77,7 +77,7 @@ export function formatUsageStatusline(
 		return formatMoonshotStatusline(report);
 	}
 	if (report.providerId === "minimax" || report.providerId === "minimax-cn") {
-		return formatMiniMaxStatusline(report);
+		return formatMiniMaxStatusline(report, model);
 	}
 	if (report.providerId === "zai" || report.providerId === "zai-coding-cn") {
 		return formatZaiStatusline(report);
@@ -351,24 +351,70 @@ function formatMiniMaxReport(lines: string[], report: UsageReport): void {
 	}
 }
 
-function formatMiniMaxStatusline(report: UsageReport): string | undefined {
+function formatMiniMaxStatusline(report: UsageReport, model?: UsageModel): string | undefined {
 	const prefix = report.providerId === "minimax-cn" ? "minimax cn" : "minimax";
 	if (report.source === "minimax-account-balance") {
 		const available = report.metrics.find((metric) => metric.id === "available-balance");
 		return available ? `${prefix} ${available.currency} ${available.value}` : undefined;
 	}
-	const firstGroup = report.buckets[0]?.groupId;
-	const selected = report.buckets.filter((bucket) => bucket.groupId === firstGroup);
-	if (selected.some((bucket) => bucket.period === "unlimited")) return `${prefix} unlimited`;
+	const selectedGroup = selectMiniMaxGroup(report, model);
+	if (!selectedGroup) return undefined;
+	const selected = report.buckets.filter((bucket) => bucket.groupId === selectedGroup);
 	const parts = [prefix];
 	for (const bucket of selected) {
-		if (!bucket.limit || bucket.remaining === undefined) continue;
 		const fallback = bucket.id.endsWith(":weekly") ? "weekly" : "5h";
-		parts.push(
-			`${percentRemaining(bucket)}% ${formatWindowLabel(bucket.windowMinutes, fallback, true)}`,
-		);
+		const window = formatWindowLabel(bucket.windowMinutes, fallback, true);
+		if (bucket.period === "unlimited") {
+			parts.push(`unlimited ${window}`);
+			continue;
+		}
+		if (!bucket.limit || bucket.remaining === undefined) continue;
+		parts.push(`${percentRemaining(bucket)}% ${window}`);
 	}
 	return parts.length > 1 ? parts.join(" ") : undefined;
+}
+
+function selectMiniMaxGroup(report: UsageReport, model?: UsageModel): string | undefined {
+	const groups = [
+		...new Set(
+			report.buckets
+				.map((bucket) => bucket.groupId)
+				.filter((group): group is string => group !== undefined),
+		),
+	];
+	if (groups.length <= 1) return groups[0];
+	if (model?.provider !== report.providerId) return undefined;
+	const modelKeys = [model.id, model.name]
+		.map(normalizeMiniMaxModelKey)
+		.filter((key): key is string => key !== undefined);
+	for (const group of groups) {
+		const bucket = report.buckets.find((candidate) => candidate.groupId === group);
+		const patterns = [bucket?.groupLabel, ...(bucket?.modelKeys ?? []), group]
+			.map(normalizeMiniMaxModelKey)
+			.filter((key): key is string => key !== undefined);
+		if (patterns.some((pattern) => modelKeys.some((key) => wildcardKeyMatches(pattern, key)))) {
+			return group;
+		}
+	}
+	return undefined;
+}
+
+function normalizeMiniMaxModelKey(value: string | undefined): string | undefined {
+	const key = value?.toLowerCase().replace(/[^a-z0-9*]+/gu, "");
+	return key && /[a-z0-9]/u.test(key) ? key : undefined;
+}
+
+function wildcardKeyMatches(pattern: string, value: string): boolean {
+	if (!pattern.includes("*")) return pattern === value;
+	const segments = pattern.split("*").filter(Boolean);
+	let offset = 0;
+	for (const [index, segment] of segments.entries()) {
+		const found = value.indexOf(segment, offset);
+		if (found < 0 || (index === 0 && !pattern.startsWith("*") && found !== 0)) return false;
+		offset = found + segment.length;
+	}
+	const last = segments.at(-1);
+	return pattern.endsWith("*") || (last !== undefined && value.endsWith(last));
 }
 
 function formatZaiStatusline(report: UsageReport): string | undefined {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -40,6 +40,11 @@ export {
 } from "./providers/fireworks.js";
 export { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 export { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
+export type { MiniMaxProviderId, MiniMaxUsageKind } from "./providers/minimax.js";
+export {
+	miniMaxUsageKind,
+	normalizeMiniMaxUsagePayload,
+} from "./providers/minimax.js";
 export type { MoonshotProviderId } from "./providers/moonshot.js";
 export { normalizeMoonshotBalancePayload } from "./providers/moonshot.js";
 export { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
@@ -74,6 +79,7 @@ export type {
 	FireworksAccountsPayload,
 	FireworksBillingSummaryPayload,
 	KimiCodingUsagePayload,
+	MiniMaxUsagePayload,
 	MoonshotBalancePayload,
 	ProviderUsageState,
 	ResolvedUsageAuth,

--- a/packages/pi-usage/src/providers/minimax.ts
+++ b/packages/pi-usage/src/providers/minimax.ts
@@ -1,0 +1,264 @@
+import { sanitizeDisplayText } from "../core.js";
+import type { MiniMaxUsagePayload, UsageBucket, UsageMetric, UsageReport } from "../types.js";
+
+export type MiniMaxProviderId = "minimax" | "minimax-cn";
+export type MiniMaxUsageKind = "token-plan" | "account-balance";
+
+const PROVIDERS = {
+	minimax: { name: "MiniMax", currency: "USD" },
+	"minimax-cn": { name: "MiniMax CN", currency: "CNY" },
+} as const;
+const DECIMAL_AMOUNT = /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/u;
+const PERCENT_TOLERANCE = 1;
+
+export function miniMaxUsageKind(apiKey: string): MiniMaxUsageKind {
+	return apiKey.startsWith("sk-api-") ? "account-balance" : "token-plan";
+}
+
+export function normalizeMiniMaxUsagePayload(
+	providerId: MiniMaxProviderId,
+	kind: MiniMaxUsageKind,
+	payload: MiniMaxUsagePayload,
+	capturedAt: number,
+): UsageReport {
+	return kind === "account-balance"
+		? normalizeBalance(providerId, payload, capturedAt)
+		: normalizeTokenPlan(providerId, payload, capturedAt);
+}
+
+function normalizeBalance(
+	providerId: MiniMaxProviderId,
+	payload: MiniMaxUsagePayload,
+	capturedAt: number,
+): UsageReport {
+	assertSuccess(payload);
+	const provider = PROVIDERS[providerId];
+	const metrics: UsageMetric[] = [
+		balanceMetric(
+			"available-balance",
+			"Available balance",
+			payload.available_amount,
+			provider.currency,
+		),
+		balanceMetric("cash-balance", "Cash balance", payload.cash_balance, provider.currency, true),
+		balanceMetric("voucher-balance", "Voucher balance", payload.voucher_balance, provider.currency),
+		balanceMetric("credit-balance", "Credit balance", payload.credit_balance, provider.currency),
+		balanceMetric("owed-amount", "Owed amount", payload.owed_amount, provider.currency),
+	];
+	return {
+		providerId,
+		providerName: provider.name,
+		capturedAt,
+		source: "minimax-account-balance",
+		semantics: { kind: "api-key", label: "MiniMax pay-as-you-go account balance" },
+		buckets: [],
+		metrics,
+	};
+}
+
+function normalizeTokenPlan(
+	providerId: MiniMaxProviderId,
+	payload: MiniMaxUsagePayload,
+	capturedAt: number,
+): UsageReport {
+	assertSuccess(payload);
+	if (!Array.isArray(payload.model_remains) || payload.model_remains.length === 0) {
+		throw new Error("MiniMax Token Plan returned no quota rows.");
+	}
+	const provider = PROVIDERS[providerId];
+	const buckets: UsageBucket[] = [];
+	const groups = new Set<string>();
+	for (const [index, raw] of payload.model_remains.entries()) {
+		const row = asObject(raw);
+		if (!row) throw new Error("MiniMax Token Plan quota row was not an object.");
+		const groupLabel = safeLabel(row.model_name, `Quota ${index + 1}`);
+		const groupId = uniqueGroupId(groupLabel, index, groups);
+		buckets.push(
+			normalizeWindow(row, {
+				id: `${groupId}:interval`,
+				label: "Rolling window",
+				groupId,
+				groupLabel,
+				countField: "current_interval_usage_count",
+				totalField: "current_interval_total_count",
+				percentField: "current_interval_remaining_percent",
+				statusField: "current_interval_status",
+				startField: "start_time",
+				endField: "end_time",
+			}),
+			normalizeWindow(row, {
+				id: `${groupId}:weekly`,
+				label: "Weekly window",
+				groupId,
+				groupLabel,
+				countField: "current_weekly_usage_count",
+				totalField: "current_weekly_total_count",
+				percentField: "current_weekly_remaining_percent",
+				statusField: "current_weekly_status",
+				startField: "weekly_start_time",
+				endField: "weekly_end_time",
+				boostPermille: row.weekly_boost_permille,
+			}),
+		);
+	}
+	return {
+		providerId,
+		providerName: provider.name,
+		capturedAt,
+		source: "minimax-token-plan",
+		semantics: { kind: "consumer-subscription", label: "MiniMax Token Plan quota" },
+		buckets,
+		metrics: [],
+	};
+}
+
+type WindowFields = {
+	id: string;
+	label: string;
+	groupId: string;
+	groupLabel: string;
+	countField: string;
+	totalField: string;
+	percentField: string;
+	statusField: string;
+	startField: string;
+	endField: string;
+	boostPermille?: unknown;
+};
+
+function normalizeWindow(row: Record<string, unknown>, fields: WindowFields): UsageBucket {
+	const status = optionalInteger(row[fields.statusField], fields.statusField);
+	if (status !== undefined && ![1, 2, 3].includes(status)) {
+		throw new Error(`MiniMax Token Plan ${fields.label} status was unsupported.`);
+	}
+	const percent = optionalPercent(row[fields.percentField], fields.percentField);
+	validateBoost(fields.boostPermille);
+	const start = timestamp(row[fields.startField], fields.startField);
+	const end = timestamp(row[fields.endField], fields.endField);
+	if (end < start) throw new Error(`MiniMax Token Plan ${fields.label} timestamps were reversed.`);
+	const resetsAt = Math.floor(end / 1_000);
+	const windowMinutes = Math.max(1, Math.round((end - start) / 60_000));
+	if (status === 3) {
+		return {
+			id: fields.id,
+			label: fields.label,
+			groupId: fields.groupId,
+			groupLabel: fields.groupLabel,
+			remaining: 100,
+			unit: "percent",
+			period: "unlimited",
+			windowMinutes,
+		};
+	}
+	const total = nonnegativeInteger(row[fields.totalField], fields.totalField);
+	const count = nonnegativeInteger(row[fields.countField], fields.countField);
+	const resolved = resolveQuotaCounts(count, total, percent);
+	if (!resolved) throw new Error(`MiniMax Token Plan ${fields.label} counts were inconsistent.`);
+	return {
+		id: fields.id,
+		label: fields.label,
+		groupId: fields.groupId,
+		groupLabel: fields.groupLabel,
+		...resolved,
+		unit: "count",
+		windowMinutes,
+		resetsAt,
+	};
+}
+
+function resolveQuotaCounts(
+	reportedCount: number,
+	total: number,
+	remainingPercent: number | undefined,
+): Pick<UsageBucket, "used" | "remaining" | "limit"> | undefined {
+	if (total <= 0 || reportedCount > total) return undefined;
+	let remaining = reportedCount;
+	if (remainingPercent !== undefined) {
+		const asRemaining = (reportedCount / total) * 100;
+		const asUsed = ((total - reportedCount) / total) * 100;
+		const remainingDistance = Math.abs(asRemaining - remainingPercent);
+		const usedDistance = Math.abs(asUsed - remainingPercent);
+		if (Math.min(remainingDistance, usedDistance) > PERCENT_TOLERANCE) return undefined;
+		if (usedDistance < remainingDistance) remaining = total - reportedCount;
+	}
+	return { used: total - remaining, remaining, limit: total };
+}
+
+function assertSuccess(payload: MiniMaxUsagePayload): void {
+	const base = asObject(payload.base_resp);
+	if (base?.status_code !== 0) {
+		throw new Error("MiniMax usage response did not report success.");
+	}
+}
+
+function balanceMetric(
+	id: string,
+	label: string,
+	value: unknown,
+	currency: "CNY" | "USD",
+	allowNegative = false,
+): UsageMetric {
+	if (
+		typeof value !== "string" ||
+		value.length > 64 ||
+		!DECIMAL_AMOUNT.test(value) ||
+		(!allowNegative && value.startsWith("-"))
+	) {
+		throw new Error(`MiniMax ${label.toLowerCase()} was not a valid amount.`);
+	}
+	return { id, label, value, unit: "currency", currency };
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}
+
+function safeLabel(value: unknown, fallback: string): string {
+	if (typeof value !== "string") throw new Error("MiniMax Token Plan model name was not a string.");
+	return sanitizeDisplayText(value, 80) || fallback;
+}
+
+function uniqueGroupId(label: string, index: number, groups: Set<string>): string {
+	const base =
+		label
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/gu, "-")
+			.replace(/^-|-$/gu, "") || "quota";
+	const id = groups.has(base) ? `${base}-${index + 1}` : base;
+	groups.add(id);
+	return id;
+}
+
+function nonnegativeInteger(value: unknown, field: string): number {
+	if (!Number.isSafeInteger(value) || (value as number) < 0) {
+		throw new Error(`MiniMax Token Plan ${field} was not a nonnegative safe integer.`);
+	}
+	return value as number;
+}
+
+function optionalInteger(value: unknown, field: string): number | undefined {
+	if (value === undefined || value === null) return undefined;
+	return nonnegativeInteger(value, field);
+}
+
+function optionalPercent(value: unknown, field: string): number | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 100) {
+		throw new Error(`MiniMax Token Plan ${field} was not a percentage.`);
+	}
+	return value;
+}
+
+function validateBoost(boost: unknown): void {
+	if (boost === undefined || boost === null) return;
+	const permille = nonnegativeInteger(boost, "weekly_boost_permille");
+	if (permille > 10_000) throw new Error("MiniMax Token Plan weekly boost was unreasonable.");
+}
+
+function timestamp(value: unknown, field: string): number {
+	if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+		throw new Error(`MiniMax Token Plan ${field} was not a valid timestamp.`);
+	}
+	return value as number;
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -14,6 +14,11 @@ import {
 } from "./providers/fireworks.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
+import {
+	type MiniMaxProviderId,
+	miniMaxUsageKind,
+	normalizeMiniMaxUsagePayload,
+} from "./providers/minimax.js";
 import { normalizeMoonshotBalancePayload } from "./providers/moonshot.js";
 import { normalizeOpenCodeZenPayload } from "./providers/opencode-zen.js";
 import { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
@@ -27,6 +32,7 @@ import type {
 	FireworksBillingSummaryPayload,
 	GitHubCopilotUsagePayload,
 	KimiCodingUsagePayload,
+	MiniMaxUsagePayload,
 	MoonshotBalancePayload,
 	OpenCodeZenPayload,
 	OpenRouterKeyPayload,
@@ -51,6 +57,10 @@ const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const VERCEL_AI_GATEWAY_CREDITS_URL = "https://ai-gateway.vercel.sh/v1/credits";
 const OPENCODE_GO_USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
 const KIMI_CODING_USAGE_URL = "https://api.kimi.com/coding/v1/usages";
+const MINIMAX_API_ROOTS = Object.freeze({
+	minimax: "https://api.minimax.io",
+	"minimax-cn": "https://api.minimaxi.com",
+});
 const MOONSHOT_BALANCE_URLS = Object.freeze({
 	moonshotai: "https://api.moonshot.ai/v1/users/me/balance",
 	"moonshotai-cn": "https://api.moonshot.cn/v1/users/me/balance",
@@ -221,6 +231,22 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 				{ redirect: "error" },
 			);
 			return normalizeKimiCodingUsagePayload(payload as KimiCodingUsagePayload, Date.now());
+		},
+	},
+	{
+		id: "minimax",
+		displayName: "MiniMax",
+		semantics: { kind: "consumer-subscription", label: "MiniMax usage" },
+		async query(auth, signal, timeoutMs, guard) {
+			return queryMiniMaxUsage("minimax", auth, signal, timeoutMs, guard);
+		},
+	},
+	{
+		id: "minimax-cn",
+		displayName: "MiniMax CN",
+		semantics: { kind: "consumer-subscription", label: "MiniMax usage" },
+		async query(auth, signal, timeoutMs, guard) {
+			return queryMiniMaxUsage("minimax-cn", auth, signal, timeoutMs, guard);
 		},
 	},
 	{
@@ -825,6 +851,8 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 		if (providerId === "vercel-ai-gateway") return url.origin === "https://ai-gateway.vercel.sh";
 		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
 		if (providerId === "kimi-coding") return url.origin === "https://api.kimi.com";
+		if (providerId === "minimax") return url.origin === "https://api.minimax.io";
+		if (providerId === "minimax-cn") return url.origin === "https://api.minimaxi.com";
 		if (providerId === "moonshotai") return url.origin === "https://api.moonshot.ai";
 		if (providerId === "moonshotai-cn") return url.origin === "https://api.moonshot.cn";
 		if (providerId === "xai") return url.origin === "https://api.x.ai";
@@ -860,6 +888,32 @@ function validatedXaiUserId(value: unknown): string {
 		throw new Error("xAI consumer identity returned an unsafe canonical user ID.");
 	}
 	return value;
+}
+
+async function queryMiniMaxUsage(
+	providerId: MiniMaxProviderId,
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+	guard: UsageRequestGuard | undefined,
+): Promise<UsageReport> {
+	if (!guard) throw new Error("MiniMax usage requires request-boundary revalidation.");
+	const apiKey = auth.apiKey ?? bearerToken(headerValue(auth.headers, "Authorization"));
+	if (!apiKey) throw new Error("MiniMax runtime API key was unavailable.");
+	const kind = miniMaxUsageKind(apiKey);
+	const path = kind === "account-balance" ? "/account/query_balance" : "/v1/token_plan/remains";
+	const startedAt = Date.now();
+	await guard();
+	const payload = (await fetchProviderJson(
+		`${MINIMAX_API_ROOTS[providerId]}${path}`,
+		auth,
+		signal,
+		remainingTimeout(timeoutMs, startedAt, "fetching MiniMax usage"),
+		"MiniMax usage endpoint",
+		{ redirect: "error" },
+	)) as MiniMaxUsagePayload;
+	await guard();
+	return normalizeMiniMaxUsagePayload(providerId, kind, payload, Date.now());
 }
 
 async function queryMoonshotBalance(

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -426,7 +426,8 @@ export async function resolveUsageAuth(
 		if (!result.ok) throw new Error(redactUsageError(result.error));
 		return authorizationFrom(result) ? result : undefined;
 	};
-	if (adapter.id !== "deepseek") modelAuth = await resolveCurrentModelAuth();
+	const resolveSelectedAuthLast = ["deepseek", "minimax", "minimax-cn"].includes(adapter.id);
+	if (!resolveSelectedAuthLast) modelAuth = await resolveCurrentModelAuth();
 	if (typeof registry.getProviderAuth !== "function") {
 		throw new Error("pi-usage requires Pi 0.81.0 or newer to validate resolved provider auth.");
 	}
@@ -439,9 +440,9 @@ export async function resolveUsageAuth(
 			`${adapter.displayName} usage cannot send a proxy-resolved credential to the official usage endpoint.`,
 		);
 	}
-	// DeepSeek reads selected-model auth last so a rotation during provider-origin validation
-	// cannot leave the earlier credential queued for the balance request.
-	if (adapter.id === "deepseek") modelAuth = await resolveCurrentModelAuth();
+	// Providers with credential-change retries read selected-model auth last so a rotation during
+	// provider-origin validation cannot leave the earlier credential queued for the usage request.
+	if (resolveSelectedAuthLast) modelAuth = await resolveCurrentModelAuth();
 	const auth = modelAuth ?? providerResult?.auth;
 	if (!auth) return undefined;
 	if (adapter.id === "github-copilot") {

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -898,7 +898,7 @@ async function queryMiniMaxUsage(
 	guard: UsageRequestGuard | undefined,
 ): Promise<UsageReport> {
 	if (!guard) throw new Error("MiniMax usage requires request-boundary revalidation.");
-	const apiKey = auth.apiKey ?? bearerToken(headerValue(auth.headers, "Authorization"));
+	const apiKey = bearerToken(headerValue(auth.headers, "Authorization")) ?? auth.apiKey;
 	if (!apiKey) throw new Error("MiniMax runtime API key was unavailable.");
 	const kind = miniMaxUsageKind(apiKey);
 	const path = kind === "account-balance" ? "/account/query_balance" : "/v1/token_plan/remains";

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -119,6 +119,18 @@ export type OpenRouterKeyPayload = {
 	data?: unknown;
 };
 
+export type MiniMaxUsagePayload = {
+	available_amount?: unknown;
+	balance_alert_switch?: unknown;
+	balance_alert_threshold?: unknown;
+	base_resp?: unknown;
+	cash_balance?: unknown;
+	credit_balance?: unknown;
+	model_remains?: unknown;
+	owed_amount?: unknown;
+	voucher_balance?: unknown;
+};
+
 export type MoonshotBalancePayload = {
 	code?: unknown;
 	data?: unknown;

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -354,7 +354,7 @@ export default function usageExtension(
 		const queryId = querySequence;
 		setBoundedMap(latestQueries, failureKey, queryId, MAX_ACCOUNT_STATES);
 
-		let deepSeekAuthChanged = false;
+		let retryableAuthChanged = false;
 		try {
 			const remainingMs = Math.max(1, deadlineAt - Date.now());
 			const guard = requiresRequestBoundaryGuard
@@ -368,9 +368,11 @@ export default function usageExtension(
 						);
 						if (signal.aborted || requestContextChanged()) throw abortError();
 						if (revalidated?.fingerprint !== auth.fingerprint) {
-							if (adapter.id === "deepseek") {
-								deepSeekAuthChanged = true;
-								throw new Error("DeepSeek runtime credential changed during the balance query.");
+							if (["deepseek", "minimax", "minimax-cn"].includes(adapter.id)) {
+								retryableAuthChanged = true;
+								throw new Error(
+									`${adapter.displayName} runtime credential changed during the usage query.`,
+								);
 							}
 							throw abortError();
 						}
@@ -402,7 +404,7 @@ export default function usageExtension(
 		} catch (error) {
 			if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
 			if (
-				deepSeekAuthChanged &&
+				retryableAuthChanged &&
 				authRetry === 0 &&
 				!signal.aborted &&
 				!requestContextChanged() &&

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -284,6 +284,8 @@ export default function usageExtension(
 		const requiresRequestBoundaryGuard = [
 			"deepseek",
 			"fireworks",
+			"minimax",
+			"minimax-cn",
 			"moonshotai",
 			"moonshotai-cn",
 			"vercel-ai-gateway",

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -170,6 +170,26 @@ test("MiniMax statusline preserves mixed windows and selects the active model gr
 	);
 });
 
+test("MiniMax statusline prefers an exact model group over an earlier wildcard", () => {
+	const overlappingPayload = quotaPayload();
+	overlappingPayload.model_remains = [
+		{
+			...overlappingPayload.model_remains[0],
+			current_interval_usage_count: 1_200,
+			current_weekly_usage_count: 600,
+			current_weekly_remaining_percent: 60,
+		},
+		{ ...overlappingPayload.model_remains[0], model_name: "MiniMax-M3" },
+	];
+	const overlapping = normalizeMiniMaxUsagePayload(
+		"minimax",
+		"token-plan",
+		overlappingPayload,
+		2_700,
+	);
+	assert.equal(formatUsageStatusline(overlapping, MODELS.minimax), "minimax 15% 5h 80% wk");
+});
+
 test("MiniMax pay-as-you-go keeps exact regional balance strings and debt components", () => {
 	for (const [providerId, currency] of [
 		["minimax", "USD"],

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -139,7 +139,35 @@ test("MiniMax Token Plan preserves unlimited windows and sanitizes model labels"
 	assert.equal(report.buckets[0]?.groupLabel, "MiniMax Unlimited");
 	assert.equal(report.buckets[0]?.period, "unlimited");
 	assert.match(formatUsageReport(report, "configured"), /Rolling window:\s+unlimited/u);
-	assert.equal(formatUsageStatusline(report), "minimax cn unlimited");
+	assert.equal(formatUsageStatusline(report), "minimax cn unlimited 5h unlimited wk");
+});
+
+test("MiniMax statusline preserves mixed windows and selects the active model group", () => {
+	const mixedPayload = quotaPayload();
+	mixedPayload.model_remains[0] = {
+		...mixedPayload.model_remains[0],
+		current_interval_status: 3,
+	};
+	const mixed = normalizeMiniMaxUsagePayload("minimax", "token-plan", mixedPayload, 2_500);
+	assert.equal(formatUsageStatusline(mixed), "minimax unlimited 5h 80% wk");
+
+	const groupedPayload = quotaPayload();
+	groupedPayload.model_remains = [
+		{ ...groupedPayload.model_remains[0], model_name: "MiniMax-M2" },
+		{
+			...groupedPayload.model_remains[0],
+			model_name: "MiniMax-M*",
+			current_interval_usage_count: 1_200,
+			current_weekly_usage_count: 600,
+			current_weekly_remaining_percent: 60,
+		},
+	];
+	const grouped = normalizeMiniMaxUsagePayload("minimax", "token-plan", groupedPayload, 2_600);
+	assert.equal(formatUsageStatusline(grouped, MODELS.minimax), "minimax 80% 5h 60% wk");
+	assert.equal(
+		formatUsageStatusline(grouped, { ...MODELS.minimax, id: "Other-X", name: "Other X" }),
+		undefined,
+	);
 });
 
 test("MiniMax pay-as-you-go keeps exact regional balance strings and debt components", () => {
@@ -253,6 +281,39 @@ test("MiniMax runtime auth accepts only its matching official region", async () 
 		assert.equal(fetchMock.mock.calls.length, 0);
 	} finally {
 		fetchMock.mockRestore();
+	}
+});
+
+test("MiniMax endpoint selection follows the Bearer credential actually sent", async () => {
+	const requests: string[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (input: string | URL | Request) => {
+			const url = String(input);
+			requests.push(url);
+			const body = url.endsWith("/account/query_balance") ? balancePayload() : quotaPayload();
+			return new Response(JSON.stringify(body), { status: 200 });
+		}),
+	);
+	try {
+		for (const [apiKey, bearer, expectedPath] of [
+			["sk-api-stale", "token-plan-active", "/v1/token_plan/remains"],
+			["token-plan-stale", "sk-api-active", "/account/query_balance"],
+		] as const) {
+			const auth = miniMaxAuth("minimax", apiKey);
+			auth.headers.Authorization = `Bearer ${bearer}`;
+			await queryProviderUsage(
+				miniMaxAdapter("minimax"),
+				auth,
+				new AbortController().signal,
+				1_000,
+				async () => undefined,
+			);
+			assert.ok(requests.at(-1)?.endsWith(expectedPath));
+		}
+		assert.equal(requests.length, 2);
+	} finally {
+		vi.unstubAllGlobals();
 	}
 });
 

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	miniMaxUsageKind,
+	normalizeMiniMaxUsagePayload,
+	queryProviderUsage,
+	type ResolvedUsageAuth,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+	type UsageProviderAdapter,
+} from "../src/index.js";
+
+const MODELS = {
+	minimax: {
+		id: "MiniMax-M3",
+		name: "MiniMax M3",
+		provider: "minimax",
+		baseUrl: "https://api.minimax.io/anthropic",
+	},
+	"minimax-cn": {
+		id: "MiniMax-M3",
+		name: "MiniMax M3",
+		provider: "minimax-cn",
+		baseUrl: "https://api.minimaxi.com/anthropic",
+	},
+} as const;
+
+type ProviderId = keyof typeof MODELS;
+
+function miniMaxAdapter(providerId: ProviderId): UsageProviderAdapter {
+	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === providerId);
+	assert.ok(candidate);
+	return candidate;
+}
+
+function miniMaxAuth(providerId: ProviderId, apiKey: string): ResolvedUsageAuth {
+	return {
+		apiKey,
+		headers: { Authorization: `Bearer ${apiKey}` },
+		fingerprint: "fingerprint",
+		secrets: [apiKey, `Bearer ${apiKey}`],
+		model: MODELS[providerId] as never,
+	};
+}
+
+function quotaPayload() {
+	return {
+		base_resp: { status_code: 0, status_msg: "success" },
+		model_remains: [
+			{
+				model_name: "MiniMax-M*",
+				start_time: 1_800_000_000_000,
+				end_time: 1_800_018_000_000,
+				current_interval_total_count: 1_500,
+				current_interval_usage_count: 228,
+				current_interval_status: 1,
+				current_weekly_total_count: 1_000,
+				current_weekly_usage_count: 200,
+				current_weekly_remaining_percent: 80,
+				current_weekly_status: 1,
+				weekly_start_time: 1_799_971_200_000,
+				weekly_end_time: 1_800_576_000_000,
+				weekly_boost_permille: 1_500,
+			},
+		],
+	};
+}
+
+function balancePayload() {
+	return {
+		base_resp: { status_code: 0, status_msg: "success" },
+		available_amount: "98.00001",
+		cash_balance: "-2.50",
+		voucher_balance: "100.50001",
+		credit_balance: "0",
+		owed_amount: "2.50",
+		balance_alert_switch: true,
+		balance_alert_threshold: "10",
+	};
+}
+
+test("MiniMax deterministically selects Token Plan or pay-as-you-go by first-party key prefix", () => {
+	assert.equal(miniMaxUsageKind("sk-token-plan"), "token-plan");
+	assert.equal(miniMaxUsageKind("oauth-looking-token"), "token-plan");
+	assert.equal(miniMaxUsageKind("sk-api-secret"), "account-balance");
+});
+
+test("MiniMax Token Plan normalizes legacy and current count semantics", () => {
+	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", quotaPayload(), 1_000);
+	assert.equal(report.providerId, "minimax");
+	assert.equal(report.source, "minimax-token-plan");
+	assert.deepEqual(report.semantics, {
+		kind: "consumer-subscription",
+		label: "MiniMax Token Plan quota",
+	});
+	assert.deepEqual(report.buckets[0], {
+		id: "minimax-m:interval",
+		label: "Rolling window",
+		groupId: "minimax-m",
+		groupLabel: "MiniMax-M*",
+		used: 1_272,
+		remaining: 228,
+		limit: 1_500,
+		unit: "count",
+		windowMinutes: 300,
+		resetsAt: 1_800_018_000,
+	});
+	assert.deepEqual(report.buckets[1], {
+		id: "minimax-m:weekly",
+		label: "Weekly window",
+		groupId: "minimax-m",
+		groupLabel: "MiniMax-M*",
+		used: 200,
+		remaining: 800,
+		limit: 1_000,
+		unit: "count",
+		windowMinutes: 10_080,
+		resetsAt: 1_800_576_000,
+	});
+	const formatted = formatUsageReport(report, "current");
+	assert.match(formatted, /^MiniMax Token Plan · Current/mu);
+	assert.match(formatted, /Rolling window:\s+228 of 1500 left · 15%/u);
+	assert.match(formatted, /Weekly window:\s+800 of 1000 left · 80%/u);
+	assert.equal(formatUsageStatusline(report), "minimax 15% 5h 80% wk");
+});
+
+test("MiniMax Token Plan preserves unlimited windows and sanitizes model labels", () => {
+	const payload = quotaPayload();
+	payload.model_remains[0] = {
+		...payload.model_remains[0],
+		model_name: "MiniMax\u001b[31m\nUnlimited",
+		current_interval_status: 3,
+		current_weekly_status: 3,
+	};
+	const report = normalizeMiniMaxUsagePayload("minimax-cn", "token-plan", payload, 2_000);
+	assert.equal(report.buckets[0]?.groupLabel, "MiniMax Unlimited");
+	assert.equal(report.buckets[0]?.period, "unlimited");
+	assert.match(formatUsageReport(report, "configured"), /Rolling window:\s+unlimited/u);
+	assert.equal(formatUsageStatusline(report), "minimax cn unlimited");
+});
+
+test("MiniMax pay-as-you-go keeps exact regional balance strings and debt components", () => {
+	for (const [providerId, currency] of [
+		["minimax", "USD"],
+		["minimax-cn", "CNY"],
+	] as const) {
+		const report = normalizeMiniMaxUsagePayload(
+			providerId,
+			"account-balance",
+			balancePayload(),
+			3_000,
+		);
+		assert.equal(report.source, "minimax-account-balance");
+		assert.deepEqual(
+			report.metrics.map((metric) => [metric.id, metric.value, metric.currency]),
+			[
+				["available-balance", "98.00001", currency],
+				["cash-balance", "-2.50", currency],
+				["voucher-balance", "100.50001", currency],
+				["credit-balance", "0", currency],
+				["owed-amount", "2.50", currency],
+			],
+		);
+		assert.match(
+			formatUsageReport(report, "current"),
+			/Available balance:\s+(?:USD|CNY) 98\.00001/u,
+		);
+		assert.equal(
+			formatUsageStatusline(report),
+			`${providerId === "minimax-cn" ? "minimax cn" : "minimax"} ${currency} 98.00001`,
+		);
+	}
+});
+
+test("MiniMax normalizers reject failed, malformed, or contradictory responses", () => {
+	for (const [kind, payload] of [
+		["token-plan", {}],
+		["token-plan", { ...quotaPayload(), base_resp: { status_code: 1 } }],
+		["token-plan", { ...quotaPayload(), model_remains: [] }],
+		["token-plan", { ...quotaPayload(), model_remains: [null] }],
+		[
+			"token-plan",
+			{
+				...quotaPayload(),
+				model_remains: [
+					{ ...quotaPayload().model_remains[0], current_interval_usage_count: 2_000 },
+				],
+			},
+		],
+		[
+			"token-plan",
+			{
+				...quotaPayload(),
+				model_remains: [
+					{ ...quotaPayload().model_remains[0], current_weekly_remaining_percent: 5 },
+				],
+			},
+		],
+		["account-balance", { ...balancePayload(), available_amount: "1e3" }],
+		["account-balance", { ...balancePayload(), voucher_balance: "-1" }],
+		["account-balance", { ...balancePayload(), cash_balance: 1 }],
+	] as const) {
+		assert.throws(
+			() => normalizeMiniMaxUsagePayload("minimax", kind, payload, 0),
+			/did not report success|no quota rows|not an object|inconsistent|not a valid amount/iu,
+		);
+	}
+});
+
+test("MiniMax runtime auth accepts only its matching official region", async () => {
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		for (const providerId of ["minimax", "minimax-cn"] as const) {
+			const model = MODELS[providerId];
+			const adapter = miniMaxAdapter(providerId);
+			const { ctx } = createMockContext({
+				model,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true, apiKey: `${providerId}-key` }),
+					getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+					getAvailable: () => [model],
+					getAll: () => [model],
+				},
+			});
+			const auth = await resolveUsageAuth(ctx, adapter);
+			assert.deepEqual(auth?.headers, { Authorization: `Bearer ${providerId}-key` });
+
+			for (const [modelBaseUrl, authBaseUrl, pattern] of [
+				["https://proxy.example.test/anthropic", undefined, /custom.*official/iu],
+				[model.baseUrl, "https://proxy.example.test/v1", /proxy-resolved.*official/iu],
+			] as const) {
+				const rejectedModel = { ...model, baseUrl: modelBaseUrl };
+				const { ctx: rejectedContext } = createMockContext({
+					model: rejectedModel,
+					modelRegistry: {
+						getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-send" }),
+						getProviderAuth: async () => ({
+							auth: {
+								apiKey: "must-not-send",
+								...(authBaseUrl ? { baseUrl: authBaseUrl } : {}),
+							},
+						}),
+						getAvailable: () => [rejectedModel],
+						getAll: () => [rejectedModel],
+					},
+				});
+				await assert.rejects(() => resolveUsageAuth(rejectedContext, adapter), pattern);
+			}
+		}
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("MiniMax transport selects one fixed endpoint without credential probing", async () => {
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		requests.push({ url: String(input), init });
+		const body = String(input).endsWith("/account/query_balance")
+			? balancePayload()
+			: quotaPayload();
+		return new Response(JSON.stringify(body), { status: 200 });
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		for (const [providerId, apiKey, expectedUrl] of [
+			["minimax", "sk-token-plan", "https://api.minimax.io/v1/token_plan/remains"],
+			["minimax", "sk-api-secret", "https://api.minimax.io/account/query_balance"],
+			["minimax-cn", "sk-token-plan", "https://api.minimaxi.com/v1/token_plan/remains"],
+			["minimax-cn", "sk-api-secret", "https://api.minimaxi.com/account/query_balance"],
+		] as const) {
+			let guardCalls = 0;
+			await queryProviderUsage(
+				miniMaxAdapter(providerId),
+				miniMaxAuth(providerId, apiKey),
+				new AbortController().signal,
+				1_000,
+				async () => {
+					guardCalls += 1;
+				},
+			);
+			assert.equal(guardCalls, 2);
+			const request = requests.at(-1);
+			assert.equal(request?.url, expectedUrl);
+			assert.equal(request?.init?.redirect, "error");
+			assert.deepEqual(request?.init?.headers, {
+				Authorization: `Bearer ${apiKey}`,
+				"User-Agent": "pi-usage",
+			});
+		}
+		assert.equal(requests.length, 4);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("MiniMax transport requires revalidation and handles redirects, bounds, and redaction", async () => {
+	const adapter = miniMaxAdapter("minimax");
+	const auth = miniMaxAuth("minimax", "sk-token-plan");
+	const fetchMock = vi.fn(
+		async () => new Response(JSON.stringify(quotaPayload()), { status: 200 }),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() => queryProviderUsage(adapter, auth, new AbortController().signal, 1_000),
+			/request-boundary revalidation/iu,
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+
+		const redirected = new Response(JSON.stringify(quotaPayload()), { status: 200 });
+		Object.defineProperty(redirected, "redirected", { value: true });
+		fetchMock.mockResolvedValueOnce(redirected);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					auth,
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			/refused a redirected response/iu,
+		);
+		fetchMock.mockResolvedValueOnce(new Response("x".repeat(70_000), { status: 200 }));
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					auth,
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			/exceeded.*bytes/iu,
+		);
+		fetchMock.mockResolvedValueOnce(
+			new Response("Bearer sk-token-plan failed\u001b[31m", {
+				status: 401,
+				statusText: "Denied",
+			}),
+		);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					auth,
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			(error: unknown) =>
+				error instanceof Error &&
+				error.message.includes("401") &&
+				!error.message.includes("sk-token-plan") &&
+				!error.message.includes("\u001b"),
+		);
+
+		fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(quotaPayload()), { status: 200 }));
+		let guardCalls = 0;
+		await assert.rejects(
+			() =>
+				queryProviderUsage(adapter, auth, new AbortController().signal, 1_000, async () => {
+					guardCalls += 1;
+					if (guardCalls === 2) {
+						throw Object.assign(new Error("stale auth"), { name: "AbortError" });
+					}
+				}),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -284,6 +284,33 @@ test("MiniMax runtime auth accepts only its matching official region", async () 
 	}
 });
 
+test("MiniMax reads current model auth after provider validation when the key rotates", async () => {
+	for (const providerId of ["minimax", "minimax-cn"] as const) {
+		const model = MODELS[providerId];
+		let activeKey = `stale-${providerId}-key`;
+		const { ctx } = createMockContext({
+			model,
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => {
+					const resolvedKey = activeKey;
+					await Promise.resolve();
+					return { ok: true, apiKey: resolvedKey };
+				},
+				getProviderAuth: async () => {
+					activeKey = `current-${providerId}-key`;
+					return { auth: { apiKey: activeKey, baseUrl: model.baseUrl } };
+				},
+				getAvailable: () => [model],
+				getAll: () => [model],
+			},
+		});
+
+		const auth = await resolveUsageAuth(ctx, miniMaxAdapter(providerId));
+		assert.deepEqual(auth?.headers, { Authorization: `Bearer current-${providerId}-key` });
+		assert.ok(!auth?.secrets.includes(`stale-${providerId}-key`));
+	}
+});
+
 test("MiniMax endpoint selection follows the Bearer credential actually sent", async () => {
 	const requests: string[] = [];
 	vi.stubGlobal(

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -58,6 +58,13 @@ const deepSeekModel = {
 	baseUrl: "https://api.deepseek.com",
 };
 
+const miniMaxModel = {
+	id: "MiniMax-M3",
+	name: "MiniMax M3",
+	provider: "minimax",
+	baseUrl: "https://api.minimax.io/anthropic",
+};
+
 const fireworksModel = {
 	id: "accounts/fireworks/models/kimi-k2p6",
 	name: "Kimi K2.6",
@@ -1154,6 +1161,69 @@ test("DeepSeek account rotation at the request boundary retries without querying
 	assert.ok(authLookups >= 5);
 	assert.deepEqual(fetchedKeys, ["Bearer deepseek-account-b"]);
 	assert.equal(statuses.get("usage"), "deepseek USD 7.25");
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("MiniMax account rotation at the request boundary retries without querying the stale key", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let authLookups = 0;
+	const fetchedKeys: string[] = [];
+	globalThis.fetch = async (_input, init) => {
+		fetchedKeys.push(new Headers(init?.headers).get("authorization") ?? "");
+		return new Response(
+			JSON.stringify({
+				base_resp: { status_code: 0, status_msg: "success" },
+				model_remains: [
+					{
+						model_name: "MiniMax-M3",
+						start_time: 1_800_000_000_000,
+						end_time: 1_800_018_000_000,
+						current_interval_total_count: 1_500,
+						current_interval_usage_count: 228,
+						current_interval_status: 1,
+						current_weekly_total_count: 1_000,
+						current_weekly_usage_count: 200,
+						current_weekly_remaining_percent: 80,
+						current_weekly_status: 1,
+						weekly_start_time: 1_799_971_200_000,
+						weekly_end_time: 1_800_576_000_000,
+					},
+				],
+			}),
+			{ status: 200 },
+		);
+	};
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx, statuses } = createMockContext({
+		model: miniMaxModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => {
+				authLookups += 1;
+				return {
+					ok: true,
+					apiKey: authLookups === 1 ? "minimax-account-a" : "minimax-account-b",
+				};
+			},
+			getProviderAuth: async () => ({
+				auth: { apiKey: "minimax-account-b", baseUrl: miniMaxModel.baseUrl },
+			}),
+			getAvailable: () => [miniMaxModel],
+			getAll: () => [miniMaxModel],
+		},
+	});
+
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	await settle();
+
+	assert.ok(authLookups >= 5);
+	assert.deepEqual(fetchedKeys, ["Bearer minimax-account-b"]);
+	assert.equal(statuses.get("usage"), "minimax 15% 5h 80% wk");
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 	assert.equal(statuses.get("usage"), undefined);
 });


### PR DESCRIPTION
## Summary

- add MiniMax Global and China Token Plan quota reporting
- add pay-as-you-go account balance reporting for first-party `sk-api-` keys
- select exactly one regional endpoint without credential probing
- normalize legacy/current count semantics, reset windows, unlimited states, and regional currencies

## Verification

- `npx vitest run packages/pi-usage/test/minimax.test.ts` — 8 tests
- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` — 337 files, 3350 tests
- `just pack usage` — expected 28-file tarball with generated runtime and MiniMax provider source
- RPC package-load smoke through `pi --mode rpc --offline --no-extensions -e ./packages/pi-usage`

## Risks and unverified paths

- Live Global and China requests were not run because both providers reported `credentials_not_configured` through `pi auth check`.
- MiniMax has changed the meaning of `*_usage_count` fields over time; the adapter follows the pinned first-party CLI rule and rejects contradictory explicit percentages instead of guessing.
- The implementation rewrites the pinned first-party behavior rather than copying source because the inspected CLI revision links to MIT but does not contain a root license file.
