### PR TITLE
feat(herdr): publish bounded pane metadata

### DIFF
--- a/.changeset/fuzzy-sheep-metadata.md
+++ b/.changeset/fuzzy-sheep-metadata.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-herdr": minor
+---
+
+Publish bounded Pi model, provider, Thinking level, session, and context-usage metadata to Herdr.
+
+Synchronize the bundled Herdr blocked-agent safety guidance and align widget states with semantic Pi theme roles.

--- a/docs/roadmaps/2026-08-30_pi-herdr-bidirectional-integration-roadmap.md
+++ b/docs/roadmaps/2026-08-30_pi-herdr-bidirectional-integration-roadmap.md
@@ -4,7 +4,7 @@
 
 Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context in both directions without replacing Herdr's TUI, duplicating its CLI, or distracting users when no coordination needs attention.
 
-**Current roadmap status:** The Phase 1 agent widget is delivered and verified, while the optional footer summary and Phases 2–4 remain planned.
+**Current roadmap status:** The Phase 1 agent widget and Phase 2 bounded pane metadata are delivered and verified, while the optional footer summary and Phases 3–4 remain planned.
 
 ## Objectives
 
@@ -19,9 +19,10 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 - The extension coalesces state changes, retries bounded delivery failures, guards session generations, and aborts reporting during shutdown.
 - The bundled `herdr` skill provides explicit, on-demand CLI guidance for inspecting and controlling workspaces, tabs, panes, agents, commands, and notifications.
 - The extension now renders a terminal-safe, event-driven widget with one state, agent, pane, and workspace row per recognized sibling and maintains pane-scoped status subscriptions with bounded failure recovery.
-- The extension still has no footer status, `/herdr` command, pane metadata publication, autocomplete, or watch notification.
-- The installed Herdr 0.8.2 API exposes `pane.current`, `pane.list`, `events.subscribe`, pane lifecycle and agent-status events, `pane.report_metadata`, and protocol metadata through its public schema.
-- The bundled skill currently lists `herdr terminal` as a discovery group even though that group is absent from the installed Herdr 0.8.2 CLI.
+- The extension publishes bounded `model`, `provider`, `thinking`, `session`, and `context_usage` pane tokens with full-patch clearing, sequence ordering, a one-hour TTL, and a session-owned refresh.
+- The extension still has no footer status, `/herdr` command, autocomplete, or watch notification.
+- The installed Herdr 0.8.2 protocol 20 API exposes `pane.current`, `pane.list`, `events.subscribe`, pane lifecycle and agent-status events, `pane.report_metadata`, and protocol metadata through its public schema.
+- The bundled skill matches the installed Herdr 0.8.2 safety contract, and `herdr terminal` is a valid discovery group even though top-level `herdr --help` omits it.
 - The repository has no telemetry or grounded adoption baseline, so usage and delivery targets remain unknown.
 
 ## Guiding Principles
@@ -51,10 +52,14 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 
 ### Phase 2: Enrich Herdr with bounded Pi context
 
-- [ ] Herdr pane metadata exposes a stable Pi display identity and useful session title when available without replacing user-owned pane labels or leaking message content.
-- [ ] Model, provider, thinking level, and bounded context-usage metadata remain current through Pi lifecycle events and use a publication cadence that avoids volatile socket traffic.
-- [ ] Metadata ownership, sequence ordering, replacement, and shutdown behavior prevent an older Pi session from overwriting newer pane state.
-- [ ] The integration documents exactly which environment, session, model, and prompt-label fields cross the Herdr socket boundary.
+- [x] Herdr identifies the detected Pi agent through lifecycle reporting and can render the explicit Pi session name through `$session` without replacing user-owned pane labels, titles, or agent display metadata.
+  Evidence: metadata request tests reject presentation fields, skill and runtime smokes preserve user-owned identity, and privacy tests limit the token patch to five keys.
+- [x] Model, provider, thinking level, explicit session name, and rounded context usage remain current through authoritative Pi lifecycle events with changed-snapshot suppression and a refresh no more often than every 30 minutes.
+  Evidence: focused lifecycle tests cover every event, unchanged snapshots, rapid coalescing, unknown usage clearing, refresh timing, and one-hour TTL requests.
+- [x] Metadata ownership, sequence ordering, replacement, and shutdown behavior prevent an older Pi session from overwriting newer pane state.
+  Evidence: delayed send, replacement, repeated cleanup, orderly clear, failed clear, and stale-generation tests pass.
+- [x] The integration documents exactly which lifecycle, session, model, prompt-label, and metadata fields cross the Herdr socket boundary.
+  Evidence: the package README separately inventories lifecycle reports, the five metadata tokens, widget reads, excluded prompt and conversation content, and blocked-label behavior.
 
 **Outcome:** Herdr can explain which Pi session and model occupy a pane while preserving privacy and source ownership.
 
@@ -84,8 +89,8 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 | Steady-state CLI subprocesses for widget updates | 0 | 0 | Source review and live smoke |
 | Rendered widget lines exceeding available width | 0 in deterministic coverage | 0 | Narrow-width and untrusted-input tests |
 | Session-owned resources remaining after shutdown | 0 in deterministic coverage | 0 subscriptions, retry tasks, widgets, or statuses | Lifecycle tests |
-| Stale session metadata accepted after replacement | Existing outbound generation guards only | 0 | Sequence and replacement tests |
-| Invalid documented CLI discovery groups | At least 1 against installed Herdr 0.8.2 | 0 for the supported CLI fixture | Skill/CLI contract check |
+| Stale session metadata accepted after replacement | 0 in deterministic delayed-send coverage | 0 | Sequence, replacement, and shutdown-clear tests |
+| Invalid documented CLI discovery groups | 0 against installed Herdr 0.8.2, including the valid omitted `terminal` group | 0 for the supported CLI fixture | Deterministic skill contracts and live `herdr --skill` diff |
 | Adoption and coordination task completion | Unknown | TBD if privacy-compatible evidence becomes available | No current measurement source |
 
 ## Risks and Dependencies
@@ -109,6 +114,8 @@ Make `pi-herdr` the lightweight bridge that lets Pi and Herdr share live context
 - **2026-08-30 — Reconcile replayed topology:** Herdr replays retained topology events, so the widget coalesces them into fresh workspace reads and rebuilds status subscriptions only when the recognized pane set changes.
 - **2026-08-30 — Keep one agent per row:** each row uses theme roles to present state, agent name, pane label and short ID, then workspace label and short ID without misclassifying terminal titles as agent identity.
 - **2026-08-30 — Defer broad model tools:** the bundled skill and installed CLI remain authoritative until a narrow typed tool proves additional safety or reliability.
