### PR TITLE
feat(usage): add Baseten Model APIs spend

### DIFF
--- a/.changeset/steady-baseten-spend.md
+++ b/.changeset/steady-baseten-spend.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": minor
+---
+
+Add trailing 30-day Baseten organization Model APIs spend reporting with credits and net subtotal.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -17,6 +17,7 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
 - Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
 - Reports Vercel AI Gateway credit balance and lifetime spend.
+- Reports Baseten organization Model APIs spend after credits for the last 30 days.
 - Reports xAI OAuth subscription allowances and credits.
 - Toggles persistent Codex Fast routing through `/fast` or the usage menu.
 - Redeems eligible Codex resets only after fresh account matching and explicit confirmation.
@@ -265,6 +266,21 @@ The credits endpoint does not provide reset times, request-rate counters, or dat
 Vercel's separate Custom Reporting API is limited to eligible paid plans and is intentionally outside this first integration.
 
 The contract was verified on 2026-08-30 against Vercel's [REST API Reference](https://vercel.com/docs/ai-gateway/sdks-and-apis/rest-api#check-credit-balance) and the first-party [`vercel/ai` Gateway implementation](https://github.com/vercel/ai/blob/69428b1f8b037e4d118fb4853428d5c4e620493c/packages/gateway/src/gateway-fetch-metadata.ts).
+### Baseten Model APIs spend
+
+- Provider ID: `baseten`
+- Semantics: organization-wide Model APIs spend, not per-key quota or account balance
+- Source: `GET https://api.baseten.co/v1/billing/usage_summary` using Pi's resolved Baseten API key
+- Displayed data: trailing 30-day gross usage, credits used, and net subtotal in USD
+- Statusline example: `baseten USD 166.15 net`
+
+The extension intentionally ignores Dedicated deployment and Training categories because they do not represent Pi's Model APIs provider usage.
+The query window is a precise trailing 30 days and stays below the endpoint's 31-day maximum.
+The fixed Management API endpoint is queried only for an official `https://inference.baseten.co` model and an official resolved-auth origin.
+Custom and proxy origins fail before network access, redirects are rejected, and only the resolved Bearer credential is forwarded.
+An empty `model_apis_usage` result is reported as no Model APIs usage rather than zero account-wide spend.
+
+The contract was verified on 2026-08-30 against Baseten's [Billing and usage](https://docs.baseten.co/organization/billing#view-usage), [Model APIs usage](https://docs.baseten.co/inference/model-apis/pricing-and-limits#usage), first-party [`baseten-go` Management OpenAPI](https://github.com/basetenlabs/baseten-go/blob/f028e27beb4bde106d984833313c055ddd6fefa4/internal/tools/apigen/specs/management.json), and [`baseten-cli` billing behavior](https://github.com/basetenlabs/baseten-cli/blob/e3d002b465f49a7295ea44b5988dbfeb8197896d/internal/cmd/command.org.go).
 
 ### OpenCode Go (Zen)
 
@@ -352,6 +368,7 @@ It refreshes every five minutes while the session remains on such a provider and
 DeepSeek publishes each returned currency as a separate exact balance segment and reports when the API is unavailable.
 Fireworks publishes exact per-currency rated spend totals and reports when no rated usage exists.
 Vercel AI Gateway publishes the exact current USD credit balance.
+Baseten publishes the exact trailing 30-day Model APIs net subtotal after credits.
 xAI is always menu-only and never starts a scheduled status refresh.
 Z.AI statusline usage refreshes every five minutes while the selected model remains on Z.AI.
 
@@ -385,6 +402,7 @@ Only the selected provider's exact runtime match is used, and secrets are sent o
 DeepSeek balance requests require Bearer authentication, send only that resolved credential from Pi's runtime auth to `https://api.deepseek.com/user/balance`, and refuse redirects.
 Fireworks spend requests send only that resolved credential to the official `https://api.fireworks.ai` account-listing and billing-summary endpoints and refuse redirects.
 Vercel AI Gateway credit requests send only the resolved Bearer credential to `https://ai-gateway.vercel.sh/v1/credits` and refuse redirects.
+Baseten billing requests send only the resolved Bearer credential to `https://api.baseten.co/v1/billing/usage_summary` for an official Baseten model and refuse redirects.
 Pi extensions run with the user's process privileges, so the shared event bus is not a security boundary between installed extensions.
 Install only trusted extensions because they can read user files and process memory.
 Protocol v1 interoperability is characterized for the repository's supported Pi runtime.
