### PR TITLE
refactor(goal): isolate legacy queue state

### DIFF
--- a/packages/pi-goal/src/persistence.ts
+++ b/packages/pi-goal/src/persistence.ts
@@ -35,19 +35,21 @@ export interface ActiveGoal {
 	waiting?: GoalWait;
 }
 
+interface LegacyStoredGoal extends Omit<ActiveGoal, "status"> {
+	status: GoalStatus | "queued";
+}
+
 export interface GoalStateEntryData {
 	goal: ActiveGoal | null;
 }
 
 export interface LegacyQueueState {
-	reason: "canonical-queue" | "legacy-goals";
 	retainedGoals: number;
 }
 
 export interface LoadedGoalState {
 	goal: ActiveGoal | undefined;
 	legacyQueueState: LegacyQueueState | undefined;
-	source: "none" | "canonical" | "legacy-goals";
 }
 
 interface SessionEntry {
@@ -79,40 +81,40 @@ export function loadGoalStateFromSession(ctx: SessionContext): LoadedGoalState {
 			(entry) => entry.type === "custom" && entry.customType === LEGACY_GOALS_STATE_ENTRY_TYPE,
 		)
 		.pop();
-	return legacyEntry ? loadLegacyGoalsState(legacyEntry.data) : emptyGoalState("none");
+	return legacyEntry ? loadLegacyGoalsState(legacyEntry.data) : emptyGoalState();
 }
 
 function loadCanonicalGoalState(data: unknown): LoadedGoalState {
-	if (!isRecord(data)) return emptyGoalState("canonical");
+	if (!isRecord(data)) return emptyGoalState();
 	const rawGoal = data.goal;
-	if (rawGoal !== null && !isGoal(rawGoal)) return emptyGoalState("canonical");
+	if (rawGoal !== null && !isStoredGoal(rawGoal)) return emptyGoalState();
 	const rawQueue = Object.hasOwn(data, "queue") ? data.queue : undefined;
 	if (rawQueue !== undefined && (!Array.isArray(rawQueue) || !rawQueue.every(isQueueGoal))) {
-		return emptyGoalState("canonical");
+		return emptyGoalState();
 	}
 	const pendingAction = Object.hasOwn(data, "pendingAction")
 		? normalizeCanonicalPendingAction(data.pendingAction)
 		: undefined;
-	if (Object.hasOwn(data, "pendingAction") && !pendingAction) return emptyGoalState("canonical");
+	if (Object.hasOwn(data, "pendingAction") && !pendingAction) return emptyGoalState();
 	const hasQueueFields = rawQueue !== undefined || pendingAction !== undefined;
-	if (hasQueueFields || (isGoal(rawGoal) && rawGoal.status === "queued")) {
-		return legacyQueueState("canonical", {
-			reason: "canonical-queue",
+	if (hasQueueFields || (isStoredGoal(rawGoal) && rawGoal.status === "queued")) {
+		return legacyQueueState({
 			retainedGoals: countCanonicalLegacyGoals(rawGoal, rawQueue, pendingAction),
 		});
 	}
 
-	let goal = rawGoal === null ? undefined : normalizeLoadedGoal(rawGoal);
+	let goal =
+		rawGoal === null || !isCanonicalGoal(rawGoal) ? undefined : normalizeLoadedGoal(rawGoal);
 	if (goal?.status === "complete") goal = undefined;
-	return { goal, legacyQueueState: undefined, source: "canonical" };
+	return { goal, legacyQueueState: undefined };
 }
 
 function countCanonicalLegacyGoals(
 	goal: unknown,
-	queue: ActiveGoal[] | undefined,
+	queue: LegacyStoredGoal[] | undefined,
 	pendingAction: { kind: string } | undefined,
 ) {
-	let count = isGoal(goal) && goal.status !== "complete" ? 1 : 0;
+	let count = isStoredGoal(goal) && goal.status !== "complete" ? 1 : 0;
 	count += (queue ?? []).filter((queuedGoal) => queuedGoal.status !== "complete").length;
 	if (pendingAction?.kind === "prioritize") count += 1;
 	return count;
@@ -134,27 +136,26 @@ function normalizeCanonicalPendingAction(value: unknown): { kind: string } | und
 }
 
 function loadLegacyGoalsState(data: unknown): LoadedGoalState {
-	if (!isRecord(data)) return emptyGoalState("legacy-goals");
-	let rawGoals: ActiveGoal[];
+	if (!isRecord(data)) return emptyGoalState();
+	let rawGoals: LegacyStoredGoal[];
 	if (Array.isArray(data.goals)) {
-		if (!data.goals.every(isGoal)) return emptyGoalState("legacy-goals");
+		if (!data.goals.every(isStoredGoal)) return emptyGoalState();
 		rawGoals = data.goals.filter((goal) => goal.status !== "complete");
-	} else if (isGoal(data.goal) && data.goal.status !== "complete") {
+	} else if (isStoredGoal(data.goal) && data.goal.status !== "complete") {
 		rawGoals = [data.goal];
 	} else {
 		rawGoals = [];
 	}
 	const pendingAction = normalizeLegacyPendingPrioritize(data.pendingUnshift);
-	if (rawGoals.length === 1 && rawGoals[0]?.status !== "queued" && pendingAction === undefined) {
+	const onlyGoal = rawGoals.length === 1 ? rawGoals[0] : undefined;
+	if (onlyGoal && isCanonicalGoal(onlyGoal) && pendingAction === undefined) {
 		return {
-			goal: normalizeLoadedGoal(rawGoals[0]),
+			goal: normalizeLoadedGoal(onlyGoal),
 			legacyQueueState: undefined,
-			source: "legacy-goals",
 		};
 	}
-	if (rawGoals.length === 0 && pendingAction === undefined) return emptyGoalState("legacy-goals");
-	return legacyQueueState("legacy-goals", {
-		reason: "legacy-goals",
+	if (rawGoals.length === 0 && pendingAction === undefined) return emptyGoalState();
+	return legacyQueueState({
 		retainedGoals: rawGoals.length + (pendingAction ? 1 : 0),
 	});
 }
@@ -222,7 +223,7 @@ function readState(): Record<string, unknown> {
 	}
 }
 
-function isGoal(value: unknown): value is ActiveGoal {
+function isStoredGoal(value: unknown): value is LegacyStoredGoal {
 	if (!isRecord(value)) return false;
 	return (
 		typeof value.id === "string" &&
@@ -249,29 +250,28 @@ function isGoal(value: unknown): value is ActiveGoal {
 	);
 }
 
-function isQueueGoal(value: unknown): value is ActiveGoal {
-	return isGoal(value) && value.status !== "complete";
+function isCanonicalGoal(goal: LegacyStoredGoal): goal is ActiveGoal {
+	return goal.status !== "queued";
+}
+
+function isQueueGoal(value: unknown): value is LegacyStoredGoal {
+	return isStoredGoal(value) && value.status !== "complete";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function emptyGoalState(source: LoadedGoalState["source"]): LoadedGoalState {
+function emptyGoalState(): LoadedGoalState {
 	return {
 		goal: undefined,
 		legacyQueueState: undefined,
-		source,
 	};
 }
 
-function legacyQueueState(
-	source: LoadedGoalState["source"],
-	legacyQueue: LegacyQueueState,
-): LoadedGoalState {
+function legacyQueueState(legacyQueue: LegacyQueueState): LoadedGoalState {
 	return {
 		goal: undefined,
 		legacyQueueState: legacyQueue,
-		source,
 	};
 }

--- a/packages/pi-goal/src/prompts.ts
+++ b/packages/pi-goal/src/prompts.ts
@@ -3,7 +3,6 @@ import { MIN_GOAL_WAIT_DELAY_MS } from "./wait.js";
 
 export type GoalStatus =
 	| "active"
-	| "queued"
 	| "paused"
 	| "blocked"
 	| "usage_limited"

--- a/packages/pi-goal/src/run-protocol.ts
+++ b/packages/pi-goal/src/run-protocol.ts
@@ -15,7 +15,7 @@ export const GOAL_RUN_CANCEL_CHANNEL = "pi-goal:cancel";
 const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 const MAX_CANCEL_REASON_LENGTH = 1_000;
 
-export type GoalRunStatus = Exclude<GoalStateSnapshot["status"], "queued">;
+export type GoalRunStatus = GoalStateSnapshot["status"];
 export type GoalRunErrorCode =
 	| "RPC_DISABLED"
 	| "INVALID_REQUEST"
@@ -324,7 +324,7 @@ export class GoalRunController {
 			});
 			return;
 		}
-		if (snapshot.status === "queued" || run.lastStatus === snapshot.status) return;
+		if (run.lastStatus === snapshot.status) return;
 		this.publishStateEvent(run, snapshot);
 	}
 
@@ -333,7 +333,6 @@ export class GoalRunController {
 		snapshot: Pick<GoalStateSnapshot, "goalId" | "status" | "summary" | "reason">,
 	) {
 		const status = snapshot.status;
-		if (status === "queued") return;
 		run.lastStatus = status;
 		const event: GoalRunEvent = {
 			type: "state",

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -139,7 +139,7 @@ export interface GoalStateSnapshot {
 
 /** Terminal statuses for Goal persistence and managed-run lifecycle publication. */
 export function isTerminalGoalStatus(status: GoalStateSnapshotStatus): boolean {
-	return status !== "active" && status !== "queued";
+	return status !== "active";
 }
 
 function buildGoalStateSnapshot(
@@ -203,10 +203,10 @@ const CONTRADICTORY_COMPLETION_PATTERNS = [
 // One instance belongs to one extension factory. It owns all mutable session state
 // and the cross-cutting invariants used by command and lifecycle orchestration.
 // Keep this state machine cohesive despite its size: prompt ownership, continuation,
-// budget, safety, external-wait, and queue transitions share ordering-sensitive invariants.
+// budget, safety, and external-wait transitions share ordering-sensitive invariants.
 // Tool availability and generic wait-timer mechanics are delegated to focused collaborators.
-// Cohesion justification: Goal transitions, continuation and wait ownership, queue state, and
-// budget/retry recovery share one generation-guarded runtime; separating them further would
+// Cohesion justification: Goal transitions, continuation and wait ownership, and budget/retry
+// recovery share one generation-guarded runtime; separating them further would
 // duplicate stale-turn, timer, and persistence invariants across modules.
 export class GoalRuntime {
 	settings: GoalSettings = DEFAULT_GOAL_SETTINGS;
@@ -1466,7 +1466,6 @@ export function formatStatus(
 		automaticTurnLimit === null
 			? "automatic Unlimited"
 			: `automatic ${goal.automaticModelTurns}/${automaticTurnLimit}`;
-	if (goal.status === "queued") return `queued · ${automatic}`;
 	if (goal.waiting) {
 		return `waiting ${safeGoalMenuText(goal.waiting.reason)} · ${automatic}`;
 	}
@@ -1615,20 +1614,17 @@ async function sendPrompt(
 	}
 }
 
-function goalCommandHint(goal: ActiveGoal, experimentalGoals = false) {
-	const queueCommands = experimentalGoals
-		? ", /goal add <objective>, /goal prioritize <objective>, /goal drop-last, /goal skip"
-		: "";
+function goalCommandHint(goal: ActiveGoal) {
 	if (goal.waiting) {
-		return `/goal resume, /goal edit <objective>, /goal pause, /goal clear${queueCommands}`;
+		return "/goal resume, /goal edit <objective>, /goal pause, /goal clear";
 	}
 	if (goal.status === "active") {
-		return `/goal edit <objective>, /goal pause, /goal clear${queueCommands}`;
+		return "/goal edit <objective>, /goal pause, /goal clear";
 	}
 	if (isResumableGoalStatus(goal.status)) {
-		return `/goal edit <objective>, /goal resume, /goal clear${queueCommands}`;
+		return "/goal edit <objective>, /goal resume, /goal clear";
 	}
-	return `/goal edit <objective>, /goal clear${queueCommands}`;
+	return "/goal edit <objective>, /goal clear";
 }
 
 function continuationMarker(goal: ActiveGoal) {

--- a/packages/pi-goal/test/persistence.test.ts
+++ b/packages/pi-goal/test/persistence.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../src/persistence.js";
 
 const active = storedGoal("active", "active");
-const queued = storedGoal("queued", "queued");
+const queued = { ...storedGoal("queued", "active"), status: "queued" as const };
 
 function branch(...entries: Array<{ customType: string; data: unknown }>) {
 	return {
@@ -32,7 +32,6 @@ test("canonical persistence restores ordinary single goals", () => {
 		branch({ customType: "goal-state", data: serializeGoalState(active) }),
 	);
 
-	assert.equal(loaded.source, "canonical");
 	assert.equal(loaded.goal?.text, "active");
 	assert.equal(loaded.legacyQueueState, undefined);
 });
@@ -51,12 +50,8 @@ test("canonical queue metadata is inert legacy state", () => {
 		}),
 	);
 
-	assert.equal(loaded.source, "canonical");
 	assert.equal(loaded.goal, undefined);
-	assert.deepEqual(loaded.legacyQueueState, {
-		reason: "canonical-queue",
-		retainedGoals: 3,
-	});
+	assert.deepEqual(loaded.legacyQueueState, { retainedGoals: 3 });
 });
 
 test("queued canonical heads are inert legacy queue state", () => {
@@ -65,14 +60,11 @@ test("queued canonical heads are inert legacy queue state", () => {
 	);
 
 	assert.equal(loaded.goal, undefined);
-	assert.deepEqual(loaded.legacyQueueState, {
-		reason: "canonical-queue",
-		retainedGoals: 1,
-	});
+	assert.deepEqual(loaded.legacyQueueState, { retainedGoals: 1 });
 });
 
 test("canonical entries take precedence over older plural state, including explicit clear", () => {
-	const plural = { goals: [storedGoal("legacy", "active"), storedGoal("later", "queued")] };
+	const plural = { goals: [storedGoal("legacy", "active"), queued] };
 	const loaded = loadGoalStateFromSession(
 		branch(
 			{ customType: "goals-state", data: plural },
@@ -80,7 +72,6 @@ test("canonical entries take precedence over older plural state, including expli
 		),
 	);
 
-	assert.equal(loaded.source, "canonical");
 	assert.equal(loaded.goal, undefined);
 	assert.equal(loaded.legacyQueueState, undefined);
 });
@@ -94,12 +85,8 @@ test("legacy plural state is inert unless it contains exactly one ordinary goal"
 		}),
 	);
 
-	assert.equal(loaded.source, "legacy-goals");
 	assert.equal(loaded.goal, undefined);
-	assert.deepEqual(loaded.legacyQueueState, {
-		reason: "legacy-goals",
-		retainedGoals: 3,
-	});
+	assert.deepEqual(loaded.legacyQueueState, { retainedGoals: 3 });
 });
 
 test("a legacy single goal becomes ordinary singular state", () => {
@@ -114,7 +101,6 @@ test("a legacy single goal becomes ordinary singular state", () => {
 		branch({ customType: "goals-state", data: { goals: [legacyGoal] } }),
 	);
 
-	assert.equal(loaded.source, "legacy-goals");
 	assert.equal(loaded.goal?.text, "active");
 	assert.equal(loaded.goal?.automaticModelTurns, 0);
 	assert.equal(loaded.goal?.toolFreeRepeatCount, 0);


### PR DESCRIPTION
## Summary

- confine the retired `queued` status to the legacy session persistence boundary
- remove unused migration metadata, runtime branches, and stale queue comments
- preserve single-goal restoration and inert handling for queued or multi-goal legacy sessions

## Verification

- `npm run check`
- `npm test` — 3,394 tests passed
- headless Pi RPC load smoke with `get_commands` against `./packages/pi-goal`

No changeset is included because this refactor preserves published behavior and the legacy compatibility contract.
