### PR TITLE
fix(usage): guard stale countdown context

### DIFF
--- a/.changeset/safe-usage-countdowns.md
+++ b/.changeset/safe-usage-countdowns.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Prevent Codex reset countdown timers from crashing Pi when their captured extension context becomes stale during session replacement.

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -207,13 +207,7 @@ export default function usageExtension(
 			const generation = statusGeneration;
 			statusCountdownTimer = setTimeout(() => {
 				statusCountdownTimer = undefined;
-				if (
-					!sessionActive ||
-					generation !== statusGeneration ||
-					modelIdentity(ctx.model) !== modelIdentity(model)
-				) {
-					return;
-				}
+				if (!sessionActive || generation !== statusGeneration) return;
 				publishStatus(ctx, outcome, model, false);
 			}, STATUS_COUNTDOWN_REFRESH_MS);
 			statusCountdownTimer.unref?.();

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -1586,6 +1586,84 @@ test("Codex reset countdown repaints locally and stops across replacement and sh
 	assert.equal(fetches, 2);
 });
 
+test("Codex reset countdown ignores a stale extension context", async (t) => {
+	const originalFetch = globalThis.fetch;
+	vi.useFakeTimers();
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+		vi.useRealTimers();
+	});
+	const now = Date.parse("2026-08-29T00:00:00Z");
+	vi.setSystemTime(now);
+	let fetches = 0;
+	globalThis.fetch = async () => {
+		fetches += 1;
+		return new Response(
+			JSON.stringify({
+				rate_limit: {
+					primary_window: {
+						used_percent: 20,
+						limit_window_seconds: 18_000,
+						reset_at: (now + 150_000) / 1_000,
+					},
+				},
+			}),
+			{ status: 200 },
+		);
+	};
+	const settings = memorySettingsRuntime({ codexStatusResetCountdown: true });
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const { ctx, statuses } = createMockContext({
+		model: codexModel,
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: codexToken } }),
+			getAvailable: () => [codexModel],
+			getAll: () => [codexModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: (provider: string) => provider,
+		},
+	});
+
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	await vi.advanceTimersByTimeAsync(0);
+	assert.equal(statuses.get("usage"), "codex 80% ↻ 3m");
+	assert.equal(fetches, 1);
+
+	const staleError = new Error(
+		"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+	);
+	let staleModelReads = 0;
+	let staleUiReads = 0;
+	Object.defineProperties(ctx, {
+		model: {
+			configurable: true,
+			get() {
+				staleModelReads += 1;
+				throw staleError;
+			},
+		},
+		ui: {
+			configurable: true,
+			get() {
+				staleUiReads += 1;
+				throw staleError;
+			},
+		},
+	});
+
+	await vi.advanceTimersByTimeAsync(60_000);
+	assert.equal(staleModelReads, 0);
+	assert.equal(staleUiReads, 1);
+	assert.equal(statuses.get("usage"), "codex 80% ↻ 3m");
+	assert.equal(fetches, 1);
+
+	await vi.advanceTimersByTimeAsync(60_000);
+	assert.equal(staleModelReads, 0);
+	assert.equal(staleUiReads, 1);
+	assert.equal(fetches, 1);
+});
+
 test("a slow command cannot overwrite status after the selected model changes", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.onTestFinished(() => {


### PR DESCRIPTION
## Summary

- stop Codex reset countdown callbacks from reading `ctx.model` after their session context becomes stale
- retain the existing session and status generation guards while letting `safeSetStatus()` ignore stale UI writes
- add deterministic regression coverage proving stale callbacks do not crash, mutate status, reschedule, or fetch again
- add a patch Changeset for `@narumitw/pi-usage`

Fixes #1149

## Verification

- `npm --workspace @narumitw/pi-usage run check`
- `npm exec vitest -- run packages/pi-usage/test` — 209 tests passed
- `npm run check`
- `npm test` — 3,393 tests passed
- built `packages/pi-usage/dist/index.ts` loaded through Pi's official extension loader with zero stale model reads and no crash
- `git diff --check`

## Audit

Reviewed against `docs/extension-conventions.md` for delayed-context safety, timer cleanup, session replacement, shutdown, status ownership, generated runtime behavior, and Changeset requirements.
The existing five-minute refresh timer reaches context only through its stale-safe refresh path, so no related change was required.
Settings, commands, provider queries, countdown formatting, and refresh frequency remain unchanged.

## Remaining risk

A live Windows 11 interactive `/new` smoke was not run.
The deterministic source regression and generated-runtime loader smoke exercise the reported stale-context boundary.
