### PR TITLE
fix(usage): select current Z.AI subscription

### DIFF
--- a/.changeset/zai-active-subscription.md
+++ b/.changeset/zai-active-subscription.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Select the current valid Z.AI subscription instead of reporting an earlier expired plan.

--- a/packages/pi-usage/src/providers/zai.ts
+++ b/packages/pi-usage/src/providers/zai.ts
@@ -76,21 +76,50 @@ export function normalizeZaiQuotaPayload(
 	};
 }
 
-// The undocumented subscription endpoint returns the purchased Coding Plan products; the first
-// entry with a product name supplies the plan label, and its renewal date is best-effort.
+// The undocumented subscription endpoint can include historical products. Prefer the current,
+// valid product and fail closed to the quota plan level when only explicitly inactive products exist.
 export function normalizeZaiSubscriptionPayload(
 	payload: ZaiSubscriptionPayload,
 ): ZaiPlanInfo | undefined {
+	if (payload.success === false) return undefined;
+	if (typeof payload.code === "number" && payload.code !== 0 && payload.code !== 200) {
+		return undefined;
+	}
 	if (!Array.isArray(payload.data)) return undefined;
+
+	const candidates: Array<{
+		plan: ZaiPlanInfo;
+		status?: string;
+		inCurrentPeriod?: boolean;
+	}> = [];
 	for (const raw of payload.data) {
 		const entry = asObject(raw);
 		if (!entry) continue;
 		const name = asString(entry.productName);
 		if (!name) continue;
 		const renewsAt = planRenewalDate(entry.nextRenewTime);
-		return { name, ...(renewsAt !== undefined ? { renewsAt } : {}) };
+		const status = asString(entry.status)?.toUpperCase();
+		const inCurrentPeriod = asBoolean(entry.inCurrentPeriod);
+		candidates.push({
+			plan: { name, ...(renewsAt !== undefined ? { renewsAt } : {}) },
+			...(status !== undefined ? { status } : {}),
+			...(inCurrentPeriod !== undefined ? { inCurrentPeriod } : {}),
+		});
 	}
-	return undefined;
+
+	const hasStateMetadata = candidates.some(
+		(candidate) => candidate.status !== undefined || candidate.inCurrentPeriod !== undefined,
+	);
+	if (!hasStateMetadata) return candidates[0]?.plan;
+	return (
+		candidates.find(
+			(candidate) => candidate.inCurrentPeriod === true && candidate.status === "VALID",
+		)?.plan ??
+		candidates.find(
+			(candidate) => candidate.inCurrentPeriod === true && candidate.status === undefined,
+		)?.plan ??
+		candidates.find((candidate) => candidate.status === "VALID")?.plan
+	);
 }
 
 function planRenewalDate(value: unknown): string | undefined {
@@ -194,6 +223,13 @@ function asNonnegativeNumber(value: unknown): number | undefined {
 function asPositiveNumber(value: unknown): number | undefined {
 	const number = asNonnegativeNumber(value);
 	return number !== undefined && number > 0 ? number : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (value === 1) return true;
+	if (value === 0) return false;
+	return undefined;
 }
 
 function asEpochSeconds(value: unknown): number | undefined {

--- a/packages/pi-usage/src/providers/zai.ts
+++ b/packages/pi-usage/src/providers/zai.ts
@@ -118,7 +118,9 @@ export function normalizeZaiSubscriptionPayload(
 		candidates.find(
 			(candidate) => candidate.inCurrentPeriod === true && candidate.status === undefined,
 		)?.plan ??
-		candidates.find((candidate) => candidate.status === "VALID")?.plan
+		candidates.find(
+			(candidate) => candidate.status === "VALID" && candidate.inCurrentPeriod === undefined,
+		)?.plan
 	);
 }
 

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -159,6 +159,7 @@ export type ZaiQuotaPayload = {
 
 export type ZaiSubscriptionPayload = {
 	code?: unknown;
+	success?: unknown;
 	data?: unknown;
 };
 

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -459,6 +459,44 @@ test("Z.AI subscription normalizer extracts the plan name and renewal date", () 
 	assert.equal(normalizeZaiSubscriptionPayload({}), undefined);
 });
 
+test("Z.AI subscription normalizer prefers the current valid product over history", () => {
+	assert.deepEqual(
+		normalizeZaiSubscriptionPayload({
+			code: 200,
+			success: true,
+			data: [
+				{
+					productName: "GLM Coding Lite",
+					status: "EXPIRED",
+					inCurrentPeriod: false,
+					nextRenewTime: "2026-01-01",
+				},
+				{
+					productName: "GLM Coding Pro",
+					status: "VALID",
+					inCurrentPeriod: 1,
+					nextRenewTime: "2026-12-01",
+				},
+			],
+		}),
+		{ name: "GLM Coding Pro", renewsAt: "2026-12-01" },
+	);
+	assert.equal(
+		normalizeZaiSubscriptionPayload({
+			data: [{ productName: "GLM Coding Lite", status: "EXPIRED", inCurrentPeriod: false }],
+		}),
+		undefined,
+	);
+	assert.equal(
+		normalizeZaiSubscriptionPayload({
+			code: 500,
+			success: false,
+			data: [{ productName: "GLM Coding Lite", status: "VALID" }],
+		}),
+		undefined,
+	);
+});
+
 test("Z.AI adapters send an already unprefixed authorization unchanged", async () => {
 	const requests: Array<{ url: string; authorization: string | undefined }> = [];
 	vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -489,6 +489,12 @@ test("Z.AI subscription normalizer prefers the current valid product over histor
 	);
 	assert.equal(
 		normalizeZaiSubscriptionPayload({
+			data: [{ productName: "GLM Coding Pro", status: "VALID", inCurrentPeriod: false }],
+		}),
+		undefined,
+	);
+	assert.equal(
+		normalizeZaiSubscriptionPayload({
 			code: 500,
 			success: false,
 			data: [{ productName: "GLM Coding Lite", status: "VALID" }],


### PR DESCRIPTION
## Summary

- select the current valid Z.AI subscription instead of the first historical product
- fall back to the quota plan level for failed envelopes or explicitly inactive subscriptions
- add regression coverage for expired-first, active-second payloads and a patch changeset

## Verification

- `npm run check`
- `npm test` — 344 files, 3416 tests passed
- `npx vitest run packages/pi-usage/test/zai.test.ts` — 15 tests passed
- `npm run changeset:status`

## Notes

The subscription endpoint remains undocumented and was not exercised with a live Z.AI credential.