+- **2026-08-31 — Publish only bounded Pi tokens:** Phase 2 uses five full-patch tokens with explicit null clearing, one-hour TTL, 30-minute refresh, monotonic sequence ordering, and no Herdr presentation-field ownership.
+- **2026-08-31 — Treat `herdr terminal` as valid discovery:** Herdr 0.8.2 exposes the group when invoked directly even though top-level help omits it.
 
 ## Non-Goals
 

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -7,6 +7,7 @@ Connect Pi's interactive lifecycle to Herdr and bundle the operating guidance ne
 ## ✨ Features
 
 - Reports Pi session identity and `working`, `blocked`, and `idle` lifecycle states to the current Herdr pane.
+- Publishes bounded `model`, `provider`, `thinking`, `session`, and `context_usage` tokens for Herdr sidebar rows.
 - Shows recognized sibling agents from the current Herdr workspace in a passive widget above Pi's editor.
 - Updates the widget from Herdr pane lifecycle and agent-status events without polling the CLI.
 - Coalesces rapid state changes and retries short-lived local socket failures without interrupting Pi.
@@ -65,11 +66,40 @@ Local socket delivery is best-effort.
 A failed request is retried once with bounded timeouts, and reporting failures never stop Pi.
 Session shutdown aborts in-flight reporting and prevents stale session work from publishing later state.
 
+## 🏷️ Pane metadata
+
+The extension publishes only the `model`, `provider`, `thinking`, `session`, and `context_usage` token keys through `pane.report_metadata` under the `herdr:pi` source.
+`model` and `provider` come from Pi's selected model, `thinking` comes from Pi's effective Thinking level, and `session` comes only from Pi's explicit session display name.
+`context_usage` is Pi's current context percentage rounded to the nearest whole percent.
+Every report is a full five-key patch, and an unavailable value is sent as JSON `null` so old data is cleared instead of retained.
+Values are stripped of terminal controls, trimmed, and limited to 80 Unicode characters before crossing the socket.
+The extension never publishes prompts, conversation text, tool arguments, credentials, raw session paths, or inferred session titles as metadata tokens.
+It also never sets Herdr's pane `title`, `display_agent`, `state_labels`, agent lifecycle state, or session restore fields through metadata.
+
+Metadata is evaluated after `session_start`, `session_info_changed`, `model_select`, `thinking_level_select`, `agent_settled`, and successful `session_compact` events.
+Unchanged event snapshots are suppressed, rapid changes are coalesced, and the latest unchanged snapshot is refreshed no more often than every 30 minutes.
+Each token has a one-hour TTL, so data from a crashed Pi process expires without steady socket traffic.
+Orderly shutdown sends one best-effort five-key clear patch, while abrupt shutdown and failed clears fall back to the TTL.
+Metadata uses the lifecycle reporter's monotonic sequence allocator and bounded best-effort sender, so older delayed reports cannot replace newer accepted values and socket failures never interrupt Pi.
+
+Herdr custom pane tokens use a `$name` row entry.
+For example, this Herdr configuration displays Pi's model context without replacing pane labels or agent identity:
+
+```toml
+[ui.sidebar.agents]
+rows = [
+  ["state_icon", "agent"],
+  ["$provider", "$model", "$thinking"],
+  ["$session", "$context_usage"],
+]
+```
+
 ## 🐑 Agent widget
 
 The widget lists only recognized agents in the current Herdr workspace and excludes the pane running the current Pi session.
 Each row presents state, agent, pane, and workspace in that order, using theme hierarchy instead of repeating field labels.
 State icons follow Herdr's distinct static symbols: `×` blocked, `◐` working, `✓` done, `○` idle, and `·` unknown.
+Pi theme roles map blocked to `error`, working to `warning`, done to `accent`, idle to `success`, and unknown to `dim` without hard-coded terminal colors.
 Agent identity prefers the name assigned by `herdr agent rename`, then Herdr display metadata, and finally the detected agent kind.
 Pane identity uses its label or metadata title with a short pane ID, while workspace identity uses its label with a short workspace ID.
 Terminal titles are not used as agent identity.
@@ -85,7 +115,8 @@ Session replacement and shutdown abort the subscription, pending requests, recon
 ## 🔒 Security and privacy
 
 The extension connects only to the Unix socket or Windows named pipe provided by `HERDR_SOCKET_PATH`.
-It sends the current Herdr pane ID, Pi session path or ID, lifecycle state, session start reason, and blocked label to that endpoint.
+Lifecycle reporting sends the current Herdr pane ID, Pi session path or ID, lifecycle state, session start reason, and blocked label to that endpoint.
+Metadata reporting sends the current Herdr pane ID plus only the selected model ID, provider ID, effective Thinking level, explicit Pi session name, and rounded context-usage percentage.
 For the widget, it reads the canonical current pane, current workspace metadata, current workspace pane list, and session agent list, then subscribes to pane creation, closure, movement, exit, agent detection, and agent-status events.
 The session agent list can contain agent metadata from other workspaces, but the extension retains names only for panes in the current workspace list.
 Widget fields can include workspace, tab, pane, terminal, agent, display, name, title, label, state-label, and lifecycle identifiers supplied by Herdr.
@@ -96,10 +127,11 @@ The package does not authenticate the endpoint, so trust the environment that la
 The bundled skill can direct Pi to inspect terminals, create panes, start agents, send input, and run commands through the local `herdr` CLI.
 Those commands execute with the same user permissions as Pi and can affect live terminal sessions.
 The skill requires an explicit user request involving Herdr and stops when `HERDR_ENV` is not `1`.
+It treats a startup-blocked agent as not ready, refuses to prompt an already blocked agent, requires inspecting the blocked UI, and requires asking the user before answering an approval or question dialog.
 
 ## 🚧 Limitations
 
-- State reporting and the agent widget are disabled in RPC, JSON, and print modes.
+- Lifecycle reporting, metadata reporting, and the agent widget are disabled in RPC, JSON, and print modes.
 - The widget has no settings for placement, workspace scope, visibility, or row count.
 - The widget cannot show blocked prompt text because Herdr does not expose it through public pane responses.
 - Herdr exposes no rename event, so agent and pane renames appear after the next topology refresh, reconnect, Pi `/reload`, or session start rather than immediately.
@@ -117,13 +149,16 @@ packages/pi-herdr/
 │   ├── index.ts              # Thin Pi entrypoint
 │   ├── herdr-agent-state.ts  # Pi lifecycle and integration ownership
 │   ├── herdr-client.ts       # Bounded Herdr socket transport
+│   ├── herdr-metadata.ts     # Token normalization and request helpers
 │   ├── herdr-observer.ts     # Read-only event subscription lifecycle
 │   ├── herdr-protocol.ts     # Narrow response and event validation
 │   └── herdr-widget.ts       # Agent state model and presentation
 ├── test/
 │   ├── herdr-agent-state.test.ts
 │   ├── herdr-client.test.ts
+│   ├── herdr-metadata.test.ts
 │   ├── herdr-observer.test.ts
+│   ├── herdr-skill.test.ts
 │   └── herdr-widget.test.ts
 ├── package.json              # Pi extension and skill declarations
 ├── tsconfig.json

