### PR TITLE
feat(todo): enhance session todo tracking

### DIFF
--- a/.changeset/bright-todos-adapt.md
+++ b/.changeset/bright-todos-adapt.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-todo": minor
+---
+
+Add adaptive widget layouts, transient completion summaries, actionable validation, read-only display settings, and blocked todos with versioned session migration.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -5,17 +5,20 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 Pi Todo gives the model a focused list for tracking multi-step work above Pi's editor.
-The list follows the active session branch and disappears when no tracked work remains or the session ends.
+The list follows the active session branch, adapts to terminal space, and disappears when no tracked work remains or the session ends.
 
 ## ✨ Features
 
 - Registers one `update_todo_list` tool for meaningful multi-step work.
 - Keeps todo steps concise and action-oriented, with at most one todo in progress.
-- Shows a compact themed task list and completion count above the editor in TUI mode.
+- Represents externally blocked work with a required reason instead of treating it as complete.
+- Adapts the themed TUI widget to terminal height while keeping active and blocked work visible.
+- Shows a transient completion summary when every tracked todo becomes complete.
 - Restores the latest valid list when Pi starts a session or navigates between branches.
 - Restores the exact current list to model context only when compaction removes its latest visible successful tool update.
+- Supports optional display preferences from a read-only user settings file.
 - Sanitizes terminal and bidirectional controls before rendering model-provided text.
-- Works without settings, files, network access, or external services.
+- Works without settings writes, network access, or external services.
 
 ## 📦 Install
 
@@ -39,13 +42,12 @@ pi --no-extensions -e ./packages/pi-todo
 ```
 
 The package declares `dist/index.ts`, so an unbuilt local checkout must run the build before Pi loads the package directory.
-
 Pi extensions run with the user's permissions, so install only trusted code.
 
 ## 🚀 Quick start
 
 Ask Pi to perform work with multiple meaningful steps.
-The model can use `update_todo_list` to create a concise list, mark one todo `in_progress`, and revise the plan as work changes.
+The model can use `update_todo_list` to create a concise list, mark one todo `in_progress`, record externally blocked work with a reason, and revise the plan as work changes.
 Each update replaces the complete `todos` array, and an empty array clears it.
 Tool guidance tells the model to update changed statuses promptly and reconcile the list before progress reports or the final response.
 
@@ -62,20 +64,27 @@ The tool accepts this shape:
     {
       "step": "Run the focused tests",
       "status": "in_progress"
+    },
+    {
+      "step": "Deploy the release candidate",
+      "status": "blocked",
+      "reason": "Waiting for approval"
     }
   ]
 }
 ```
 
-Accepted statuses are `pending`, `in_progress`, and `completed`.
-The `todos` array may contain up to 50 entries, each `step` may contain up to 300 characters, and at most one todo may be `in_progress`.
+Accepted statuses are `pending`, `in_progress`, `completed`, and `blocked`.
+A `blocked` todo must include a non-whitespace `reason`, and other statuses must omit `reason`.
+The `todos` array may contain up to 50 entries, each `step` may contain up to 300 characters, each blocked `reason` may contain up to 200 characters, and at most one todo may be `in_progress`.
 
 ### Session and compaction behavior
 
 Each successful tool result stores a versioned snapshot on the active session branch.
 Session startup and branch navigation reconstruct the latest valid list from those results.
-New results store version 2 `{ todos: [{ step, status }] }` details.
-Reconstruction also migrates valid version 1 `{ items: [{ text, status }] }` details stored under `update_todo_list` or the former `todo_widget` name, but new calls use only the version 2 schema.
+New results store version 3 `{ todos: [{ step, status, reason? }] }` details.
+Reconstruction migrates valid version 2 `{ todos: [{ step, status }] }` details and version 1 `{ items: [{ text, status }] }` details stored under `update_todo_list` or the former `todo_widget` name.
+New calls use only the version 3 schema.
 
 During ordinary turns, the persisted assistant tool call and successful result keep the complete current list visible to the model without rewriting prompt history.
 If leading compaction or branch summaries remove that matching pair, the extension inserts one hidden, non-persistent state message immediately after the summaries.
@@ -86,39 +95,74 @@ An ordinary context without a leading summary receives no fallback.
 A new summary epoch restores only the list that is current when restoration becomes necessary.
 
 In TUI mode, updates appear immediately above the editor.
-The widget shows completed and total task counts, followed by themed completed, in-progress, and pending rows.
-Long task text wraps to the terminal width, with continuation lines aligned beneath the text.
+Adaptive mode uses up to one third of the terminal height, bounded between four and twelve rows.
+When the full list does not fit, the widget prioritizes the in-progress todo, blocked todos, and upcoming pending todos, then summarizes completed and hidden rows.
+Long task text wraps to the terminal width, with continuation lines aligned beneath the text and bounded when compact rendering runs out of rows.
+When a non-empty list becomes fully complete, the widget shows a three-second completion summary and then hides without clearing the persisted todo state.
+A later update, clear, tree navigation, reload, or session replacement cancels any stale completion summary.
 In RPC, print, and JSON modes, the tool still returns structured details but does not create a visual widget.
+
+## ⚙️ Settings
+
+Settings are optional and user-scoped at `<Pi agent directory>/pi-todo.json`, normally `~/.pi/agent/pi-todo.json`.
+
+```json
+{
+  "widget": {
+    "enabled": true,
+    "displayMode": "adaptive",
+    "showCompleted": true,
+    "maxVisibleItems": null,
+    "showProgress": true
+  }
+}
+```
+
+`displayMode` accepts `adaptive`, `expanded`, or `collapsed`.
+`maxVisibleItems` accepts `null` for no item-count cap or an integer from 1 through 50.
+The other widget settings are booleans with the defaults shown above.
+Missing settings use defaults without creating a file or directory.
+Settings load at session start, including `/reload`, and do not change during an active session until the next load.
+Invalid, oversized, non-regular, symlinked, malformed, or non-UTF-8 settings use defaults without overwriting the file.
+Pi reports invalid settings through a warning in TUI and RPC modes, while print and JSON modes continue with defaults without writing ad hoc output.
+This extension intentionally provides manual JSON settings without a slash command or SettingsList UI.
 
 ## 🔒 Security and privacy
 
-The extension does not read or write files, start processes, access credentials, or make network requests.
-Pi stores todo steps in normal session tool results, so they follow the user's session persistence choices.
+The extension reads only the optional user settings file and never writes settings or other files.
+It does not start processes, access credentials, or make network requests.
+Pi stores todo steps and blocked reasons in normal session tool results, so they follow the user's session persistence choices.
 Terminal escape sequences, control characters, and bidirectional display controls are removed at the rendering boundary without changing the stored tool payload.
 
 ## 🚧 Limitations
 
-- The visual widget appears above the editor only in TUI mode.
-- The extension provides a model tool rather than a slash command or manual task editor.
+- The visual widget and completion summary appear above the editor only in TUI mode.
+- The extension provides a model tool rather than a slash command, SettingsList, or manual task editor.
 - The extension reminds the model to update statuses but cannot infer task completion or force a tool call.