@@ -401,6 +419,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
 - Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `fireworksAccountId` in `pi-usage.json`.
 - Vercel AI Gateway reports current team credits and lifetime spend only; Custom Reporting and request-rate counters are not queried.
+- Baseten reports organization-wide Model APIs spend, not usage attributable only to Pi's current key; Dedicated and Training spend are excluded.
 - OpenRouter successful inference responses do not expose proactive request-rate counters; `/usage` reports the documented per-key credit/spend fields instead.
 - A provider may not return a safe human-readable account identity.
   In that case the provider and runtime credential state remain visible without exposing secrets.
@@ -444,6 +463,7 @@ The generated runtime is built from the authoritative `src/index.ts` graph and d
 ## 🔎 Keywords
 
 Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, Vercel AI Gateway credits, Vercel AI Gateway usage, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
+Pi extension, Pi coding agent, usage, quota, DeepSeek API balance, DeepSeek balance, Fireworks API spend, Fireworks rated spend, Baseten Model APIs spend, Baseten usage, OpenAI Codex usage, ChatGPT subscription limits, Kimi For Coding, Kimi Coding Plan usage, GitHub Copilot AI credits, GitHub Copilot premium requests, OpenRouter credits, xAI OAuth usage, Grok subscription allowance, API-key spend limits, TypeScript Pi package, npm Pi extension.
 
 ## 📄 License
 

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -14,6 +14,7 @@
 		"balance",
 		"deepseek",
 		"fireworks",
+		"baseten",
 		"vercel-ai-gateway",
 		"codex",
 		"kimi",

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -12,18 +12,21 @@ const VALUE_COLUMN = 29;
 export function formatUsageReport(report: UsageReport, displayState: UsageDisplayState): string {
 	const stateLabel = displayState === "current" ? "Current" : "Configured";
 	const title =
-		report.providerId === "deepseek"
-			? "DeepSeek API Balance"
-			: report.providerId === "fireworks"
-				? "Fireworks API Spend"
-				: report.providerId === "vercel-ai-gateway"
-					? "Vercel AI Gateway Credits"
-					: `${report.providerName} Usage`;
+		report.providerId === "baseten"
+			? "Baseten Model APIs Spend"
+			: report.providerId === "deepseek"
+				? "DeepSeek API Balance"
+				: report.providerId === "fireworks"
+					? "Fireworks API Spend"
+					: report.providerId === "vercel-ai-gateway"
+						? "Vercel AI Gateway Credits"
+						: `${report.providerName} Usage`;
 	const lines = [`${title} · ${stateLabel}`];
 	if (report.accountLabel) lines.push(`Account: ${report.accountLabel}`);
 	lines.push(`Semantics: ${report.semantics.label}`, "");
 
-	if (report.providerId === "openai-codex") formatCodexReport(lines, report);
+	if (report.providerId === "baseten") formatBasetenReport(lines, report);
+	else if (report.providerId === "openai-codex") formatCodexReport(lines, report);
 	else if (report.providerId === "deepseek") formatDeepSeekReport(lines, report);
 	else if (report.providerId === "fireworks") formatFireworksReport(lines, report);
 	else if (report.providerId === "vercel-ai-gateway") formatVercelAIGatewayReport(lines, report);
@@ -48,6 +51,7 @@ export function formatUsageStatusline(
 	now = Date.now(),
 	showCodexResetCountdown = true,
 ): string | undefined {
+	if (report.providerId === "baseten") return formatBasetenStatusline(report);
 	if (report.providerId === "openai-codex") {
 		return formatCodexStatusline(report, model, now, showCodexResetCountdown);
 	}
@@ -83,6 +87,18 @@ export function formatProviderStates(states: readonly ProviderUsageState[]): str
 			return `${state.providerName} · ${label}\n${status}: ${state.message}`;
 		})
 		.join("\n\n");
