### PR TITLE
docs: improve README paragraph formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@
 - Use clear, familiar words and concise, accurate sentences without repetition.
 - Explain the main idea simply before adding technical detail.
 - Make documented rules specific and verifiable.
-- Write one sentence per source line in prose.
+- In human-facing documentation such as README files, use concise paragraphs for narrative text and lists only when separate items are easier to scan.
+- Keep AGENTS.md instructions as bullet lists with one enforceable sentence per bullet.
 
 ## Repository structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,7 @@
 
 ## Commands
 
-Run commands from the repository root unless a command says otherwise.
-
+- Run commands from the repository root unless a command says otherwise.
 - Run `npm install` to install dependencies.
 - Run `npm run format` to format with Biome.
 - Run `npm run typecheck` to typecheck every workspace.

--- a/docs/readme-conventions.md
+++ b/docs/readme-conventions.md
@@ -55,7 +55,8 @@ Do not remove supported behavior, compatibility guidance, or safety details mere
 ## Content rules
 
 Write user-facing prose in English.
-Put each prose sentence on its own source line.
+Group narrative text into concise Markdown paragraphs, keeping related source lines together without blank lines between every sentence.
+Use lists when independent items, choices, steps, or references are easier to scan separately.
 Keep the introduction and Features section concise enough to scan before installation.
 Document only commands, tools, settings, modes, and guarantees implemented by the package.
 Treat model IDs, paths, session text, and pasted text shown in examples as untrusted terminal input where relevant.

--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -146,7 +146,6 @@ It applies the returned API key, headers, and endpoint, then verifies the effect
 If refresh, conversion, provider overlay, or verification fails, the extension installs a non-secret failing runtime credential and aborts turns for that provider.
 It does not silently fall back to Pi's built-in login, an environment API key, or another named account.
 Other providers remain independent and usable.
-
 Selecting `default` removes the package-owned runtime override and restores the exact provider registration that existed before activation.
 Pi's built-in credentials are never deleted.
 

--- a/packages/pi-analytics/README.md
+++ b/packages/pi-analytics/README.md
@@ -131,7 +131,6 @@ Linked storage roots, markers, and writer files are rejected.
 
 Stored fields are limited to timestamps and durations; extension-generated record IDs; provider/model IDs and thinking level; tool and skill names; user/model skill source; counts, outcomes, and completion states; HTTP status codes; and classified provider-error categories.
 Provider-supplied tool-call IDs are replaced with local ordinals before publication.
-
 The extension does **not** store prompts, responses, thinking content, tool arguments or results, raw error messages, HTTP headers, cwd/project/file paths, session names or IDs, or credentials.
 
 Each finalized response cycle is one versioned, newline-terminated frame.

--- a/packages/pi-chat/README.md
+++ b/packages/pi-chat/README.md
@@ -5,7 +5,6 @@
 Join ephemeral peer-to-peer chat rooms without leaving Pi.
 Chat messages stay out of prompts, model context, repositories, and agent output.
 Pi Chat is not an anonymous or reliable messaging service.
-
 Pi Chat uses Hyperswarm and HyperDHT for peer discovery and encrypted Noise streams for direct connections.
 
 ## ✨ Features

