### PR TITLE
feat(todo)!: rename todo payload fields

### DIFF
--- a/.changeset/clear-todos-step.md
+++ b/.changeset/clear-todos-step.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-todo": minor
+---
+
+Replace the `update_todo_list` payload and current result details with `{ todos: [{ step, status }] }` while preserving branch restoration from valid version 1 `{ items: [{ text, status }] }` details.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -11,7 +11,7 @@ The list follows the active session branch and disappears when no tracked work r
 ## ✨ Features
 
 - Registers one `update_todo_list` tool for meaningful multi-step work.
-- Keeps task text concise and action-oriented, with at most one task in progress.
+- Keeps todo steps concise and action-oriented, with at most one todo in progress.
 - Shows a compact themed task list and completion count above the editor in TUI mode.
 - Restores the latest valid list when Pi starts a session or navigates between branches.
 - Restores the exact current list to model context only when compaction removes its latest visible successful tool update.
@@ -47,9 +47,9 @@ Pi extensions run with the user's permissions, so install only trusted code.
 
 Ask Pi to perform work with multiple meaningful steps.
 
-The model can use `update_todo_list` to create a concise list, mark one task `in_progress`, and revise the plan as work changes.
+The model can use `update_todo_list` to create a concise list, mark one todo `in_progress`, and revise the plan as work changes.
 
-Each update replaces the complete list, and an empty list clears it.
+Each update replaces the complete `todos` array, and an empty array clears it.
 
 Tool guidance tells the model to update changed statuses promptly and reconcile the list before progress reports or the final response.
 
@@ -59,18 +59,22 @@ Tool guidance tells the model to update changed statuses promptly and reconcile 
 
 Replaces the complete todo list for the active session.
 
-Each item has this shape:
+The tool accepts this shape:
 
 ```json
 {
-  "text": "Run the focused tests",
-  "status": "in_progress"
+  "todos": [
+    {
+      "step": "Run the focused tests",
+      "status": "in_progress"
+    }
+  ]
 }
 ```
 
 Accepted statuses are `pending`, `in_progress`, and `completed`.
 
-A list may contain up to 50 items, each item may contain up to 300 characters, and at most one item may be `in_progress`.
+The `todos` array may contain up to 50 entries, each `step` may contain up to 300 characters, and at most one todo may be `in_progress`.
 
 ### Session and compaction behavior
 
@@ -78,7 +82,9 @@ Each successful tool result stores a versioned snapshot on the active session br
 
 Session startup and branch navigation reconstruct the latest valid list from those results.
 
-Reconstruction also accepts valid results stored under the former `todo_widget` name, but new calls use only `update_todo_list`.
+New results store version 2 `{ todos: [{ step, status }] }` details.
+
+Reconstruction also migrates valid version 1 `{ items: [{ text, status }] }` details stored under `update_todo_list` or the former `todo_widget` name, but new calls use only the version 2 schema.
 
 During ordinary turns, the persisted assistant tool call and successful result keep the complete current list visible to the model without rewriting prompt history.
 
@@ -106,7 +112,7 @@ In RPC, print, and JSON modes, the tool still returns structured details but doe
 
 The extension does not read or write files, start processes, access credentials, or make network requests.
 
-Pi stores task text in normal session tool results, so it follows the user's session persistence choices.
+Pi stores todo steps in normal session tool results, so they follow the user's session persistence choices.
 
 Terminal escape sequences, control characters, and bidirectional display controls are removed at the rendering boundary without changing the stored tool payload.
 

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -13,12 +13,13 @@ import { Type } from "typebox";
 export const TOOL_NAME = "update_todo_list";
 export const WIDGET_KEY = "todo";
 export const TODO_CONTEXT_MESSAGE_TYPE = "todo-list-status";
-export const TODO_CONTEXT_VERSION = 1;
-export const TODO_DETAILS_VERSION = 1;
+export const TODO_CONTEXT_VERSION = 2;
+export const TODO_DETAILS_VERSION = 2;
 export const TODO_RESTORED_BOUNDARY_ENTRY_TYPE = "todo-restored-context-boundary";
 const TODO_RESTORED_BOUNDARY_VERSION = 1;
-export const MAX_TODO_ITEMS = 50;
-export const MAX_TODO_TEXT_LENGTH = 300;
+const LEGACY_TODO_DETAILS_VERSION = 1;
+export const MAX_TODOS = 50;
+export const MAX_TODO_STEP_LENGTH = 300;
 
 const WIDGET_OPTIONS = { placement: "aboveEditor" } as const;
 const LEGACY_TOOL_NAME = "todo_widget";
@@ -27,50 +28,55 @@ const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
 
 type TodoStatus = (typeof TODO_STATUSES)[number];
 