--- a/packages/pi-herdr/skills/herdr/SKILL.md
+++ b/packages/pi-herdr/skills/herdr/SKILL.md
@@ -117,7 +117,7 @@ Use the kind requested by the user. Run `herdr agent` to inspect the installed k
 herdr agent start reviewer --kind codex --pane <returned-pane-id> -- <agent-args...>
 ```
 
-`agent start` returns only after Herdr detects the expected agent in the same pane and considers it ready for interactive input. It defaults to a 30-second startup timeout.
+A successful `agent start` returns only after Herdr detects the expected agent in the same pane and considers it ready for interactive input. If the agent is blocked during startup, the command returns `agent_not_ready` immediately but keeps the name available for `agent read` and `agent send-keys`. Wait until the agent becomes idle before prompting it. Startup defaults to a 30-second timeout.
 
 Submit work through the agent surface:
 
@@ -125,7 +125,7 @@ Submit work through the agent surface:
 herdr agent prompt reviewer "Review the current diff and report only actionable findings." --wait --timeout 120000
 ```
 
-`agent prompt` atomically submits text and encoded Enter while honoring the pane's live bracketed-paste mode. For normal agent work, `--wait` is enough: it waits for the first settled `idle`, `done`, or `blocked` state. Do not repeat those defaults with `--until`.
+`agent prompt` honors the pane's live bracketed-paste mode and sends text followed by encoded Enter after a short delay. It rejects an agent already waiting at an approval or question dialog with `agent_blocked` before sending any input. Inspect the blocked UI and ask the user before answering it. For normal agent work, `--wait` is enough: it waits for the first settled `idle`, `done`, or `blocked` state. Do not repeat those defaults with `--until`.
 
 A prompt sent from a non-working state must produce an observed lifecycle change within five seconds. Otherwise Herdr returns `agent_prompt_stalled` instead of waiting indefinitely. This wait tracks lifecycle state, not an individual turn; if the agent is already working, completion of the active turn may satisfy it.
 

--- a/packages/pi-herdr/src/herdr-agent-state.ts
+++ b/packages/pi-herdr/src/herdr-agent-state.ts
@@ -1,6 +1,14 @@
 import path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createBestEffortSender, type HerdrRequest } from "./herdr-client.js";
+import {
+	createHerdrMetadataClearSnapshot,
+	createHerdrMetadataRequest,
+	createHerdrMetadataSnapshot,
+	HERDR_METADATA_REFRESH_MS,
+	type HerdrMetadataSnapshot,
+	herdrMetadataSnapshotsEqual,
+} from "./herdr-metadata.js";
 import { createHerdrWidgetObserver, type HerdrWidgetObserver } from "./herdr-observer.js";
 
 const SOURCE = "herdr:pi";