--- a/packages/pi-chrome-devtools/README.md
+++ b/packages/pi-chrome-devtools/README.md
@@ -3,9 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-chrome-devtools)](https://www.npmjs.com/package/@narumitw/pi-chrome-devtools) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 Inspect browser tabs, navigate pages, evaluate JavaScript, and capture screenshots from Pi through the Chrome DevTools Protocol.
-
 Use these native Pi tools for web debugging, UI validation, and browser-assisted investigation without an MCP server.
-
 The design is inspired by [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp), but compatibility is not guaranteed.
 
 ## ✨ Features
@@ -206,29 +204,21 @@ It never closes user-started browsers or remote endpoints.
 ### Tool exposure
 
 The extension registers eight tools: one loader, five stable DevTools capabilities, and two fixed experimental WebMCP gateways.
-
 With native deferred-tool support, only `chrome_devtools_load` starts active.
-
 The loader accepts a task-oriented `query`, matches it against the five stable capabilities plus enabled WebMCP gateways, and adds matching available tools without removing any active Pi tool.
-
 Loaded capability tools remain active for the rest of the session unless the user makes them unavailable through `/chrome-devtools`.
 
 Pi uses native deferred tool references on compatible Anthropic models, native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models, and native Kimi loading on compatible OpenAI Chat Completions models.
-
 Kimi-compatible models declare `compat.deferredToolsMode: "kimi"` in Pi's model metadata.
-
 `azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
 
 When the selected model/provider lacks native deferred support, the extension activates every capability allowed by settings before the next model request instead of using Pi's cache-invalidating lazy-loading fallback.
-
 After a session enters eager exposure, it stays eager across later model switches to avoid removing tool definitions within that session.
-
 The capability tools omit active-only prompt snippets so native deferred loading does not rebuild the system-prompt prefix.
 
 The saved `tools` array controls which capabilities the extension may expose.
 The `webmcp.enabled` gate takes precedence, so persisted WebMCP names cannot bypass a disabled gate.
 Page-provided tool definitions appear only in list results and never alter Pi's provider-visible tool definitions.
-
 An empty array leaves the loader active but makes every browser capability unavailable.
 
 ### Screenshot files

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -4,7 +4,6 @@
 
 Use Codex Remote Compaction V2 in Pi for models that use the `openai-codex-responses` API.
 The extension stores an opaque server-generated checkpoint and replays it in later compatible requests instead of generating a local plaintext summary.
-
 Pi still decides when compaction runs and keeps its normal `/compact`, threshold, overflow, and session-publication behavior.
 
 ## ✨ Features
@@ -188,11 +187,8 @@ These hard byte ceilings are intentionally not configurable.
 ## 📊 Benchmark
 
 The repository includes a seeded benchmark that compares uncompressed full context, Pi-native plaintext compaction, and this extension's Remote V2 path.
-
 It keeps history length nearly fixed while varying information density across five state categories and ten history epochs.
-
 Benchmark v3 uses repeated artifacts, isolated evaluator probes, seed-level paired statistics, one Pi SDK estimator for dry and live fixtures, and committed protocol manifests for confirmatory candidates.
-
 It never treats nominal Pi 20K and Codex 20K settings as equal information capacity or automatically claims that protocol-conformant evidence was genuinely held out.
 
 Preview its exploratory diagnostic without making a provider request:
@@ -202,9 +198,7 @@ npm run benchmark:codex-compact
 ```
 
 A live run requires `--live`, review of the request and cost exposure, OpenAI Codex OAuth, and Remote V2 entitlement.
-
 The repository preserves the explicitly labeled v2 matched-tail diagnostic and the v3 calibration evidence, while seeds 301–304 remain consumed and unavailable for future confirmatory protocols.
-
 See the [benchmark guide](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-codex-compact/benchmark) for manifests, repetitions, commands, privacy, cost semantics, and interpretation limits.
 
 ## 🧪 Development

--- a/packages/pi-file-context/README.md
+++ b/packages/pi-file-context/README.md
@@ -102,7 +102,6 @@ Diff context is never attached automatically.
 ## ⚙️ Settings
 
 File Context reads optional user settings from `~/.pi/agent/pi-file-context.json`, or the equivalent file under Pi's configured agent directory.
-
 Using the defaults does not create the file.
 
 Open `/file-context`, choose **Settings**, then choose **Open shortcut** to change or disable it.

--- a/packages/pi-firecrawl/README.md
+++ b/packages/pi-firecrawl/README.md
@@ -95,37 +95,24 @@ The legacy filename is deprecated and will be removed in a future major release.
 ### Tool exposure
 
 The extension registers six tools: one loader and five API capabilities.
-
 With native deferred-tool support, only `firecrawl_load` starts active.
-
 The loader accepts a task-oriented `query`, filters to capabilities allowed by settings, and adds up to three matching tools by default without removing any active Pi tool.
-
 Set `limit` from 1 to 5 to change the maximum number loaded by one call.
-
 A general website-crawl query can load both `firecrawl_crawl` and `firecrawl_crawl_status`, while a status-specific query loads the status capability.
-
 Loaded capability tools remain active for the current session until you make them unavailable through `/firecrawl`.
-
 On reload, resume, or fork, capabilities recorded by `firecrawl_load` on the active branch are restored when the current catalog still allows them.
 
 Pi uses native deferred tool references on compatible Anthropic models, native additional-tools or tool-search loading on compatible OpenAI and Codex Responses models, and native Kimi loading on compatible OpenAI Chat Completions models.
-
 Kimi-compatible models declare `compat.deferredToolsMode: "kimi"` in Pi's model metadata.
-
 `azure-openai-responses` remains eager because Pi's Azure adapter does not implement native deferred tool-search serialization.
-
 When the selected model/provider lacks native deferred support, the extension activates every capability allowed by settings before the next model request instead of using Pi's cache-invalidating lazy-loading fallback.
-
 After a session enters eager exposure, it stays eager across later model switches to avoid removing tool definitions within that session.
-
 The capability tools omit active-only prompt metadata so native deferred loading does not rebuild the system-prompt prefix.
 
 The saved `tools` array controls which capabilities the extension may expose.
-
 An empty array leaves the loader active but makes every Firecrawl API capability unavailable.
 
 `firecrawl_load` performs no network request and does not create response artifacts.
-
 Every API capability fails with a clear configuration error when `FIRECRAWL_API_KEY` is missing, and the always-active loader guidance tells the agent not to retry repeatedly.
 
 Tool output is limited to 50 KB or 2,000 lines, whichever is reached first.
@@ -165,13 +152,10 @@ Direct subcommands are also available:
   The slash command and `firecrawl_load` remain available.
 
 The menu, `tools`, `help`, `config`, `quickstart`, and `status` routes require TUI or RPC mode.
-
 Print and JSON modes reject those routes and unknown commands before entering interactive UI.
-
 The deterministic `enable` and `disable` routes remain available in every mode.
 
 Tool-selector toggles save immediately in user action order.
-
 Done, Escape, or cancellation closes the selector without undoing changes that were already saved.
 
 ## 🔒 Security and privacy
@@ -241,7 +225,6 @@ packages/pi-firecrawl/
 ```
 
 `index.ts` is the Pi entrypoint and forwards to `firecrawl.ts`; the other source modules are internal.
-
 The generated runtime is built from the authoritative `src/index.ts` graph and does not import back into `src`.
 
 ## 🔎 Keywords

--- a/packages/pi-fleet/README.md
+++ b/packages/pi-fleet/README.md
@@ -4,7 +4,6 @@
 
 Launch another Pi process in a terminal split without replacing the current session.
 You can also connect trusted local Pi sessions for bounded notifications and one-turn requests.
-
 Pi Fleet detects tmux, Zellij, or Ghostty automatically, and you can pin a backend when needed.
 
 ## ✨ Features
@@ -39,7 +38,6 @@ pi --no-extensions --no-skills --no-session -e ./packages/pi-fleet
 ```
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
-
 A child started in any supported terminal uses normal Pi extension discovery.
 Install Pi Fleet persistently to test split-and-auto-join because the child does not inherit the parent's temporary `-e` argument.
 

--- a/packages/pi-github-pr/README.md
+++ b/packages/pi-github-pr/README.md
@@ -3,7 +3,6 @@
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-github-pr)](https://www.npmjs.com/package/@narumitw/pi-github-pr) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 See the current branch's pull request number, checks, review state, and discussion count in Pi's statusline.
-
 The extension reads only GitHub pull request metadata.
 It does not register a command or model tool, render a widget, or inject model context.
 

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -4,7 +4,6 @@
 
 Give Pi one session-scoped objective and let it continue after Pi becomes fully idle.
 Goal mode stops when work completes, pauses, waits for an external event, or reaches a safety limit.
-
 Explicit completion, blocker, and wait tools give each managed run a clear stopping reason.
 
 ## ✨ Features
@@ -124,8 +123,8 @@ Settings are reread at Pi startup, session replacement, and `/reload`.
 Direct file edits are not watched, while Goal-menu changes apply immediately.
 A missing file remains absent and uses the built-in defaults.
 The first successful settings change creates the file atomically; later saves preserve unknown fields.
-
 Omitted fields use the defaults above.
+
 Invalid or malformed existing settings are never overwritten; they produce a warning and fall back to all defaults.
 In the TUI, Goal Settings becomes a read-only summary that identifies the invalid file and tells you to fix it and run `/reload`.
 
@@ -227,7 +226,6 @@ Guaranteed coexistence with Plan mode requires `@narumitw/pi-plan-mode` `0.52.0`
 The experimental ordered-goal queue has been removed.
 Use `/goal edit <objective>` to reprioritize the active objective instead.
 For example, if `task b` is complete and `task c` is in progress, edit the objective to say: `task b is complete; do task a next; after task a, continue task c, then task d; do not redo task b unless verification shows it is incomplete.`
-
 Former queue command words such as `add`, `prioritize`, `drop-last`, `skip`, `push`, `unshift`, `pop`, and `shift` are ordinary objective text for unaffected users.
 If a session still has legacy queue settings or persisted queue state, those words show a migration warning instead of replacing the active Goal.
 

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -295,6 +295,7 @@ Saved plans and ordinary implementation after Plan handoff do not hold the group
 Every inactive start performs one final synchronous admission after asynchronous preflight and before changing Plan state, persistence, prompts, tools, thinking level, queues, or status.
 If another participant is active, TUI and RPC show an anonymous warning that another workflow is active.
 Print and JSON direct routes throw the same anonymous error before mutation.
+
 Launch-menu, selected-tool, shortcut, active-implementation **Start a new plan**, and restored activation use the same admission boundary.
 A rejected selected-tool launch does not save its draft choices.
 

--- a/packages/pi-recall/README.md
+++ b/packages/pi-recall/README.md
@@ -97,7 +97,6 @@ The saved-message TUI has three flat display views:
 The view uses Pi's injected `app.tree.filter.cycleForward` and `app.tree.filter.cycleBackward` bindings, which default to `Ctrl+O` and `Ctrl+Shift+O`.
 Pi Recall reserves `Ctrl+D` for deletion instead of reusing `/tree`'s direct filter bindings.
 The picker shows the active view, filtered count, cursor position, and configured cycle keys.
-
 Scope, view, query, and selection survive record opening and deletion attempts within one `/recall` flow.
 After successful deletion, selection moves to a neighboring visible record.
 RPC asks for scope explicitly and shows the complete scoped list without TUI-only view or search shortcuts.
@@ -140,7 +139,6 @@ This provenance is shown locally but is excluded from generated quote payloads e
 
 Pi Recall creates no settings, session custom entries, tools, background work, or automatic model context.
 It reads storage only while `/recall` needs it.
-
 Save and delete operations acquire one cross-process lock, reread canonical storage under that lock, and publish a complete JSONL replacement through a unique same-directory `0600` temporary file.
 Lock waiting is abort-aware.
 The canonical file is required to be a regular non-symlink file and is kept at `0600`.

--- a/packages/pi-stamp/README.md
+++ b/packages/pi-stamp/README.md
@@ -130,7 +130,6 @@ Missing settings do not create a file or directory.
 Updates preserve unknown fields and publish through a private temporary file plus atomic rename.
 Malformed or invalid files become read-only and are never overwritten; fix the reported file and run `/reload`.
 A fresh process uses defaults while the file is invalid, and a running process retains its last valid settings.
-
 Reads and writes are serialized within one Pi process.
 Separate Pi processes do not share a lock, so concurrent saves are last-writer-wins even though each process rereads immediately before atomic publication.
 

--- a/packages/pi-starship/README.md
+++ b/packages/pi-starship/README.md
@@ -713,7 +713,6 @@ The Cargo package lookup is the only ancestor walk and stops after eight parents
 Create `src/modules/<name>.ts` with its format variables, defaults, and runtime value resolver, then register it in display order in `src/modules/catalog.ts`.
 Configuration names, validation variables, defaults, and `$all` ordering are derived from that catalog.
 Add the module to the built-in root format only when it should be visible by default, then document and test its user-facing values.
-
 Keep `extension_status` last in the catalog so arbitrary third-party statuses follow native module output.
 
 ## 🗂️ Package layout

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -20,7 +20,6 @@ Pi Subagents runs Pi jobs in separate child processes and supports authenticated
 ## 📦 Install
 
 The version 3 runtime documented here is not yet published to npm.
-
 The npm package still contains the legacy 2.x runtime and does not provide the tools below.
 
 Install the repository source as one Pi package:
@@ -49,11 +48,9 @@ pi --no-extensions -e ./packages/pi-subagents
 ```
 
 The package entry is generated at `dist/index.ts` and loaded through Pi's Jiti runtime.
-
 An unbuilt local package directory cannot load its declared extension entry.
 
 Pi extensions and children with `bash`, `powershell`, `edit`, or `write` execute with your user permissions.
-
 Review the source before installing or invoking the extension.
 
 ## 🚀 Quick start
@@ -61,27 +58,19 @@ Review the source before installing or invoking the extension.
 Call `subagent_spawn` with a self-contained task and only the work tools that task needs.
 
 The package intentionally does not register or publish a skill.
-
 Create a project skill under `.pi/skills/<your-skill>/SKILL.md` or a global skill under `~/.pi/agent/skills/<your-skill>/SKILL.md` when you want reusable delegation policy.
-
 Choose a name, trigger description, tool policy, task format, and verification workflow for your own use case.
-
 The repository-only [`using-pi-subagents` example](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-subagents/skills/using-pi-subagents) demonstrates one possible design without imposing it on installed users.
 
-The call returns a `jobId` immediately, and the job continues in the background.
-
-Continue useful main-agent work until the result is required or a completion arrives.
-
-Call `subagent_send` with `recipient: jobId` to ask an active child a question.
-
-If `subagent_wait` returns `reason: "subagent_message"`, handle the visible request or response and wait for the job again only when needed.
-
-Answer a child-originated request by calling `subagent_send` with its `requestId`.
+1. The call returns a `jobId` immediately, and the job continues in the background.
+2. Continue useful main-agent work until the result is required or a completion arrives.
+3. Call `subagent_send` with `recipient: jobId` to ask an active child a question.
+4. If `subagent_wait` returns `reason: "subagent_message"`, handle the visible request or response and wait for the job again only when needed.
+5. Answer a child-originated request by calling `subagent_send` with its `requestId`.
 
 Completion messages follow Pi's global tool-output expansion state and the `app.tools.expand` binding (`Ctrl+O` by default).
 
 In TUI mode, the above-editor widget shows each queued or running job's ID, state, elapsed time, timeout, and selected work tools.
-
 The widget omits the fixed communication tools, disappears when no jobs remain active, and clears when the session ends.
 
 ## 🛠️ Tools
@@ -103,34 +92,23 @@ Every child exposes these communication tools in addition to its selected work t
 | `subagent_send` | optional `requestId`, plus `message` | Omit `requestId` to send a new request to main, or provide it to answer one pending main-agent request. |
 | `subagent_wait` | `requestId`, optional `timeout` | Wait for the main agent's plain-text response to a child-originated request. |
 
-Main and child processes receive separate provider-visible `subagent_send` definitions for their own context.
+Main and child processes receive separate provider-visible `subagent_send` definitions for their own context:
 
-The main agent starts a request with an active job ID as `recipient` and omits `requestId`.
-
-The main agent answers a child request with `requestId` and omits `recipient`.
-
-A child starts a request to main by omitting `requestId`.
-
-A child answers a main-agent request by providing `requestId`.
+- The main agent starts a request with an active job ID as `recipient` and omits `requestId`.
+- The main agent answers a child request with `requestId` and omits `recipient`.
+- A child starts a request to main by omitting `requestId`.
+- A child answers a main-agent request by providing `requestId`.
 
 Execution and wait timeouts use seconds, accept finite numbers greater than zero through 2,147,483.647, and have no default.
-
 Omitting a job execution timeout lets the child run until it exits, is cancelled, the session shuts down, or the Pi process exits.
-
 A wait timeout or caller cancellation stops only that wait and does not cancel its job or message request.
-
 An incoming main-agent request interrupts an active child `subagent_wait` after RPC steering is queued so the child can receive the new request.
-
 The interrupted child-originated request remains active and may be waited on again.
 
 Tasks are limited to 50 KiB of UTF-8 text.
-
 Requests and responses are limited to 48 KiB and 1,992 lines so their protocol envelopes fit Pi's 50 KiB and 2,000-line model-text bounds without truncating accepted content.
-
 Each job may have up to four unresolved or answered-but-not-consumed requests across both directions.
-
 The terminal states are `completed`, `partial`, `failed`, `timed_out`, and `cancelled`.
-
 `subagent_inspect` never returns complete task text, child output, prompts, selected tools, context, credentials, environment variables, requests, responses, or secrets.
 
 See [`docs/tools.md`](./docs/tools.md) for the concise schema reference.
@@ -138,85 +116,56 @@ See [`docs/tools.md`](./docs/tools.md) for the concise schema reference.
 ## ⚙️ Job configuration
 
 The task should state the child's role, objective, scope, constraints, and expected result.
+The optional `tools` list limits what the child can do:
 
-The optional `tools` list limits what the child can do.
-
-Accepted names are `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`.
-
-Unavailable or extension-only tool names are rejected before a job is queued.
-
-Omitting `tools` selects `read`, `grep`, `find`, and `ls`.
-
-Passing an empty list gives the child no work tools.
-
-The runtime always adds `subagent_send` and child `subagent_wait` and removes duplicate names.
+- Accepted names are `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`.
+- Unavailable or extension-only tool names are rejected before a job is queued.
+- Omitting `tools` selects `read`, `grep`, `find`, and `ls`.
+- Passing an empty list gives the child no work tools.
+- The runtime always adds `subagent_send` and child `subagent_wait` and removes duplicate names.
 
 Adding `edit` or `write` lets the child modify files.
-
 Adding `bash` or `powershell` grants unrestricted command execution and can also modify the workspace.
 
 The optional `thinkingLevel` accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
-
 Omitting `thinkingLevel` captures the main agent's effective level when `subagent_spawn` executes.
-
 The child inherits the main agent's effective provider and model when `subagent_spawn` executes.
 
 Spawn rejects providers registered by a parent extension because child processes disable unrelated extensions.
-
 Spawn also rejects process-local runtime API keys, including a parent-only `--api-key` value.
-
 Use stored or environment credentials that child processes can read.
-
 The extension does not expose a per-job model override.
 
 ## 🔄 Messaging, lifecycle, and retention
 
 The session starts one TCP broker on `127.0.0.1` with an operating-system-assigned ephemeral port.
-
 Each job receives one cryptographically random token bound to its job identity and session generation.
-
 The parent passes the broker credentials once through a private inherited pipe instead of placing them in the child's initial environment or command line.
-
 The child bridge reads and closes that descriptor before model tool execution.
 
 Each child runs in Pi RPC mode so the parent can inject a main-originated request through `steer` after the initial prompt is accepted.
-
 Each child broker call uses one request-scoped connection, while a response wait uses an abortable long poll.
-
 A main-originated request to a queued job waits for RPC readiness before delivery is accepted.
-
 After RPC accepts the steering message, the runtime interrupts active child response waits so the queued request can reach the child model.
-
 Caller cancellation before RPC delivery starts rolls the request back.
-
 Once RPC delivery starts, cancellation stops only the caller's wait; the request may still arrive and remains answerable until delivery fails or the job terminates.
-
 The interrupted child-originated requests remain active and retryable.
 
 The first accepted `subagent_send` response wins.
-
 Repeated responses acknowledge the existing answer without replacing it.
-
 A child may retry `subagent_wait` after a wait timeout because the underlying request remains active.
 
 A new job starts as `queued`, transitions to `running`, and reaches exactly one terminal state.
-
 The runtime retains up to 32 recent terminal records for up to 24 hours within the current extension session.
-
 Inspection reports older records removed by retention bounds through `omitted.jobs`.
-
 Cancelling or terminalizing a job revokes its token and rejects pending child waits before stale output can replace the terminal state.
-
 Session replacement and shutdown cancel active work, suppress stale completion delivery, revoke credentials, close sockets, and stop the broker.
 
 ## 🔀 Migrating from 2.x
 
 Version 3.0 replaces the previous orchestration runtime.
-
 It does not migrate legacy settings, persisted jobs, retained conversations, or recovery state.
-
 Finish or record any required work before upgrading, then start a fresh Pi session so stored calls do not request removed tool names.
-
 Use these replacements where the new job model supports the previous intent:
 
 | Previous interface | Version 3 interface |
@@ -229,58 +178,40 @@ Use these replacements where the new job model supports the previous intent:
 | Running main-to-child questions | Main and child `subagent_send` |
 
 The version 3 `subagent_send` contracts are not compatible with the legacy retained-agent follow-up tool of the same name.
-
 The `/subagents` command, extension settings, legacy retained follow-ups, `subagent_mailbox`, `subagent_consult`, custom agent catalogs, advanced orchestration, alternate transports, trust-aware cwd policy, and extension-owned worktrees have no direct replacement.
-
 Describe the child's specialization in `task` and grant only the required work tools through `tools`.
 
 ## 🔒 Security and privacy
 
 The selected work tools run in the current working directory.
-
 The default list contains no shell or file-mutation tool.
-
 It is not a filesystem sandbox because its read tools can inspect files available to the user account.
-
 Selecting `bash`, `powershell`, `edit`, or `write` permits workspace mutation with the Pi process environment and user permissions.
 
 Every child disables session persistence, unrelated extensions, skills, and prompt templates.
-
 Provider selection therefore supports Pi's child-visible built-in and configured providers, not providers registered only by a parent extension.
-
 Credentials must be available independently to the child through Pi's stored credentials or its inherited environment.
 
 The broker accepts only loopback TCP connections with an active per-job token.
-
 The token is bootstrapped through a private inherited pipe and is absent from the child's initial environment and command line.
 
 A child request or response is visible main-agent model context, but its envelope explicitly identifies it as untrusted subagent content rather than user authorization.
-
 A child message cannot grant permission for writes, shell commands, credential access, or other privileged actions.
-
 A main-agent request is visible child model context, but it cannot expand the child's selected tools or grant capabilities the child did not receive at spawn time.
 
 Terminal controls and bidirectional controls are stripped before untrusted child text is displayed.
-
 Tasks, repository context, requests, responses, and inspected file content may be sent to the selected model provider.
-
 Parallel writers require disjoint ownership or workspace isolation outside this extension.
 
 ## 🚧 Limitations
 
-The extension does not load arbitrary extension tools or parent-registered model providers in child processes.
-
-Process-local runtime API keys are not forwarded to children.
-
-The extension does not provide custom agents, per-job models, custom system prompts, peer-to-peer child messaging, retained conversations, user-directed follow-up work, mailboxes, Agent Teams, chains, fan-in aggregators, panels, workflow DAGs, dynamic scheduling, verification orchestration, nested subagents, or extension-owned semantic memory.
-
-Bidirectional messages use request-response coordination, not a retained conversational session.
-
-The main agent must verify child claims against the actual diff and deterministic checks.
-
-Child requests and responses trigger a main-agent turn, but asynchronous job completions do not wake an otherwise idle model turn automatically.
-
-Jobs, broker requests, and retained results do not survive extension reload, session replacement, or process exit.
+- The extension does not load arbitrary extension tools or parent-registered model providers in child processes.
+- Process-local runtime API keys are not forwarded to children.
+- The extension does not provide custom agents, per-job models, custom system prompts, peer-to-peer child messaging, retained conversations, user-directed follow-up work, mailboxes, Agent Teams, chains, fan-in aggregators, panels, workflow DAGs, dynamic scheduling, verification orchestration, nested subagents, or extension-owned semantic memory.
+- Bidirectional messages use request-response coordination, not a retained conversational session.
+- The main agent must verify child claims against the actual diff and deterministic checks.
+- Child requests and responses trigger a main-agent turn, but asynchronous job completions do not wake an otherwise idle model turn automatically.
+- Jobs, broker requests, and retained results do not survive extension reload, session replacement, or process exit.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -62,11 +62,14 @@ Create a project skill under `.pi/skills/<your-skill>/SKILL.md` or a global skil
 Choose a name, trigger description, tool policy, task format, and verification workflow for your own use case.
 The repository-only [`using-pi-subagents` example](https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-subagents/skills/using-pi-subagents) demonstrates one possible design without imposing it on installed users.
 
-1. The call returns a `jobId` immediately, and the job continues in the background.
-2. Continue useful main-agent work until the result is required or a completion arrives.
-3. Call `subagent_send` with `recipient: jobId` to ask an active child a question.
-4. If `subagent_wait` returns `reason: "subagent_message"`, handle the visible request or response and wait for the job again only when needed.
-5. Answer a child-originated request by calling `subagent_send` with its `requestId`.
+The call returns a `jobId` immediately, and the job continues in the background.
+Continue useful main-agent work until the result is required or a completion arrives.
+
+Use messaging only when needed:
+
+- Call `subagent_send` with `recipient: jobId` to ask an active child a question.
+- If `subagent_wait` returns `reason: "subagent_message"`, handle the visible request or response and wait for the job again only when needed.
+- Answer a child-originated request by calling `subagent_send` with its `requestId`.
 
 Completion messages follow Pi's global tool-output expansion state and the `app.tools.expand` binding (`Ctrl+O` by default).
 

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -3,7 +3,6 @@
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-sync)](https://www.npmjs.com/package/@narumitw/pi-sync) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 Pi Sync synchronizes selected Pi settings and content across machines through Git, WebDAV, Cloudflare R2, or another S3-compatible store.
-
 Reusable storage connections hold credentials, while named sync setups define exactly what to sync, where to store it, and whether to sync automatically.
 
 ## ✨ Features
@@ -42,11 +41,9 @@ Extensions run with Pi's permissions, so install only packages from sources you 
 ## 🚀 Quick start
 
 Run `/sync` and choose **Set up sync**.
-
 Before saving, review the storage connection, exact remote path, included content, automatic-sync choice, and masked credentials.
 
 Buckets and remote repositories must already exist.
-
 Git uses existing non-interactive SSH or credential-helper configuration and never stores Git credentials.
 
 ## 🧭 Manager, conflicts, and recovery
@@ -64,47 +61,33 @@ Remote status: Not checked
 Primary actions include **Sync now**, **Switch sync setup**, **Status & changes**, **Settings**, and **More…**.
 
 After Pi Sync detects an included-content mismatch, the manager shows **Sync status: Review needed** and puts **Review synced content (recommended)** first.
-
 **Sync now** remains unavailable until you review the mismatch.
-
 Opening the manager does not make another remote request.
-
 The manager also provides setup and connection details, history, and recovery.
 
 On secondary screens, **Back** and Escape return to the previous screen, while Ctrl+C closes the flow.
-
 Specialized operation and masked-credential prompts show the effective cancellation bindings and keep Ctrl+C as a hard-cancel input when Back is remapped.
-
 Destructive, credential-bearing, and externally visible operations show exact previews and confirmations.
 
 ### Restore sync access
 
 While an operation is running, the manager shows its command and process ID, disables sync and settings changes, and puts **Refresh operation status** first.
-
 When an active guard still protects lock metadata, the manager asks you to wait because another Pi Sync process may be starting or finishing.
-
 It never offers lock removal while an owner or guard may still be active.
 
 If a stopped operation leaves its local lock behind, the manager shows **Sync paused** and puts **Restore sync access… (recommended)** first.
-
 Unreadable metadata receives a stronger warning because Pi Sync cannot verify its owner.
-
 Close every other Pi session that may still be syncing, review the local-lock-only confirmation, and choose **Remove local lock and continue**.
-
 Before removal, the guarded recovery path rechecks metadata and ownership.
 
 Successful recovery changes no settings, local files, sync state, or remote data and returns to the normal manager.
-
 Cancellation leaves the lock unchanged.
-
 If ownership changes or a guard is still expiring, Pi Sync refuses removal and keeps refresh or retry available.
-
 After the same no-other-sync verification, `/sync unlock --stale` provides a deterministic fallback.
 
 ### Resolve conflicts in the manager
 
 When **Sync now**, **Pull from remote…**, or **Push to remote…** requires a direction choice, the manager opens **Resolve sync conflict**.
-
 The flow names the current setup and explains whether local content, remote content, or the included-content policy changed.
 
 An explicit remote content-list mismatch opens **Synced content differs** in the same manager flow.
@@ -143,7 +126,6 @@ Interactive TUI `/sync sync`, `/sync pull`, and `/sync push` routes without `--y
 Explicit `--yes` routes remain non-interactive and report exact remote-only, device-only, or order-only guidance while leaving visible attention for later review.
 Shutdown automatic sync never opens a dialog because Pi is exiting.
 RPC startup mismatch review remains read-only and notification-based.
-
 Print and JSON modes do not support `/sync` because UI output is not observable there.
 
 ## ⚙️ Settings
@@ -163,9 +145,7 @@ Pi-sync processes coordinate settings access through `pi-sync.json.mutation-lock
 Credentials stay in this canonical private file and are never shown in menus, reviews, status, notifications, errors, logs, or completion metadata.
 
 A private `pi-sync.local.json` containing a valid version 3 document is copied byte-for-byte to `pi-sync.json`.
-
 The old file remains as a recovery copy.
-
 If both paths exist, `pi-sync.json` wins and the legacy file remains untouched.
 
 ### Complete version 3 example
@@ -303,9 +283,7 @@ Automatic apply protects the currently open session file; restart Pi or resume a
 ### Unsupported old settings and recovery
 
 Version 1, version 2, and non-empty unversioned documents are unsupported after the version 3 schema reset.
-
 Pi Sync does **not** migrate, partially interpret, downgrade, or overwrite them.
-
 Automatic sync pauses and reports an actionable version 3 error without displaying secrets.
 
 Recovery:
@@ -351,9 +329,7 @@ Unknown flags, unknown commands, trailing values, and missing setup/snapshot val
 Completion includes known setup names and preserves preceding command tokens.
 
 TUI mode provides manager, settings, resource, included-content, secret, wizard, confirmation, and operation-review screens.
-
 In RPC mode, the **Settings** and **Included Content** interfaces provide read-only summaries through Pi's dialog and notification protocol.
-
 Print and JSON modes reject `/sync` before entering interactive screens.
 
 ## 🔄 Backend and recovery model
@@ -402,11 +378,8 @@ Preserve both roots before manual recovery; with every Pi process closed and no 
 ## ♿ Terminal accessibility
 
 Pi exposes terminal components rather than a semantic or ARIA tree.
-
 Release checks cover textual state, keyboard operation, Escape and Back behavior, control escaping, and narrow rendering.
-
 Critical meaning appears in text such as `(current)`, `Review needed`, `Later`, `Warning`, `Invalid`, `Saved`, `Cancelled`, and `Applied`.
-
 Color is supplementary, and the attention widget is informational rather than interactive.
 
 ## 🗂️ Package layout

--- a/packages/pi-ticker/README.md
+++ b/packages/pi-ticker/README.md
@@ -36,7 +36,6 @@ pi --no-extensions -e ./packages/pi-ticker
 ```
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
-
 Pi loads the generated TypeScript entrypoint through Jiti while menu code remains in lazy JavaScript chunks.
 
 Extensions run with Pi's permissions, so install only trusted packages.
@@ -50,29 +49,20 @@ Open the ticker manager in TUI mode:
 ```
 
 Choose **Add custom ticker…** and enter a Yahoo Finance symbol such as `MSFT`, `SPY`, or `BTC-USD`.
-
 The widget appears after the settings save and the first quote request completes.
 
 ## 🧭 Ticker manager
 
 `/ticker` opens **Manage tickers** in TUI and RPC modes.
-
 In TUI mode, one screen provides search, symbol removal, direct add, widget visibility, and refresh actions.
-
 The configured confirm binding or Space activates the focused row.
-
 When a valid search has no match, the add row changes to **Add SYMBOL** for direct addition.
-
 `Shift+Up` and `Shift+Down` reorder the focused ticker when the search field is empty and those keys do not conflict with configured standard bindings.
 
 RPC mode exposes portable dialogs for choosing and moving a ticker.
-
 Each accepted change saves immediately.
-
 If a save fails, the manager restores the previous displayed and effective value.
-
 Removing the final symbol hides the widget and stops polling.
-
 Escape closes transient TUI flows, and `Ctrl+C` remains a hard-close path.
 
 ## 💬 Commands
@@ -84,9 +74,7 @@ Escape closes transient TUI flows, and `Ctrl+C` remains a hard-close path.
 - `/ticker reset` reports that no default symbol list exists and leaves settings unchanged.
 
 Known routes reject trailing arguments.
-
 All command routes support TUI and RPC modes.
-
 Print and JSON modes reject the command before changing settings.
 
 ## ⚙️ Settings
@@ -98,11 +86,8 @@ The canonical user settings file is:
 ```
 
 The normal path is `~/.pi/agent/pi-ticker.json`.
-
 Pi's configured agent directory replaces `~/.pi/agent` when applicable.
-
 Ticker preferences are user-scoped and apply across projects.
-
 The extension does not read project settings or extension-specific environment-variable overrides.
 
 A missing file uses an empty symbol list, keeps the widget enabled, and does not create the file, its parent directory, or a polling task.
@@ -115,7 +100,6 @@ The settings file must contain a JSON object with these optional fields:
 | `widgetEnabled` | boolean | `true` | Controls widget visibility and quote polling. |
 
 Each symbol may contain up to 15 uppercase letters, digits, `.`, `^`, `=`, or `-`.
-
 Lowercase command and menu input is normalized to uppercase.
 
 Example:
@@ -128,38 +112,27 @@ Example:
 ```
 
 Unknown JSON fields are preserved during saves.
-
 Malformed or invalid settings use runtime defaults and leave the file unchanged.
-
 Pi shows a warning when UI is available.
 
 Writes are ordered within one Pi process and published through a temporary file plus atomic rename.
-
 Reload and session replacement wait for accepted writes before loading the next settings snapshot.
-
 Separate Pi processes do not share a cross-process lock.
-
 Settings reload on startup and `/reload`.
 
 ## 🔒 Security and privacy
 
 The extension requests public quote metadata from Yahoo Finance over HTTPS without an API key.
-
 Requested ticker symbols and the host network address are visible to Yahoo Finance.
-
 The user settings file contains only ticker symbols and widget visibility; it stores no credential or secret.
-
 The extension displays ticker symbols and quote data locally without adding them to model context.
 
 ## 🚧 Limitations
 
-Yahoo Finance is an unofficial dependency and may rate-limit, delay, change, or remove the endpoint.
-
-Quotes may be delayed and are not suitable for trading decisions.
-
-Each request times out after 10 seconds, and one symbol failure does not discard successful symbols.
-
-Each Pi session owns its polling queue, and separate Pi processes do not share one.
+- Yahoo Finance is an unofficial dependency and may rate-limit, delay, change, or remove the endpoint.
+- Quotes may be delayed and are not suitable for trading decisions.
+- Each request times out after 10 seconds, and one symbol failure does not discard successful symbols.
+- Each Pi session owns its polling queue, and separate Pi processes do not share one.
 
 ## 🗂️ Package layout
 

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -5,7 +5,6 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 Pi Todo gives the model a focused list for tracking multi-step work above Pi's editor.
-
 The list follows the active session branch and disappears when no tracked work remains or the session ends.
 
 ## ✨ Features
@@ -46,11 +45,8 @@ Pi extensions run with the user's permissions, so install only trusted code.
 ## 🚀 Quick start
 
 Ask Pi to perform work with multiple meaningful steps.
-
 The model can use `update_todo_list` to create a concise list, mark one todo `in_progress`, and revise the plan as work changes.
-
 Each update replaces the complete `todos` array, and an empty array clears it.
-
 Tool guidance tells the model to update changed statuses promptly and reconcile the list before progress reports or the final response.
 
 ## 🛠️ Tools
@@ -58,7 +54,6 @@ Tool guidance tells the model to update changed statuses promptly and reconcile 
 ### `update_todo_list`
 
 Replaces the complete todo list for the active session.
-
 The tool accepts this shape:
 
 ```json
@@ -73,47 +68,32 @@ The tool accepts this shape:
 ```
 
 Accepted statuses are `pending`, `in_progress`, and `completed`.
-
 The `todos` array may contain up to 50 entries, each `step` may contain up to 300 characters, and at most one todo may be `in_progress`.
 
 ### Session and compaction behavior
 
 Each successful tool result stores a versioned snapshot on the active session branch.
-
 Session startup and branch navigation reconstruct the latest valid list from those results.
-
 New results store version 2 `{ todos: [{ step, status }] }` details.
-
 Reconstruction also migrates valid version 1 `{ items: [{ text, status }] }` details stored under `update_todo_list` or the former `todo_widget` name, but new calls use only the version 2 schema.
 
 During ordinary turns, the persisted assistant tool call and successful result keep the complete current list visible to the model without rewriting prompt history.
-
 If leading compaction or branch summaries remove that matching pair, the extension inserts one hidden, non-persistent state message immediately after the summaries.
-
 The restored message stays fixed for that leading-summary epoch, even after a later valid update or clear.
-
 Branch-local boundary metadata preserves the established prefix across reload and branch navigation without persisting the hidden message as model context.
-
 A later tool call and result supersede the restored state at the conversation tail without rewriting the earlier provider prefix.
-
 An ordinary context without a leading summary receives no fallback.
-
 A new summary epoch restores only the list that is current when restoration becomes necessary.
 
 In TUI mode, updates appear immediately above the editor.
-
 The widget shows completed and total task counts, followed by themed completed, in-progress, and pending rows.
-
 Long task text wraps to the terminal width, with continuation lines aligned beneath the text.
-
 In RPC, print, and JSON modes, the tool still returns structured details but does not create a visual widget.
 
 ## 🔒 Security and privacy
 
 The extension does not read or write files, start processes, access credentials, or make network requests.
-
 Pi stores todo steps in normal session tool results, so they follow the user's session persistence choices.
-
 Terminal escape sequences, control characters, and bidirectional display controls are removed at the rendering boundary without changing the stored tool payload.
 
 ## 🚧 Limitations

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -48,14 +48,11 @@ Run:
 /tool
 ```
 
-Choose **Browse tools** to search the catalog and inspect a tool.
-
-Choose **Active tool status** to turn the widget on or off.
+1. Choose **Browse tools** to search the catalog and inspect a tool.
+2. Choose **Active tool status** to turn the widget on or off.
 
 The widget remains off until you enable it.
-
 The command works in TUI and RPC modes.
-
 It rejects arguments, print mode, and JSON mode before opening an interactive flow.
 
 ## 💬 Commands
@@ -65,13 +62,11 @@ It rejects arguments, print mode, and JSON mode before opening an interactive fl
 | `/tool` | Browse configured tools and configure the active-tool widget. |
 
 `/tool` accepts no arguments and never enables, disables, or executes tools.
-
 Its menu provides **Browse tools**, **Active tool status**, **Status**, and **Help**.
 
 ## ⚙️ Settings
 
 The user settings file is `<getAgentDir()>/pi-tool.json`, normally `~/.pi/agent/pi-tool.json`.
-
 The extension does not create the file while the widget remains at its default.
 
 Use this document to enable the widget manually:
@@ -83,45 +78,31 @@ Use this document to enable the widget manually:
 ```
 
 `activeToolStatus` accepts `true` or `false` and defaults to `false` when absent.
-
 Manual edits apply after `/reload` or the next session start.
-
 The `/tool` menu toggle applies changes immediately and persists them through atomic file replacement.
-
 Settings writes preserve unknown fields.
-
 Malformed JSON, invalid values, symbolic links, and non-file settings paths are treated as invalid and remain unchanged.
-
 Pi shows a warning when UI is available.
-
 Writes are ordered within one Pi process, but separate Pi processes do not share a settings lock.
 
 ## ℹ️ Active-tool widget
 
 When enabled, the widget shows every name returned by Pi's public `pi.getActiveTools()` API above the editor.
-
 It refreshes on relevant lifecycle events and polls for changes made by other extensions.
-
 It clears immediately when disabled or when the session is replaced, reloaded, or shut down.
-
 Tool names are sanitized and bounded before terminal rendering.
 
 ## 🔒 Security and privacy
 
 The catalog reads Pi's public tool metadata and displays it through the `/tool` interface.
-
 It does not execute tools, change the active tool set, make network requests, or add catalog data to model context.
-
 Tool metadata can include local paths and prompt text, so review the screen before sharing terminal output.
 
 ## 🚧 Limitations
 
 The catalog shows the name, description, parameter schema, prompt guidelines, and source metadata returned by Pi's public `pi.getAllTools()` API.
-
 It adds effective snippets from `ctx.getSystemPromptOptions()` for the current active tool set.
-
 Pi does not expose an inactive tool's configured snippet, implementation, runtime secrets, or label through these APIs.
-
 Therefore, **None in the current system prompt** does not prove that an inactive tool's full definition has no snippet.
 
 ## 🗂️ Package layout

--- a/packages/pi-tool/README.md
+++ b/packages/pi-tool/README.md
@@ -48,8 +48,8 @@ Run:
 /tool
 ```
 
-1. Choose **Browse tools** to search the catalog and inspect a tool.
-2. Choose **Active tool status** to turn the widget on or off.
+- Choose **Browse tools** to search the catalog and inspect a tool.
+- Choose **Active tool status** to turn the widget on or off.
 
 The widget remains off until you enable it.
 The command works in TUI and RPC modes.

--- a/packages/pi-tui-kit-showcase/README.md
+++ b/packages/pi-tui-kit-showcase/README.md
@@ -3,7 +3,6 @@
 [![private](https://img.shields.io/badge/npm-private-lightgrey)](./package.json) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 This local maintainer demo previews the public `@narumitw/pi-tui-kit` screens and standalone interactions in one menu.
-
 All demo state stays in memory, and the showcase writes no settings.
 
 ## ✨ Features
@@ -18,7 +17,6 @@ All demo state stays in memory, and the showcase writes no settings.
 ## 📦 Install
 
 This package is private and is not meant for npm publication.
-
 Build Kit, then load only this extension from a local checkout:
 
 ```bash
@@ -41,19 +39,14 @@ Run this command in Pi TUI mode:
 ```
 
 Choose a row to inspect its screen or interaction pattern.
-
 Questionnaire, task, confirmation, and live-choice rows temporarily close the menu and reopen it after the interaction finishes.
-
 RPC mode reports that the showcase requires TUI mode.
-
 Print and JSON modes reject the command without ad hoc output.
 
 ## ⚙️ Settings
 
 The showcase has no extension-owned settings file.
-
 The **Settings screen** row changes only in-memory demo values.
-
 Those values reset when the command runs again or Pi replaces the session owner.
 
 ## 💬 Commands
@@ -61,9 +54,7 @@ Those values reset when the command runs again or Pi replaces the session owner.
 ### `/tui-kit-showcase`
 
 Opens the showcase menu in TUI mode.
-
 The command accepts no arguments.
-
 Any argument is rejected with `Usage: /tui-kit-showcase`.
 
 ## 🗂️ Package layout

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -4,7 +4,6 @@
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Pi TUI Kit provides typed menus and interactions for independently installable [Pi](https://pi.dev) extensions.
-
 It supplies declarative screens, standalone interactions, terminal-display helpers, and interaction lifecycle ownership.
 Consumers reuse its navigation, rendering, cancellation, and mode adaptation instead of rebuilding them.
 
@@ -25,7 +24,6 @@ npm install @narumitw/pi-tui-kit
 ```
 
 The published package contains built ESM and declarations in `dist/`; consumers do not need a TypeScript loader for dependencies.
-
 The package root remains the supported entrypoint for menus and interaction runners.
 When startup does not need the full Kit runtime, import a lightweight display-helper subpath.
 The available subpaths are `editor-status-widget`, `terminal-document`, `terminal-text`, and `interaction-hints` under `@narumitw/pi-tui-kit`.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -3,7 +3,6 @@
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-usage)](https://www.npmjs.com/package/@narumitw/pi-usage) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 Inspect usage and DeepSeek API balance for Pi's active provider account, query other configured providers, and toggle Fast mode for supported OpenAI Codex models.
-
 The extension keeps each provider's native quota, allowance, and spending semantics instead of treating unlike values as equivalent.
 xAI OAuth subscription reporting follows the reviewed Grok Build contract and runs only after an explicit `/usage` action.
 
@@ -122,7 +121,6 @@ Submit a blank value from the TUI input, or remove the JSON field and run `/relo
 ### Codex Fast mode
 
 Run `/fast` without arguments to toggle Fast for the active supported Codex model, or use **Turn Fast mode on/off** in `/usage`.
-
 Fast is about 1.5× faster and uses more of your plan allowance.
 The `codexFastMode` preference defaults to Off.
 
@@ -138,7 +136,6 @@ Repair or remove an invalid file, then run `/reload` before trying the toggle ag
 ### Codex statusline reset countdown
 
 The `codexStatusResetCountdown` preference defaults to `true`. It replaces the window labels with the time remaining until each returned limit resets.
-
 Turn **Codex reset countdown** Off in the TUI Settings screen, or set it to `false` in `pi-usage.json` and run `/reload`, to restore the legacy `5h` and `wk` labels:
 
 ```json
@@ -501,7 +498,6 @@ packages/pi-usage/
 ```
 
 `index.ts` is the Pi entrypoint and forwards the default factory from `usage.ts` while retaining the package's named helper exports; other source modules are internal.
-
 The generated runtime is built from the authoritative `src/index.ts` graph and does not import back into `src`.
 
 ## 🔎 Keywords

--- a/packages/pi-worktree/README.md
+++ b/packages/pi-worktree/README.md
@@ -3,7 +3,6 @@
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-worktree)](https://www.npmjs.com/package/@narumitw/pi-worktree) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 Create, inspect, switch, remove, and prune Git worktrees through one guarded `/worktree` manager.
-
 Because `cd` cannot change Pi's parent process directory, switching prepares a Pi session whose cwd is the selected worktree and carries over the active conversation when possible.
 
 ## ✨ Features


### PR DESCRIPTION
## Summary

- clarify that human-facing documentation should use coherent paragraphs and situational lists
- keep `AGENTS.md` guidance in one-rule-per-bullet form
- reorganize package READMEs to remove one-sentence paragraph formatting while preserving documented behavior

## Verification

- `npm run check`
- `npm test` (342 files, 3394 tests)
- fenced-code-aware audit of all 29 package READMEs
- `git diff --check`

## Release

- no changeset required because this is documentation-only
- no pack or runtime smoke required because package metadata and runtime loading are unchanged