-export interface TodoItem {
-	text: string;
+export interface Todo {
+	step: string;
 	status: TodoStatus;
 }
 
 export interface TodoDetails {
 	version: typeof TODO_DETAILS_VERSION;
-	items: TodoItem[];
+	todos: Todo[];
+}
+
+interface LegacyTodoItem {
+	text: string;
+	status: TodoStatus;
 }
 
 const TodoParameters = Type.Object({
-	items: Type.Array(
+	todos: Type.Array(
 		Type.Object({
-			text: Type.String({
+			step: Type.String({
 				minLength: 1,
-				maxLength: MAX_TODO_TEXT_LENGTH,
-				description: "A concise, action-oriented task",
+				maxLength: MAX_TODO_STEP_LENGTH,
+				description: "A concise, action-oriented step",
 			}),
 			status: StringEnum(TODO_STATUSES, {
-				description: "The task's current status",
+				description: "The step's current status",
 			}),
 		}),
 		{
-			maxItems: MAX_TODO_ITEMS,
-			description: "The complete current todo list; send an empty list to clear it",
+			maxItems: MAX_TODOS,
+			description: "The complete current todo list; send an empty array to clear it",
 		},
 	),
 });
 
 export default function todoWidgetExtension(pi: ExtensionAPI): void {
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
-	let items: TodoItem[] = [];
+	let todos: Todo[] = [];
 	let restoredBoundary: { summaryEpoch: string; content: string } | undefined;
 
 	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
 
 	const publish = (ctx: ExtensionContext): void => {
 		if (!ownsSession(ctx) || ctx.mode !== "tui") return;
-		if (items.length === 0) {
+		if (todos.length === 0) {
 			ctx.ui.setWidget(WIDGET_KEY, undefined);
 			return;
 		}
 
-		const snapshot = cloneItems(items);
+		const snapshot = cloneTodos(todos);
 		ctx.ui.setWidget(
 			WIDGET_KEY,
 			(_tui, theme) => ({
@@ -85,13 +91,13 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		name: TOOL_NAME,
 		label: "Todo List",
 		description:
-			"Replace the current session todo list with the complete supplied list. Call update_todo_list whenever actual task state changes; keep at most one item in_progress and send an empty list to clear it.",
+			"Replace the current session todo list with the complete supplied todos. Call update_todo_list whenever actual step state changes; keep at most one todo in_progress and send an empty todos array to clear it.",
 		promptSnippet: "Maintain the complete session todo list as multi-step work progresses",
 		promptGuidelines: [
 			"Use update_todo_list to track work with multiple meaningful steps; skip it for simple, single-step tasks.",
-			"Use update_todo_list to keep the list aligned with actual work: mark a task in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
-			"Before a progress report or final response, call update_todo_list to reconcile every item with actual work; do not report completion while the list is stale.",
-			"On every update_todo_list call, send the complete current list, keep at most one task in_progress, and send an empty list when no tracked work remains.",
+			"Use update_todo_list to keep the list aligned with actual work: mark a step in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
+			"Before a progress report or final response, call update_todo_list to reconcile every todo with actual work; do not report completion while the list is stale.",
+			"On every update_todo_list call, send the complete current todos array, keep at most one todo in_progress, and send an empty array when no tracked work remains.",
 		],
 		parameters: TodoParameters,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
@@ -99,29 +105,29 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 			if (!ownsSession(ctx)) {
 				throw new Error("Cannot update the todo list because the session changed.");
 			}
-			validateItems(params.items);
+			validateTodos(params.todos);
 
-			items = cloneItems(params.items);
+			todos = cloneTodos(params.todos);
 			publish(ctx);
 
 			const details: TodoDetails = {
 				version: TODO_DETAILS_VERSION,
-				items: cloneItems(items),
+				todos: cloneTodos(todos),
 			};
-			if (items.length === 0) {
+			if (todos.length === 0) {
 				return {
 					content: [{ type: "text", text: "Todo list cleared." }],
 					details,
 				};
 			}
 
-			const completed = items.filter((item) => item.status === "completed").length;
-			const inProgress = items.some((item) => item.status === "in_progress");
+			const completed = todos.filter((todo) => todo.status === "completed").length;
+			const inProgress = todos.some((todo) => todo.status === "in_progress");
 			return {
 				content: [
 					{
 						type: "text",
-						text: `Todo list updated: ${completed} of ${items.length} complete${inProgress ? "; 1 in progress" : ""}.`,
+						text: `Todo list updated: ${completed} of ${todos.length} complete${inProgress ? "; 1 in progress" : ""}.`,
 					},
 				],
 				details,
@@ -131,7 +137,7 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 
 	const restoreBranchState = (ctx: ExtensionContext): void => {
 		const branch = ctx.sessionManager.getBranch();
-		items = reconstructItems(branch);
+		todos = reconstructTodos(branch);
 		restoredBoundary = reconstructRestoredTodoBoundary(branch);
 	};
 
@@ -145,7 +151,7 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		if (!ownsSession(ctx)) return;
 		const summaryEpoch = leadingSummaryEpoch(event.messages);
 		if (restoredBoundary?.summaryEpoch !== summaryEpoch) restoredBoundary = undefined;
-		const messages = reconcileTodoContext(event.messages, items, restoredBoundary?.content);
+		const messages = reconcileTodoContext(event.messages, todos, restoredBoundary?.content);
 		if (restoredBoundary === undefined && summaryEpoch) {
 			const boundaryMessage = messages[leadingSummaryBoundary(messages)];
 			if (isTodoContextMessage(boundaryMessage)) {
@@ -168,38 +174,34 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (!ownsSession(ctx)) return;
 		if (ctx.mode === "tui") ctx.ui.setWidget(WIDGET_KEY, undefined);
-		items = [];
+		todos = [];
 		restoredBoundary = undefined;
 		activeSession = undefined;
 	});
 }
 
-export function renderTodoWidget(
-	items: readonly TodoItem[],
-	theme: Theme,
-	width: number,
-): string[] {
-	const completed = items.filter((item) => item.status === "completed").length;
+export function renderTodoWidget(todos: readonly Todo[], theme: Theme, width: number): string[] {
+	const completed = todos.filter((todo) => todo.status === "completed").length;
 	const divider = theme.fg("borderMuted", "─".repeat(Math.max(0, width)));
-	const lines = [divider, theme.fg("muted", `Todo · ${completed}/${items.length} complete`)];
+	const lines = [divider, theme.fg("muted", `Todo · ${completed}/${todos.length} complete`)];
 
 	const renderWidth = Math.max(0, width);
-	for (const item of items) {
-		const text = sanitizeTodoText(item.text);
+	for (const todo of todos) {
+		const step = sanitizeTodoStep(todo.step);
 		let prefix: string;
-		let styledText: string;
-		switch (item.status) {
+		let styledStep: string;
+		switch (todo.status) {
 			case "completed":
 				prefix = theme.fg("success", "✓ ");
-				styledText = theme.fg("muted", theme.strikethrough(text));
+				styledStep = theme.fg("muted", theme.strikethrough(step));
 				break;
 			case "in_progress":
 				prefix = theme.fg("accent", "▶ ");
-				styledText = theme.fg("accent", theme.bold(text));
+				styledStep = theme.fg("accent", theme.bold(step));
 				break;
 			case "pending":
 				prefix = theme.fg("dim", "○ ");
-				styledText = theme.fg("text", text);
+				styledStep = theme.fg("text", step);
 				break;
 		}
 
@@ -208,8 +210,8 @@ export function renderTodoWidget(
 			continue;
 		}
 
-		const wrappedText = wrapTextWithAnsi(styledText, renderWidth - 2);
-		lines.push(...wrappedText.map((line, index) => `${index === 0 ? prefix : "  "}${line}`));
+		const wrappedStep = wrapTextWithAnsi(styledStep, renderWidth - 2);
+		lines.push(...wrappedStep.map((line, index) => `${index === 0 ? prefix : "  "}${line}`));
 	}
 
 	return lines.map((line) => truncateToWidth(line, renderWidth, ""));
@@ -217,15 +219,15 @@ export function renderTodoWidget(
 
 export function reconcileTodoContext(
 	messages: ContextEvent["messages"],
-	items: readonly TodoItem[],
+	todos: readonly Todo[],
 	restoredBoundaryContent?: string,
 ): ContextEvent["messages"] {
 	const existing = messages.filter(isTodoContextMessage);
 	const withoutExisting = messages.filter((message) => !isTodoContextMessage(message));
 	const summaryBoundary = leadingSummaryBoundary(withoutExisting);
 	const currentContent =
-		items.length > 0 && !hasModelVisibleTodoState(withoutExisting, items)
-			? todoContextContent(items)
+		todos.length > 0 && !hasModelVisibleTodoState(withoutExisting, todos)
+			? todoContextContent(todos)
 			: undefined;
 	const content = summaryBoundary > 0 ? (restoredBoundaryContent ?? currentContent) : undefined;
 	if (
@@ -254,20 +256,20 @@ export function reconcileTodoContext(
 	];
 }
 
-export function sanitizeTodoText(value: string): string {
-	let text = "";
+export function sanitizeTodoStep(value: string): string {
+	let step = "";
 	for (const character of stripTerminalSequences(value).replace(BIDI_CONTROLS, "")) {
 		const codePoint = character.codePointAt(0) ?? 0;
 		const isControl = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
-		text += isControl ? " " : character;
+		step += isControl ? " " : character;
 	}
-	return text.replace(/\s+/gu, " ").trim();
+	return step.replace(/\s+/gu, " ").trim();
 }
 
-function todoContextContent(items: readonly TodoItem[]): string {
+function todoContextContent(todos: readonly Todo[]): string {
 	return `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]
 Current todo list as JSON data:
-${JSON.stringify(items)}`;
+${JSON.stringify({ todos })}`;
 }
 
 function reconstructRestoredTodoBoundary(
@@ -302,11 +304,11 @@ function isRestoredTodoBoundaryData(
 	const prefix = `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]\nCurrent todo list as JSON data:\n`;
 	if (!data.content.startsWith(prefix)) return false;
 	try {
-		const restoredItems: unknown = JSON.parse(data.content.slice(prefix.length));
+		const restoredTodos = todosFromToolArguments(JSON.parse(data.content.slice(prefix.length)));
 		return (
-			isTodoItems(restoredItems) &&
-			restoredItems.length > 0 &&
-			todoContextContent(restoredItems) === data.content
+			restoredTodos !== undefined &&
+			restoredTodos.length > 0 &&
+			todoContextContent(restoredTodos) === data.content
 		);
 	} catch {
 		return false;
@@ -315,17 +317,19 @@ function isRestoredTodoBoundaryData(
 
 function hasModelVisibleTodoState(
 	messages: ContextEvent["messages"],
-	items: readonly TodoItem[],
+	todos: readonly Todo[],
 ): boolean {
 	const currentResults = new Map<string, string>();
 	for (const message of messages) {
 		if (
-			message.role === "toolResult" &&
-			!message.isError &&
-			(message.toolName === TOOL_NAME || message.toolName === LEGACY_TOOL_NAME) &&
-			isTodoDetails(message.details) &&
-			todoItemsEqual(message.details.items, items)
+			message.role !== "toolResult" ||
+			message.isError ||
+			(message.toolName !== TOOL_NAME && message.toolName !== LEGACY_TOOL_NAME)
 		) {
+			continue;
+		}
+		const resultTodos = todosFromDetails(message.details);
+		if (resultTodos !== undefined && todosEqual(resultTodos, todos)) {
 			currentResults.set(message.toolCallId, message.toolName);
 		}
 	}
@@ -334,19 +338,22 @@ function hasModelVisibleTodoState(
 	return messages.some(
 		(message) =>
 			message.role === "assistant" &&
-			message.content.some(
-				(content) =>
-					content.type === "toolCall" &&
-					currentResults.get(content.id) === content.name &&
-					isTodoToolArguments(content.arguments) &&
-					todoItemsEqual(content.arguments.items, items),
-			),
+			message.content.some((content) => {
+				if (content.type !== "toolCall" || currentResults.get(content.id) !== content.name) {
+					return false;
+				}
+				const argumentTodos = todosFromToolArguments(content.arguments);
+				return argumentTodos !== undefined && todosEqual(argumentTodos, todos);
+			}),
 	);
 }
 
-function isTodoToolArguments(value: unknown): value is { items: TodoItem[] } {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	return isTodoItems((value as Record<string, unknown>).items);
+function todosFromToolArguments(value: unknown): Todo[] | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	if (isTodos(record.todos)) return cloneTodos(record.todos);
+	if (isLegacyTodoItems(record.items)) return migrateLegacyItems(record.items);
+	return undefined;
 }
 
 type TodoContextMessage = Extract<ContextEvent["messages"][number], { role: "custom" }> & {
@@ -383,21 +390,21 @@ function leadingSummaryBoundary(messages: ContextEvent["messages"]): number {
 	return index;
 }
 
-function validateItems(items: readonly TodoItem[]): void {
-	for (const [index, item] of items.entries()) {
-		if (item.text.trim().length === 0) {
-			throw new Error(`Todo item ${index + 1} must contain non-whitespace text.`);
+function validateTodos(todos: readonly Todo[]): void {
+	for (const [index, todo] of todos.entries()) {
+		if (todo.step.trim().length === 0) {
+			throw new Error(`Todo ${index + 1} must contain a non-whitespace step.`);
 		}
 	}
 
-	const currentCount = items.filter((item) => item.status === "in_progress").length;
+	const currentCount = todos.filter((todo) => todo.status === "in_progress").length;
 	if (currentCount > 1) {
-		throw new Error("Todo list can contain at most one in_progress item.");
+		throw new Error("Todo list can contain at most one in_progress todo.");
 	}
 }
 
-function reconstructItems(entries: readonly SessionEntry[]): TodoItem[] {
-	let restored: TodoItem[] = [];
+function reconstructTodos(entries: readonly SessionEntry[]): Todo[] {
+	let restored: Todo[] = [];
 	for (const entry of entries) {
 		if (entry.type !== "message") continue;
 		const message = entry.message;
@@ -407,48 +414,67 @@ function reconstructItems(entries: readonly SessionEntry[]): TodoItem[] {
 		) {
 			continue;
 		}
-		if (!isTodoDetails(message.details)) continue;
-		restored = cloneItems(message.details.items);
+		const resultTodos = todosFromDetails(message.details);
+		if (resultTodos !== undefined) restored = resultTodos;
 	}
 	return restored;
 }
 
-function isTodoDetails(value: unknown): value is TodoDetails {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+function todosFromDetails(value: unknown): Todo[] | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
 	const record = value as Record<string, unknown>;
-	return record.version === TODO_DETAILS_VERSION && isTodoItems(record.items);
+	if (record.version === TODO_DETAILS_VERSION && isTodos(record.todos)) {
+		return cloneTodos(record.todos);
+	}
+	if (record.version === LEGACY_TODO_DETAILS_VERSION && isLegacyTodoItems(record.items)) {
+		return migrateLegacyItems(record.items);
+	}
+	return undefined;
 }
 
-function isTodoItems(value: unknown): value is TodoItem[] {
-	if (!Array.isArray(value) || value.length > MAX_TODO_ITEMS) return false;
+function isTodos(value: unknown): value is Todo[] {
+	return hasValidTodoShape(value, "step");
+}
+
+function isLegacyTodoItems(value: unknown): value is LegacyTodoItem[] {
+	return hasValidTodoShape(value, "text");
+}
+
+function hasValidTodoShape(value: unknown, stepProperty: "step" | "text"): boolean {
+	if (!Array.isArray(value) || value.length > MAX_TODOS) return false;
 
 	let currentCount = 0;
-	for (const item of value) {
-		if (typeof item !== "object" || item === null || Array.isArray(item)) return false;
-		const candidate = item as Record<string, unknown>;
+	for (const entry of value) {
+		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return false;
+		const record = entry as Record<string, unknown>;
+		const step = record[stepProperty];
 		if (
-			typeof candidate.text !== "string" ||
-			candidate.text.length === 0 ||
-			candidate.text.length > MAX_TODO_TEXT_LENGTH ||
-			candidate.text.trim().length === 0 ||
-			!TODO_STATUSES.includes(candidate.status as TodoStatus)
+			typeof step !== "string" ||
+			step.length === 0 ||
+			step.length > MAX_TODO_STEP_LENGTH ||
+			step.trim().length === 0 ||
+			!TODO_STATUSES.includes(record.status as TodoStatus)
 		) {
 			return false;
 		}
-		if (candidate.status === "in_progress") currentCount += 1;
+		if (record.status === "in_progress") currentCount += 1;
 	}
 	return currentCount <= 1;
 }
 
-function todoItemsEqual(left: readonly TodoItem[], right: readonly TodoItem[]): boolean {
+function todosEqual(left: readonly Todo[], right: readonly Todo[]): boolean {
 	return (
 		left.length === right.length &&
 		left.every(
-			(item, index) => item.text === right[index]?.text && item.status === right[index]?.status,
+			(todo, index) => todo.step === right[index]?.step && todo.status === right[index]?.status,
 		)
 	);
 }
 
-function cloneItems(items: readonly TodoItem[]): TodoItem[] {
-	return items.map((item) => ({ text: item.text, status: item.status }));
+function migrateLegacyItems(items: readonly LegacyTodoItem[]): Todo[] {
+	return items.map((item) => ({ step: item.text, status: item.status }));
+}
+
+function cloneTodos(todos: readonly Todo[]): Todo[] {
+	return todos.map((todo) => ({ step: todo.step, status: todo.status }));
 }

--- a/packages/pi-todo/test/build-runtime.test.ts
+++ b/packages/pi-todo/test/build-runtime.test.ts
@@ -200,7 +200,7 @@ test("generated runtime is loadable by Pi's Jiti resource loader", async () => {
 		assert.ok(tool);
 		await tool.definition.execute(
 			"generated-todo",
-			{ items: [{ text: "Verify generated runtime", status: "in_progress" }] },
+			{ todos: [{ step: "Verify generated runtime", status: "in_progress" }] },
 			undefined,
 			undefined,
 			ctx,

--- a/packages/pi-todo/test/todo-cache-contract.test.ts
+++ b/packages/pi-todo/test/todo-cache-contract.test.ts
@@ -4,8 +4,9 @@ import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import todoWidgetExtension, {
 	reconcileTodoContext,
+	TODO_DETAILS_VERSION,
 	TOOL_NAME,
-	type TodoItem,
+	type Todo,
 } from "../src/todo-widget.js";
 
 interface RegisteredTool {
@@ -61,14 +62,14 @@ function assistantMessage(text: string): ContextEvent["messages"][number] {
 	return assistantMessageWithContent([{ type: "text", text }], "stop");
 }
 
-function todoToolCallMessage(items: readonly TodoItem[]): ContextEvent["messages"][number] {
+function todoToolCallMessage(todos: readonly Todo[]): ContextEvent["messages"][number] {
 	return assistantMessageWithContent(
 		[
 			{
 				type: "toolCall",
-				id: `todo-call-${items.length}`,
+				id: `todo-call-${todos.length}`,
 				name: TOOL_NAME,
-				arguments: { items },
+				arguments: { todos },
 			},
 		],
 		"toolUse",
@@ -98,22 +99,22 @@ function assistantMessageWithContent(
 	};
 }
 
-function todoToolResultMessage(items: readonly TodoItem[]): ContextEvent["messages"][number] {
+function todoToolResultMessage(todos: readonly Todo[]): ContextEvent["messages"][number] {
 	return {
 		role: "toolResult",
-		toolCallId: `todo-call-${items.length}`,
+		toolCallId: `todo-call-${todos.length}`,
 		toolName: TOOL_NAME,
-		content: [{ type: "text", text: items.length === 0 ? "cleared" : "updated" }],
-		details: { version: 1, items },
+		content: [{ type: "text", text: todos.length === 0 ? "cleared" : "updated" }],
+		details: { version: TODO_DETAILS_VERSION, todos },
 		isError: false,
 		timestamp: 0,
 	};
 }
 
 test("todo compaction restoration preserves normalized ordinary-request prefixes", () => {
-	const items: TodoItem[] = [
-		{ text: "inspect", status: "completed" },
-		{ text: "implement", status: "in_progress" },
+	const todos: Todo[] = [
+		{ step: "inspect", status: "completed" },
+		{ step: "implement", status: "in_progress" },
 	];
 	const summaries: ContextEvent["messages"] = [
 		{
@@ -130,14 +131,14 @@ test("todo compaction restoration preserves normalized ordinary-request prefixes
 		},
 	];
 	const firstRaw = [...summaries, userMessage("continue")];
-	const firstMessages = reconcileTodoContext(firstRaw, items);
+	const firstMessages = reconcileTodoContext(firstRaw, todos);
 	const restored = firstMessages[2];
 	if (restored?.role !== "custom" || typeof restored.content !== "string") {
 		assert.fail("expected restored todo boundary");
 	}
 	const first = normalizedRequest(firstMessages);
 	const secondRaw = [...firstRaw, assistantMessage("working"), userMessage("continue again")];
-	const second = normalizedRequest(reconcileTodoContext(secondRaw, items, restored.content));
+	const second = normalizedRequest(reconcileTodoContext(secondRaw, todos, restored.content));
 
 	assert.deepEqual(second.effectiveSystemGuidance, first.effectiveSystemGuidance);
 	assert.deepEqual(second.activeToolNames, [TOOL_NAME]);
@@ -145,14 +146,14 @@ test("todo compaction restoration preserves normalized ordinary-request prefixes
 	assert.deepEqual(second.toolDefinitions, first.toolDefinitions);
 	assert.deepEqual(second.messages.slice(0, first.messages.length), first.messages);
 
-	const updatedItems: TodoItem[] = [{ text: "implement", status: "completed" }];
+	const updatedTodos: Todo[] = [{ step: "implement", status: "completed" }];
 	const updatedRaw = [
 		...secondRaw,
-		todoToolCallMessage(updatedItems),
-		todoToolResultMessage(updatedItems),
+		todoToolCallMessage(updatedTodos),
+		todoToolResultMessage(updatedTodos),
 	];
 	const updated = normalizedRequest(
-		reconcileTodoContext(updatedRaw, updatedItems, restored.content),
+		reconcileTodoContext(updatedRaw, updatedTodos, restored.content),
 	);
 	assert.deepEqual(updated.messages.slice(0, second.messages.length), second.messages);
 
@@ -160,5 +161,5 @@ test("todo compaction restoration preserves normalized ordinary-request prefixes
 	const cleared = normalizedRequest(reconcileTodoContext(clearedRaw, [], restored.content));
 	assert.deepEqual(cleared.messages.slice(0, updated.messages.length), updated.messages);
 
-	assert.equal(reconcileTodoContext(firstMessages, items, restored.content), firstMessages);
+	assert.equal(reconcileTodoContext(firstMessages, todos, restored.content), firstMessages);
 });

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -11,14 +11,14 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import todoWidgetExtension, {
 	renderTodoWidget,
-	sanitizeTodoText,
+	sanitizeTodoStep,
 	TODO_CONTEXT_MESSAGE_TYPE,
 	TODO_CONTEXT_VERSION,
 	TODO_DETAILS_VERSION,
 	TODO_RESTORED_BOUNDARY_ENTRY_TYPE,
 	TOOL_NAME,
+	type Todo,
 	type TodoDetails,
-	type TodoItem,
 	WIDGET_KEY,
 } from "../src/todo-widget.js";
 
@@ -31,9 +31,10 @@ interface RegisteredTool {
 	description: string;
 	promptSnippet: string;
 	promptGuidelines: string[];
+	parameters: unknown;
 	execute(
 		toolCallId: string,
-		params: { items: TodoItem[] },
+		params: { todos: Todo[] },
 		signal: AbortSignal | undefined,
 		onUpdate: undefined,
 		ctx: ExtensionContext,
@@ -126,7 +127,7 @@ function identityTheme() {
 }
 
 function todoToolResultMessage(
-	details: TodoDetails,
+	details: unknown,
 	toolName = TOOL_NAME,
 	isError = false,
 ): ContextEvent["messages"][number] {
@@ -142,8 +143,9 @@ function todoToolResultMessage(
 }
 
 function todoToolCallMessage(
-	items: unknown,
+	todos: unknown,
 	toolName = TOOL_NAME,
+	argumentName: "todos" | "items" = "todos",
 ): ContextEvent["messages"][number] {
 	return {
 		role: "assistant",
@@ -152,7 +154,7 @@ function todoToolCallMessage(
 				type: "toolCall",
 				id: "todo-call",
 				name: toolName,
-				arguments: { items },
+				arguments: { [argumentName]: todos },
 			},
 		],
 		api: "openai-responses",
@@ -172,7 +174,7 @@ function todoToolCallMessage(
 }
 
 function toolResultEntry(
-	details: TodoDetails,
+	details: unknown,
 	toolName = TOOL_NAME,
 	id = "tool-result",
 	parentId: string | null = null,
@@ -205,35 +207,60 @@ function customEntry(
 async function setTodos(
 	harness: ReturnType<typeof createHarness>,
 	ctx: ExtensionContext,
-	items: TodoItem[],
+	todos: Todo[],
 ) {
-	return harness.tool.execute("todo-call", { items }, undefined, undefined, ctx);
+	return harness.tool.execute("todo-call", { todos }, undefined, undefined, ctx);
 }
 
-test("registers concise guidance for using and maintaining the todo list", () => {
+test("registers the todos-by-step schema and concise maintenance guidance", () => {
 	const { tool } = createHarness();
 
 	assert.equal(tool.name, "update_todo_list");
 	assert.equal(tool.label, "Todo List");
-	assert.match(tool.description, /whenever actual task state changes/u);
+	assert.match(tool.description, /whenever actual step state changes/u);
 	assert.match(tool.promptSnippet, /multi-step work progresses/u);
 	assert.deepEqual(tool.promptGuidelines, [
 		"Use update_todo_list to track work with multiple meaningful steps; skip it for simple, single-step tasks.",
-		"Use update_todo_list to keep the list aligned with actual work: mark a task in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
-		"Before a progress report or final response, call update_todo_list to reconcile every item with actual work; do not report completion while the list is stale.",
-		"On every update_todo_list call, send the complete current list, keep at most one task in_progress, and send an empty list when no tracked work remains.",
+		"Use update_todo_list to keep the list aligned with actual work: mark a step in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
+		"Before a progress report or final response, call update_todo_list to reconcile every todo with actual work; do not report completion while the list is stale.",
+		"On every update_todo_list call, send the complete current todos array, keep at most one todo in_progress, and send an empty array when no tracked work remains.",
 	]);
+
+	const parameters = tool.parameters as {
+		required?: string[];
+		properties?: Record<string, unknown>;
+	};
+	assert.deepEqual(parameters.required, ["todos"]);
+	assert.deepEqual(Object.keys(parameters.properties ?? {}), ["todos"]);
+	const todosSchema = parameters.properties?.todos as {
+		maxItems?: number;
+		items?: { required?: string[]; properties?: Record<string, unknown> };
+	};
+	assert.equal(todosSchema.maxItems, 50);
+	assert.deepEqual(todosSchema.items?.required, ["step", "status"]);
+	assert.deepEqual(Object.keys(todosSchema.items?.properties ?? {}), ["step", "status"]);
+	assert.deepEqual(todosSchema.items?.properties?.step, {
+		description: "A concise, action-oriented step",
+		type: "string",
+		minLength: 1,
+		maxLength: 300,
+	});
+	assert.deepEqual(todosSchema.items?.properties?.status, {
+		type: "string",
+		enum: ["pending", "in_progress", "completed"],
+		description: "The step's current status",
+	});
 });
 
 test("restores missing todo state and retains its summary boundary", async () => {
 	const harness = createHarness();
 	const current = createContext();
 	await harness.emit("session_start", current.ctx);
-	const items: TodoItem[] = [
-		{ text: "inspect", status: "completed" },
-		{ text: "implement", status: "in_progress" },
+	const todos: Todo[] = [
+		{ step: "inspect", status: "completed" },
+		{ step: "implement", status: "in_progress" },
 	];
-	await setTodos(harness, current.ctx, items);
+	await setTodos(harness, current.ctx, todos);
 
 	const ordinary: ContextEvent["messages"] = [
 		{
@@ -263,10 +290,10 @@ test("restores missing todo state and retains its summary boundary", async () =>
 			timestamp: 0,
 		},
 	];
-	const initialDetails: TodoDetails = { version: TODO_DETAILS_VERSION, items };
+	const initialDetails: TodoDetails = { version: TODO_DETAILS_VERSION, todos };
 	const initiallyVisible = [
 		...base,
-		todoToolCallMessage(items),
+		todoToolCallMessage(todos),
 		todoToolResultMessage(initialDetails),
 	];
 	assert.equal(
@@ -285,7 +312,7 @@ test("restores missing todo state and retains its summary boundary", async () =>
 	assert.deepEqual(reminder.details, { version: TODO_CONTEXT_VERSION });
 	assert.equal(
 		reminder.content,
-		`[PI TODO STATUS v${TODO_CONTEXT_VERSION}]\nCurrent todo list as JSON data:\n${JSON.stringify(items)}`,
+		`[PI TODO STATUS v${TODO_CONTEXT_VERSION}]\nCurrent todo list as JSON data:\n${JSON.stringify({ todos })}`,
 	);
 	assert.doesNotMatch(reminder.content as string, /call update_todo_list/u);
 
@@ -315,24 +342,34 @@ test("restores missing todo state and retains its summary boundary", async () =>
 	});
 
 	for (const toolName of [TOOL_NAME, "todo_widget"]) {
-		const details: TodoDetails = { version: TODO_DETAILS_VERSION, items };
+		const details: TodoDetails = { version: TODO_DETAILS_VERSION, todos };
 		const visible = [
 			...base,
-			todoToolCallMessage(items, toolName),
+			todoToolCallMessage(todos, toolName),
 			todoToolResultMessage(details, toolName),
 		];
 		const retained = await harness.context(visible, current.ctx);
 		assert.deepEqual(retained[2], reminder);
 		assert.deepEqual(retained.slice(3), visible.slice(2));
+
+		const legacyItems = todos.map((todo) => ({ text: todo.step, status: todo.status }));
+		const legacyVisible = [
+			...base,
+			todoToolCallMessage(legacyItems, toolName, "items"),
+			todoToolResultMessage({ version: 1, items: legacyItems }, toolName),
+		];
+		const legacyRetained = await harness.context(legacyVisible, current.ctx);
+		assert.deepEqual(legacyRetained[2], reminder);
+		assert.deepEqual(legacyRetained.slice(3), legacyVisible.slice(2));
 	}
 
-	const details: TodoDetails = { version: TODO_DETAILS_VERSION, items };
+	const details: TodoDetails = { version: TODO_DETAILS_VERSION, todos };
 	const incompleteContexts = [
 		[...base, todoToolCallMessage("invalid")],
-		[...base, todoToolCallMessage([{ text: "stale", status: "pending" }])],
-		[...base, todoToolCallMessage(items)],
+		[...base, todoToolCallMessage([{ step: "stale", status: "pending" }])],
+		[...base, todoToolCallMessage(todos)],
 		[...base, todoToolResultMessage(details)],
-		[...base, todoToolCallMessage(items), todoToolResultMessage(details, TOOL_NAME, true)],
+		[...base, todoToolCallMessage(todos), todoToolResultMessage(details, TOOL_NAME, true)],
 	];
 	for (const incomplete of incompleteContexts) {
 		const fallback = await harness.context(incomplete, current.ctx);
@@ -346,15 +383,15 @@ test("restores missing todo state and retains its summary boundary", async () =>
 		assert.equal(fallbackReminder.content, reminder.content);
 	}
 
-	const replacementItems: TodoItem[] = [{ text: "implement", status: "completed" }];
-	await setTodos(harness, current.ctx, replacementItems);
+	const replacementTodos: Todo[] = [{ step: "implement", status: "completed" }];
+	await setTodos(harness, current.ctx, replacementTodos);
 	const replacementDetails: TodoDetails = {
 		version: TODO_DETAILS_VERSION,
-		items: replacementItems,
+		todos: replacementTodos,
 	};
 	const replacement = [
 		...transformed,
-		todoToolCallMessage(replacementItems),
+		todoToolCallMessage(replacementTodos),
 		todoToolResultMessage(replacementDetails),
 	];
 	assert.equal(
@@ -383,8 +420,8 @@ test("restores missing todo state and retains its summary boundary", async () =>
 });
 
 test("restored todo boundaries survive reload and stay branch-local", async () => {
-	const initialItems: TodoItem[] = [{ text: "before compaction", status: "in_progress" }];
-	const initialDetails: TodoDetails = { version: TODO_DETAILS_VERSION, items: initialItems };
+	const initialTodos: Todo[] = [{ step: "before compaction", status: "in_progress" }];
+	const initialDetails: TodoDetails = { version: TODO_DETAILS_VERSION, todos: initialTodos };
 	const branch: SessionEntry[] = [
 		toolResultEntry(initialDetails, TOOL_NAME, "initial", null),
 		{
@@ -419,7 +456,7 @@ test("restored todo boundaries survive reload and stay branch-local", async () =
 	assert.equal(persisted?.customType, TODO_RESTORED_BOUNDARY_ENTRY_TYPE);
 	branch.push(customEntry(persisted?.customType ?? "", persisted?.data, "boundary", "compaction"));
 
-	const cleared: TodoDetails = { version: TODO_DETAILS_VERSION, items: [] };
+	const cleared: TodoDetails = { version: TODO_DETAILS_VERSION, todos: [] };
 	const clearCall = todoToolCallMessage([]);
 	const clearResult = todoToolResultMessage(cleared);
 	branch.push(
@@ -479,13 +516,13 @@ test("restored todo boundaries survive reload and stay branch-local", async () =
 	assert.equal(await reloadedHarness.context(sibling, current.ctx), sibling);
 });
 
-test("renders completed, current, and pending tasks with themed semantic symbols", () => {
+test("renders completed, current, and pending todos with themed semantic symbols", () => {
 	const { calls, theme } = identityTheme();
 	const lines = renderTodoWidget(
 		[
-			{ text: "done", status: "completed" },
-			{ text: "working", status: "in_progress" },
-			{ text: "later", status: "pending" },
+			{ step: "done", status: "completed" },
+			{ step: "working", status: "in_progress" },
+			{ step: "later", status: "pending" },
 		],
 		theme,
 		80,
@@ -506,21 +543,21 @@ test("renders completed, current, and pending tasks with themed semantic symbols
 	assert.ok(calls.some(([kind, role]) => kind === "style" && role === "strikethrough"));
 });
 
-test("wraps task text with hanging indentation at narrow widths", () => {
+test("wraps todo steps with hanging indentation at narrow widths", () => {
 	const { theme } = identityTheme();
 	const wrappedWords = renderTodoWidget(
-		[{ text: "alpha beta gamma", status: "in_progress" }],
+		[{ step: "alpha beta gamma", status: "in_progress" }],
 		theme,
 		10,
 	);
 	assert.deepEqual(wrappedWords.slice(2), ["▶ alpha", "  beta", "  gamma"]);
 
-	const wrappedCjk = renderTodoWidget([{ text: "界界界", status: "pending" }], theme, 6);
+	const wrappedCjk = renderTodoWidget([{ step: "界界界", status: "pending" }], theme, 6);
 	assert.deepEqual(wrappedCjk.slice(2), ["○ 界界", "  界"]);
 
 	for (const width of [0, 1, 2]) {
 		const lines = renderTodoWidget(
-			[{ text: "hidden until enough room", status: "completed" }],
+			[{ step: "hidden until enough room", status: "completed" }],
 			theme,
 			width,
 		);
@@ -530,10 +567,10 @@ test("wraps task text with hanging indentation at narrow widths", () => {
 
 test("sanitizes terminal and bidi controls and bounds every rendered line", () => {
 	const hostile = "safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007\n界界\u202e";
-	assert.equal(sanitizeTodoText(hostile), "safelink 界界");
+	assert.equal(sanitizeTodoStep(hostile), "safelink 界界");
 
 	const { theme } = identityTheme();
-	const lines = renderTodoWidget([{ text: hostile, status: "in_progress" }], theme, 6);
+	const lines = renderTodoWidget([{ step: hostile, status: "in_progress" }], theme, 6);
 	for (const line of lines) assert.ok(visibleWidth(line) <= 6);
 	const unsafeSequences = [
 		`${String.fromCharCode(0x1b)}]`,
@@ -554,22 +591,22 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 	const cancelled = new AbortController();
 	cancelled.abort();
 	await assert.rejects(
-		harness.tool.execute("todo-call", { items: [] }, cancelled.signal, undefined, current.ctx),
+		harness.tool.execute("todo-call", { todos: [] }, cancelled.signal, undefined, current.ctx),
 		/aborted/iu,
 	);
 
 	const result = await setTodos(harness, current.ctx, [
-		{ text: "task 1", status: "completed" },
-		{ text: "task 2", status: "in_progress" },
-		{ text: "task 3", status: "pending" },
+		{ step: "task 1", status: "completed" },
+		{ step: "task 2", status: "in_progress" },
+		{ step: "task 3", status: "pending" },
 	]);
 	assert.equal(result.content[0]?.text, "Todo list updated: 1 of 3 complete; 1 in progress.");
 	assert.deepEqual(result.details, {
 		version: TODO_DETAILS_VERSION,
-		items: [
-			{ text: "task 1", status: "completed" },
-			{ text: "task 2", status: "in_progress" },
-			{ text: "task 3", status: "pending" },
+		todos: [
+			{ step: "task 1", status: "completed" },
+			{ step: "task 2", status: "in_progress" },
+			{ step: "task 3", status: "pending" },
 		],
 	});
 
@@ -588,14 +625,14 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 
 	await assert.rejects(
 		setTodos(harness, current.ctx, [
-			{ text: "one", status: "in_progress" },
-			{ text: "two", status: "in_progress" },
+			{ step: "one", status: "in_progress" },
+			{ step: "two", status: "in_progress" },
 		]),
 		/at most one in_progress/u,
 	);
 	await assert.rejects(
-		setTodos(harness, current.ctx, [{ text: " \n ", status: "pending" }]),
-		/non-whitespace text/u,
+		setTodos(harness, current.ctx, [{ step: " \n ", status: "pending" }]),
+		/non-whitespace step/u,
 	);
 
 	const cleared = await setTodos(harness, current.ctx, []);
@@ -608,12 +645,12 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 });
 
 test("restores current and legacy branch-local state on startup and tree navigation", async () => {
-	const initial: TodoDetails = {
-		version: TODO_DETAILS_VERSION,
+	const legacyDetails = {
+		version: 1,
 		items: [{ text: "restored", status: "in_progress" }],
 	};
 	const harness = createHarness();
-	const current = createContext({ branch: [toolResultEntry(initial, "todo_widget")] });
+	const current = createContext({ branch: [toolResultEntry(legacyDetails, "todo_widget")] });
 	await harness.emit("session_start", current.ctx);
 
 	const { theme } = identityTheme();
@@ -625,10 +662,41 @@ test("restores current and legacy branch-local state on startup and tree navigat
 		["─".repeat(80), "Todo · 0/1 complete", "▶ restored"],
 	);
 
+	const migratedContext = await harness.context(
+		[
+			{
+				role: "compactionSummary",
+				summary: "Legacy state was compacted.",
+				tokensBefore: 100,
+				timestamp: 0,
+			},
+		],
+		current.ctx,
+	);
+	assert.equal(
+		migratedContext[1]?.role === "custom" ? migratedContext[1].content : undefined,
+		`[PI TODO STATUS v${TODO_CONTEXT_VERSION}]\nCurrent todo list as JSON data:\n${JSON.stringify({ todos: [{ step: "restored", status: "in_progress" }] })}`,
+	);
+
+	current.branch.push(
+		toolResultEntry({
+			version: 1,
+			items: [{ text: "restored from current tool name", status: "in_progress" }],
+		}),
+	);
+	await harness.emit("session_tree", current.ctx);
+	assert.deepEqual(
+		current.widgets
+			.at(-1)
+			?.content?.(undefined as never, theme)
+			.render(80),
+		["─".repeat(80), "Todo · 0/1 complete", "▶ restored from current tool name"],
+	);
+
 	current.branch.push(
 		toolResultEntry({
 			version: TODO_DETAILS_VERSION,
-			items: [{ text: "finished branch", status: "completed" }],
+			todos: [{ step: "finished branch", status: "completed" }],
 		}),
 	);
 	await harness.emit("session_tree", current.ctx);
@@ -646,9 +714,9 @@ test("guards component widgets to TUI mode and ignores stale session shutdown", 
 	const previous = createContext();
 	const current = createContext();
 	await harness.emit("session_start", previous.ctx);
-	await setTodos(harness, previous.ctx, [{ text: "old", status: "in_progress" }]);
+	await setTodos(harness, previous.ctx, [{ step: "old", status: "in_progress" }]);
 	await harness.emit("session_start", current.ctx);
-	await setTodos(harness, current.ctx, [{ text: "current", status: "in_progress" }]);
+	await setTodos(harness, current.ctx, [{ step: "current", status: "in_progress" }]);
 	const currentWidgetCount = current.widgets.length;
 	const staleMessages = [
 		{ role: "user" as const, content: [{ type: "text" as const, text: "old" }], timestamp: 0 },
@@ -658,7 +726,7 @@ test("guards component widgets to TUI mode and ignores stale session shutdown", 
 	await harness.emit("session_shutdown", previous.ctx);
 	assert.equal(current.widgets.length, currentWidgetCount);
 	await assert.rejects(
-		setTodos(harness, previous.ctx, [{ text: "stale", status: "pending" }]),
+		setTodos(harness, previous.ctx, [{ step: "stale", status: "pending" }]),
 		/session changed/u,
 	);
 
@@ -672,7 +740,7 @@ test("guards component widgets to TUI mode and ignores stale session shutdown", 
 	const rpcHarness = createHarness();
 	const rpc = createContext({ mode: "rpc" });
 	await rpcHarness.emit("session_start", rpc.ctx);
-	const result = await setTodos(rpcHarness, rpc.ctx, [{ text: "headless", status: "in_progress" }]);
-	assert.equal(result.details.items[0]?.text, "headless");
+	const result = await setTodos(rpcHarness, rpc.ctx, [{ step: "headless", status: "in_progress" }]);
+	assert.equal(result.details.todos[0]?.step, "headless");
 	assert.equal(rpc.widgets.length, 0);
 });


### PR DESCRIPTION
## Summary

- Change `update_todo_list` calls from `items[].text` to `todos[].step`.
- Persist version 2 `{ todos: [{ step, status }] }` details and matching compaction context.
- Restore valid version 1 `{ items: [{ text, status }] }` details from both current and legacy tool names.
- Update documentation, generated-runtime coverage, cache-contract coverage, and release metadata.

## Breaking change

New tool calls must use `todos[].step`; the former `items[].text` call schema is no longer published.

Existing valid version 1 session details remain readable and migrate into the current runtime shape.

## Verification

- `npm --workspace @narumitw/pi-todo run typecheck`
- Focused pi-todo tests: 15 passed
- `npm run check`
- `npm test`: 3,363 passed
- README heading audit
- `npm pack --workspace @narumitw/pi-todo --dry-run --json`
- Generated Jiti loader test and non-interactive Pi package-path smoke