@@ -18,6 +26,13 @@ interface QueuedState {
 	message?: string;
 	seq: number;
 	signal: AbortSignal;
+}
+
+interface QueuedMetadata {
+	snapshot: HerdrMetadataSnapshot;
+	seq: number;
+	signal: AbortSignal;
+	generation: number;
 }
 
 export interface HerdrAgentStateOptions {
@@ -77,6 +92,7 @@ export function createHerdrAgentStateExtension(
 
 		let sessionGeneration = 0;
 		let sessionController = new AbortController();
+		let activeSession: ExtensionContext["sessionManager"] | undefined;
 		let currentAgentSessionId: string | undefined;
 		let currentAgentSessionPath: string | undefined;
 		let agentActive = false;
@@ -87,6 +103,13 @@ export function createHerdrAgentStateExtension(
 		let rootSession = false;
 		let queuedState: QueuedState | undefined;
 		let drainTask: Promise<void> | undefined;
+		let queuedMetadata: QueuedMetadata | undefined;
+		let metadataDrainTask: Promise<void> | undefined;
+		let lastMetadataSnapshot: HerdrMetadataSnapshot | undefined;
+		let metadataRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+		let shutdownClearController: AbortController | undefined;
+		let shutdownSession: ExtensionContext["sessionManager"] | undefined;
+		let shutdownTask: Promise<void> | undefined;
 
 		function requestId(kind?: "session"): string {
 			const segment = kind ? `${kind}:` : "";
@@ -163,6 +186,38 @@ export function createHerdrAgentStateExtension(
 			};
 		}
 
+		function readMetadataSnapshot(ctx: ExtensionContext): HerdrMetadataSnapshot {
+			let session: string | undefined;
+			let contextUsagePercent: number | null | undefined;
+			try {
+				session = pi.getSessionName();
+			} catch {
+				// Metadata is best-effort and optional Pi fields can be unavailable.
+			}
+			try {
+				contextUsagePercent = ctx.getContextUsage()?.percent;
+			} catch {
+				// Clear unknown usage instead of retaining a stale percentage.
+			}
+			return createHerdrMetadataSnapshot({
+				model: ctx.model?.id,
+				provider: ctx.model?.provider,
+				thinking: ctx.thinkingLevel,
+				session,
+				contextUsagePercent,
+			});
+		}
+
+		function metadataRequest(metadata: QueuedMetadata): HerdrRequest {
+			return createHerdrMetadataRequest({
+				id: requestId(),
+				paneId: environment.paneId,
+				source: SOURCE,
+				seq: metadata.seq,
+				snapshot: metadata.snapshot,
+			});
+		}
+
 		async function drainStateQueue(): Promise<void> {
 			while (queuedState) {
 				const next = queuedState;
@@ -185,6 +240,65 @@ export function createHerdrAgentStateExtension(
 			});
 		}
 
+		async function drainMetadataQueue(): Promise<void> {
+			while (queuedMetadata) {
+				const next = queuedMetadata;
+				queuedMetadata = undefined;
+				if (next.signal.aborted || next.generation !== sessionGeneration || !rootSession) {
+					continue;
+				}
+				await safeSend(metadataRequest(next), next.signal);
+			}
+		}
+
+		function startMetadataDrain(): void {
+			if (metadataDrainTask) return;
+			metadataDrainTask = drainMetadataQueue().finally(() => {
+				metadataDrainTask = undefined;
+				if (queuedMetadata) startMetadataDrain();
+			});
+		}
+
+		function scheduleMetadataRefresh(generation: number): void {
+			if (metadataRefreshTimer) clearTimeout(metadataRefreshTimer);
+			metadataRefreshTimer = setTimeout(() => {
+				metadataRefreshTimer = undefined;
+				if (
+					generation !== sessionGeneration ||
+					sessionController.signal.aborted ||
+					!rootSession ||
+					!lastMetadataSnapshot
+				) {
+					return;
+				}
+				queueMetadata(lastMetadataSnapshot, true);
+			}, HERDR_METADATA_REFRESH_MS);
+			metadataRefreshTimer.unref?.();
+		}
+
+		function queueMetadata(snapshot: HerdrMetadataSnapshot, force = false): void {
+			if (!rootSession || sessionController.signal.aborted) return;
+			if (!force && herdrMetadataSnapshotsEqual(lastMetadataSnapshot, snapshot)) return;
+			lastMetadataSnapshot = snapshot;
+			queuedMetadata = {
+				snapshot,
+				seq: nextReportSeq(),
+				signal: sessionController.signal,
+				generation: sessionGeneration,
+			};
+			scheduleMetadataRefresh(sessionGeneration);
+			startMetadataDrain();
+		}
+
+		function owns(ctx: ExtensionContext): boolean {
+			return rootSession && ctx.sessionManager === activeSession;
+		}
+
+		function publishMetadata(ctx: ExtensionContext): void {
+			if (!owns(ctx)) return;
+			queueMetadata(readMetadataSnapshot(ctx));
+		}
+
 		function desiredState(): { state: AgentState; message?: string } {
 			if (blockedCount > 0) return { state: "blocked", message: blockedMessage };
 			if (agentActive) return { state: "working" };
@@ -199,15 +313,15 @@ export function createHerdrAgentStateExtension(
 			queueState(next.state, next.message);
 		}
 
-		pi.on("ui_prompt_start", (event) => {
-			if (!rootSession) return;
+		pi.on("ui_prompt_start", (event, ctx) => {
+			if (!owns(ctx)) return;
 			blockedCount += 1;
 			blockedMessage = event.title?.trim() || event.kind;
 			publishState();
 		});
 
-		pi.on("ui_prompt_end", () => {
-			if (!rootSession) return;
+		pi.on("ui_prompt_end", (_event, ctx) => {
+			if (!owns(ctx)) return;
 			blockedCount = Math.max(0, blockedCount - 1);
 			if (blockedCount === 0) blockedMessage = undefined;
 			publishState();
@@ -215,8 +329,16 @@ export function createHerdrAgentStateExtension(
 
 		pi.on("session_start", async (event, ctx) => {
 			const generation = ++sessionGeneration;
-			sessionController.abort(new DOMException("Herdr session replaced", "AbortError"));
+			const replaced = new DOMException("Herdr session replaced", "AbortError");
+			sessionController.abort(replaced);
+			shutdownClearController?.abort(replaced);
+			shutdownClearController = undefined;
+			if (metadataRefreshTimer) clearTimeout(metadataRefreshTimer);
+			metadataRefreshTimer = undefined;
+			queuedMetadata = undefined;
+			lastMetadataSnapshot = undefined;
 			sessionController = new AbortController();
+			activeSession = ctx.sessionManager;
 			rootSession = ctx.mode === "tui";
 			if (rootSession) widgetObserver.start(ctx);
 			agentActive = false;
@@ -227,7 +349,9 @@ export function createHerdrAgentStateExtension(
 			if (!rootSession) return;
 
 			updateSessionRef(ctx);
-			await reportSession(event.reason);
+			const sessionReport = reportSession(event.reason);
+			publishMetadata(ctx);
+			await sessionReport;
 			if (generation !== sessionGeneration || sessionController.signal.aborted || !rootSession) {
 				return;
 			}
@@ -236,7 +360,7 @@ export function createHerdrAgentStateExtension(
 		});
 
 		pi.on("agent_start", (_event, ctx) => {
-			if (!rootSession) return;
+			if (!owns(ctx)) return;
 			updateSessionRef(ctx);
 			void reportSession();
 			agentActive = true;
@@ -244,19 +368,71 @@ export function createHerdrAgentStateExtension(
 		});
 
 		pi.on("agent_settled", (_event, ctx) => {
-			if (!rootSession || !ctx.isIdle()) return;
+			if (!owns(ctx)) return;
+			publishMetadata(ctx);
+			if (!ctx.isIdle()) return;
 			agentActive = false;
 			publishState();
 		});
 
+		pi.on("session_info_changed", (_event, ctx) => publishMetadata(ctx));
+		pi.on("model_select", (_event, ctx) => publishMetadata(ctx));
+		pi.on("thinking_level_select", (_event, ctx) => publishMetadata(ctx));
+		pi.on("session_compact", (_event, ctx) => publishMetadata(ctx));
+
 		pi.on("session_shutdown", async (_event, ctx) => {
-			++sessionGeneration;
-			rootSession = false;
-			sessionController.abort(new DOMException("Herdr session shut down", "AbortError"));
-			queuedState = undefined;
-			await Promise.all([drainTask, widgetObserver.shutdown(ctx)]);
-			currentAgentSessionId = undefined;
-			currentAgentSessionPath = undefined;
+			if (ctx.sessionManager !== activeSession) {
+				await Promise.allSettled([widgetObserver.shutdown(ctx)]);
+				return;
+			}
+			if (shutdownTask && shutdownSession === ctx.sessionManager) {
+				await shutdownTask;
+				return;
+			}
+
+			const session = ctx.sessionManager;
+			const task = (async () => {
+				const shouldClearMetadata = rootSession;
+				const shutdownGeneration = ++sessionGeneration;
+				rootSession = false;
+				if (metadataRefreshTimer) clearTimeout(metadataRefreshTimer);
+				metadataRefreshTimer = undefined;
+				sessionController.abort(new DOMException("Herdr session shut down", "AbortError"));
+				queuedState = undefined;
+				queuedMetadata = undefined;
+				await Promise.allSettled([drainTask, metadataDrainTask, widgetObserver.shutdown(ctx)]);
+				const stillOwnsShutdown =
+					shutdownGeneration === sessionGeneration && activeSession === session && !rootSession;
+				if (shouldClearMetadata && stillOwnsShutdown) {
+					const controller = new AbortController();
+					shutdownClearController = controller;
+					await safeSend(
+						createHerdrMetadataRequest({
+							id: requestId(),
+							paneId: environment.paneId,
+							source: SOURCE,
+							seq: nextReportSeq(),
+							snapshot: createHerdrMetadataClearSnapshot(),
+						}),
+						controller.signal,
+					);
+					if (shutdownClearController === controller) shutdownClearController = undefined;
+				}
+				if (shutdownGeneration !== sessionGeneration || activeSession !== session || rootSession) {
+					return;
+				}
+				lastMetadataSnapshot = undefined;
+				currentAgentSessionId = undefined;
+				currentAgentSessionPath = undefined;
+				activeSession = undefined;
+			})();
+			shutdownSession = session;
+			shutdownTask = task;
+			await task;
+			if (shutdownTask === task) {
+				shutdownTask = undefined;
+				shutdownSession = undefined;
+			}
 		});
 	};
 }

--- a/packages/pi-herdr/src/herdr-metadata.ts
+++ b/packages/pi-herdr/src/herdr-metadata.ts
@@ -1,0 +1,87 @@
+import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+import type { HerdrRequest } from "./herdr-client.js";
+
+export const HERDR_METADATA_TOKEN_KEYS = [
+	"model",
+	"provider",
+	"thinking",
+	"session",
+	"context_usage",
+] as const;
+
+export type HerdrMetadataTokenKey = (typeof HERDR_METADATA_TOKEN_KEYS)[number];
+export type HerdrMetadataSnapshot = Readonly<Record<HerdrMetadataTokenKey, string | null>>;
+
+export const HERDR_METADATA_MAX_CHARACTERS = 80;
+export const HERDR_METADATA_TTL_MS = 60 * 60 * 1000;
+export const HERDR_METADATA_REFRESH_MS = 30 * 60 * 1000;
+
+export interface HerdrMetadataInputs {
+	model?: unknown;
+	provider?: unknown;
+	thinking?: unknown;
+	session?: unknown;
+	contextUsagePercent?: unknown;
+}
+
+export interface HerdrMetadataRequestOptions {
+	id: string;
+	paneId: string;
+	source: string;
+	seq: number;
+	snapshot: HerdrMetadataSnapshot;
+	ttlMs?: number;
+}
+
+export function normalizeHerdrMetadataValue(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = sanitizeTerminalText(value).trim();
+	if (normalized.length === 0) return null;
+	return [...normalized].slice(0, HERDR_METADATA_MAX_CHARACTERS).join("");
+}
+
+export function formatContextUsagePercent(value: unknown): string | null {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+	return `${Math.round(value)}%`;
+}
+
+export function createHerdrMetadataSnapshot(inputs: HerdrMetadataInputs): HerdrMetadataSnapshot {
+	return Object.freeze({
+		model: normalizeHerdrMetadataValue(inputs.model),
+		provider: normalizeHerdrMetadataValue(inputs.provider),
+		thinking: normalizeHerdrMetadataValue(inputs.thinking),
+		session: normalizeHerdrMetadataValue(inputs.session),
+		context_usage: formatContextUsagePercent(inputs.contextUsagePercent),
+	});
+}
+
+export function createHerdrMetadataClearSnapshot(): HerdrMetadataSnapshot {
+	return Object.freeze({
+		model: null,
+		provider: null,
+		thinking: null,
+		session: null,
+		context_usage: null,
+	});
+}
+
+export function herdrMetadataSnapshotsEqual(
+	left: HerdrMetadataSnapshot | undefined,
+	right: HerdrMetadataSnapshot,
+): boolean {
+	return left !== undefined && HERDR_METADATA_TOKEN_KEYS.every((key) => left[key] === right[key]);
+}
+
+export function createHerdrMetadataRequest(options: HerdrMetadataRequestOptions): HerdrRequest {
+	return {
+		id: options.id,
+		method: "pane.report_metadata",
+		params: {
+			pane_id: options.paneId,
+			source: options.source,
+			seq: options.seq,
+			tokens: { ...options.snapshot },
+			ttl_ms: options.ttlMs ?? HERDR_METADATA_TTL_MS,
+		},
+	};
+}

--- a/packages/pi-herdr/src/herdr-widget.ts
+++ b/packages/pi-herdr/src/herdr-widget.ts
@@ -225,13 +225,13 @@ export class HerdrWidgetModel {
 function stateStyle(theme: Theme, state: HerdrAgentStatus, text: string): string {
 	switch (state) {
 		case "blocked":
-			return theme.fg("warning", text);
+			return theme.fg("error", text);
 		case "done":
-			return theme.fg("success", text);
-		case "working":
 			return theme.fg("accent", text);
+		case "working":
+			return theme.fg("warning", text);
 		case "idle":
-			return theme.fg("muted", text);
+			return theme.fg("success", text);
 		case "unknown":
 			return theme.fg("dim", text);
 	}

--- a/packages/pi-herdr/test/herdr-agent-state.test.ts
+++ b/packages/pi-herdr/test/herdr-agent-state.test.ts
@@ -4,9 +4,10 @@ import net from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { DefaultResourceLoader, SettingsManager } from "@earendil-works/pi-coding-agent";
-import { afterAll, beforeAll, test } from "vitest";
+import { afterAll, afterEach, beforeAll, test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import type { HerdrAgentStateOptions } from "../src/herdr-agent-state.js";
+import { HERDR_METADATA_REFRESH_MS, HERDR_METADATA_TOKEN_KEYS } from "../src/herdr-metadata.js";
 
 type HerdrModule = typeof import("../src/herdr-agent-state.js");
 type HerdrRequest = Parameters<NonNullable<HerdrAgentStateOptions["sendRequest"]>>[0];
@@ -27,6 +28,10 @@ afterAll(async () => {
 	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 	else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 	await rm(agentDir, { force: true, recursive: true });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
 });
 
 function enabledOptions(requests: HerdrRequest[]): HerdrAgentStateOptions {
@@ -223,16 +228,268 @@ test("TUI sessions start and shut down the widget observer", async () => {
 	assert.deepEqual(events, ["start:tui", "shutdown:tui"]);
 });
 
+test("publishes changed metadata from every authoritative event and refreshes bounded TTL", async () => {
+	vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+	const requests: HerdrRequest[] = [];
+	const mock = createMockPi();
+	mock.rawPi.setSessionName("Initial session");
+	let contextUsagePercent: number | null = 24.4;
+	const started = tuiContext();
+	const mutableContext = started.ctx as unknown as {
+		model?: { id: string; provider: string };
+		thinkingLevel?: string;
+	};
+	mutableContext.model = { id: "claude-sonnet", provider: "anthropic" };
+	mutableContext.thinkingLevel = "high";
+	(started.ctx as unknown as { getContextUsage(): unknown }).getContextUsage = () => ({
+		tokens: 24,
+		contextWindow: 100,
+		percent: contextUsagePercent,
+	});
+	herdrModule.createHerdrAgentStateExtension(enabledOptions(requests))(mock.pi);
+
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await flushReporting();
+	const metadataRequests = () => requests.filter(({ method }) => method === "pane.report_metadata");
+	assert.deepEqual(metadataRequests().at(-1)?.params.tokens, {
+		model: "claude-sonnet",
+		provider: "anthropic",
+		thinking: "high",
+		session: "Initial session",
+		context_usage: "24%",
+	});
+	assert.equal(metadataRequests().at(-1)?.params.ttl_ms, 3_600_000);
+
+	for (const name of [
+		"session_info_changed",
+		"model_select",
+		"thinking_level_select",
+		"agent_settled",
+		"session_compact",
+	]) {
+		await emit(mock, name, {}, started.ctx);
+	}
+	await flushReporting();
+	assert.equal(metadataRequests().length, 1);
+
+	mock.rawPi.setSessionName("Renamed session");
+	await emit(mock, "session_info_changed", { name: "Renamed session" }, started.ctx);
+	mutableContext.model = { id: "gpt-5", provider: "openai" };
+	await emit(mock, "model_select", {}, started.ctx);
+	mutableContext.thinkingLevel = "medium";
+	await emit(mock, "thinking_level_select", {}, started.ctx);
+	contextUsagePercent = 49.6;
+	await emit(mock, "agent_settled", {}, started.ctx);
+	contextUsagePercent = null;
+	await emit(mock, "session_compact", {}, started.ctx);
+	await flushReporting();
+	assert.deepEqual(metadataRequests().at(-1)?.params.tokens, {
+		model: "gpt-5",
+		provider: "openai",
+		thinking: "medium",
+		session: "Renamed session",
+		context_usage: null,
+	});
+	assert.equal(metadataRequests().length, 6);
+
+	const beforeRefresh = metadataRequests().length;
+	await vi.advanceTimersByTimeAsync(HERDR_METADATA_REFRESH_MS - 1);
+	assert.equal(metadataRequests().length, beforeRefresh);
+	await vi.advanceTimersByTimeAsync(1);
+	assert.equal(metadataRequests().length, beforeRefresh + 1);
+	assert.deepEqual(
+		metadataRequests().at(-1)?.params.tokens,
+		metadataRequests().at(-2)?.params.tokens,
+	);
+
+	mock.rawPi.setSessionName(undefined as never);
+	await emit(mock, "session_info_changed", { name: undefined }, started.ctx);
+	await flushReporting();
+	const renamedMetadata = metadataRequests().at(-1);
+	assert.ok(renamedMetadata);
+	assert.equal((renamedMetadata.params.tokens as Record<string, unknown>).session, null);
+	await emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
+	const clear = metadataRequests().at(-1);
+	assert.deepEqual(
+		clear?.params.tokens,
+		Object.fromEntries(HERDR_METADATA_TOKEN_KEYS.map((key) => [key, null])),
+	);
+	assert.deepEqual(Object.keys(clear?.params.tokens as object), [...HERDR_METADATA_TOKEN_KEYS]);
+	const afterShutdown = metadataRequests().length;
+	await vi.advanceTimersByTimeAsync(HERDR_METADATA_REFRESH_MS * 2);
+	assert.equal(metadataRequests().length, afterShutdown);
+});
+
+test("coalesces rapid metadata changes behind one delayed send", async () => {
+	const requests: HerdrRequest[] = [];
+	let release!: () => void;
+	const delayed = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let delayedMetadata = true;
+	const mock = createMockPi();
+	const started = tuiContext();
+	const mutableContext = started.ctx as unknown as {
+		model?: { id: string; provider: string };
+	};
+	mutableContext.model = { id: "first", provider: "provider" };
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions(requests),
+		async sendRequest(request) {
+			requests.push(request);
+			if (request.method === "pane.report_metadata" && delayedMetadata) {
+				delayedMetadata = false;
+				await delayed;
+			}
+		},
+	})(mock.pi);
+
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await flushReporting();
+	mutableContext.model = { id: "second", provider: "provider" };
+	await emit(mock, "model_select", {}, started.ctx);
+	mutableContext.model = { id: "latest", provider: "provider" };
+	await emit(mock, "model_select", {}, started.ctx);
+	assert.equal(requests.filter(({ method }) => method === "pane.report_metadata").length, 1);
+	release();
+	await flushReporting();
+	await flushReporting();
+	const metadata = requests.filter(({ method }) => method === "pane.report_metadata");
+	assert.equal(metadata.length, 2);
+	assert.ok(metadata[0]);
+	assert.ok(metadata[1]);
+	assert.equal((metadata[0].params.tokens as Record<string, unknown>).model, "first");
+	assert.equal((metadata[1].params.tokens as Record<string, unknown>).model, "latest");
+	await emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
+});
+
+test("replacement aborts stale metadata and prevents an older shutdown clear", async () => {
+	const requests: Array<{ request: HerdrRequest; signal: AbortSignal }> = [];
+	let release!: () => void;
+	const delayed = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let delayFirstMetadata = true;
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions([]),
+		async sendRequest(request, signal) {
+			requests.push({ request, signal });
+			if (request.method === "pane.report_metadata" && delayFirstMetadata) {
+				delayFirstMetadata = false;
+				await delayed;
+			}
+		},
+	})(mock.pi);
+	const oldSession = tuiContext();
+	const replacement = tuiContext();
+	(oldSession.ctx as unknown as { model: unknown }).model = {
+		id: "old",
+		provider: "provider",
+	};
+	(replacement.ctx as unknown as { model: unknown }).model = {
+		id: "replacement",
+		provider: "provider",
+	};
+
+	await emit(mock, "session_start", { reason: "startup" }, oldSession.ctx);
+	await flushReporting();
+	const stoppingOld = emit(mock, "session_shutdown", { reason: "reload" }, oldSession.ctx);
+	const oldMetadata = requests.find(({ request }) => request.method === "pane.report_metadata");
+	assert.equal(oldMetadata?.signal.aborted, true);
+	await emit(mock, "session_start", { reason: "reload" }, replacement.ctx);
+	release();
+	await stoppingOld;
+	await flushReporting();
+	const metadataBeforeFinalShutdown = requests
+		.map(({ request }) => request)
+		.filter(({ method }) => method === "pane.report_metadata");
+	assert.equal(
+		metadataBeforeFinalShutdown.some(({ params }) =>
+			Object.values(params.tokens as Record<string, unknown>).every((value) => value === null),
+		),
+		false,
+	);
+	const firstMetadata = metadataBeforeFinalShutdown[0];
+	const latestMetadata = metadataBeforeFinalShutdown.at(-1);
+	assert.ok(firstMetadata);
+	assert.ok(latestMetadata);
+	assert.equal((latestMetadata.params.tokens as Record<string, unknown>).model, "replacement");
+	assert.ok(Number(firstMetadata.params.seq) < Number(latestMetadata.params.seq));
+	const beforeStaleEvents = metadataBeforeFinalShutdown.length;
+	await emit(mock, "agent_settled", {}, replacement.ctx);
+	await emit(mock, "model_select", {}, oldSession.ctx);
+	await flushReporting();
+	assert.equal(
+		requests.filter(({ request }) => request.method === "pane.report_metadata").length,
+		beforeStaleEvents,
+	);
+	await emit(mock, "session_shutdown", { reason: "quit" }, replacement.ctx);
+});
+
+test("repeated shutdown shares cleanup and sends exactly one clear patch", async () => {
+	const requests: HerdrRequest[] = [];
+	let release!: () => void;
+	const delayed = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let delayMetadata = true;
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions(requests),
+		async sendRequest(request) {
+			requests.push(request);
+			if (request.method === "pane.report_metadata" && delayMetadata) {
+				delayMetadata = false;
+				await delayed;
+			}
+		},
+	})(mock.pi);
+	const started = tuiContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await flushReporting();
+	const metadataBeforeShutdown = requests.filter(
+		({ method }) => method === "pane.report_metadata",
+	).length;
+	const firstShutdown = emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
+	const repeatedShutdown = emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
+	release();
+	await Promise.all([firstShutdown, repeatedShutdown]);
+	const metadataAfterShutdown = requests.filter(({ method }) => method === "pane.report_metadata");
+	assert.equal(metadataAfterShutdown.length, metadataBeforeShutdown + 1);
+	const clearPatch = metadataAfterShutdown.at(-1);
+	assert.ok(clearPatch);
+	assert.equal(
+		Object.values(clearPatch.params.tokens as Record<string, unknown>).every(
+			(value) => value === null,
+		),
+		true,
+	);
+});
+
+test("metadata failures never interrupt lifecycle or orderly shutdown", async () => {
+	const mock = createMockPi();
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions([]),
+		async sendRequest() {
+			throw new Error("socket unavailable");
+		},
+	})(mock.pi);
+	const started = tuiContext();
+	await emit(mock, "session_start", { reason: "startup" }, started.ctx);
+	await emit(mock, "model_select", {}, started.ctx);
+	await emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
+});
+
 test("socket transport retries one failed delivery and preserves the request", async () => {
 	const socketPath = join(agentDir, "herdr-test.sock");
 	const received: HerdrRequest[] = [];
-	let connectionCount = 0;
+	const attemptsById = new Map<string, number>();
 	let reportState!: () => void;
 	const stateReceived = new Promise<void>((resolve) => {
 		reportState = resolve;
 	});
 	const server = net.createServer((socket) => {
-		connectionCount += 1;
 		let input = "";
 		socket.on("error", () => {
 			// The client closes immediately after Herdr acknowledges delivery.
@@ -243,7 +500,9 @@ test("socket transport retries one failed delivery and preserves the request", a
 			if (newline < 0) return;
 			const request = JSON.parse(input.slice(0, newline)) as HerdrRequest;
 			received.push(request);
-			if (connectionCount === 1) socket.end();
+			const attempts = (attemptsById.get(request.id) ?? 0) + 1;
+			attemptsById.set(request.id, attempts);
+			if (request.method === "pane.report_agent_session" && attempts === 1) socket.end();
 			else socket.write("{}\n");
 			if (request.method === "pane.report_agent") reportState();
 		});
@@ -265,10 +524,16 @@ test("socket transport retries one failed delivery and preserves the request", a
 	try {
 		await emit(mock, "session_start", { reason: "startup" }, started.ctx);
 		await stateReceived;
-		assert.equal(connectionCount, 3);
-		assert.equal(received[0]?.id, received[1]?.id);
-		assert.equal(received[0]?.method, "pane.report_agent_session");
-		assert.equal(received[2]?.params.state, "idle");
+		const sessionReports = received.filter(
+			(request) => request.method === "pane.report_agent_session",
+		);
+		assert.equal(sessionReports.length, 2);
+		assert.equal(sessionReports[0]?.id, sessionReports[1]?.id);
+		assert.equal(
+			received.some((request) => request.method === "pane.report_metadata"),
+			true,
+		);
+		assert.equal(stateRequests(received).at(-1)?.params.state, "idle");
 	} finally {
 		await emit(mock, "session_shutdown", { reason: "quit" }, started.ctx);
 		await new Promise<void>((resolve, reject) => {
@@ -298,14 +563,20 @@ test("shutdown aborts a delayed session report before it can publish state", asy
 
 	const starting = emit(mock, "session_start", { reason: "startup" }, started.ctx);
 	await flushReporting();
-	assert.equal(requests.length, 1);
+	assert.equal(requests.filter(({ method }) => method === "pane.report_agent_session").length, 1);
+	assert.equal(requests.filter(({ method }) => method === "pane.report_metadata").length, 1);
 	const shuttingDown = emit(mock, "session_shutdown", { reason: "reload" }, started.ctx);
 	assert.equal(firstSignal?.aborted, true);
 	release();
 	await Promise.all([starting, shuttingDown]);
 	await flushReporting();
 	assert.equal(stateRequests(requests).length, 0);
+	assert.deepEqual(
+		requests.filter(({ method }) => method === "pane.report_metadata").at(-1)?.params.tokens,
+		Object.fromEntries(HERDR_METADATA_TOKEN_KEYS.map((key) => [key, null])),
+	);
 
+	const requestCount = requests.length;
 	await emit(
 		mock,
 		"ui_prompt_start",
@@ -313,7 +584,7 @@ test("shutdown aborts a delayed session report before it can publish state", asy
 		started.ctx,
 	);
 	await flushReporting();
-	assert.equal(requests.length, 1);
+	assert.equal(requests.length, requestCount);
 });
 
 test("package resources load one extension and the bundled herdr skill", async () => {

--- a/packages/pi-herdr/test/herdr-metadata.test.ts
+++ b/packages/pi-herdr/test/herdr-metadata.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	createHerdrMetadataClearSnapshot,
+	createHerdrMetadataRequest,
+	createHerdrMetadataSnapshot,
+	formatContextUsagePercent,
+	HERDR_METADATA_MAX_CHARACTERS,
+	HERDR_METADATA_REFRESH_MS,
+	HERDR_METADATA_TOKEN_KEYS,
+	HERDR_METADATA_TTL_MS,
+	herdrMetadataSnapshotsEqual,
+	normalizeHerdrMetadataValue,
+} from "../src/herdr-metadata.js";
+
+test("normalizes hostile and overlong metadata without splitting Unicode", () => {
+	assert.equal(normalizeHerdrMetadataValue(undefined), null);
+	assert.equal(normalizeHerdrMetadataValue(" \n\t "), null);
+	assert.equal(
+		normalizeHerdrMetadataValue(" model\nname\u001b]8;;https://spoof\u0007\u202e "),
+		"model name",
+	);
+	const normalized = normalizeHerdrMetadataValue("🐑".repeat(HERDR_METADATA_MAX_CHARACTERS + 1));
+	assert.equal([...String(normalized)].length, HERDR_METADATA_MAX_CHARACTERS);
+	assert.equal(String(normalized).endsWith("🐑"), true);
+});
+
+test("builds complete snapshots and rounds valid context usage", () => {
+	assert.equal(formatContextUsagePercent(12.49), "12%");
+	assert.equal(formatContextUsagePercent(12.5), "13%");
+	assert.equal(formatContextUsagePercent(101.2), "101%");
+	for (const value of [undefined, null, Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+		assert.equal(formatContextUsagePercent(value), null);
+	}
+
+	assert.deepEqual(
+		createHerdrMetadataSnapshot({
+			model: "claude",
+			provider: "anthropic",
+			thinking: "high",
+			session: "Review metadata",
+			contextUsagePercent: 48.6,
+		}),
+		{
+			model: "claude",
+			provider: "anthropic",
+			thinking: "high",
+			session: "Review metadata",
+			context_usage: "49%",
+		},
+	);
+	assert.deepEqual(createHerdrMetadataSnapshot({}), createHerdrMetadataClearSnapshot());
+});
+
+test("compares snapshots by the five stable owned keys", () => {
+	const snapshot = createHerdrMetadataSnapshot({ model: "m" });
+	assert.equal(herdrMetadataSnapshotsEqual(undefined, snapshot), false);
+	assert.equal(herdrMetadataSnapshotsEqual(snapshot, snapshot), true);
+	assert.equal(
+		herdrMetadataSnapshotsEqual(snapshot, createHerdrMetadataSnapshot({ model: "next" })),
+		false,
+	);
+	assert.deepEqual(Object.keys(snapshot), [...HERDR_METADATA_TOKEN_KEYS]);
+	assert.equal(Object.isFrozen(snapshot), true);
+});
+
+test("constructs bounded full-patch requests without pane presentation fields", () => {
+	const snapshot = createHerdrMetadataSnapshot({ model: "m", provider: "p" });
+	const request = createHerdrMetadataRequest({
+		id: "metadata-1",
+		paneId: "w1:p1",
+		source: "herdr:pi",
+		seq: 42,
+		snapshot,
+	});
+	assert.deepEqual(request, {
+		id: "metadata-1",
+		method: "pane.report_metadata",
+		params: {
+			pane_id: "w1:p1",
+			source: "herdr:pi",
+			seq: 42,
+			tokens: {
+				model: "m",
+				provider: "p",
+				thinking: null,
+				session: null,
+				context_usage: null,
+			},
+			ttl_ms: HERDR_METADATA_TTL_MS,
+		},
+	});
+	assert.equal(HERDR_METADATA_REFRESH_MS <= HERDR_METADATA_TTL_MS / 2, true);
+	for (const forbidden of ["title", "display_agent", "state_labels", "agent"]) {
+		assert.equal(forbidden in request.params, false);
+	}
+});

--- a/packages/pi-herdr/test/herdr-skill.test.ts
+++ b/packages/pi-herdr/test/herdr-skill.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "vitest";
+
+const skillUrl = new URL("../skills/herdr/SKILL.md", import.meta.url);
+
+async function readSkill(): Promise<string> {
+	return readFile(skillUrl, "utf8");
+}
+
+test("protects blocked agent startup and prompting contracts", async () => {
+	const skill = await readSkill();
+	for (const contract of [
+		"the command returns `agent_not_ready` immediately but keeps the name available for `agent read` and `agent send-keys`",
+		"Wait until the agent becomes idle before prompting it.",
+		"with `agent_blocked` before sending any input",
+		"Inspect the blocked UI and ask the user before answering it.",
+	]) {
+		assert.ok(skill.includes(contract), `missing safety contract: ${contract}`);
+	}
+});
+
+test("protects stalled prompting and logical-key contracts", async () => {
+	const skill = await readSkill();
+	assert.match(
+		skill,
+		/A prompt sent from a non-working state must produce an observed lifecycle change within five seconds\. Otherwise Herdr returns `agent_prompt_stalled`/u,
+	);
+	assert.match(skill, /Use logical keys for interactive agent UI controls:/u);
+	assert.match(skill, /herdr agent send-keys reviewer esc/u);
+	assert.match(skill, /Herdr validates all keys before writing any bytes\./u);
+});

--- a/packages/pi-herdr/test/herdr-widget.test.ts
+++ b/packages/pi-herdr/test/herdr-widget.test.ts
@@ -204,10 +204,14 @@ test("tracks moved current panes plus agent detection, release, and exit", () =>
 	assert.equal(model.snapshot(), undefined);
 });
 
-test("renders Herdr's distinct static symbol for every agent state", () => {
+test("renders Herdr's distinct static symbol and semantic theme role for every agent state", () => {
+	const roles = new Map<string, string>();
 	const theme = {
 		bold: (text: string) => text,
-		fg: (_role: string, text: string) => text,
+		fg: (role: string, text: string) => {
+			if (/^[×◐✓○·] /u.test(text)) roles.set(text, role);
+			return text;
+		},
 	} as Theme;
 	const widget = createHerdrWidget(
 		{
@@ -249,6 +253,13 @@ test("renders Herdr's distinct static symbol for every agent state", () => {
 	for (const state of ["× blocked", "◐ working", "✓ done", "○ idle", "· unknown"]) {
 		assert.ok(rendered.includes(state), `missing ${state}`);
 	}
+	assert.deepEqual(Object.fromEntries(roles), {
+		"× blocked": "error",
+		"◐ working": "warning",
+		"✓ done": "accent",
+		"○ idle": "success",
+		"· unknown": "dim",
+	});
 });
 
 test("sanitizes before sorting and renders terminal-width-safe themed rows", () => {


### PR DESCRIPTION
## Summary

- publish bounded `model`, `provider`, `thinking`, `session`, and `context_usage` pane tokens with full-patch null clearing, monotonic sequences, one-hour TTL, and 30-minute refresh
- harden metadata coalescing, delayed sends, session replacement, repeated shutdown, stale events, failure tolerance, and orderly clearing
- synchronize the bundled Herdr blocked-agent safety contract and align all widget states with semantic Pi theme roles
- document privacy, sidebar configuration, Phase 2 roadmap completion, package contents, and minor release intent

## Verification

- `npm exec vitest -- run packages/pi-herdr/test --reporter=dot` — 37 tests passed
- `npm run check` — build, Biome, boundaries, and all workspace typechecks passed
- `npm test` — 342 files and 3,391 tests passed
- `npm exec -- changeset status --verbose` — `@narumitw/pi-herdr` remains a minor bump
- live `diff -u packages/pi-herdr/skills/herdr/SKILL.md <(herdr --skill)` — exact match with Herdr 0.8.2
- fenced-code-aware README heading audit — all 29 active package READMEs passed
- `just pack herdr` plus JSON pack inspection — 11 declared files, including the new metadata runtime and bundled skill
- Herdr-managed Pi smoke — initial tokens, `/name` update, `Ctrl+P` model update, Thinking update, preserved user label/title and foreign token, distinct live ANSI widget roles, `/reload`, and orderly five-token shutdown clearing all passed

## Semantic audits

- **Lifecycle:** session-manager ownership, generation guards, abort signals, timer cancellation, coalesced queues, replacement, concurrent repeated shutdown, and stale continuations are covered after every asynchronous boundary.
- **Privacy:** metadata requests contain exactly five documented tokens and never include prompts, conversation content, tool arguments, credentials, paths, or Herdr presentation fields.
- **Terminal safety:** metadata values remove terminal and bidi controls before the 80-character bound; widget rendering remains width-safe and theme-invalidatable.
- **Skill safety:** deterministic tests protect startup-blocked, prompt-blocked, stalled-prompt, logical-key, inspect-first, and user-approval contracts.
- **Conventions:** audited against `docs/extension-conventions.md`, `docs/readme-conventions.md`, Pi extension/TUI/theme/skill/package documentation, and the extension touched-area checklist; no deviations.

Live Windows named-pipe behavior was not exercised on this Linux host; existing deterministic endpoint tests remain passing.
