### PR TITLE
feat(goal): render completion summaries as markdown

### DIFF
--- a/.changeset/cool-goals-markdown.md
+++ b/.changeset/cool-goals-markdown.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-goal": patch
+---
+
+Render accepted `goal_complete` summaries as sanitized Markdown in the TUI.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -13,6 +13,7 @@ Explicit completion, blocker, and wait tools give each managed run a clear stopp
 - Continues exactly once from Pi's settled idle boundary after queued work, retries, and compaction have finished.
 - Waits quietly for a follow-up when transient provider retries are exhausted instead of terminally blocking the Goal.
 - Uses explicit `goal_complete`, `goal_blocked`, and `goal_wait` tools with stale-goal guards and evidence requirements.
+- Renders an accepted `goal_complete` summary as Markdown in the TUI.
 - Tracks active, paused, blocked, usage-limited, budget-limited, waiting, and complete outcomes separately.
 - Pauses after a configurable response limit or repeated no-progress runs and offers a guided review before continuing.
 - Supports optional token budgets that stop Goal-owned work immediately when exhausted.
@@ -235,7 +236,7 @@ Put longer instructions in a file and reference the file path from `/goal`.
 
 ## 🛠️ Tools
 
-- `goal_complete` records completion only for the exact active goal id and requires an evidence-based summary.
+- `goal_complete` records completion only for the exact active goal id, requires an evidence-based summary, and renders an accepted summary as Markdown in the TUI.
 - `goal_blocked` records a true repeated impasse with the exact goal id, reason, evidence, and repeated-turn count.
 - `goal_wait` pauses automatic continuation after the agent arranges an external wake source, with an optional bounded resume deadline.
 

--- a/packages/pi-goal/src/tools.ts
+++ b/packages/pi-goal/src/tools.ts
@@ -3,8 +3,10 @@ import {
 	DEFAULT_MAX_LINES,
 	defineTool,
 	type ExtensionAPI,
+	getMarkdownTheme,
 	truncateHead,
 } from "@earendil-works/pi-coding-agent";
+import { Markdown } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { notifyTerminal, safeTerminalText } from "./errors.js";
 import {
@@ -76,6 +78,9 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 					"State what was completed and what evidence verified it. Do not use this tool to report partial progress, blockers, failures, or remaining work.",
 			}),
 		}),
+		renderResult(result) {
+			return renderGoalCompletion(result);
+		},
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const completedGoal = runtime.activeGoal;
 			const goal = completedGoal?.text ?? "unknown goal";
@@ -344,6 +349,36 @@ export function registerGoalTools(pi: ExtensionAPI, runtime: GoalRuntime) {
 	pi.registerTool(goalCompleteTool);
 	pi.registerTool(goalBlockedTool);
 	pi.registerTool(goalWaitTool);
+}
+
+interface GoalCompletionRenderResult {
+	content: Array<{ type: string; text?: string }>;
+	details?: unknown;
+}
+
+export function goalCompletionMarkdown(result: GoalCompletionRenderResult) {
+	const content = result.content
+		.filter((block) => block.type === "text" && typeof block.text === "string")
+		.map((block) => block.text)
+		.join("\n")
+		.trim();
+	const completionPrefix = "Goal complete:";
+	if (!content.startsWith(completionPrefix)) return content;
+
+	const details = result.details;
+	const summary =
+		details &&
+		typeof details === "object" &&
+		"summary" in details &&
+		typeof details.summary === "string"
+			? details.summary
+			: content.slice(completionPrefix.length);
+	const safeSummary = safeTerminalText(summary);
+	return safeSummary ? `**Goal complete**\n\n${safeSummary}` : "**Goal complete**";
+}
+
+export function renderGoalCompletion(result: GoalCompletionRenderResult) {
+	return new Markdown(goalCompletionMarkdown(result), 0, 0, getMarkdownTheme());
 }
 
 function toolContent(text: string) {

--- a/packages/pi-goal/test/goal-contracts.test.ts
+++ b/packages/pi-goal/test/goal-contracts.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
 import { test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
 import {
@@ -557,6 +559,40 @@ test("goal_complete requires current goal_id before validating summary", async (
 		assert.doesNotMatch(staleId.content?.[0]?.text ?? "", new RegExp(escapeRegExp(currentGoal.id)));
 		assert.equal(requireLastGoal(mock).id, currentGoal.id);
 		assert.equal(lastGoalStatus(mock), "active");
+	} finally {
+		mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	}
+});
+
+test("goal_complete renders successful summaries as sanitized Markdown", async () => {
+	initTheme("dark", false);
+	const { mock, ctx } = await startGoalForTest();
+	const tool = requireGoalTool(mock, "goal_complete");
+	const goalId = requireLastGoal(mock).id;
+	const summary =
+		"# Verification\n\n- `npm test` passed\n\n```ts\nconst done = true;\n```\n\n\u001b]52;c;clipboard\u0007";
+
+	try {
+		const accepted = await tool.execute(
+			"render-completion",
+			{ goal_id: goalId, summary },
+			new AbortController().signal,
+			() => undefined,
+			ctx,
+		);
+		assert.equal(typeof tool.renderResult, "function");
+
+		const lines = tool
+			.renderResult?.(accepted, { expanded: false, isPartial: false })
+			.render(80)
+			.map((line) => stripTerminalSequences(line));
+		const rendered = lines?.join("\n") ?? "";
+		assert.match(rendered, /Goal complete/);
+		assert.match(rendered, /Verification/);
+		assert.match(rendered, /npm test/);
+		assert.match(rendered, /const done = true;/);
+		assert.doesNotMatch(rendered, /\*\*Goal complete\*\*|# Verification|clipboard/u);
+		assert.ok(lines?.every((line) => line.length <= 80));
 	} finally {
 		mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 	}

--- a/packages/pi-goal/test/support/goal-fixture.ts
+++ b/packages/pi-goal/test/support/goal-fixture.ts
@@ -51,6 +51,10 @@ export function registerGoalWithSettingsPath(
 	goal(pi, { settingsPath: goalSettingsPath });
 }
 export type GoalTool = {
+	renderResult?: (
+		result: unknown,
+		options: { expanded: boolean; isPartial: boolean },
+	) => { render(width: number): string[] };
 	execute: (...args: unknown[]) => Promise<{
 		content?: Array<{ type: string; text: string }>;
 		details?: {


### PR DESCRIPTION
## Summary

- render accepted `goal_complete` summaries as Markdown in the TUI
- sanitize completion text at the display boundary while preserving rejection output
- document the behavior and add a patch Changeset

## Verification

- `npx vitest run packages/pi-goal/test/goal-contracts.test.ts`
- `npm run check`
- `npm test` (3,393 tests)
- `npm run pack:goal`
- `pi --no-extensions -e ./packages/pi-goal --list-models`