### PR TITLE
fix(todo): preserve version 1 restored boundaries

### DIFF
--- a/.changeset/warm-todos-boundary.md
+++ b/.changeset/warm-todos-boundary.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-todo": patch
+---
+
+Preserve version 1 restored todo boundaries across reloads and branch navigation.

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -17,6 +17,7 @@ export const TODO_CONTEXT_VERSION = 2;
 export const TODO_DETAILS_VERSION = 2;
 export const TODO_RESTORED_BOUNDARY_ENTRY_TYPE = "todo-restored-context-boundary";
 const TODO_RESTORED_BOUNDARY_VERSION = 1;
+const LEGACY_TODO_CONTEXT_VERSION = 1;
 const LEGACY_TODO_DETAILS_VERSION = 1;
 export const MAX_TODOS = 50;
 export const MAX_TODO_STEP_LENGTH = 300;
@@ -267,9 +268,7 @@ export function sanitizeTodoStep(value: string): string {
 }
 
 function todoContextContent(todos: readonly Todo[]): string {
-	return `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]
-Current todo list as JSON data:
-${JSON.stringify({ todos })}`;
+	return `${todoContextPrefix(TODO_CONTEXT_VERSION)}${JSON.stringify({ todos })}`;
 }
 
 function reconstructRestoredTodoBoundary(
@@ -301,18 +300,45 @@ function isRestoredTodoBoundaryData(
 	) {
 		return false;
 	}
-	const prefix = `[PI TODO STATUS v${TODO_CONTEXT_VERSION}]\nCurrent todo list as JSON data:\n`;
-	if (!data.content.startsWith(prefix)) return false;
+	return isCanonicalTodoContextContent(data.content);
+}
+
+function isCanonicalTodoContextContent(content: string): boolean {
+	const currentPrefix = todoContextPrefix(TODO_CONTEXT_VERSION);
+	if (content.startsWith(currentPrefix)) {
+		try {
+			const restoredTodos = todosFromToolArguments(JSON.parse(content.slice(currentPrefix.length)));
+			return (
+				restoredTodos !== undefined &&
+				restoredTodos.length > 0 &&
+				todoContextContent(restoredTodos) === content
+			);
+		} catch {
+			return false;
+		}
+	}
+
+	const legacyPrefix = todoContextPrefix(LEGACY_TODO_CONTEXT_VERSION);
+	if (!content.startsWith(legacyPrefix)) return false;
 	try {
-		const restoredTodos = todosFromToolArguments(JSON.parse(data.content.slice(prefix.length)));
+		const restoredItems: unknown = JSON.parse(content.slice(legacyPrefix.length));
 		return (
-			restoredTodos !== undefined &&
-			restoredTodos.length > 0 &&
-			todoContextContent(restoredTodos) === data.content
+			isLegacyTodoItems(restoredItems) &&
+			restoredItems.length > 0 &&
+			legacyTodoContextContent(restoredItems) === content
 		);
 	} catch {
 		return false;
 	}
+}
+
+function todoContextPrefix(version: number): string {
+	return `[PI TODO STATUS v${version}]\nCurrent todo list as JSON data:\n`;
+}
+
+function legacyTodoContextContent(items: readonly LegacyTodoItem[]): string {
+	const canonicalItems = items.map((item) => ({ text: item.text, status: item.status }));
+	return `${todoContextPrefix(LEGACY_TODO_CONTEXT_VERSION)}${JSON.stringify(canonicalItems)}`;
 }
 
 function hasModelVisibleTodoState(

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -516,6 +516,112 @@ test("restored todo boundaries survive reload and stay branch-local", async () =
 	assert.equal(await reloadedHarness.context(sibling, current.ctx), sibling);
 });
 
