### PR TITLE
fix(usage): restrict shared Moonshot region auth

### DIFF
--- a/.changeset/fresh-moonshot-balances.md
+++ b/.changeset/fresh-moonshot-balances.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-usage": minor
 ---
 
-Add Moonshot AI Global and China API balance reporting with region-bound credentials and native USD or CNY semantics.
+Add Moonshot AI Global and China API balance reporting with region-bound credentials, shared environment-key safeguards, and native USD or CNY semantics.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -201,6 +201,8 @@ The pinned Kimi managed-usage source at `cd7c97b377a77f7ae1b9d541cafe314e986ec07
 - Statusline examples: `moonshot USD 49.58894` or `moonshot CNY 49.58894`
 
 Each endpoint uses Pi's resolved inference Bearer key for the matching region.
+Pi maps both built-in providers to `MOONSHOT_API_KEY`, so that shared environment credential is eligible only for the currently selected region.
+Querying the sibling region requires a provider-specific stored, runtime, or `models.json` credential.
 The extension rejects custom, proxy, and cross-region origins before network access and refuses redirects.
 Available and voucher balances must be nonnegative, while cash balance may be negative when the account owes money.
 The endpoint does not provide historical spend, token totals, quota windows, or reset times.

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -404,7 +404,9 @@ export async function resolveUsageAuth(
 	if (typeof registry.getProviderAuth !== "function") {
 		throw new Error("pi-usage requires Pi 0.81.0 or newer to validate resolved provider auth.");
 	}
+	if (!moonshotProviderAuthIsAllowed(ctx, adapter.id)) return undefined;
 	const providerResult = await registry.getProviderAuth(adapter.id);
+	if (!moonshotProviderAuthIsAllowed(ctx, adapter.id)) return undefined;
 	if (
 		providerResult?.auth.baseUrl &&
 		!hasOfficialUrlOrigin(providerResult.auth.baseUrl, adapter.id)
@@ -493,10 +495,44 @@ export async function queryProviderUsage(
 
 export function providerIsConfigured(ctx: ExtensionContext, providerId: string): boolean {
 	try {
-		return ctx.modelRegistry.getProviderAuthStatus(providerId).configured;
+		const status = ctx.modelRegistry.getProviderAuthStatus(providerId);
+		return status.configured && moonshotProviderAuthSourceIsAllowed(ctx, providerId, status.source);
 	} catch {
-		return candidateModels(ctx, providerId).length > 0;
+		return (
+			!isMoonshotSiblingProvider(ctx, providerId) && candidateModels(ctx, providerId).length > 0
+		);
 	}
+}
+
+function moonshotProviderAuthIsAllowed(ctx: ExtensionContext, providerId: string): boolean {
+	if (!isMoonshotSiblingProvider(ctx, providerId)) return true;
+	try {
+		return moonshotProviderAuthSourceIsAllowed(
+			ctx,
+			providerId,
+			ctx.modelRegistry.getProviderAuthStatus(providerId).source,
+		);
+	} catch {
+		return false;
+	}
+}
+
+function moonshotProviderAuthSourceIsAllowed(
+	ctx: ExtensionContext,
+	providerId: string,
+	source: string | undefined,
+): boolean {
+	return (
+		!isMoonshotSiblingProvider(ctx, providerId) ||
+		(source !== undefined && source !== "environment")
+	);
+}
+
+function isMoonshotSiblingProvider(ctx: ExtensionContext, providerId: string): boolean {
+	return (
+		(providerId === "moonshotai" || providerId === "moonshotai-cn") &&
+		ctx.model?.provider !== providerId
+	);
 }
 
 function candidateModels(ctx: ExtensionContext, providerId: string): PiModel[] {

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -59,6 +59,7 @@ const MOONSHOT_BALANCE_URLS = Object.freeze({
 	moonshotai: "https://api.moonshot.ai/v1/users/me/balance",
 	"moonshotai-cn": "https://api.moonshot.cn/v1/users/me/balance",
 });
+const SHARED_MOONSHOT_ENV_VAR = "MOONSHOT_API_KEY";
 const XAI_USER_URL = "https://cli-chat-proxy.grok.com/v1/user?include=subscription";
 const XAI_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 const XAI_CLIENT_HEADERS = Object.freeze({
@@ -496,7 +497,10 @@ export async function queryProviderUsage(
 export function providerIsConfigured(ctx: ExtensionContext, providerId: string): boolean {
 	try {
 		const status = ctx.modelRegistry.getProviderAuthStatus(providerId);
-		return status.configured && moonshotProviderAuthSourceIsAllowed(ctx, providerId, status.source);
+		return (
+			status.configured &&
+			moonshotProviderAuthSourceIsAllowed(ctx, providerId, status.source, status.label)
+		);
 	} catch {
 		return (
 			!isMoonshotSiblingProvider(ctx, providerId) && candidateModels(ctx, providerId).length > 0
@@ -507,11 +511,8 @@ export function providerIsConfigured(ctx: ExtensionContext, providerId: string):
 function moonshotProviderAuthIsAllowed(ctx: ExtensionContext, providerId: string): boolean {
 	if (!isMoonshotSiblingProvider(ctx, providerId)) return true;
 	try {
-		return moonshotProviderAuthSourceIsAllowed(
-			ctx,
-			providerId,
-			ctx.modelRegistry.getProviderAuthStatus(providerId).source,
-		);
+		const status = ctx.modelRegistry.getProviderAuthStatus(providerId);
+		return moonshotProviderAuthSourceIsAllowed(ctx, providerId, status.source, status.label);
 	} catch {
 		return false;
 	}
@@ -521,10 +522,17 @@ function moonshotProviderAuthSourceIsAllowed(
 	ctx: ExtensionContext,
 	providerId: string,
 	source: string | undefined,
+	label: string | undefined,
 ): boolean {
+	if (!isMoonshotSiblingProvider(ctx, providerId)) return true;
+	if (source === undefined) return false;
+	if (source !== "environment") return true;
 	return (
-		!isMoonshotSiblingProvider(ctx, providerId) ||
-		(source !== undefined && source !== "environment")
+		label !== undefined &&
+		!label
+			.split(",")
+			.map((name) => name.trim())
+			.includes(SHARED_MOONSHOT_ENV_VAR)
 	);
 }
 

--- a/packages/pi-usage/test/moonshot.test.ts
+++ b/packages/pi-usage/test/moonshot.test.ts
@@ -5,6 +5,7 @@ import {
 	formatUsageReport,
 	formatUsageStatusline,
 	normalizeMoonshotBalancePayload,
+	providerIsConfigured,
 	queryProviderUsage,
 	type ResolvedUsageAuth,
 	resolveUsageAuth,
@@ -119,6 +120,63 @@ test("Moonshot balance rejects failed, incomplete, or hostile responses", () => 
 			/not report success|not an object|not a valid amount/iu,
 		);
 	}
+});
+
+test("Moonshot shared environment auth is limited to the selected region", async () => {
+	const globalModel = MODELS.moonshotai;
+	const resolvedProviders: string[] = [];
+	const { ctx } = createMockContext({
+		model: globalModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "shared-environment-key" }),
+			getProviderAuth: async (providerId: string) => {
+				resolvedProviders.push(providerId);
+				return { auth: { apiKey: "shared-environment-key" } };
+			},
+			getProviderAuthStatus: () => ({
+				configured: true,
+				source: "environment" as const,
+				label: "MOONSHOT_API_KEY",
+			}),
+			getAvailable: () => Object.values(MODELS),
+			getAll: () => Object.values(MODELS),
+		},
+	});
+
+	assert.equal(providerIsConfigured(ctx, "moonshotai"), true);
+	assert.equal(providerIsConfigured(ctx, "moonshotai-cn"), false);
+	assert.ok(await resolveUsageAuth(ctx, moonshotAdapter("moonshotai")));
+	assert.equal(await resolveUsageAuth(ctx, moonshotAdapter("moonshotai-cn")), undefined);
+	assert.deepEqual(resolvedProviders, ["moonshotai"]);
+});
+
+test("Moonshot sibling auth requires a region-specific source throughout resolution", async () => {
+	let source: "environment" | "stored" = "stored";
+	let changeSourceDuringResolution = false;
+	const unrelatedModel = {
+		id: "unrelated",
+		name: "Unrelated",
+		provider: "unrelated",
+		baseUrl: "https://unrelated.example.test/v1",
+	};
+	const { ctx } = createMockContext({
+		model: unrelatedModel,
+		modelRegistry: {
+			getProviderAuth: async () => {
+				if (changeSourceDuringResolution) source = "environment";
+				return { auth: { apiKey: `${source}-key` } };
+			},
+			getProviderAuthStatus: () => ({ configured: true, source }),
+			getAvailable: () => Object.values(MODELS),
+			getAll: () => Object.values(MODELS),
+		},
+	});
+
+	assert.equal(providerIsConfigured(ctx, "moonshotai-cn"), true);
+	assert.ok(await resolveUsageAuth(ctx, moonshotAdapter("moonshotai-cn")));
+	changeSourceDuringResolution = true;
+	assert.equal(await resolveUsageAuth(ctx, moonshotAdapter("moonshotai-cn")), undefined);
+	assert.equal(providerIsConfigured(ctx, "moonshotai-cn"), false);
 });
 
 test("Moonshot runtime auth keeps Global and China credentials on their official origin", async () => {

--- a/packages/pi-usage/test/moonshot.test.ts
+++ b/packages/pi-usage/test/moonshot.test.ts
@@ -30,6 +30,13 @@ const MODELS = {
 
 type ProviderId = keyof typeof MODELS;
 
+const UNRELATED_MODEL = {
+	id: "unrelated",
+	name: "Unrelated",
+	provider: "unrelated",
+	baseUrl: "https://unrelated.example.test/v1",
+};
+
 function moonshotAdapter(providerId: ProviderId): UsageProviderAdapter {
 	const candidate = SUPPORTED_ADAPTERS.find((adapter) => adapter.id === providerId);
 	assert.ok(candidate);
@@ -150,23 +157,47 @@ test("Moonshot shared environment auth is limited to the selected region", async
 	assert.deepEqual(resolvedProviders, ["moonshotai"]);
 });
 
-test("Moonshot sibling auth requires a region-specific source throughout resolution", async () => {
+test("Moonshot sibling accepts provider-specific environment credentials", async () => {
+	for (const [providerId, label] of [
+		["moonshotai", "MOONSHOT_GLOBAL_API_KEY"],
+		["moonshotai-cn", "MOONSHOT_CN_API_KEY"],
+	] as const) {
+		const { ctx } = createMockContext({
+			model: UNRELATED_MODEL,
+			modelRegistry: {
+				getProviderAuth: async () => ({ auth: { apiKey: `${providerId}-key` } }),
+				getProviderAuthStatus: () => ({
+					configured: true,
+					source: "environment" as const,
+					label,
+				}),
+				getAvailable: () => Object.values(MODELS),
+				getAll: () => Object.values(MODELS),
+			},
+		});
+
+		assert.equal(providerIsConfigured(ctx, providerId), true);
+		assert.deepEqual((await resolveUsageAuth(ctx, moonshotAdapter(providerId)))?.headers, {
+			Authorization: `Bearer ${providerId}-key`,
+		});
+	}
+});
+
+test("Moonshot sibling revalidates credential provenance throughout resolution", async () => {
 	let source: "environment" | "stored" = "stored";
+	let label: string | undefined;
 	let changeSourceDuringResolution = false;
-	const unrelatedModel = {
-		id: "unrelated",
-		name: "Unrelated",
-		provider: "unrelated",
-		baseUrl: "https://unrelated.example.test/v1",
-	};
 	const { ctx } = createMockContext({
-		model: unrelatedModel,
+		model: UNRELATED_MODEL,
 		modelRegistry: {
 			getProviderAuth: async () => {
-				if (changeSourceDuringResolution) source = "environment";
+				if (changeSourceDuringResolution) {
+					source = "environment";
+					label = "MOONSHOT_API_KEY";
+				}
 				return { auth: { apiKey: `${source}-key` } };
 			},
-			getProviderAuthStatus: () => ({ configured: true, source }),
+			getProviderAuthStatus: () => ({ configured: true, source, label }),
 			getAvailable: () => Object.values(MODELS),
 			getAll: () => Object.values(MODELS),
 		},


### PR DESCRIPTION
## Summary

- Limit the shared `MOONSHOT_API_KEY` environment credential to the currently selected Moonshot region.
- Require a provider-specific auth source before listing or querying the sibling Global or China region.
- Preserve region-specific `models.json` environment references by distinguishing their Pi auth-status labels from the shared variable.
- Revalidate the auth source and label after asynchronous provider auth resolution and fail closed when their provenance is unavailable.
- Document the behavior and update the pending Moonshot changeset.

## Review feedback

- Addresses the unresolved P1 review comment from #1140: https://github.com/narumiruna/pi-extensions/pull/1140#discussion_r3889747594
- Addresses the provider-specific environment credential review on this PR: https://github.com/narumiruna/pi-extensions/pull/1144#discussion_r3889952057

## Verification

- Installed Pi 0.84.4 auth-status smoke — both built-in regions report `source: "environment", label: "MOONSHOT_API_KEY"` for the shared variable.
- Fenced-code-aware README heading audit — 29 active packages passed.
- `npx vitest run packages/pi-usage/test/moonshot.test.ts` — 10 tests passed.
- `npm --workspace @narumitw/pi-usage run check` — passed.
- `npm run check` — passed.
- `npm test` — final rerun passed 339 files and 3366 tests.
- The first full test run had one unrelated `pi-tui-kit` package-export timeout; its focused rerun passed in 483 ms without changing the timeout.
- Signed commit verification — GitHub reports `verified: true` for `573b6e918f45a5ebee8b217ff1959bb8ceca2b9a`.
- GitHub CI — passed for `573b6e918f45a5ebee8b217ff1959bb8ceca2b9a`.

## Risks and unverified paths

- No live Moonshot balance request was sent because the regression is deterministic at auth selection and resolution boundaries.