+}
+
+function formatBasetenReport(lines: string[], report: UsageReport): void {
+	lines.push(`${"Spend window:".padEnd(VALUE_COLUMN)}Last 30 days`);
+	for (const metric of report.metrics) {
+		lines.push(`${`${metric.label}:`.padEnd(VALUE_COLUMN)}USD ${metric.value}`);
+	}
+}
+
+function formatBasetenStatusline(report: UsageReport): string {
+	const subtotal = report.metrics.find((metric) => metric.id === "net-subtotal");
+	return subtotal ? `baseten USD ${subtotal.value} net` : "baseten no Model APIs usage";
 }
 
 function formatCodexReport(lines: string[], report: UsageReport): void {

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -32,6 +32,7 @@ export {
 	UsageCache,
 } from "./core.js";
 export { formatProviderStates, formatUsageReport, formatUsageStatusline } from "./format.js";
+export { normalizeBasetenBillingUsagePayload } from "./providers/baseten.js";
 export { normalizeCodexBackendPayload } from "./providers/codex.js";
 export { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
 export {
@@ -68,6 +69,7 @@ export {
 	usageSettingsPath,
 } from "./settings.js";
 export type {
+	BasetenBillingUsagePayload,
 	DeepSeekBalancePayload,
 	FireworksAccountsPayload,
 	FireworksBillingSummaryPayload,

--- a/packages/pi-usage/src/providers/baseten.ts
+++ b/packages/pi-usage/src/providers/baseten.ts
@@ -1,0 +1,55 @@
+import type { BasetenBillingUsagePayload, UsageMetric, UsageReport } from "../types.js";
+
+const DECIMAL_AMOUNT = /^(?:0|[1-9]\d*)(?:\.\d+)?$/u;
+
+export function normalizeBasetenBillingUsagePayload(
+	payload: BasetenBillingUsagePayload,
+	capturedAt: number,
+): UsageReport {
+	if (payload.model_apis_usage === undefined || payload.model_apis_usage === null) {
+		return report(capturedAt, [], ["Baseten returned no Model APIs usage for the last 30 days."]);
+	}
+	const usage = asObject(payload.model_apis_usage);
+	if (!usage) throw new Error("Baseten Model APIs usage was not an object.");
+	const metrics: UsageMetric[] = [
+		metric("gross-usage", "Gross usage", usage.total),
+		metric("credits-used", "Credits used", usage.credits_used),
+		metric("net-subtotal", "Net subtotal", usage.subtotal),
+	];
+	return report(capturedAt, metrics);
+}
+
+function report(capturedAt: number, metrics: UsageMetric[], notes?: string[]): UsageReport {
+	return {
+		providerId: "baseten",
+		providerName: "Baseten",
+		capturedAt,
+		source: "baseten-billing-usage-summary",
+		semantics: { kind: "api-key", label: "Organization Model APIs spend" },
+		buckets: [],
+		metrics,
+		...(notes ? { notes } : {}),
+	};
+}
+
+function metric(id: string, label: string, value: unknown): UsageMetric {
+	const amount = decimalAmount(value, label);
+	return { id, label, value: amount, unit: "currency", currency: "USD" };
+}
+
+function decimalAmount(value: unknown, label: string): string {
+	const normalized = typeof value === "number" && Number.isFinite(value) ? String(value) : value;
+	if (
+		typeof normalized !== "string" ||
+		normalized.length > 64 ||
+		!DECIMAL_AMOUNT.test(normalized)
+	) {
+		throw new Error(`Baseten ${label.toLowerCase()} was not a valid nonnegative amount.`);
+	}
+	return normalized;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value as Record<string, unknown>;
+}

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -5,6 +5,7 @@ import {
 	fallbackOAuthCredentialCandidates,
 	type OAuthCredentialCandidateReader,
 } from "./oauth-credential-source.js";
+import { normalizeBasetenBillingUsagePayload } from "./providers/baseten.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
 import { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
 import {
@@ -20,6 +21,7 @@ import { normalizeVercelAIGatewayCreditsPayload } from "./providers/vercel-ai-ga
 import { normalizeXaiBillingPayload } from "./providers/xai.js";
 import { normalizeZaiQuotaPayload } from "./providers/zai.js";
 import type {
+	BasetenBillingUsagePayload,
 	CodexBackendPayload,
 	DeepSeekBalancePayload,
 	FireworksAccountsPayload,
@@ -39,6 +41,8 @@ import type {
 	ZaiQuotaPayload,
 } from "./types.js";
 
+const BASETEN_BILLING_USAGE_URL = "https://api.baseten.co/v1/billing/usage_summary";
+const BASETEN_USAGE_WINDOW_DAYS = 30;
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance";
 const FIREWORKS_BILLING_SUMMARY_ORIGIN = "https://api.fireworks.ai";
@@ -64,6 +68,27 @@ export const AUTH_FINGERPRINT_SALT = randomBytes(32);
 export type UsageRequestGuard = () => Promise<void>;
 
 export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
+	{
+		id: "baseten",
+		displayName: "Baseten",
+		semantics: { kind: "api-key", label: "Organization Model APIs spend" },
+		async query(auth, signal, timeoutMs, guard) {
+			if (!guard) throw new Error("Baseten billing usage requires request-boundary revalidation.");
+			const startedAt = Date.now();
+			await guard();
+			const windowAt = Date.now();
+			const payload = (await fetchProviderJson(
+				basetenBillingUsageUrl(windowAt),
+				auth,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "fetching Baseten billing usage"),
+				"Baseten billing usage endpoint",
+				{ redirect: "error" },
+			)) as BasetenBillingUsagePayload;
+			await guard();
+			return normalizeBasetenBillingUsagePayload(payload, Date.now());
+		},
+	},
 	{
 		id: "openai-codex",
 		displayName: "OpenAI Codex",
@@ -796,6 +821,9 @@ function hasOfficialOrigin(model: PiModel, providerId: string): boolean {
 function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 	try {
 		const url = new URL(value);
+		if (providerId === "baseten") {
+			return ["https://inference.baseten.co", "https://api.baseten.co"].includes(url.origin);
+		}
 		if (providerId === "openai-codex") return url.origin === "https://chatgpt.com";
 		if (providerId === "deepseek") return url.origin === "https://api.deepseek.com";
 		if (providerId === "fireworks") return url.origin === FIREWORKS_BILLING_SUMMARY_ORIGIN;
@@ -836,6 +864,16 @@ function validatedXaiUserId(value: unknown): string {
 		throw new Error("xAI consumer identity returned an unsafe canonical user ID.");
 	}
 	return value;
+}
+
+function basetenBillingUsageUrl(windowAt: number): string {
+	const url = new URL(BASETEN_BILLING_USAGE_URL);
+	url.searchParams.set(
+		"start_date",
+		new Date(windowAt - BASETEN_USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1_000).toISOString(),
+	);
+	url.searchParams.set("end_date", new Date(windowAt).toISOString());
+	return url.toString();
 }
 
 function remainingTimeout(

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -89,6 +89,12 @@ export type ProviderUsageState =
 			message: string;
 	  };
 
+export type BasetenBillingUsagePayload = {
+	dedicated_usage?: unknown;
+	model_apis_usage?: unknown;
+	training_usage?: unknown;
+};
+
 export type DeepSeekBalancePayload = {
 	is_available?: unknown;
 	balance_infos?: unknown;

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -282,6 +282,7 @@ export default function usageExtension(
 			};
 		}
 		const requiresRequestBoundaryGuard = [
+			"baseten",
 			"deepseek",
 			"fireworks",
 			"vercel-ai-gateway",

--- a/packages/pi-usage/test/baseten.test.ts
+++ b/packages/pi-usage/test/baseten.test.ts
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	formatUsageReport,
+	formatUsageStatusline,
+	normalizeBasetenBillingUsagePayload,
+	queryProviderUsage,
+	type ResolvedUsageAuth,
+	resolveUsageAuth,
+	SUPPORTED_ADAPTERS,
+	type UsageProviderAdapter,
+} from "../src/index.js";
+
+const BASETEN_MODEL = {
+	id: "zai-org/GLM-5.2",
+	name: "GLM-5.2",
+	provider: "baseten",
+	baseUrl: "https://inference.baseten.co/v1",
+};
+
+function basetenAdapter(): UsageProviderAdapter {
+	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === "baseten");
+	assert.ok(candidate);
+	return candidate;
+}
+
+const adapter = basetenAdapter();
+
+function basetenAuth(secret = "baseten-test-secret"): ResolvedUsageAuth {
+	return {
+		apiKey: secret,
+		headers: { Authorization: `Bearer ${secret}` },
+		fingerprint: "fingerprint",
+		secrets: [secret, `Bearer ${secret}`],
+		model: BASETEN_MODEL as never,
+	};
+}
+
+function billingPayload() {
+	return {
+		dedicated_usage: {
+			total: "1000.00",
+			credits_used: "100.00",
+			subtotal: "900.00",
+		},
+		model_apis_usage: {
+			total: "171.150000000000000001",
+			credits_used: 5,
+			subtotal: "166.150000000000000001",
+		},
+		training_usage: {
+			total: "500.00",
+			credits_used: "0",
+			subtotal: "500.00",
+		},
+	};
+}
+
+test("Baseten billing reports only Model APIs gross, credits, and net spend", () => {
+	const report = normalizeBasetenBillingUsagePayload(billingPayload(), 1_000);
+	assert.equal(report.providerId, "baseten");
+	assert.equal(report.source, "baseten-billing-usage-summary");
+	assert.deepEqual(report.semantics, {
+		kind: "api-key",
+		label: "Organization Model APIs spend",
+	});
+	assert.deepEqual(
+		report.metrics.map((metric) => [metric.id, metric.value, metric.currency]),
+		[
+			["gross-usage", "171.150000000000000001", "USD"],
+			["credits-used", "5", "USD"],
+			["net-subtotal", "166.150000000000000001", "USD"],
+		],
+	);
+	const formatted = formatUsageReport(report, "current");
+	assert.match(formatted, /^Baseten Model APIs Spend · Current/mu);
+	assert.match(formatted, /Spend window:\s+Last 30 days/u);
+	assert.match(formatted, /Gross usage:\s+USD 171\.150000000000000001/u);
+	assert.doesNotMatch(formatted, /1000\.00|500\.00/u);
+	assert.equal(formatUsageStatusline(report), "baseten USD 166.150000000000000001 net");
+});
+
+test("Baseten billing treats absent Model APIs usage as an empty provider report", () => {
+	for (const payload of [
+		{},
+		{ dedicated_usage: {}, training_usage: {} },
+		{ model_apis_usage: null },
+	]) {
+		const report = normalizeBasetenBillingUsagePayload(payload, 2_000);
+		assert.deepEqual(report.metrics, []);
+		assert.deepEqual(report.notes, ["Baseten returned no Model APIs usage for the last 30 days."]);
+		assert.equal(formatUsageStatusline(report), "baseten no Model APIs usage");
+	}
+});
+
+test("Baseten billing rejects malformed, negative, or ambiguous Model APIs money", () => {
+	for (const payload of [
+		{ model_apis_usage: [] },
+		{ model_apis_usage: { total: "1", credits_used: "0", subtotal: "-1" } },
+		{ model_apis_usage: { total: "1e3", credits_used: "0", subtotal: "1" } },
+		{ model_apis_usage: { total: Number.NaN, credits_used: "0", subtotal: "1" } },
+		{ model_apis_usage: { total: "1", credits_used: {}, subtotal: "1" } },
+		{ model_apis_usage: { total: "9".repeat(65), credits_used: "0", subtotal: "1" } },
+	]) {
+		assert.throws(
+			() => normalizeBasetenBillingUsagePayload(payload, 0),
+			/not an object|not a valid nonnegative amount/iu,
+		);
+	}
+});
+
+test("Baseten runtime auth accepts only official inference or management origins", async () => {
+	const { ctx: officialContext } = createMockContext({
+		model: BASETEN_MODEL,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({
+				ok: true,
+				headers: {
+					Authorization: "Bearer current-baseten-key",
+					"X-Private": "must-not-send",
+				},
+			}),
+			getProviderAuth: async () => ({ auth: { apiKey: "provider-key" } }),
+			getAvailable: () => [BASETEN_MODEL],
+			getAll: () => [BASETEN_MODEL],
+		},
+	});
+	const auth = await resolveUsageAuth(officialContext, adapter);
+	assert.deepEqual(auth?.headers, { Authorization: "Bearer current-baseten-key" });
+	assert.ok(!auth?.secrets.includes("must-not-send"));
+
+	const fetchMock = vi.spyOn(globalThis, "fetch");
+	try {
+		for (const [modelBaseUrl, authBaseUrl, pattern] of [
+			["https://proxy.example.test/v1", undefined, /custom.*official/iu],
+			[BASETEN_MODEL.baseUrl, "https://proxy.example.test/v1", /proxy-resolved.*official/iu],
+		] as const) {
+			const model = { ...BASETEN_MODEL, baseUrl: modelBaseUrl };
+			const { ctx } = createMockContext({
+				model,
+				modelRegistry: {
+					getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-send" }),
+					getProviderAuth: async () => ({
+						auth: {
+							apiKey: "must-not-send",
+							...(authBaseUrl ? { baseUrl: authBaseUrl } : {}),
+						},
+					}),
+					getAvailable: () => [model],
+					getAll: () => [model],
+				},
+			});
+			await assert.rejects(() => resolveUsageAuth(ctx, adapter), pattern);
+		}
+		assert.equal(fetchMock.mock.calls.length, 0);
+	} finally {
+		fetchMock.mockRestore();
+	}
+});
+
+test("Baseten transport uses a trailing 30-day fixed management request", async () => {
+	const requests: Array<{ url: string; init?: RequestInit }> = [];
+	const nowMock = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-30T12:34:56Z"));
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		requests.push({ url: String(input), init });
+		return new Response(JSON.stringify(billingPayload()), { status: 200 });
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		let guardCalls = 0;
+		const report = await queryProviderUsage(
+			adapter,
+			basetenAuth(),
+			new AbortController().signal,
+			1_000,
+			async () => {
+				guardCalls += 1;
+			},
+		);
+		assert.equal(report.providerId, "baseten");
+		assert.equal(guardCalls, 2);
+		assert.equal(requests.length, 1);
+		assert.equal(
+			requests[0]?.url,
+			"https://api.baseten.co/v1/billing/usage_summary?start_date=2026-07-31T12%3A34%3A56.000Z&end_date=2026-08-30T12%3A34%3A56.000Z",
+		);
+		assert.equal(requests[0]?.init?.method, "GET");
+		assert.equal(requests[0]?.init?.redirect, "error");
+		assert.deepEqual(requests[0]?.init?.headers, {
+			Authorization: "Bearer baseten-test-secret",
+			"User-Agent": "pi-usage",
+		});
+	} finally {
+		nowMock.mockRestore();
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Baseten transport requires auth guards and rejects redirects or stale post-response auth", async () => {
+	const fetchMock = vi.fn(
+		async () => new Response(JSON.stringify(billingPayload()), { status: 200 }),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() => queryProviderUsage(adapter, basetenAuth(), new AbortController().signal, 1_000),
+			/request-boundary revalidation/iu,
+		);
+		assert.equal(fetchMock.mock.calls.length, 0);
+
+		const redirected = new Response(JSON.stringify(billingPayload()), { status: 200 });
+		Object.defineProperty(redirected, "redirected", { value: true });
+		fetchMock.mockResolvedValueOnce(redirected);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					basetenAuth(),
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			/refused a redirected response/iu,
+		);
+
+		let guardCalls = 0;
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					basetenAuth(),
+					new AbortController().signal,
+					1_000,
+					async () => {
+						guardCalls += 1;
+						if (guardCalls === 2) {
+							throw Object.assign(new Error("stale auth"), { name: "AbortError" });
+						}
+					},
+				),
+			(error: unknown) => error instanceof Error && error.name === "AbortError",
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Baseten transport bounds bodies and redacts credential errors", async () => {
+	const fetchMock = vi.fn(async () => new Response("x".repeat(70_000), { status: 200 }));
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					basetenAuth(),
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			/exceeded.*bytes/iu,
+		);
+		fetchMock.mockResolvedValueOnce(
+			new Response("Bearer baseten-test-secret failed\u001b[31m", {
+				status: 401,
+				statusText: "Denied",
+			}),
+		);
+		await assert.rejects(
+			() =>
+				queryProviderUsage(
+					adapter,
+					basetenAuth(),
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+				),
+			(error: unknown) =>
+				error instanceof Error &&
+				error.message.includes("401") &&
+				!error.message.includes("baseten-test-secret") &&
+				!error.message.includes("\u001b"),
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});


### PR DESCRIPTION
## Summary

- add trailing 30-day Baseten organization Model APIs billing reporting
- display gross usage, credits used, and net subtotal while excluding Dedicated and Training categories
- bind runtime credentials to official Baseten origins and the fixed Management API endpoint
- publish the Model APIs net subtotal to the usage statusline

## Verification

- `npx vitest run packages/pi-usage/test/baseten.test.ts` — 7 tests
- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` — 337 files, 3349 tests
- `just pack usage` — expected 28-file tarball with generated runtime and Baseten provider source
- RPC package-load smoke through `pi --mode rpc --offline --no-extensions -e ./packages/pi-usage`

## Risks and unverified paths

- A live billing request was not run because `pi auth check --provider baseten --json --no-refresh` reported `credentials_not_configured`.
- The endpoint reports organization-wide Model APIs spend, not only usage attributable to Pi's current API key; the README and UI semantics state that boundary.
- The wire contract is backed by Baseten's official documentation, generated Management OpenAPI, Go client, and CLI behavior/tests.