+test("preserves version 1 restored boundaries after updates, clears, and tree restoration", async () => {
+	const legacyItems = [{ text: "before schema migration", status: "in_progress" as const }];
+	const branch: SessionEntry[] = [
+		toolResultEntry({ version: 1, items: legacyItems }, "todo_widget", "initial", null),
+		{
+			type: "compaction",
+			id: "compaction",
+			parentId: "initial",
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "kept",
+			tokensBefore: 100,
+		} as SessionEntry,
+	];
+	const summaries: ContextEvent["messages"] = [
+		{
+			role: "compactionSummary",
+			summary: "Earlier work was compacted.",
+			tokensBefore: 100,
+			timestamp: 0,
+		},
+	];
+	const firstHarness = createHarness();
+	const current = createContext({ branch });
+	await firstHarness.emit("session_start", current.ctx);
+	await firstHarness.context(summaries, current.ctx);
+	const persisted = firstHarness.entries[0];
+	assert.ok(persisted);
+	assert.equal(persisted.customType, TODO_RESTORED_BOUNDARY_ENTRY_TYPE);
+	assert.ok(
+		typeof persisted.data === "object" && persisted.data !== null && !Array.isArray(persisted.data),
+	);
+	const legacyContent = `[PI TODO STATUS v1]\nCurrent todo list as JSON data:\n${JSON.stringify(legacyItems)}`;
+	branch.push(
+		customEntry(
+			persisted.customType,
+			{ ...(persisted.data as Record<string, unknown>), content: legacyContent },
+			"boundary",
+			"compaction",
+		),
+	);
+
+	const updatedTodos: Todo[] = [{ step: "after schema migration", status: "completed" }];
+	const updateCall = todoToolCallMessage(updatedTodos);
+	const updateResult = todoToolResultMessage({
+		version: TODO_DETAILS_VERSION,
+		todos: updatedTodos,
+	});
+	branch.push(
+		{
+			type: "message",
+			id: "update-call",
+			parentId: "boundary",
+			timestamp: new Date(1).toISOString(),
+			message: updateCall,
+		} as SessionEntry,
+		{
+			type: "message",
+			id: "update-result",
+			parentId: "update-call",
+			timestamp: new Date(2).toISOString(),
+			message: updateResult,
+		} as SessionEntry,
+	);
+
+	const reloadedHarness = createHarness();
+	await reloadedHarness.emit("session_start", current.ctx);
+	const afterReload = await reloadedHarness.context(
+		[...summaries, updateCall, updateResult],
+		current.ctx,
+	);
+	assert.equal(
+		afterReload[1]?.role === "custom" ? afterReload[1].content : undefined,
+		legacyContent,
+	);
+	assert.equal(reloadedHarness.entries.length, 0, "reload must reuse the version 1 boundary");
+
+	const clearCall = todoToolCallMessage([]);
+	const clearResult = todoToolResultMessage({ version: TODO_DETAILS_VERSION, todos: [] });
+	branch.push(
+		{
+			type: "message",
+			id: "clear-call",
+			parentId: "update-result",
+			timestamp: new Date(3).toISOString(),
+			message: clearCall,
+		} as SessionEntry,
+		{
+			type: "message",
+			id: "clear-result",
+			parentId: "clear-call",
+			timestamp: new Date(4).toISOString(),
+			message: clearResult,
+		} as SessionEntry,
+	);
+	await reloadedHarness.emit("session_tree", current.ctx);
+	const afterTreeChange = await reloadedHarness.context(
+		[...summaries, updateCall, updateResult, clearCall, clearResult],
+		current.ctx,
+	);
+	assert.equal(
+		afterTreeChange[1]?.role === "custom" ? afterTreeChange[1].content : undefined,
+		legacyContent,
+	);
+});
+
 test("renders completed, current, and pending todos with themed semantic symbols", () => {
 	const { calls, theme } = identityTheme();
 	const lines = renderTodoWidget(


### PR DESCRIPTION
## Summary

- Accept canonical version 1 and version 2 `todo-restored-context-boundary` content.
- Preserve the historical version 1 model-visible boundary after later updates or clears across reload and `session_tree` restoration.
- Add regression coverage and a patch Changeset for `@narumitw/pi-todo`.

This resolves the finding in [PR #1145 review 5061442736](https://github.com/narumiruna/pi-extensions/pull/1145#pullrequestreview-5061442736).

## Verification

- `npx vitest run packages/pi-todo/test/todo-widget.test.ts packages/pi-todo/test/todo-cache-contract.test.ts`
- `npm --workspace @narumitw/pi-todo run typecheck`
- `npm run check`
- `npm test`

## Convention audit

- Reviewed `docs/extension-conventions.md` prompt-cache stability and touched-area requirements.
- Confirmed the established summary prefix remains byte-for-byte stable and branch-local after reload and tree navigation.
- No asynchronous UI or lifecycle flow, settings, metadata, or runtime-loading behavior changed.