-- Branch reconstruction uses only valid versioned `update_todo_list` or legacy `todo_widget` tool results on the active branch.
-- The widget has no independent scrolling or height-based collapsing, so Pi may clip later rows when terminal height is constrained.
+- Branch reconstruction uses only successful, valid, versioned `update_todo_list` or legacy `todo_widget` tool results on the active branch.
+- Adaptive sizing uses terminal height rather than the exact remaining editor viewport, so it applies a conservative row budget.
+- The widget has no independent scrolling.
 
 ## 🗂️ Package layout
 
 ```text
 packages/pi-todo/
 ├── dist/
-│   └── index.ts              # Generated Jiti runtime entrypoint
+│   └── index.ts                        # Generated Jiti runtime entrypoint
 ├── scripts/
-│   └── build-runtime.mjs     # Deterministic runtime builder and validator
+│   └── build-runtime.mjs               # Deterministic runtime builder and validator
 ├── src/
-│   ├── index.ts              # Thin extension entrypoint
-│   └── todo-widget.ts        # Tool, lifecycle, state reconstruction, and rendering
+│   ├── index.ts                        # Thin extension entrypoint
+│   ├── settings.ts                     # Read-only user settings loader and validation
+│   ├── todo-widget.ts                  # Tool, lifecycle, and state reconstruction
+│   └── widget-renderer.ts              # Adaptive themed widget rendering
 ├── test/
-│   ├── build-runtime.test.ts       # Build, boundary, and Jiti loader coverage
-│   ├── todo-cache-contract.test.ts # Normalized provider-prefix coverage
-│   └── todo-widget.test.ts         # Extension behavior coverage
+│   ├── build-runtime.test.ts           # Build, boundary, and Jiti loader coverage
+│   ├── settings.test.ts                # Settings validation and read safety
+│   ├── todo-cache-contract.test.ts     # Normalized provider-prefix coverage
+│   ├── todo-harness.ts                 # Shared extension lifecycle harness
+│   ├── todo-widget-enhancements.test.ts # Adaptive, settings, and blocked coverage
+│   └── todo-widget.test.ts             # Core extension behavior coverage
 ├── LICENSE
 ├── README.md
 ├── package.json

--- a/packages/pi-todo/src/settings.ts
+++ b/packages/pi-todo/src/settings.ts
@@ -1,0 +1,197 @@
+import { constants } from "node:fs";
+import { type FileHandle, open } from "node:fs/promises";
+import { join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const TODO_SETTINGS_FILE = "pi-todo.json";
+export const MAX_TODO_SETTINGS_BYTES = 64 * 1024;
+export const TODO_DISPLAY_MODES = ["adaptive", "expanded", "collapsed"] as const;
+
+export type TodoDisplayMode = (typeof TODO_DISPLAY_MODES)[number];
+
+export interface TodoWidgetSettings {
+	enabled: boolean;
+	displayMode: TodoDisplayMode;
+	showCompleted: boolean;
+	maxVisibleItems: number | null;
+	showProgress: boolean;
+}
+
+export interface TodoSettings {
+	widget: TodoWidgetSettings;
+}
+
+export const DEFAULT_TODO_SETTINGS: Readonly<TodoSettings> = Object.freeze({
+	widget: Object.freeze({
+		enabled: true,
+		displayMode: "adaptive",
+		showCompleted: true,
+		maxVisibleItems: null,
+		showProgress: true,
+	}),
+});
+
+export type TodoSettingsLoadResult =
+	| { kind: "missing"; path: string; settings: TodoSettings }
+	| { kind: "loaded"; path: string; settings: TodoSettings }
+	| { kind: "invalid"; path: string; settings: TodoSettings; issue: string };
+
+export function todoSettingsPath(): string {
+	return join(getAgentDir(), TODO_SETTINGS_FILE);
+}
+
+export function normalizeTodoSettings(value: unknown): TodoSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	const widgetValue = Object.hasOwn(value, "widget") ? value.widget : undefined;
+	if (widgetValue !== undefined && !isRecord(widgetValue)) return undefined;
+	const widget = widgetValue ?? {};
+
+	const enabled = booleanSetting(widget, "enabled", DEFAULT_TODO_SETTINGS.widget.enabled);
+	const showCompleted = booleanSetting(
+		widget,
+		"showCompleted",
+		DEFAULT_TODO_SETTINGS.widget.showCompleted,
+	);
+	const showProgress = booleanSetting(
+		widget,
+		"showProgress",
+		DEFAULT_TODO_SETTINGS.widget.showProgress,
+	);
+	if (enabled === undefined || showCompleted === undefined || showProgress === undefined) {
+		return undefined;
+	}
+
+	const displayMode = Object.hasOwn(widget, "displayMode")
+		? widget.displayMode
+		: DEFAULT_TODO_SETTINGS.widget.displayMode;
+	if (!TODO_DISPLAY_MODES.includes(displayMode as TodoDisplayMode)) return undefined;
+
+	const maxVisibleItems = Object.hasOwn(widget, "maxVisibleItems")
+		? widget.maxVisibleItems
+		: DEFAULT_TODO_SETTINGS.widget.maxVisibleItems;
+	if (
+		maxVisibleItems !== null &&
+		(typeof maxVisibleItems !== "number" ||
+			!Number.isSafeInteger(maxVisibleItems) ||
+			maxVisibleItems < 1 ||
+			maxVisibleItems > 50)
+	) {
+		return undefined;
+	}
+
+	return {
+		widget: {
+			enabled,
+			displayMode: displayMode as TodoDisplayMode,
+			showCompleted,
+			maxVisibleItems,
+			showProgress,
+		},
+	};
+}
+
+export async function loadTodoSettings(
+	path = todoSettingsPath(),
+	signal?: AbortSignal,
+): Promise<TodoSettingsLoadResult> {
+	throwIfAborted(signal);
+	let handle: FileHandle;
+	try {
+		handle = await open(
+			path,
+			constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | (constants.O_NOFOLLOW ?? 0),
+		);
+	} catch (error) {
+		throwIfAborted(signal);
+		if (isNodeError(error) && error.code === "ENOENT") {
+			return { kind: "missing", path, settings: cloneDefaultSettings() };
+		}
+		return {
+			kind: "invalid",
+			path,
+			settings: cloneDefaultSettings(),
+			issue: safeReadIssue(error),
+		};
+	}
+
+	try {
+		const stats = await handle.stat();
+		throwIfAborted(signal);
+		if (!stats.isFile()) return invalidResult(path, "settings path is not a regular file");
+		if (stats.size > MAX_TODO_SETTINGS_BYTES) {
+			return invalidResult(path, `settings file exceeds ${MAX_TODO_SETTINGS_BYTES} bytes`);
+		}
+
+		const buffer = Buffer.alloc(MAX_TODO_SETTINGS_BYTES + 1);
+		let offset = 0;
+		while (offset < buffer.byteLength) {
+			throwIfAborted(signal);
+			const { bytesRead } = await handle.read(buffer, offset, buffer.byteLength - offset, offset);
+			throwIfAborted(signal);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		if (offset > MAX_TODO_SETTINGS_BYTES) {
+			return invalidResult(path, `settings file exceeds ${MAX_TODO_SETTINGS_BYTES} bytes`);
+		}
+
+		let text: string;
+		try {
+			text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+				buffer.subarray(0, offset),
+			);
+		} catch {
+			return invalidResult(path, "settings file is not valid UTF-8");
+		}
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(text) as unknown;
+		} catch {
+			return invalidResult(path, "invalid JSON");
+		}
+		const settings = normalizeTodoSettings(parsed);
+		return settings
+			? { kind: "loaded", path, settings }
+			: invalidResult(path, "invalid settings shape or values");
+	} catch (error) {
+		throwIfAborted(signal);
+		return invalidResult(path, safeReadIssue(error));
+	} finally {
+		await handle.close();
+	}
+}
+
+function booleanSetting(
+	record: Record<string, unknown>,
+	key: string,
+	fallback: boolean,
+): boolean | undefined {
+	const value = Object.hasOwn(record, key) ? record[key] : fallback;
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function cloneDefaultSettings(): TodoSettings {
+	return { widget: { ...DEFAULT_TODO_SETTINGS.widget } };
+}
+
+function invalidResult(path: string, issue: string): TodoSettingsLoadResult {
+	return { kind: "invalid", path, settings: cloneDefaultSettings(), issue };
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+	signal?.throwIfAborted();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function safeReadIssue(error: unknown): string {
+	if (isNodeError(error) && error.code === "ELOOP") return "symbolic links are not accepted";
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-todo/src/settings.ts
+++ b/packages/pi-todo/src/settings.ts
@@ -137,9 +137,7 @@ export async function loadTodoSettings(
 
 		let text: string;
 		try {
-			text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
-				buffer.subarray(0, offset),
-			);
+			text = new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, offset));
 		} catch {
 			return invalidResult(path, "settings file is not valid UTF-8");
 		}

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -5,33 +5,45 @@ import {
 	type ExtensionAPI,
 	type ExtensionContext,
 	type SessionEntry,
-	type Theme,
 } from "@earendil-works/pi-coding-agent";
-import { stripTerminalSequences, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import {
+	DEFAULT_TODO_SETTINGS,
+	loadTodoSettings,
+	type TodoSettings,
+	type TodoSettingsLoadResult,
+} from "./settings.js";
+import { renderCompletionSummary, renderTodoWidget, sanitizeTodoText } from "./widget-renderer.js";
 
 export const TOOL_NAME = "update_todo_list";
 export const WIDGET_KEY = "todo";
 export const TODO_CONTEXT_MESSAGE_TYPE = "todo-list-status";
-export const TODO_CONTEXT_VERSION = 2;
-export const TODO_DETAILS_VERSION = 2;
+export const TODO_CONTEXT_VERSION = 3;
+export const TODO_DETAILS_VERSION = 3;
 export const TODO_RESTORED_BOUNDARY_ENTRY_TYPE = "todo-restored-context-boundary";
-const TODO_RESTORED_BOUNDARY_VERSION = 1;
-const LEGACY_TODO_CONTEXT_VERSION = 1;
-const LEGACY_TODO_DETAILS_VERSION = 1;
 export const MAX_TODOS = 50;
 export const MAX_TODO_STEP_LENGTH = 300;
+export const MAX_TODO_REASON_LENGTH = 200;
+export const COMPLETION_SUMMARY_MS = 3_000;
 
+const TODO_RESTORED_BOUNDARY_VERSION = 1;
+const PREVIOUS_TODO_CONTEXT_VERSION = 2;
+const PREVIOUS_TODO_DETAILS_VERSION = 2;
+const LEGACY_TODO_CONTEXT_VERSION = 1;
+const LEGACY_TODO_DETAILS_VERSION = 1;
 const WIDGET_OPTIONS = { placement: "aboveEditor" } as const;
 const LEGACY_TOOL_NAME = "todo_widget";
-const TODO_STATUSES = ["pending", "in_progress", "completed"] as const;
-const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
+const TODO_STATUSES = ["pending", "in_progress", "completed", "blocked"] as const;
+const PREVIOUS_TODO_STATUSES = ["pending", "in_progress", "completed"] as const;
+const RESUBMIT_GUIDANCE = "Fix the input and resubmit the complete todos array.";
 
 type TodoStatus = (typeof TODO_STATUSES)[number];
+type PreviousTodoStatus = (typeof PREVIOUS_TODO_STATUSES)[number];
 
 export interface Todo {
 	step: string;
 	status: TodoStatus;
+	reason?: string;
 }
 
 export interface TodoDetails {
@@ -39,9 +51,20 @@ export interface TodoDetails {
 	todos: Todo[];
 }
 
+interface PreviousTodo {
+	step: string;
+	status: PreviousTodoStatus;
+}
+
 interface LegacyTodoItem {
 	text: string;
-	status: TodoStatus;
+	status: PreviousTodoStatus;
+}
+
+export interface TodoWidgetDependencies {
+	loadSettings?: typeof loadTodoSettings;
+	setTimeout?: typeof globalThis.setTimeout;
+	clearTimeout?: typeof globalThis.clearTimeout;
 }
 
 const TodoParameters = Type.Object({
@@ -55,6 +78,13 @@ const TodoParameters = Type.Object({
 			status: StringEnum(TODO_STATUSES, {
 				description: "The step's current status",
 			}),
+			reason: Type.Optional(
+				Type.String({
+					minLength: 1,
+					maxLength: MAX_TODO_REASON_LENGTH,
+					description: "Required only for blocked todos; explain what must unblock the step",
+				}),
+			),
 		}),
 		{
 			maxItems: MAX_TODOS,
@@ -63,53 +93,117 @@ const TodoParameters = Type.Object({
 	),
 });
 
-export default function todoWidgetExtension(pi: ExtensionAPI): void {
+export default function todoWidgetExtension(
+	pi: ExtensionAPI,
+	dependencies: TodoWidgetDependencies = {},
+): void {
+	const readSettings = dependencies.loadSettings ?? loadTodoSettings;
+	const scheduleTimeout = dependencies.setTimeout ?? globalThis.setTimeout;
+	const cancelTimeout = dependencies.clearTimeout ?? globalThis.clearTimeout;
 	let activeSession: ExtensionContext["sessionManager"] | undefined;
 	let todos: Todo[] = [];
+	let settings = cloneDefaultSettings();
 	let restoredBoundary: { summaryEpoch: string; content: string } | undefined;
+	let settingsController = new AbortController();
+	let generation = 0;
+	let completionTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+	let completionToken = 0;
+	let completionSummaryHidden = false;
 
 	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
 
+	const cancelCompletionSummary = (): void => {
+		completionToken += 1;
+		if (completionTimer !== undefined) cancelTimeout(completionTimer);
+		completionTimer = undefined;
+	};
+
 	const publish = (ctx: ExtensionContext): void => {
 		if (!ownsSession(ctx) || ctx.mode !== "tui") return;
-		if (todos.length === 0) {
+		if (!settings.widget.enabled || todos.length === 0 || completionSummaryHidden) {
 			ctx.ui.setWidget(WIDGET_KEY, undefined);
 			return;
 		}
 
 		const snapshot = cloneTodos(todos);
+		const widgetSettings = { ...settings.widget };
 		ctx.ui.setWidget(
 			WIDGET_KEY,
-			(_tui, theme) => ({
-				render: (width) => renderTodoWidget(snapshot, theme, width),
+			(tui, theme) => ({
+				render: (width) =>
+					renderTodoWidget(snapshot, theme, width, {
+						settings: widgetSettings,
+						terminalRows: tui.terminal.rows,
+					}),
 				invalidate: () => {},
 			}),
 			WIDGET_OPTIONS,
 		);
 	};
 
+	const publishCompletionSummary = (ctx: ExtensionContext): void => {
+		cancelCompletionSummary();
+		completionSummaryHidden = false;
+		if (!ownsSession(ctx) || ctx.mode !== "tui" || !settings.widget.enabled) {
+			publish(ctx);
+			return;
+		}
+
+		const total = todos.length;
+		ctx.ui.setWidget(
+			WIDGET_KEY,
+			(_tui, theme) => ({
+				render: (width) => renderCompletionSummary(total, theme, width),
+				invalidate: () => {},
+			}),
+			WIDGET_OPTIONS,
+		);
+		const ownerSession = activeSession;
+		const token = completionToken;
+		completionTimer = scheduleTimeout(() => {
+			if (
+				completionToken !== token ||
+				activeSession !== ownerSession ||
+				ctx.sessionManager !== ownerSession ||
+				!settings.widget.enabled ||
+				!allTodosCompleted(todos)
+			) {
+				return;
+			}
+			completionTimer = undefined;
+			completionSummaryHidden = true;
+			ctx.ui.setWidget(WIDGET_KEY, undefined);
+		}, COMPLETION_SUMMARY_MS);
+	};
+
 	pi.registerTool({
 		name: TOOL_NAME,
 		label: "Todo List",
 		description:
-			"Replace the current session todo list with the complete supplied todos. Call update_todo_list whenever actual step state changes; keep at most one todo in_progress and send an empty todos array to clear it.",
+			"Replace the current session todo list with the complete supplied todos. Call update_todo_list whenever actual step state changes; keep at most one todo in_progress, require a reason for each blocked todo, and send an empty todos array to clear it.",
 		promptSnippet: "Maintain the complete session todo list as multi-step work progresses",
 		promptGuidelines: [
 			"Use update_todo_list to track work with multiple meaningful steps; skip it for simple, single-step tasks.",
 			"Use update_todo_list to keep the list aligned with actual work: mark a step in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
+			"Use blocked with a concise reason only when progress depends on an external action or condition; blocked does not mean completed.",
 			"Before a progress report or final response, call update_todo_list to reconcile every todo with actual work; do not report completion while the list is stale.",
 			"On every update_todo_list call, send the complete current todos array, keep at most one todo in_progress, and send an empty array when no tracked work remains.",
 		],
 		parameters: TodoParameters,
+		prepareArguments: validateTodoArguments,
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			signal?.throwIfAborted();
 			if (!ownsSession(ctx)) {
 				throw new Error("Cannot update the todo list because the session changed.");
 			}
-			validateTodos(params.todos);
-
-			todos = cloneTodos(params.todos);
-			publish(ctx);
+			const nextTodos = validateTodoArguments(params).todos;
+			const wasComplete = allTodosCompleted(todos);
+			cancelCompletionSummary();
+			completionSummaryHidden = false;
+			todos = cloneTodos(nextTodos);
+			const becameComplete = todos.length > 0 && allTodosCompleted(todos) && !wasComplete;
+			if (becameComplete) publishCompletionSummary(ctx);
+			else publish(ctx);
 
 			const details: TodoDetails = {
 				version: TODO_DETAILS_VERSION,
@@ -124,11 +218,16 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 
 			const completed = todos.filter((todo) => todo.status === "completed").length;
 			const inProgress = todos.some((todo) => todo.status === "in_progress");
+			const blocked = todos.filter((todo) => todo.status === "blocked").length;
+			const suffixes = [
+				...(inProgress ? ["1 in progress"] : []),
+				...(blocked > 0 ? [`${blocked} blocked`] : []),
+			];
 			return {
 				content: [
 					{
 						type: "text",
-						text: `Todo list updated: ${completed} of ${todos.length} complete${inProgress ? "; 1 in progress" : ""}.`,
+						text: `Todo list updated: ${completed} of ${todos.length} complete${suffixes.length > 0 ? `; ${suffixes.join("; ")}` : ""}.`,
 					},
 				],
 				details,
@@ -142,9 +241,45 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 		restoredBoundary = reconstructRestoredTodoBoundary(branch);
 	};
 
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", async (_event, ctx) => {
+		settingsController.abort();
+		settingsController = new AbortController();
+		const ownerController = settingsController;
+		generation += 1;
+		const ownerGeneration = generation;
 		activeSession = ctx.sessionManager;
+		cancelCompletionSummary();
+		completionSummaryHidden = false;
+		settings = cloneDefaultSettings();
 		restoreBranchState(ctx);
+		if (ctx.mode === "tui") ctx.ui.setWidget(WIDGET_KEY, undefined);
+
+		let loaded: TodoSettingsLoadResult;
+		try {
+			loaded = await readSettings(undefined, ownerController.signal);
+		} catch (error) {
+			if (ownerController.signal.aborted || ownerGeneration !== generation || !ownsSession(ctx)) {
+				return;
+			}
+			loaded = {
+				kind: "invalid",
+				path: "pi-todo.json",
+				settings: cloneDefaultSettings(),
+				issue: error instanceof Error ? error.message : String(error),
+			};
+		}
+		if (ownerController.signal.aborted || ownerGeneration !== generation || !ownsSession(ctx)) {
+			return;
+		}
+		settings = cloneSettings(loaded.settings);
+		if (loaded.kind === "invalid" && ctx.hasUI) {
+			ctx.ui.notify(
+				sanitizeTodoText(
+					`Invalid pi-todo settings at ${loaded.path}; using defaults. ${loaded.issue}`,
+				),
+				"warning",
+			);
+		}
 		publish(ctx);
 	});
 
@@ -168,55 +303,27 @@ export default function todoWidgetExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_tree", (_event, ctx) => {
 		if (!ownsSession(ctx)) return;
+		cancelCompletionSummary();
+		completionSummaryHidden = false;
 		restoreBranchState(ctx);
 		publish(ctx);
 	});
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		if (!ownsSession(ctx)) return;
+		settingsController.abort();
+		generation += 1;
+		cancelCompletionSummary();
 		if (ctx.mode === "tui") ctx.ui.setWidget(WIDGET_KEY, undefined);
 		todos = [];
+		settings = cloneDefaultSettings();
 		restoredBoundary = undefined;
+		completionSummaryHidden = false;
 		activeSession = undefined;
 	});
 }
 
-export function renderTodoWidget(todos: readonly Todo[], theme: Theme, width: number): string[] {
-	const completed = todos.filter((todo) => todo.status === "completed").length;
-	const divider = theme.fg("borderMuted", "─".repeat(Math.max(0, width)));
-	const lines = [divider, theme.fg("muted", `Todo · ${completed}/${todos.length} complete`)];
-
-	const renderWidth = Math.max(0, width);
-	for (const todo of todos) {
-		const step = sanitizeTodoStep(todo.step);
-		let prefix: string;
-		let styledStep: string;
-		switch (todo.status) {
-			case "completed":
-				prefix = theme.fg("success", "✓ ");
-				styledStep = theme.fg("muted", theme.strikethrough(step));
-				break;
-			case "in_progress":
-				prefix = theme.fg("accent", "▶ ");
-				styledStep = theme.fg("accent", theme.bold(step));
-				break;
-			case "pending":
-				prefix = theme.fg("dim", "○ ");
-				styledStep = theme.fg("text", step);
-				break;
-		}
-
-		if (renderWidth <= 2) {
-			lines.push(prefix);
-			continue;
-		}
-
-		const wrappedStep = wrapTextWithAnsi(styledStep, renderWidth - 2);
-		lines.push(...wrappedStep.map((line, index) => `${index === 0 ? prefix : "  "}${line}`));
-	}
-
-	return lines.map((line) => truncateToWidth(line, renderWidth, ""));
-}
+export { renderTodoWidget, sanitizeTodoText as sanitizeTodoStep };
 
 export function reconcileTodoContext(
 	messages: ContextEvent["messages"],
@@ -257,14 +364,57 @@ export function reconcileTodoContext(
 	];
 }
 
-export function sanitizeTodoStep(value: string): string {
-	let step = "";
-	for (const character of stripTerminalSequences(value).replace(BIDI_CONTROLS, "")) {
-		const codePoint = character.codePointAt(0) ?? 0;
-		const isControl = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
-		step += isControl ? " " : character;
+export function validateTodoArguments(value: unknown): { todos: Todo[] } {
+	if (!isRecord(value)) rejectTodos("input must be an object with a todos array.");
+	if (!Array.isArray(value.todos)) rejectTodos("todos must be an array.");
+	if (value.todos.length > MAX_TODOS) {
+		rejectTodos(`todos contains ${value.todos.length} items; the maximum is ${MAX_TODOS}.`);
 	}
-	return step.replace(/\s+/gu, " ").trim();
+
+	const todos: Todo[] = [];
+	const inProgressIndices: number[] = [];
+	for (const [index, entry] of value.todos.entries()) {
+		const item = index + 1;
+		if (!isRecord(entry)) rejectTodos(`item ${item} must be an object.`);
+		if (typeof entry.step !== "string") rejectTodos(`item ${item} step must be a string.`);
+		if (entry.step.trim().length === 0) {
+			rejectTodos(`item ${item} step must contain non-whitespace text.`);
+		}
+		if (characterLength(entry.step) > MAX_TODO_STEP_LENGTH) {
+			rejectTodos(`item ${item} step exceeds ${MAX_TODO_STEP_LENGTH} characters.`);
+		}
+		if (!TODO_STATUSES.includes(entry.status as TodoStatus)) {
+			rejectTodos(`item ${item} status must be pending, in_progress, completed, or blocked.`);
+		}
+		const status = entry.status as TodoStatus;
+		if (status === "in_progress") inProgressIndices.push(item);
+
+		if (status === "blocked") {
+			if (typeof entry.reason !== "string" || entry.reason.trim().length === 0) {
+				rejectTodos(`item ${item} is blocked and requires a non-whitespace reason.`);
+			}
+			if (characterLength(entry.reason) > MAX_TODO_REASON_LENGTH) {
+				rejectTodos(`item ${item} reason exceeds ${MAX_TODO_REASON_LENGTH} characters.`);
+			}
+			todos.push({ step: entry.step, status, reason: entry.reason });
+			continue;
+		}
+		if (Object.hasOwn(entry, "reason")) {
+			rejectTodos(`item ${item} may include reason only when status is blocked.`);
+		}
+		todos.push({ step: entry.step, status });
+	}
+
+	if (inProgressIndices.length > 1) {
+		rejectTodos(
+			`items ${inProgressIndices.join(" and ")} are in_progress; keep at most one in_progress item.`,
+		);
+	}
+	return { todos };
+}
+
+function rejectTodos(message: string): never {
+	throw new Error(`Todo list rejected: ${message} ${RESUBMIT_GUIDANCE}`);
 }
 
 function todoContextContent(todos: readonly Todo[]): string {
@@ -291,27 +441,44 @@ function isRestoredTodoBoundaryData(
 	value: unknown,
 	summaryEpoch: string,
 ): value is { version: number; summaryEpoch: string; content: string } {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	const data = value as Record<string, unknown>;
+	if (!isRecord(value)) return false;
 	if (
-		data.version !== TODO_RESTORED_BOUNDARY_VERSION ||
-		data.summaryEpoch !== summaryEpoch ||
-		typeof data.content !== "string"
+		value.version !== TODO_RESTORED_BOUNDARY_VERSION ||
+		value.summaryEpoch !== summaryEpoch ||
+		typeof value.content !== "string"
 	) {
 		return false;
 	}
-	return isCanonicalTodoContextContent(data.content);
+	return isCanonicalTodoContextContent(value.content);
 }
 
 function isCanonicalTodoContextContent(content: string): boolean {
 	const currentPrefix = todoContextPrefix(TODO_CONTEXT_VERSION);
 	if (content.startsWith(currentPrefix)) {
 		try {
-			const restoredTodos = todosFromToolArguments(JSON.parse(content.slice(currentPrefix.length)));
+			const restoredTodos = currentTodosFromToolArguments(
+				JSON.parse(content.slice(currentPrefix.length)),
+			);
 			return (
 				restoredTodos !== undefined &&
 				restoredTodos.length > 0 &&
 				todoContextContent(restoredTodos) === content
+			);
+		} catch {
+			return false;
+		}
+	}
+
+	const previousPrefix = todoContextPrefix(PREVIOUS_TODO_CONTEXT_VERSION);
+	if (content.startsWith(previousPrefix)) {
+		try {
+			const restoredTodos = previousTodoDataFromToolArguments(
+				JSON.parse(content.slice(previousPrefix.length)),
+			);
+			return (
+				restoredTodos !== undefined &&
+				restoredTodos.length > 0 &&
+				previousTodoContextContent(restoredTodos) === content
 			);
 		} catch {
 			return false;
@@ -334,6 +501,11 @@ function isCanonicalTodoContextContent(content: string): boolean {
 
 function todoContextPrefix(version: number): string {
 	return `[PI TODO STATUS v${version}]\nCurrent todo list as JSON data:\n`;
+}
+
+function previousTodoContextContent(todos: readonly PreviousTodo[]): string {
+	const canonicalTodos = todos.map((todo) => ({ step: todo.step, status: todo.status }));
+	return `${todoContextPrefix(PREVIOUS_TODO_CONTEXT_VERSION)}${JSON.stringify({ todos: canonicalTodos })}`;
 }
 
 function legacyTodoContextContent(items: readonly LegacyTodoItem[]): string {
@@ -375,11 +547,24 @@ function hasModelVisibleTodoState(
 }
 
 function todosFromToolArguments(value: unknown): Todo[] | undefined {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
-	const record = value as Record<string, unknown>;
-	if (isTodos(record.todos)) return cloneTodos(record.todos);
-	if (isLegacyTodoItems(record.items)) return migrateLegacyItems(record.items);
+	return currentTodosFromToolArguments(value) ?? previousTodosFromToolArguments(value);
+}
+
+function currentTodosFromToolArguments(value: unknown): Todo[] | undefined {
+	if (!isRecord(value)) return undefined;
+	if (isTodos(value.todos)) return cloneTodos(value.todos);
+	if (isLegacyTodoItems(value.items)) return migrateLegacyItems(value.items);
 	return undefined;
+}
+
+function previousTodosFromToolArguments(value: unknown): Todo[] | undefined {
+	const previous = previousTodoDataFromToolArguments(value);
+	return previous ? migratePreviousTodos(previous) : undefined;
+}
+
+function previousTodoDataFromToolArguments(value: unknown): PreviousTodo[] | undefined {
+	if (!isRecord(value) || !isPreviousTodos(value.todos)) return undefined;
+	return value.todos.map((todo) => ({ step: todo.step, status: todo.status }));
 }
 
 type TodoContextMessage = Extract<ContextEvent["messages"][number], { role: "custom" }> & {
@@ -393,12 +578,7 @@ function isTodoContextMessage(
 }
 
 function hasTodoContextVersion(message: TodoContextMessage): boolean {
-	return (
-		typeof message.details === "object" &&
-		message.details !== null &&
-		!Array.isArray(message.details) &&
-		(message.details as Record<string, unknown>).version === TODO_CONTEXT_VERSION
-	);
+	return isRecord(message.details) && message.details.version === TODO_CONTEXT_VERSION;
 }
 
 function leadingSummaryEpoch(messages: ContextEvent["messages"]): string | undefined {
@@ -416,19 +596,6 @@ function leadingSummaryBoundary(messages: ContextEvent["messages"]): number {
 	return index;
 }
 
-function validateTodos(todos: readonly Todo[]): void {
-	for (const [index, todo] of todos.entries()) {
-		if (todo.step.trim().length === 0) {
-			throw new Error(`Todo ${index + 1} must contain a non-whitespace step.`);
-		}
-	}
-
-	const currentCount = todos.filter((todo) => todo.status === "in_progress").length;
-	if (currentCount > 1) {
-		throw new Error("Todo list can contain at most one in_progress todo.");
-	}
-}
-
 function reconstructTodos(entries: readonly SessionEntry[]): Todo[] {
 	let restored: Todo[] = [];
 	for (const entry of entries) {
@@ -436,6 +603,7 @@ function reconstructTodos(entries: readonly SessionEntry[]): Todo[] {
 		const message = entry.message;
 		if (
 			message.role !== "toolResult" ||
+			message.isError ||
 			(message.toolName !== TOOL_NAME && message.toolName !== LEGACY_TOOL_NAME)
 		) {
 			continue;
@@ -447,54 +615,89 @@ function reconstructTodos(entries: readonly SessionEntry[]): Todo[] {
 }
 
 function todosFromDetails(value: unknown): Todo[] | undefined {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
-	const record = value as Record<string, unknown>;
-	if (record.version === TODO_DETAILS_VERSION && isTodos(record.todos)) {
-		return cloneTodos(record.todos);
+	if (!isRecord(value)) return undefined;
+	if (value.version === TODO_DETAILS_VERSION && isTodos(value.todos)) {
+		return cloneTodos(value.todos);
 	}
-	if (record.version === LEGACY_TODO_DETAILS_VERSION && isLegacyTodoItems(record.items)) {
-		return migrateLegacyItems(record.items);
+	if (value.version === PREVIOUS_TODO_DETAILS_VERSION && isPreviousTodos(value.todos)) {
+		return migratePreviousTodos(value.todos);
+	}
+	if (value.version === LEGACY_TODO_DETAILS_VERSION && isLegacyTodoItems(value.items)) {
+		return migrateLegacyItems(value.items);
 	}
 	return undefined;
 }
 
 function isTodos(value: unknown): value is Todo[] {
-	return hasValidTodoShape(value, "step");
-}
-
-function isLegacyTodoItems(value: unknown): value is LegacyTodoItem[] {
-	return hasValidTodoShape(value, "text");
-}
-
-function hasValidTodoShape(value: unknown, stepProperty: "step" | "text"): boolean {
 	if (!Array.isArray(value) || value.length > MAX_TODOS) return false;
-
-	let currentCount = 0;
+	let inProgressCount = 0;
 	for (const entry of value) {
-		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return false;
-		const record = entry as Record<string, unknown>;
-		const step = record[stepProperty];
+		if (!isRecord(entry)) return false;
 		if (
-			typeof step !== "string" ||
-			step.length === 0 ||
-			step.length > MAX_TODO_STEP_LENGTH ||
-			step.trim().length === 0 ||
-			!TODO_STATUSES.includes(record.status as TodoStatus)
+			typeof entry.step !== "string" ||
+			entry.step.trim().length === 0 ||
+			characterLength(entry.step) > MAX_TODO_STEP_LENGTH ||
+			!TODO_STATUSES.includes(entry.status as TodoStatus)
 		) {
 			return false;
 		}
-		if (record.status === "in_progress") currentCount += 1;
+		if (entry.status === "in_progress") inProgressCount += 1;
+		if (entry.status === "blocked") {
+			if (
+				typeof entry.reason !== "string" ||
+				entry.reason.trim().length === 0 ||
+				characterLength(entry.reason) > MAX_TODO_REASON_LENGTH
+			) {
+				return false;
+			}
+		} else if (Object.hasOwn(entry, "reason")) {
+			return false;
+		}
 	}
-	return currentCount <= 1;
+	return inProgressCount <= 1;
+}
+
+function isPreviousTodos(value: unknown): value is PreviousTodo[] {
+	return hasPreviousTodoShape(value, "step");
+}
+
+function isLegacyTodoItems(value: unknown): value is LegacyTodoItem[] {
+	return hasPreviousTodoShape(value, "text");
+}
+
+function hasPreviousTodoShape(value: unknown, stepProperty: "step" | "text"): boolean {
+	if (!Array.isArray(value) || value.length > MAX_TODOS) return false;
+	let inProgressCount = 0;
+	for (const entry of value) {
+		if (!isRecord(entry) || Object.hasOwn(entry, "reason")) return false;
+		const step = entry[stepProperty];
+		if (
+			typeof step !== "string" ||
+			step.trim().length === 0 ||
+			characterLength(step) > MAX_TODO_STEP_LENGTH ||
+			!PREVIOUS_TODO_STATUSES.includes(entry.status as PreviousTodoStatus)
+		) {
+			return false;
+		}
+		if (entry.status === "in_progress") inProgressCount += 1;
+	}
+	return inProgressCount <= 1;
 }
 
 function todosEqual(left: readonly Todo[], right: readonly Todo[]): boolean {
 	return (
 		left.length === right.length &&
 		left.every(
-			(todo, index) => todo.step === right[index]?.step && todo.status === right[index]?.status,
+			(todo, index) =>
+				todo.step === right[index]?.step &&
+				todo.status === right[index]?.status &&
+				todo.reason === right[index]?.reason,
 		)
 	);
+}
+
+function migratePreviousTodos(todos: readonly PreviousTodo[]): Todo[] {
+	return todos.map((todo) => ({ step: todo.step, status: todo.status }));
 }
 
 function migrateLegacyItems(items: readonly LegacyTodoItem[]): Todo[] {
@@ -502,5 +705,29 @@ function migrateLegacyItems(items: readonly LegacyTodoItem[]): Todo[] {
 }
 
 function cloneTodos(todos: readonly Todo[]): Todo[] {
-	return todos.map((todo) => ({ step: todo.step, status: todo.status }));
+	return todos.map((todo) => ({
+		step: todo.step,
+		status: todo.status,
+		...(todo.reason === undefined ? {} : { reason: todo.reason }),
+	}));
+}
+
+function allTodosCompleted(value: readonly Todo[]): boolean {
+	return value.length > 0 && value.every((todo) => todo.status === "completed");
+}
+
+function characterLength(value: string): number {
+	return [...value].length;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneDefaultSettings(): TodoSettings {
+	return { widget: { ...DEFAULT_TODO_SETTINGS.widget } };
+}
+
+function cloneSettings(value: Readonly<TodoSettings>): TodoSettings {
+	return { widget: { ...value.widget } };
 }

--- a/packages/pi-todo/src/todo-widget.ts
+++ b/packages/pi-todo/src/todo-widget.ts
@@ -380,7 +380,7 @@ export function validateTodoArguments(value: unknown): { todos: Todo[] } {
 		if (entry.step.trim().length === 0) {
 			rejectTodos(`item ${item} step must contain non-whitespace text.`);
 		}
-		if (characterLength(entry.step) > MAX_TODO_STEP_LENGTH) {
+		if (!hasMaxGraphemeLength(entry.step, MAX_TODO_STEP_LENGTH)) {
 			rejectTodos(`item ${item} step exceeds ${MAX_TODO_STEP_LENGTH} characters.`);
 		}
 		if (!TODO_STATUSES.includes(entry.status as TodoStatus)) {
@@ -393,7 +393,7 @@ export function validateTodoArguments(value: unknown): { todos: Todo[] } {
 			if (typeof entry.reason !== "string" || entry.reason.trim().length === 0) {
 				rejectTodos(`item ${item} is blocked and requires a non-whitespace reason.`);
 			}
-			if (characterLength(entry.reason) > MAX_TODO_REASON_LENGTH) {
+			if (!hasMaxGraphemeLength(entry.reason, MAX_TODO_REASON_LENGTH)) {
 				rejectTodos(`item ${item} reason exceeds ${MAX_TODO_REASON_LENGTH} characters.`);
 			}
 			todos.push({ step: entry.step, status, reason: entry.reason });
@@ -636,7 +636,7 @@ function isTodos(value: unknown): value is Todo[] {
 		if (
 			typeof entry.step !== "string" ||
 			entry.step.trim().length === 0 ||
-			characterLength(entry.step) > MAX_TODO_STEP_LENGTH ||
+			!hasMaxGraphemeLength(entry.step, MAX_TODO_STEP_LENGTH) ||
 			!TODO_STATUSES.includes(entry.status as TodoStatus)
 		) {
 			return false;
@@ -646,7 +646,7 @@ function isTodos(value: unknown): value is Todo[] {
 			if (
 				typeof entry.reason !== "string" ||
 				entry.reason.trim().length === 0 ||
-				characterLength(entry.reason) > MAX_TODO_REASON_LENGTH
+				!hasMaxGraphemeLength(entry.reason, MAX_TODO_REASON_LENGTH)
 			) {
 				return false;
 			}
@@ -674,7 +674,7 @@ function hasPreviousTodoShape(value: unknown, stepProperty: "step" | "text"): bo
 		if (
 			typeof step !== "string" ||
 			step.trim().length === 0 ||
-			characterLength(step) > MAX_TODO_STEP_LENGTH ||
+			!hasMaxGraphemeLength(step, MAX_TODO_STEP_LENGTH) ||
 			!PREVIOUS_TODO_STATUSES.includes(entry.status as PreviousTodoStatus)
 		) {
 			return false;
@@ -716,8 +716,62 @@ function allTodosCompleted(value: readonly Todo[]): boolean {
 	return value.length > 0 && value.every((todo) => todo.status === "completed");
 }
 
-function characterLength(value: string): number {
-	return [...value].length;
+// Keep this aligned with TypeBox's maxLength guard so custom validation and schema validation agree.
+function hasMaxGraphemeLength(value: string, maximum: number): boolean {
+	let count = 0;
+	let index = 0;
+	while (index < value.length) {
+		index = nextGraphemeClusterIndex(value, index);
+		count += 1;
+		if (count > maximum) return false;
+	}
+	return true;
+}
+
+function nextGraphemeClusterIndex(value: string, clusterStart: number): number {
+	const start = value.codePointAt(clusterStart) ?? 0;
+	let clusterEnd = clusterStart + codePointLength(start);
+	clusterEnd = consumeGraphemeModifiers(value, clusterEnd);
+	while (clusterEnd < value.length - 1 && value.codePointAt(clusterEnd) === 0x200d) {
+		const next = value.codePointAt(clusterEnd + 1) ?? 0;
+		clusterEnd += 1 + codePointLength(next);
+		clusterEnd = consumeGraphemeModifiers(value, clusterEnd);
+	}
+	if (
+		isBetween(start, 0x1f1e6, 0x1f1ff) &&
+		clusterEnd < value.length &&
+		isBetween(value.codePointAt(clusterEnd) ?? 0, 0x1f1e6, 0x1f1ff)
+	) {
+		clusterEnd += codePointLength(value.codePointAt(clusterEnd) ?? 0);
+	}
+	return clusterEnd;
+}
+
+function consumeGraphemeModifiers(value: string, start: number): number {
+	let index = start;
+	while (index < value.length) {
+		const point = value.codePointAt(index) ?? 0;
+		if (!isCombiningMark(point) && !isBetween(point, 0xfe00, 0xfe0f)) break;
+		index += codePointLength(point);
+	}
+	return index;
+}
+
+function isCombiningMark(value: number): boolean {
+	return (
+		isBetween(value, 0x0300, 0x036f) ||
+		isBetween(value, 0x1ab0, 0x1aff) ||
+		isBetween(value, 0x1dc0, 0x1dff) ||
+		isBetween(value, 0xfe20, 0xfe2f)
+	);
+}
+
+function codePointLength(value: number): number {
+	return value > 0xffff ? 2 : 1;
+}
+
+function isBetween(value: number, minimum: number, maximum: number): boolean {
+	return value >= minimum && value <= maximum;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/pi-todo/src/widget-renderer.ts
+++ b/packages/pi-todo/src/widget-renderer.ts
@@ -164,7 +164,7 @@ function renderCollapsed(
 	const bodyBudget = Math.max(0, rowBudget - header.length);
 	const selected: string[] = [];
 	let selectedItems = 0;
-	let clippedActive = false;
+	let clippedItem = false;
 
 	for (const item of prioritized.slice(0, itemLimit)) {
 		const remainingItems = prioritized.length - selectedItems - 1;
@@ -179,10 +179,10 @@ function renderCollapsed(
 			selectedItems += 1;
 			continue;
 		}
-		if (item.todo.status === "in_progress" && selectedItems === 0) {
+		if (selectedItems === 0) {
 			selected.push(...clipLines(item.lines, available, width));
 			selectedItems += 1;
-			clippedActive = true;
+			clippedItem = true;
 		}
 		break;
 	}
@@ -191,7 +191,7 @@ function renderCollapsed(
 	const footerParts: string[] = [];
 	if (settings.showCompleted && completed > 0) footerParts.push(`✓ ${completed} completed`);
 	if (hidden > 0) footerParts.push(`… ${hidden} more`);
-	if (clippedActive) footerParts.push("active item truncated");
+	if (clippedItem) footerParts.push("item truncated");
 	if (footerParts.length > 0 && selected.length < bodyBudget) {
 		selected.push(theme.fg("dim", footerParts.join(" · ")));
 	}

--- a/packages/pi-todo/src/widget-renderer.ts
+++ b/packages/pi-todo/src/widget-renderer.ts
@@ -1,0 +1,209 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { DEFAULT_TODO_SETTINGS, type TodoWidgetSettings } from "./settings.js";
+import type { Todo } from "./todo-widget.js";
+
+const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
+
+export interface RenderTodoWidgetOptions {
+	settings?: Readonly<TodoWidgetSettings>;
+	terminalRows?: number;
+}
+
+interface RenderedTodo {
+	todo: Todo;
+	lines: string[];
+}
+
+export function renderTodoWidget(
+	todos: readonly Todo[],
+	theme: Theme,
+	width: number,
+	options: RenderTodoWidgetOptions = {},
+): string[] {
+	const renderWidth = Math.max(0, width);
+	const settings = options.settings ?? DEFAULT_TODO_SETTINGS.widget;
+	const header = renderHeader(todos, theme, renderWidth, settings.showProgress);
+	const rendered = todos.map((todo) => ({ todo, lines: renderTodo(todo, theme, renderWidth) }));
+
+	let lines: string[];
+	switch (settings.displayMode) {
+		case "expanded":
+			lines = renderExpanded(header, rendered, settings, theme, renderWidth);
+			break;
+		case "collapsed":
+			lines = renderCollapsed(
+				header,
+				rendered,
+				settings,
+				theme,
+				renderWidth,
+				widgetRowBudget(options.terminalRows),
+			);
+			break;
+		case "adaptive": {
+			const expanded = renderExpanded(header, rendered, settings, theme, renderWidth);
+			const rowBudget = widgetRowBudget(options.terminalRows);
+			const eligibleItems = settings.showCompleted
+				? rendered.length
+				: rendered.filter(({ todo }) => todo.status !== "completed").length;
+			const itemCapHidesWork =
+				settings.maxVisibleItems !== null && eligibleItems > settings.maxVisibleItems;
+			lines =
+				expanded.length <= rowBudget && !itemCapHidesWork
+					? expanded
+					: renderCollapsed(header, rendered, settings, theme, renderWidth, rowBudget);
+			break;
+		}
+	}
+
+	return lines.map((line) => truncateToWidth(line, renderWidth, ""));
+}
+
+export function renderCompletionSummary(total: number, theme: Theme, width: number): string[] {
+	const renderWidth = Math.max(0, width);
+	return [
+		theme.fg("borderMuted", "─".repeat(renderWidth)),
+		theme.fg("success", `✓ ${total}/${total} tasks completed`),
+	].map((line) => truncateToWidth(line, renderWidth, ""));
+}
+
+export function sanitizeTodoText(value: string): string {
+	let text = "";
+	for (const character of stripTerminalSequences(value).replace(BIDI_CONTROLS, "")) {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const isControl = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		text += isControl ? " " : character;
+	}
+	return text.replace(/\s+/gu, " ").trim();
+}
+
+export function widgetRowBudget(terminalRows?: number): number {
+	const rows =
+		typeof terminalRows === "number" && Number.isFinite(terminalRows)
+			? Math.max(0, Math.floor(terminalRows))
+			: 36;
+	return Math.max(4, Math.min(12, Math.floor(rows / 3)));
+}
+
+function renderHeader(
+	todos: readonly Todo[],
+	theme: Theme,
+	width: number,
+	showProgress: boolean,
+): string[] {
+	const completed = todos.filter((todo) => todo.status === "completed").length;
+	return [
+		theme.fg("borderMuted", "─".repeat(width)),
+		theme.fg("muted", showProgress ? `Todo · ${completed}/${todos.length} complete` : "Todo"),
+	];
+}
+
+function renderTodo(todo: Todo, theme: Theme, width: number): string[] {
+	const step = sanitizeTodoText(todo.step) || "(text hidden after sanitization)";
+	let prefix: string;
+	let styledText: string;
+	switch (todo.status) {
+		case "completed":
+			prefix = theme.fg("success", "✓ ");
+			styledText = theme.fg("muted", theme.strikethrough(step));
+			break;
+		case "in_progress":
+			prefix = theme.fg("accent", "▶ ");
+			styledText = theme.fg("accent", theme.bold(step));
+			break;
+		case "blocked": {
+			prefix = theme.fg("warning", "⚠ ");
+			const reason = sanitizeTodoText(todo.reason ?? "") || "(reason hidden after sanitization)";
+			styledText = `${theme.fg("warning", step)}${reason ? theme.fg("muted", ` — ${reason}`) : ""}`;
+			break;
+		}
+		case "pending":
+			prefix = theme.fg("dim", "○ ");
+			styledText = theme.fg("text", step);
+			break;
+	}
+
+	if (width <= 2) return [prefix];
+	const wrapped = wrapTextWithAnsi(styledText, width - 2);
+	return wrapped.map((line, index) => `${index === 0 ? prefix : "  "}${line}`);
+}
+
+function renderExpanded(
+	header: readonly string[],
+	rendered: readonly RenderedTodo[],
+	settings: Readonly<TodoWidgetSettings>,
+	theme: Theme,
+	width: number,
+): string[] {
+	const candidates = settings.showCompleted
+		? rendered
+		: rendered.filter(({ todo }) => todo.status !== "completed");
+	const visible = candidates.slice(0, settings.maxVisibleItems ?? candidates.length);
+	const hidden = candidates.length - visible.length;
+	const lines = [...header, ...visible.flatMap((item) => item.lines)];
+	if (hidden > 0) lines.push(theme.fg("dim", `… ${hidden} more`));
+	return lines.map((line) => truncateToWidth(line, width, ""));
+}
+
+function renderCollapsed(
+	header: readonly string[],
+	rendered: readonly RenderedTodo[],
+	settings: Readonly<TodoWidgetSettings>,
+	theme: Theme,
+	width: number,
+	rowBudget: number,
+): string[] {
+	const prioritized = [
+		...rendered.filter(({ todo }) => todo.status === "in_progress"),
+		...rendered.filter(({ todo }) => todo.status === "blocked"),
+		...rendered.filter(({ todo }) => todo.status === "pending"),
+	];
+	const itemLimit = Math.min(settings.maxVisibleItems ?? prioritized.length, prioritized.length);
+	const completed = rendered.filter(({ todo }) => todo.status === "completed").length;
+	const bodyBudget = Math.max(0, rowBudget - header.length);
+	const selected: string[] = [];
+	let selectedItems = 0;
+	let clippedActive = false;
+
+	for (const item of prioritized.slice(0, itemLimit)) {
+		const remainingItems = prioritized.length - selectedItems - 1;
+		const needsFooter =
+			remainingItems > 0 ||
+			itemLimit < prioritized.length ||
+			(settings.showCompleted && completed > 0);
+		const available = bodyBudget - selected.length - (needsFooter ? 1 : 0);
+		if (available <= 0) break;
+		if (item.lines.length <= available) {
+			selected.push(...item.lines);
+			selectedItems += 1;
+			continue;
+		}
+		if (item.todo.status === "in_progress" && selectedItems === 0) {
+			selected.push(...clipLines(item.lines, available, width));
+			selectedItems += 1;
+			clippedActive = true;
+		}
+		break;
+	}
+
+	const hidden = prioritized.length - selectedItems;
+	const footerParts: string[] = [];
+	if (settings.showCompleted && completed > 0) footerParts.push(`✓ ${completed} completed`);
+	if (hidden > 0) footerParts.push(`… ${hidden} more`);
+	if (clippedActive) footerParts.push("active item truncated");
+	if (footerParts.length > 0 && selected.length < bodyBudget) {
+		selected.push(theme.fg("dim", footerParts.join(" · ")));
+	}
+
+	return [...header, ...selected]
+		.slice(0, rowBudget)
+		.map((line) => truncateToWidth(line, width, ""));
+}
+
+function clipLines(lines: readonly string[], count: number, width: number): string[] {
+	const clipped = lines.slice(0, count);
+	const last = clipped.at(-1);
+	if (last !== undefined) clipped[clipped.length - 1] = truncateToWidth(`${last}…`, width, "…");
+	return clipped;
+}

--- a/packages/pi-todo/test/build-runtime.test.ts
+++ b/packages/pi-todo/test/build-runtime.test.ts
@@ -176,6 +176,7 @@ test("generated runtime is loadable by Pi's Jiti resource loader", async () => {
 		assert.equal(loaded.extensions.length, 1);
 		const extension = loaded.extensions[0];
 		assert.ok(extension?.tools.has("update_todo_list"));
+		assert.equal(extension?.commands.size, 0);
 		assert.ok(extension?.handlers.has("session_start"));
 		assert.ok(extension?.handlers.has("context"));
 		assert.ok(extension?.handlers.has("session_tree"));

--- a/packages/pi-todo/test/settings.test.ts
+++ b/packages/pi-todo/test/settings.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import {
+	access,
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import {
+	DEFAULT_TODO_SETTINGS,
+	loadTodoSettings,
+	MAX_TODO_SETTINGS_BYTES,
+	normalizeTodoSettings,
+} from "../src/settings.js";
+
+async function temporaryDirectory(t: { onTestFinished(callback: () => Promise<void>): void }) {
+	const directory = await mkdtemp(join(tmpdir(), "pi-todo-settings-"));
+	t.onTestFinished(() => rm(directory, { recursive: true, force: true }));
+	return directory;
+}
+
+test("normalizes partial widget settings and rejects invalid values", () => {
+	assert.deepEqual(normalizeTodoSettings({}), DEFAULT_TODO_SETTINGS);
+	assert.deepEqual(normalizeTodoSettings({ future: true, widget: { future: "kept" } }), {
+		widget: { ...DEFAULT_TODO_SETTINGS.widget },
+	});
+	assert.deepEqual(
+		normalizeTodoSettings({
+			widget: {
+				enabled: false,
+				displayMode: "collapsed",
+				showCompleted: false,
+				maxVisibleItems: 7,
+				showProgress: false,
+			},
+		}),
+		{
+			widget: {
+				enabled: false,
+				displayMode: "collapsed",
+				showCompleted: false,
+				maxVisibleItems: 7,
+				showProgress: false,
+			},
+		},
+	);
+
+	for (const value of [
+		null,
+		[],
+		{ widget: true },
+		{ widget: { enabled: "yes" } },
+		{ widget: { displayMode: "compact" } },
+		{ widget: { showCompleted: 1 } },
+		{ widget: { showProgress: null } },
+		{ widget: { maxVisibleItems: 0 } },
+		{ widget: { maxVisibleItems: 51 } },
+		{ widget: { maxVisibleItems: 1.5 } },
+	]) {
+		assert.equal(normalizeTodoSettings(value), undefined);
+	}
+});
+
+test("missing settings load is side-effect free", async (t) => {
+	const directory = await temporaryDirectory(t);
+	const parent = join(directory, "missing-parent");
+	const path = join(parent, "pi-todo.json");
+	assert.deepEqual(await loadTodoSettings(path), {
+		kind: "missing",
+		path,
+		settings: { widget: { ...DEFAULT_TODO_SETTINGS.widget } },
+	});
+	await assert.rejects(access(parent));
+	assert.deepEqual(await readdir(directory), []);
+});
+
+test("loads valid settings without rewriting unknown fields", async (t) => {
+	const directory = await temporaryDirectory(t);
+	const path = join(directory, "pi-todo.json");
+	const source = `${JSON.stringify({
+		future: { enabled: true },
+		widget: {
+			displayMode: "expanded",
+			maxVisibleItems: null,
+			futureWidget: "untouched",
+		},
+	})}\n`;
+	await writeFile(path, source, "utf8");
+	assert.deepEqual(await loadTodoSettings(path), {
+		kind: "loaded",
+		path,
+		settings: {
+			widget: {
+				...DEFAULT_TODO_SETTINGS.widget,
+				displayMode: "expanded",
+			},
+		},
+	});
+	assert.equal(await readFile(path, "utf8"), source);
+});
+
+test("reports malformed, invalid, oversized, non-regular, and symlink settings", async (t) => {
+	const directory = await temporaryDirectory(t);
+	const path = join(directory, "pi-todo.json");
+
+	await writeFile(path, "{invalid", "utf8");
+	let result = await loadTodoSettings(path);
+	assert.equal(result.kind, "invalid");
+	assert.match(result.kind === "invalid" ? result.issue : "", /invalid JSON/u);
+	assert.equal(await readFile(path, "utf8"), "{invalid");
+
+	await writeFile(path, '{"widget":{"maxVisibleItems":0}}', "utf8");
+	result = await loadTodoSettings(path);
+	assert.equal(result.kind, "invalid");
+	assert.match(result.kind === "invalid" ? result.issue : "", /shape or values/u);
+
+	await writeFile(path, "x".repeat(MAX_TODO_SETTINGS_BYTES + 1), "utf8");
+	result = await loadTodoSettings(path);
+	assert.equal(result.kind, "invalid");
+	assert.match(result.kind === "invalid" ? result.issue : "", /exceeds/u);
+
+	const directoryPath = join(directory, "settings-directory");
+	await mkdir(directoryPath);
+	result = await loadTodoSettings(directoryPath);
+	assert.equal(result.kind, "invalid");
+	assert.match(result.kind === "invalid" ? result.issue : "", /regular file/u);
+
+	const target = join(directory, "target.json");
+	const link = join(directory, "link.json");
+	await writeFile(target, "{}", "utf8");
+	await symlink(target, link);
+	result = await loadTodoSettings(link);
+	assert.equal(result.kind, "invalid");
+	assert.match(result.kind === "invalid" ? result.issue : "", /symbolic links/u);
+});
+
+test("rejects invalid UTF-8 and honors cancellation", async (t) => {
+	const directory = await temporaryDirectory(t);
+	const path = join(directory, "pi-todo.json");
+	await writeFile(path, Buffer.from([0xc3, 0x28]));
+	const invalid = await loadTodoSettings(path);
+	assert.equal(invalid.kind, "invalid");
+	assert.match(invalid.kind === "invalid" ? invalid.issue : "", /UTF-8/u);
+
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(loadTodoSettings(path, controller.signal), /abort/iu);
+});

--- a/packages/pi-todo/test/settings.test.ts
+++ b/packages/pi-todo/test/settings.test.ts
@@ -105,6 +105,23 @@ test("loads valid settings without rewriting unknown fields", async (t) => {
 	assert.equal(await readFile(path, "utf8"), source);
 });
 
+test("loads UTF-8 BOM settings", async (t) => {
+	const directory = await temporaryDirectory(t);
+	const path = join(directory, "pi-todo.json");
+	const document = Buffer.from('{"widget":{"showProgress":false}}', "utf8");
+	await writeFile(path, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), document]));
+	assert.deepEqual(await loadTodoSettings(path), {
+		kind: "loaded",
+		path,
+		settings: {
+			widget: {
+				...DEFAULT_TODO_SETTINGS.widget,
+				showProgress: false,
+			},
+		},
+	});
+});
+
 test("reports malformed, invalid, oversized, non-regular, and symlink settings", async (t) => {
 	const directory = await temporaryDirectory(t);
 	const path = join(directory, "pi-todo.json");

--- a/packages/pi-todo/test/todo-cache-contract.test.ts
+++ b/packages/pi-todo/test/todo-cache-contract.test.ts
@@ -146,7 +146,9 @@ test("todo compaction restoration preserves normalized ordinary-request prefixes
 	assert.deepEqual(second.toolDefinitions, first.toolDefinitions);
 	assert.deepEqual(second.messages.slice(0, first.messages.length), first.messages);
 
-	const updatedTodos: Todo[] = [{ step: "implement", status: "completed" }];
+	const updatedTodos: Todo[] = [
+		{ step: "implement", status: "blocked", reason: "waiting for approval" },
+	];
 	const updatedRaw = [
 		...secondRaw,
 		todoToolCallMessage(updatedTodos),

--- a/packages/pi-todo/test/todo-harness.ts
+++ b/packages/pi-todo/test/todo-harness.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import type {
+	ContextEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	SessionEntry,
+	Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import {
+	DEFAULT_TODO_SETTINGS,
+	type TodoSettings,
+	type TodoSettingsLoadResult,
+} from "../src/settings.js";
+import todoWidgetExtension, { TOOL_NAME, type Todo, type TodoDetails } from "../src/todo-widget.js";
+
+type Handler = (event: never, ctx: ExtensionContext) => unknown;
+type WidgetFactory = (tui: TUI, theme: Theme) => Component;
+
+export interface RegisteredTool {
+	name: string;
+	label: string;
+	description: string;
+	promptSnippet: string;
+	promptGuidelines: string[];
+	parameters: unknown;
+	prepareArguments(args: unknown): { todos: Todo[] };
+	execute(
+		toolCallId: string,
+		params: unknown,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	): Promise<{ content: Array<{ type: string; text: string }>; details: TodoDetails }>;
+}
+
+export function defaultSettingsResult(): TodoSettingsLoadResult {
+	return {
+		kind: "missing",
+		path: "/tmp/pi-todo.json",
+		settings: { widget: { ...DEFAULT_TODO_SETTINGS.widget } },
+	};
+}
+
+export function loadedSettings(widget: Partial<TodoSettings["widget"]>): TodoSettingsLoadResult {
+	return {
+		kind: "loaded",
+		path: "/tmp/pi-todo.json",
+		settings: { widget: { ...DEFAULT_TODO_SETTINGS.widget, ...widget } },
+	};
+}
+
+export function createHarness(
+	options: {
+		loadSettings?: (path?: string, signal?: AbortSignal) => Promise<TodoSettingsLoadResult>;
+	} = {},
+) {
+	const handlers = new Map<string, Handler[]>();
+	const entries: Array<{ customType: string; data: unknown }> = [];
+	let tool: RegisteredTool | undefined;
+	const pi = {
+		on(event: string, handler: Handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerTool(definition: RegisteredTool) {
+			tool = definition;
+		},
+		appendEntry(customType: string, data: unknown) {
+			entries.push({ customType, data: structuredClone(data) });
+		},
+	} as unknown as ExtensionAPI;
+	todoWidgetExtension(pi, {
+		loadSettings: options.loadSettings ?? (async () => defaultSettingsResult()),
+	});
+
+	return {
+		entries,
+		get tool(): RegisteredTool {
+			assert.ok(tool);
+			return tool;
+		},
+		async emit(event: string, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) await handler({} as never, ctx);
+		},
+		async context(messages: ContextEvent["messages"], ctx: ExtensionContext) {
+			let current = messages;
+			for (const handler of handlers.get("context") ?? []) {
+				const result = (await handler({ messages: current } as never, ctx)) as
+					| { messages?: ContextEvent["messages"] }
+					| undefined;
+				current = result?.messages ?? current;
+			}
+			return current;
+		},
+	};
+}
+
+export function createContext(
+	options: { mode?: ExtensionContext["mode"]; branch?: SessionEntry[]; terminalRows?: number } = {},
+) {
+	const widgets: Array<{
+		key: string;
+		content: WidgetFactory | undefined;
+		options: { placement: "aboveEditor" } | undefined;
+	}> = [];
+	const notifications: Array<{ message: string; type: string | undefined }> = [];
+	const branch = options.branch ?? [];
+	const tui = { terminal: { rows: options.terminalRows ?? 36 } } as unknown as TUI;
+	const sessionManager = {
+		getBranch: () => branch,
+	} as unknown as ExtensionContext["sessionManager"];
+	const ctx = {
+		mode: options.mode ?? "tui",
+		hasUI: options.mode !== "print" && options.mode !== "json",
+		sessionManager,
+		ui: {
+			setWidget(
+				key: string,
+				content: WidgetFactory | undefined,
+				widgetOptions?: { placement: "aboveEditor" },
+			) {
+				widgets.push({ key, content, options: widgetOptions });
+			},
+			notify(message: string, type?: string) {
+				notifications.push({ message, type });
+			},
+		},
+	} as unknown as ExtensionContext;
+	return { branch, ctx, notifications, tui, widgets };
+}
+
+export function identityTheme() {
+	const calls: Array<[string, string]> = [];
+	const theme = {
+		fg(role: string, text: string) {
+			calls.push(["fg", role]);
+			return text;
+		},
+		bold(text: string) {
+			calls.push(["style", "bold"]);
+			return text;
+		},
+		strikethrough(text: string) {
+			calls.push(["style", "strikethrough"]);
+			return text;
+		},
+	} as unknown as Theme;
+	return { calls, theme };
+}
+
+export function todoToolResultMessage(
+	details: unknown,
+	toolName = TOOL_NAME,
+	isError = false,
+): ContextEvent["messages"][number] {
+	return {
+		role: "toolResult",
+		toolCallId: "todo-call",
+		toolName,
+		content: [{ type: "text", text: "updated" }],
+		details,
+		isError,
+		timestamp: 0,
+	};
+}
+
+export function todoToolCallMessage(
+	todos: unknown,
+	toolName = TOOL_NAME,
+	argumentName: "todos" | "items" = "todos",
+): ContextEvent["messages"][number] {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: "todo-call",
+				name: toolName,
+				arguments: { [argumentName]: todos },
+			},
+		],
+		api: "openai-responses",
+		provider: "test",
+		model: "test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 0,
+	};
+}
+
+export function toolResultEntry(
+	details: unknown,
+	toolName = TOOL_NAME,
+	id = "tool-result",
+	parentId: string | null = null,
+): SessionEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date(0).toISOString(),
+		message: todoToolResultMessage(details, toolName),
+	} as SessionEntry;
+}
+
+export function customEntry(
+	customType: string,
+	data: unknown,
+	id: string,
+	parentId: string | null,
+): SessionEntry {
+	return {
+		type: "custom",
+		id,
+		parentId,
+		timestamp: new Date(0).toISOString(),
+		customType,
+		data,
+	} as SessionEntry;
+}
+
+export async function setTodos(
+	harness: ReturnType<typeof createHarness>,
+	ctx: ExtensionContext,
+	todos: Todo[],
+) {
+	return harness.tool.execute("todo-call", { todos }, undefined, undefined, ctx);
+}

--- a/packages/pi-todo/test/todo-widget-enhancements.test.ts
+++ b/packages/pi-todo/test/todo-widget-enhancements.test.ts
@@ -89,7 +89,7 @@ test("adapts widget rows, prioritizes active work, and honors display settings",
 	]);
 });
 
-test("bounds a wrapped active todo and sanitizes collapsed raw state without mutation", () => {
+test("bounds wrapped prioritized todos and sanitizes collapsed raw state without mutation", () => {
 	const { theme } = identityTheme();
 	const todos: Todo[] = [
 		{ step: "alpha beta gamma delta epsilon", status: "in_progress" },
@@ -102,6 +102,28 @@ test("bounds a wrapped active todo and sanitizes collapsed raw state without mut
 	assert.match(lines[3] ?? "", /^… 1 more/u);
 	for (const line of lines) assert.ok(visibleWidth(line) <= 10);
 	assert.deepEqual(todos, before);
+
+	for (const [todo, prefix] of [
+		[{ step: "pending task with text that needs several rows", status: "pending" }, /^○ /u],
+		[
+			{
+				step: "blocked task with text that needs several rows",
+				status: "blocked",
+				reason: "waiting for external approval",
+			},
+			/^⚠ /u,
+		],
+	] as const) {
+		const prioritized = renderTodoWidget([todo], theme, 10, { terminalRows: 12 });
+		assert.equal(prioritized.length, 4);
+		assert.match(prioritized[2] ?? "", prefix);
+		assert.equal(
+			prioritized.some((line) => line.includes("… 1 more")),
+			false,
+		);
+		for (const line of prioritized) assert.ok(visibleWidth(line) <= 10);
+	}
+
 	assert.equal(
 		lines.some((line) => line.includes(`${String.fromCharCode(0x1b)}]`)),
 		false,
@@ -228,6 +250,24 @@ test("returns actionable validation errors before schema validation and direct e
 		],
 	];
 	for (const [input, pattern] of cases) assert.throws(() => validateTodoArguments(input), pattern);
+
+	const decomposedStep = "e\u0301".repeat(151);
+	const emojiReason = "👨‍👩‍👧‍👦".repeat(101);
+	assert.deepEqual(
+		validateTodoArguments({
+			todos: [{ step: decomposedStep, status: "blocked", reason: emojiReason }],
+		}),
+		{
+			todos: [{ step: decomposedStep, status: "blocked", reason: emojiReason }],
+		},
+	);
+	assert.throws(
+		() =>
+			validateTodoArguments({
+				todos: [{ step: "e\u0301".repeat(301), status: "pending" }],
+			}),
+		/step exceeds 300/iu,
+	);
 
 	const canonical = validateTodoArguments({
 		todos: [{ step: "wait", status: "blocked", reason: "approval" }],
@@ -429,7 +469,8 @@ test("ignores errored tool results while reconstructing branch state", async () 
 });
 
 test("restores version 2 state and keeps a canonical version 2 summary boundary", async () => {
-	const previousTodos = [{ step: "before blocked support", status: "in_progress" as const }];
+	const previousStep = "e\u0301".repeat(151);
+	const previousTodos = [{ step: previousStep, status: "in_progress" as const }];
 	const branch: SessionEntry[] = [
 		toolResultEntry({ version: 2, todos: previousTodos }, TOOL_NAME, "initial", null),
 		{

--- a/packages/pi-todo/test/todo-widget-enhancements.test.ts
+++ b/packages/pi-todo/test/todo-widget-enhancements.test.ts
@@ -1,0 +1,488 @@
+import assert from "node:assert/strict";
+import type { ContextEvent, SessionEntry } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test, vi } from "vitest";
+import { DEFAULT_TODO_SETTINGS, type TodoSettingsLoadResult } from "../src/settings.js";
+import {
+	COMPLETION_SUMMARY_MS,
+	renderTodoWidget,
+	TODO_DETAILS_VERSION,
+	TOOL_NAME,
+	type Todo,
+	validateTodoArguments,
+	WIDGET_KEY,
+} from "../src/todo-widget.js";
+import {
+	createContext,
+	createHarness,
+	customEntry,
+	identityTheme,
+	loadedSettings,
+	setTodos,
+	todoToolResultMessage,
+	toolResultEntry,
+} from "./todo-harness.js";
+
+function customText(message: ContextEvent["messages"][number] | undefined): string {
+	return message?.role === "custom" && typeof message.content === "string" ? message.content : "";
+}
+
+test("adapts widget rows, prioritizes active work, and honors display settings", async () => {
+	const { theme } = identityTheme();
+	const todos: Todo[] = [
+		{ step: "finished", status: "completed" },
+		{ step: "current", status: "in_progress" },
+		{ step: "next", status: "pending" },
+		{ step: "later", status: "pending" },
+	];
+	const compact = renderTodoWidget(todos, theme, 40, { terminalRows: 12 });
+	assert.deepEqual(compact, [
+		"─".repeat(40),
+		"Todo · 1/4 complete",
+		"▶ current",
+		"✓ 1 completed · … 2 more",
+	]);
+
+	const expanded = renderTodoWidget(todos, theme, 40, {
+		terminalRows: 12,
+		settings: {
+			enabled: true,
+			displayMode: "expanded",
+			showCompleted: false,
+			maxVisibleItems: 2,
+			showProgress: false,
+		},
+	});
+	assert.deepEqual(expanded, ["─".repeat(40), "Todo", "▶ current", "○ next", "… 1 more"]);
+	const cappedAdaptive = renderTodoWidget(todos, theme, 40, {
+		terminalRows: 60,
+		settings: {
+			enabled: true,
+			displayMode: "adaptive",
+			showCompleted: true,
+			maxVisibleItems: 1,
+			showProgress: true,
+		},
+	});
+	assert.deepEqual(cappedAdaptive, [
+		"─".repeat(40),
+		"Todo · 1/4 complete",
+		"▶ current",
+		"✓ 1 completed · … 2 more",
+	]);
+
+	const harness = createHarness();
+	const current = createContext({ terminalRows: 12 });
+	await harness.emit("session_start", current.ctx);
+	await setTodos(harness, current.ctx, todos);
+	const widget = current.widgets.at(-1)?.content?.(current.tui, theme);
+	assert.ok(widget);
+	assert.equal(widget.render(40).length, 4);
+	(current.tui.terminal as { rows: number }).rows = 60;
+	assert.deepEqual(widget.render(40), [
+		"─".repeat(40),
+		"Todo · 1/4 complete",
+		"✓ finished",
+		"▶ current",
+		"○ next",
+		"○ later",
+	]);
+});
+
+test("bounds a wrapped active todo and sanitizes collapsed raw state without mutation", () => {
+	const { theme } = identityTheme();
+	const todos: Todo[] = [
+		{ step: "alpha beta gamma delta epsilon", status: "in_progress" },
+		{ step: "safe\u001b]8;;https://evil\u0007link\u202e", status: "pending" },
+	];
+	const before = structuredClone(todos);
+	const lines = renderTodoWidget(todos, theme, 10, { terminalRows: 12 });
+	assert.equal(lines.length, 4);
+	assert.match(lines[2] ?? "", /^▶ .*…/u);
+	assert.match(lines[3] ?? "", /^… 1 more/u);
+	for (const line of lines) assert.ok(visibleWidth(line) <= 10);
+	assert.deepEqual(todos, before);
+	assert.equal(
+		lines.some((line) => line.includes(`${String.fromCharCode(0x1b)}]`)),
+		false,
+	);
+	assert.deepEqual(
+		renderTodoWidget([{ step: "\u202e", status: "blocked", reason: "\u2066" }], theme, 80, {
+			settings: {
+				enabled: true,
+				displayMode: "expanded",
+				showCompleted: true,
+				maxVisibleItems: null,
+				showProgress: true,
+			},
+		}),
+		[
+			"─".repeat(80),
+			"Todo · 0/1 complete",
+			"⚠ (text hidden after sanitization) — (reason hidden after sanitization)",
+		],
+	);
+});
+
+test("shows a transient completion summary while retaining todo state", async () => {
+	vi.useFakeTimers();
+	try {
+		const harness = createHarness();
+		const current = createContext();
+		await harness.emit("session_start", current.ctx);
+		await setTodos(harness, current.ctx, [{ step: "finish", status: "in_progress" }]);
+		const result = await setTodos(harness, current.ctx, [{ step: "finish", status: "completed" }]);
+		assert.deepEqual(result.details.todos, [{ step: "finish", status: "completed" }]);
+		const { theme } = identityTheme();
+		assert.deepEqual(current.widgets.at(-1)?.content?.(current.tui, theme).render(40), [
+			"─".repeat(40),
+			"✓ 1/1 tasks completed",
+		]);
+
+		await vi.advanceTimersByTimeAsync(COMPLETION_SUMMARY_MS - 1);
+		assert.equal(typeof current.widgets.at(-1)?.content, "function");
+		await vi.advanceTimersByTimeAsync(1);
+		assert.deepEqual(current.widgets.at(-1), {
+			key: WIDGET_KEY,
+			content: undefined,
+			options: undefined,
+		});
+
+		const restored = await harness.context(
+			[
+				{
+					role: "compactionSummary",
+					summary: "Earlier work was compacted.",
+					tokensBefore: 10,
+					timestamp: 0,
+				},
+			],
+			current.ctx,
+		);
+		assert.match(customText(restored[1]), /"status":"completed"/u);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("cancels completion timers on updates, clears, tree changes, and session replacement", async () => {
+	vi.useFakeTimers();
+	try {
+		const harness = createHarness();
+		const previous = createContext();
+		await harness.emit("session_start", previous.ctx);
+		await setTodos(harness, previous.ctx, [{ step: "old", status: "in_progress" }]);
+		await setTodos(harness, previous.ctx, [{ step: "old", status: "completed" }]);
+		await setTodos(harness, previous.ctx, [{ step: "replacement", status: "pending" }]);
+		await vi.advanceTimersByTimeAsync(COMPLETION_SUMMARY_MS);
+		assert.equal(typeof previous.widgets.at(-1)?.content, "function");
+
+		await setTodos(harness, previous.ctx, [{ step: "replacement", status: "completed" }]);
+		await setTodos(harness, previous.ctx, []);
+		await vi.advanceTimersByTimeAsync(COMPLETION_SUMMARY_MS);
+		assert.equal(previous.widgets.at(-1)?.content, undefined);
+
+		await setTodos(harness, previous.ctx, [{ step: "tree", status: "in_progress" }]);
+		await setTodos(harness, previous.ctx, [{ step: "tree", status: "completed" }]);
+		previous.branch.push(
+			toolResultEntry({
+				version: TODO_DETAILS_VERSION,
+				todos: [{ step: "tree", status: "completed" }],
+			}),
+		);
+		await harness.emit("session_tree", previous.ctx);
+		assert.equal(typeof previous.widgets.at(-1)?.content, "function");
+
+		await setTodos(harness, previous.ctx, [{ step: "session", status: "in_progress" }]);
+		await setTodos(harness, previous.ctx, [{ step: "session", status: "completed" }]);
+		const current = createContext();
+		await harness.emit("session_start", current.ctx);
+		await setTodos(harness, current.ctx, [{ step: "current", status: "in_progress" }]);
+		const widgetCount = current.widgets.length;
+		await vi.advanceTimersByTimeAsync(COMPLETION_SUMMARY_MS);
+		assert.equal(current.widgets.length, widgetCount);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("returns actionable validation errors before schema validation and direct execution", async () => {
+	const cases: Array<[unknown, RegExp]> = [
+		[null, /input must be an object.*resubmit the complete todos array/iu],
+		[{}, /todos must be an array.*resubmit/iu],
+		[
+			{ todos: Array.from({ length: 51 }, () => ({ step: "x", status: "pending" })) },
+			/maximum is 50/iu,
+		],
+		[{ todos: [null] }, /item 1 must be an object/iu],
+		[{ todos: [{ step: 1, status: "pending" }] }, /item 1 step must be a string/iu],
+		[{ todos: [{ step: "x", status: "unknown" }] }, /item 1 status must be/iu],
+		[{ todos: [{ step: "x", status: "blocked" }] }, /item 1 is blocked.*reason/iu],
+		[
+			{ todos: [{ step: "x", status: "blocked", reason: "x".repeat(201) }] },
+			/item 1 reason exceeds 200/iu,
+		],
+		[
+			{ todos: [{ step: "x", status: "pending", reason: "not allowed" }] },
+			/reason only when status is blocked/iu,
+		],
+	];
+	for (const [input, pattern] of cases) assert.throws(() => validateTodoArguments(input), pattern);
+
+	const canonical = validateTodoArguments({
+		todos: [{ step: "wait", status: "blocked", reason: "approval" }],
+	});
+	assert.deepEqual(canonical, {
+		todos: [{ step: "wait", status: "blocked", reason: "approval" }],
+	});
+
+	const harness = createHarness();
+	const current = createContext();
+	await harness.emit("session_start", current.ctx);
+	await setTodos(harness, current.ctx, [{ step: "kept", status: "pending" }]);
+	const widgetCount = current.widgets.length;
+	assert.throws(
+		() =>
+			harness.tool.prepareArguments({
+				todos: [
+					{ step: "one", status: "in_progress" },
+					{ step: "two", status: "in_progress" },
+				],
+			}),
+		/items 1 and 2.*resubmit the complete todos array/iu,
+	);
+	await assert.rejects(
+		harness.tool.execute(
+			"invalid",
+			{ todos: [{ step: "x", status: "blocked", reason: " " }] },
+			undefined,
+			undefined,
+			current.ctx,
+		),
+		/non-whitespace reason.*resubmit/iu,
+	);
+	assert.equal(current.widgets.length, widgetCount);
+});
+
+test("loads display settings, warns safely, and ignores stale async loads", async () => {
+	const collapsedHarness = createHarness({
+		loadSettings: async () =>
+			loadedSettings({
+				displayMode: "collapsed",
+				showCompleted: false,
+				maxVisibleItems: 1,
+				showProgress: false,
+			}),
+	});
+	const collapsed = createContext({ terminalRows: 60 });
+	await collapsedHarness.emit("session_start", collapsed.ctx);
+	await setTodos(collapsedHarness, collapsed.ctx, [
+		{ step: "done", status: "completed" },
+		{ step: "active", status: "in_progress" },
+		{ step: "later", status: "pending" },
+	]);
+	const { theme } = identityTheme();
+	assert.deepEqual(collapsed.widgets.at(-1)?.content?.(collapsed.tui, theme).render(40), [
+		"─".repeat(40),
+		"Todo",
+		"▶ active",
+		"… 1 more",
+	]);
+
+	const disabledHarness = createHarness({
+		loadSettings: async () => loadedSettings({ enabled: false }),
+	});
+	const disabled = createContext();
+	await disabledHarness.emit("session_start", disabled.ctx);
+	await setTodos(disabledHarness, disabled.ctx, [{ step: "hidden", status: "completed" }]);
+	assert.equal(disabled.widgets.at(-1)?.content, undefined);
+
+	let resolveFirst: ((result: TodoSettingsLoadResult) => void) | undefined;
+	let loads = 0;
+	const staleHarness = createHarness({
+		loadSettings: async () => {
+			loads += 1;
+			if (loads === 1) {
+				return await new Promise<TodoSettingsLoadResult>((resolve) => {
+					resolveFirst = resolve;
+				});
+			}
+			return loadedSettings({ showProgress: false });
+		},
+	});
+	const previous = createContext();
+	const firstStart = staleHarness.emit("session_start", previous.ctx);
+	await vi.waitFor(() => assert.ok(resolveFirst));
+	const current = createContext();
+	await staleHarness.emit("session_start", current.ctx);
+	resolveFirst?.(loadedSettings({ showProgress: true }));
+	await firstStart;
+	await setTodos(staleHarness, current.ctx, [{ step: "current", status: "pending" }]);
+	assert.equal(current.widgets.at(-1)?.content?.(current.tui, theme).render(40)[1], "Todo");
+
+	const invalidHarness = createHarness({
+		loadSettings: async () => ({
+			kind: "invalid",
+			path: "/tmp/unsafe\u001b]8;;x\u0007.json",
+			settings: { widget: { ...DEFAULT_TODO_SETTINGS.widget } },
+			issue: "bad\u202evalue",
+		}),
+	});
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		const context = createContext({ mode });
+		await invalidHarness.emit("session_start", context.ctx);
+		assert.equal(context.notifications.length, mode === "tui" || mode === "rpc" ? 1 : 0);
+		assert.equal(
+			context.notifications[0]?.message.includes(String.fromCharCode(0x1b)) ?? false,
+			false,
+		);
+		await invalidHarness.emit("session_shutdown", context.ctx);
+	}
+});
+
+test("renders blocked todos, preserves reasons, and excludes them from completion", async () => {
+	vi.useFakeTimers();
+	try {
+		const harness = createHarness();
+		const current = createContext();
+		await harness.emit("session_start", current.ctx);
+		const blocked: Todo[] = [
+			{ step: "deploy\u001b]8;;x\u0007", status: "blocked", reason: "Need approval\u202e" },
+			{ step: "verify", status: "pending" },
+		];
+		const result = await setTodos(harness, current.ctx, blocked);
+		assert.equal(result.content[0]?.text, "Todo list updated: 0 of 2 complete; 1 blocked.");
+		assert.deepEqual(result.details, { version: TODO_DETAILS_VERSION, todos: blocked });
+		const { theme, calls } = identityTheme();
+		const lines = current.widgets.at(-1)?.content?.(current.tui, theme).render(80) ?? [];
+		assert.deepEqual(lines, [
+			"─".repeat(80),
+			"Todo · 0/2 complete",
+			"⚠ deploy — Need approval",
+			"○ verify",
+		]);
+		assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "warning"));
+		const allBlocked = renderTodoWidget(
+			[
+				{ step: "first", status: "blocked", reason: "external one" },
+				{ step: "second", status: "blocked", reason: "external two" },
+			],
+			theme,
+			40,
+			{ terminalRows: 12 },
+		);
+		assert.deepEqual(allBlocked, [
+			"─".repeat(40),
+			"Todo · 0/2 complete",
+			"⚠ first — external one",
+			"⚠ second — external two",
+		]);
+		await vi.advanceTimersByTimeAsync(COMPLETION_SUMMARY_MS);
+		assert.equal(typeof current.widgets.at(-1)?.content, "function");
+
+		const context = await harness.context(
+			[
+				{
+					role: "compactionSummary",
+					summary: "Earlier work was compacted.",
+					tokensBefore: 10,
+					timestamp: 0,
+				},
+			],
+			current.ctx,
+		);
+		assert.match(customText(context[1]), /Need approval/u);
+		assert.match(customText(context[1]), /"blocked"/u);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("ignores errored tool results while reconstructing branch state", async () => {
+	const valid = toolResultEntry({
+		version: TODO_DETAILS_VERSION,
+		todos: [{ step: "valid", status: "pending" }],
+	});
+	const errored = {
+		type: "message",
+		id: "errored",
+		parentId: valid.id,
+		timestamp: new Date(1).toISOString(),
+		message: todoToolResultMessage(
+			{
+				version: TODO_DETAILS_VERSION,
+				todos: [{ step: "must not restore", status: "blocked", reason: "error" }],
+			},
+			TOOL_NAME,
+			true,
+		),
+	} as SessionEntry;
+	const harness = createHarness();
+	const current = createContext({ branch: [valid, errored] });
+	await harness.emit("session_start", current.ctx);
+	const { theme } = identityTheme();
+	assert.deepEqual(current.widgets.at(-1)?.content?.(current.tui, theme).render(80), [
+		"─".repeat(80),
+		"Todo · 0/1 complete",
+		"○ valid",
+	]);
+});
+
+test("restores version 2 state and keeps a canonical version 2 summary boundary", async () => {
+	const previousTodos = [{ step: "before blocked support", status: "in_progress" as const }];
+	const branch: SessionEntry[] = [
+		toolResultEntry({ version: 2, todos: previousTodos }, TOOL_NAME, "initial", null),
+		{
+			type: "compaction",
+			id: "compaction",
+			parentId: "initial",
+			timestamp: new Date(0).toISOString(),
+			summary: "Earlier work was compacted.",
+			firstKeptEntryId: "kept",
+			tokensBefore: 100,
+		} as SessionEntry,
+	];
+	const summaries: ContextEvent["messages"] = [
+		{
+			role: "compactionSummary",
+			summary: "Earlier work was compacted.",
+			tokensBefore: 100,
+			timestamp: 0,
+		},
+	];
+	const firstHarness = createHarness();
+	const current = createContext({ branch });
+	await firstHarness.emit("session_start", current.ctx);
+	await firstHarness.context(summaries, current.ctx);
+	const persisted = firstHarness.entries[0];
+	assert.ok(persisted);
+	const previousContent = `[PI TODO STATUS v2]\nCurrent todo list as JSON data:\n${JSON.stringify({ todos: previousTodos })}`;
+	branch.push(
+		customEntry(
+			persisted.customType,
+			{ ...(persisted.data as Record<string, unknown>), content: previousContent },
+			"boundary",
+			"compaction",
+		),
+	);
+
+	const reloaded = createHarness();
+	await reloaded.emit("session_start", current.ctx);
+	const retained = await reloaded.context(summaries, current.ctx);
+	assert.equal(retained[1]?.role === "custom" ? retained[1].content : "", previousContent);
+
+	branch.push(
+		toolResultEntry(
+			{
+				version: TODO_DETAILS_VERSION,
+				todos: [{ step: "wait", status: "blocked", reason: "approval" }],
+			},
+			TOOL_NAME,
+			"blocked",
+			"boundary",
+		),
+	);
+	await reloaded.emit("session_tree", current.ctx);
+	const sameEpoch = await reloaded.context(summaries, current.ctx);
+	assert.equal(sameEpoch[1]?.role === "custom" ? sameEpoch[1].content : "", previousContent);
+});

--- a/packages/pi-todo/test/todo-widget.test.ts
+++ b/packages/pi-todo/test/todo-widget.test.ts
@@ -1,15 +1,8 @@
 import assert from "node:assert/strict";
-import type {
-	ContextEvent,
-	ExtensionAPI,
-	ExtensionContext,
-	SessionEntry,
-	Theme,
-} from "@earendil-works/pi-coding-agent";
-import type { Component } from "@earendil-works/pi-tui";
+import type { ContextEvent, SessionEntry } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
-import todoWidgetExtension, {
+import {
 	renderTodoWidget,
 	sanitizeTodoStep,
 	TODO_CONTEXT_MESSAGE_TYPE,
@@ -21,196 +14,16 @@ import todoWidgetExtension, {
 	type TodoDetails,
 	WIDGET_KEY,
 } from "../src/todo-widget.js";
-
-type Handler = (event: never, ctx: ExtensionContext) => unknown;
-type WidgetFactory = (_tui: never, theme: Theme) => Component;
-
-interface RegisteredTool {
-	name: string;
-	label: string;
-	description: string;
-	promptSnippet: string;
-	promptGuidelines: string[];
-	parameters: unknown;
-	execute(
-		toolCallId: string,
-		params: { todos: Todo[] },
-		signal: AbortSignal | undefined,
-		onUpdate: undefined,
-		ctx: ExtensionContext,
-	): Promise<{ content: Array<{ type: string; text: string }>; details: TodoDetails }>;
-}
-
-function createHarness() {
-	const handlers = new Map<string, Handler[]>();
-	const entries: Array<{ customType: string; data: unknown }> = [];
-	let tool: RegisteredTool | undefined;
-	const pi = {
-		on(event: string, handler: Handler) {
-			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
-		},
-		registerTool(definition: RegisteredTool) {
-			tool = definition;
-		},
-		appendEntry(customType: string, data: unknown) {
-			entries.push({ customType, data: structuredClone(data) });
-		},
-	} as unknown as ExtensionAPI;
-	todoWidgetExtension(pi);
-
-	return {
-		entries,
-		get tool(): RegisteredTool {
-			assert.ok(tool);
-			return tool;
-		},
-		async emit(event: string, ctx: ExtensionContext) {
-			for (const handler of handlers.get(event) ?? []) await handler({} as never, ctx);
-		},
-		async context(messages: ContextEvent["messages"], ctx: ExtensionContext) {
-			let current = messages;
-			for (const handler of handlers.get("context") ?? []) {
-				const result = (await handler({ messages: current } as never, ctx)) as
-					| { messages?: ContextEvent["messages"] }
-					| undefined;
-				current = result?.messages ?? current;
-			}
-			return current;
-		},
-	};
-}
-
-function createContext(options: { mode?: ExtensionContext["mode"]; branch?: SessionEntry[] } = {}) {
-	const widgets: Array<{
-		key: string;
-		content: WidgetFactory | undefined;
-		options: { placement: "aboveEditor" } | undefined;
-	}> = [];
-	const branch = options.branch ?? [];
-	const sessionManager = {
-		getBranch: () => branch,
-	} as unknown as ExtensionContext["sessionManager"];
-	const ctx = {
-		mode: options.mode ?? "tui",
-		hasUI: options.mode !== "print" && options.mode !== "json",
-		sessionManager,
-		ui: {
-			setWidget(
-				key: string,
-				content: WidgetFactory | undefined,
-				widgetOptions?: { placement: "aboveEditor" },
-			) {
-				widgets.push({ key, content, options: widgetOptions });
-			},
-		},
-	} as unknown as ExtensionContext;
-	return { branch, ctx, widgets };
-}
-
-function identityTheme() {
-	const calls: Array<[string, string]> = [];
-	const theme = {
-		fg(role: string, text: string) {
-			calls.push(["fg", role]);
-			return text;
-		},
-		bold(text: string) {
-			calls.push(["style", "bold"]);
-			return text;
-		},
-		strikethrough(text: string) {
-			calls.push(["style", "strikethrough"]);
-			return text;
-		},
-	} as unknown as Theme;
-	return { calls, theme };
-}
-
-function todoToolResultMessage(
-	details: unknown,
-	toolName = TOOL_NAME,
-	isError = false,
-): ContextEvent["messages"][number] {
-	return {
-		role: "toolResult",
-		toolCallId: "todo-call",
-		toolName,
-		content: [{ type: "text", text: "updated" }],
-		details,
-		isError,
-		timestamp: 0,
-	};
-}
-
-function todoToolCallMessage(
-	todos: unknown,
-	toolName = TOOL_NAME,
-	argumentName: "todos" | "items" = "todos",
-): ContextEvent["messages"][number] {
-	return {
-		role: "assistant",
-		content: [
-			{
-				type: "toolCall",
-				id: "todo-call",
-				name: toolName,
-				arguments: { [argumentName]: todos },
-			},
-		],
-		api: "openai-responses",
-		provider: "test",
-		model: "test",
-		usage: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 0,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-		stopReason: "toolUse",
-		timestamp: 0,
-	};
-}
-
-function toolResultEntry(
-	details: unknown,
-	toolName = TOOL_NAME,
-	id = "tool-result",
-	parentId: string | null = null,
-): SessionEntry {
-	return {
-		type: "message",
-		id,
-		parentId,
-		timestamp: new Date(0).toISOString(),
-		message: todoToolResultMessage(details, toolName),
-	} as SessionEntry;
-}
-
-function customEntry(
-	customType: string,
-	data: unknown,
-	id: string,
-	parentId: string | null,
-): SessionEntry {
-	return {
-		type: "custom",
-		id,
-		parentId,
-		timestamp: new Date(0).toISOString(),
-		customType,
-		data,
-	} as SessionEntry;
-}
-
-async function setTodos(
-	harness: ReturnType<typeof createHarness>,
-	ctx: ExtensionContext,
-	todos: Todo[],
-) {
-	return harness.tool.execute("todo-call", { todos }, undefined, undefined, ctx);
-}
+import {
+	createContext,
+	createHarness,
+	customEntry,
+	identityTheme,
+	setTodos,
+	todoToolCallMessage,
+	todoToolResultMessage,
+	toolResultEntry,
+} from "./todo-harness.js";
 
 test("registers the todos-by-step schema and concise maintenance guidance", () => {
 	const { tool } = createHarness();
@@ -218,10 +31,12 @@ test("registers the todos-by-step schema and concise maintenance guidance", () =
 	assert.equal(tool.name, "update_todo_list");
 	assert.equal(tool.label, "Todo List");
 	assert.match(tool.description, /whenever actual step state changes/u);
+	assert.match(tool.description, /require a reason for each blocked todo/u);
 	assert.match(tool.promptSnippet, /multi-step work progresses/u);
 	assert.deepEqual(tool.promptGuidelines, [
 		"Use update_todo_list to track work with multiple meaningful steps; skip it for simple, single-step tasks.",
 		"Use update_todo_list to keep the list aligned with actual work: mark a step in_progress before starting it, mark it completed as soon as it finishes, and revise the list before continuing when the plan changes.",
+		"Use blocked with a concise reason only when progress depends on an external action or condition; blocked does not mean completed.",
 		"Before a progress report or final response, call update_todo_list to reconcile every todo with actual work; do not report completion while the list is stale.",
 		"On every update_todo_list call, send the complete current todos array, keep at most one todo in_progress, and send an empty array when no tracked work remains.",
 	]);
@@ -238,7 +53,7 @@ test("registers the todos-by-step schema and concise maintenance guidance", () =
 	};
 	assert.equal(todosSchema.maxItems, 50);
 	assert.deepEqual(todosSchema.items?.required, ["step", "status"]);
-	assert.deepEqual(Object.keys(todosSchema.items?.properties ?? {}), ["step", "status"]);
+	assert.deepEqual(Object.keys(todosSchema.items?.properties ?? {}), ["step", "status", "reason"]);
 	assert.deepEqual(todosSchema.items?.properties?.step, {
 		description: "A concise, action-oriented step",
 		type: "string",
@@ -247,8 +62,14 @@ test("registers the todos-by-step schema and concise maintenance guidance", () =
 	});
 	assert.deepEqual(todosSchema.items?.properties?.status, {
 		type: "string",
-		enum: ["pending", "in_progress", "completed"],
+		enum: ["pending", "in_progress", "completed", "blocked"],
 		description: "The step's current status",
+	});
+	assert.deepEqual(todosSchema.items?.properties?.reason, {
+		description: "Required only for blocked todos; explain what must unblock the step",
+		type: "string",
+		minLength: 1,
+		maxLength: 200,
 	});
 });
 
@@ -721,7 +542,7 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 	assert.deepEqual(widget?.options, { placement: "aboveEditor" });
 	assert.equal(typeof widget?.content, "function");
 	const { theme } = identityTheme();
-	assert.deepEqual(widget?.content?.(undefined as never, theme).render(80), [
+	assert.deepEqual(widget?.content?.(current.tui, theme).render(80), [
 		"─".repeat(80),
 		"Todo · 1/3 complete",
 		"✓ task 1",
@@ -738,7 +559,7 @@ test("tool replaces the complete list, updates the widget, clears it, and reject
 	);
 	await assert.rejects(
 		setTodos(harness, current.ctx, [{ step: " \n ", status: "pending" }]),
-		/non-whitespace step/u,
+		/step must contain non-whitespace/u,
 	);
 
 	const cleared = await setTodos(harness, current.ctx, []);
@@ -760,13 +581,11 @@ test("restores current and legacy branch-local state on startup and tree navigat
 	await harness.emit("session_start", current.ctx);
 
 	const { theme } = identityTheme();
-	assert.deepEqual(
-		current.widgets
-			.at(-1)
-			?.content?.(undefined as never, theme)
-			.render(80),
-		["─".repeat(80), "Todo · 0/1 complete", "▶ restored"],
-	);
+	assert.deepEqual(current.widgets.at(-1)?.content?.(current.tui, theme).render(80), [
+		"─".repeat(80),
+		"Todo · 0/1 complete",
+		"▶ restored",
+	]);
 
 	const migratedContext = await harness.context(
 		[
@@ -791,13 +610,11 @@ test("restores current and legacy branch-local state on startup and tree navigat
 		}),
 	);
 	await harness.emit("session_tree", current.ctx);
-	assert.deepEqual(
-		current.widgets
-			.at(-1)
-			?.content?.(undefined as never, theme)
-			.render(80),
-		["─".repeat(80), "Todo · 0/1 complete", "▶ restored from current tool name"],
-	);
+	assert.deepEqual(current.widgets.at(-1)?.content?.(current.tui, theme).render(80), [
+		"─".repeat(80),
+		"Todo · 0/1 complete",
+		"▶ restored from current tool name",
+	]);
 
 	current.branch.push(
 		toolResultEntry({
@@ -806,13 +623,11 @@ test("restores current and legacy branch-local state on startup and tree navigat
 		}),
 	);
 	await harness.emit("session_tree", current.ctx);
-	assert.deepEqual(
-		current.widgets
-			.at(-1)
-			?.content?.(undefined as never, theme)
-			.render(80),
-		["─".repeat(80), "Todo · 1/1 complete", "✓ finished branch"],
-	);
+	assert.deepEqual(current.widgets.at(-1)?.content?.(current.tui, theme).render(80), [
+		"─".repeat(80),
+		"Todo · 1/1 complete",
+		"✓ finished branch",
+	]);
 });
 
 test("guards component widgets to TUI mode and ignores stale session shutdown", async () => {


### PR DESCRIPTION
## Summary

- Add adaptive, expanded, and collapsed todo widget layouts with terminal-row budgeting and a transient all-complete summary.
- Add actionable tool validation, blocked todos with required reasons, and version 3 state/context migration while preserving version 1 and version 2 branches.
- Add optional read-only `pi-todo.json` display settings, lifecycle-safe loading, sanitization hardening, documentation, and a minor Changeset.

## Verification

- `npx vitest run packages/pi-todo/test/todo-widget.test.ts packages/pi-todo/test/todo-widget-enhancements.test.ts packages/pi-todo/test/settings.test.ts packages/pi-todo/test/todo-cache-contract.test.ts packages/pi-todo/test/build-runtime.test.ts`
- `npm --workspace @narumitw/pi-todo run check`
- `npm run check`
- `npm test` — 344 files and 3,408 tests passed
- `npm run changeset:status`
- `npm run package:pack -- todo` — inspected 9 published files, including generated `dist/index.ts`, source, README, and license
- Fenced-code-aware required-heading audit across 29 package READMEs
- `DefaultResourceLoader` Jiti generated-entry smoke, including zero registered commands and shutdown cleanup

## Audits

- Reviewed `docs/extension-conventions.md`, `docs/extension-settings.md`, Pi `extensions.md`, and Pi `tui.md`.
- Audited completion timers and settings reads for cancellation, stale sessions, tree navigation, reload, replacement, and shutdown.
- Audited settings reads and the intentionally absent write path for missing-file side effects, invalid-file protection, unknown fields, ordering, and failure fallback.
- Audited normalized provider prefixes, versioned compaction restoration, TUI width/theme/sanitization, package boundaries, and published contents.

## Risks and deviations

- Adaptive sizing uses terminal height rather than the exact remaining editor viewport, so it intentionally applies a conservative 4–12 row heuristic.
- Settings intentionally remain manual JSON without a slash command or SettingsList UI, matching the requested exclusion of command surface changes.
- The interactive `pi --no-extensions -e ./packages/pi-todo` TUI smoke was not run because this agent cannot open interactive TUI commands; deterministic Jiti loader, lifecycle, rendering, package, and full repository tests cover the changed paths.
- No package was published, no visibility or tag changed, and no release workflow was dispatched.
