### PR TITLE
feat(usage): add provider target picker

### DIFF
--- a/.changeset/calm-target-pickers.md
+++ b/.changeset/calm-target-pickers.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Add a provider-neutral usage target picker, starting with Fireworks accounts, and remove the free-form Fireworks account setting.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -16,7 +16,7 @@ xAI OAuth subscription reporting follows the reviewed Grok Build contract and ru
 - Reports GitHub Copilot allowances and OpenRouter per-key limits and spending windows.
 - Reports exact DeepSeek API balances with separate CNY and USD values.
 - Reports OpenCode Go plan windows and Z.AI Coding Plan quotas.
-- Reports Fireworks rated API spend for the last 30 days with per-series subtotals.
+- Reports Fireworks rated API spend for the last 30 days with per-series subtotals and account selection.
 - Reports Vercel AI Gateway credit balance and lifetime spend.
 - Reports Baseten organization Model APIs spend after credits for the last 30 days.
 - Reports xAI OAuth subscription allowances and credits.
@@ -56,6 +56,7 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must run the 
 ## 🚀 Quick start
 
 Run `/usage` in TUI or RPC mode to inspect the active provider, refresh its usage, or choose another configured provider.
+When a provider exposes several billing targets, `/usage` asks for one target before querying usage.
 Run `/fast` to toggle Fast mode for a supported active Codex model.
 
 ## 💬 Commands
@@ -84,6 +85,21 @@ Escape returns from provider selection or closes the root menu.
 Print and JSON modes reject `/usage` because they cannot host the interactive flow.
 The extension owns the cancellable live-query progress view because it streams provider work and supports in-flight abort.
 
+### Provider targets
+
+A target is the provider-owned account, organization, project, team, or workspace used for one usage query.
+Providers without target discovery query immediately, and a single returned target is selected automatically without writing settings.
+When several targets are available, `/usage` remembers an explicit selection by provider and reuses it only while it remains in a fresh listing.
+A missing remembered target returns **Selection required** instead of querying another target silently.
+The current provider then offers **Select &lt;target&gt;…**, while a ready current or individually viewed provider offers **Change &lt;target&gt;…**.
+
+Selecting another provider may open one Pi target prompt after that provider is queried lazily.
+Cancelling the prompt changes nothing.
+An explicit selection is saved first, then auth and targets are resolved again before billing is queried.
+**View all configured providers…** never opens nested target prompts: unresolved providers remain visible with guidance to view them individually.
+Background status refresh also stays non-interactive and shows `selection required` until `/usage` completes the choice.
+Fireworks accounts are the first implementation of this provider-neutral flow.
+
 For the current OpenAI Codex provider, **Redeem usage limit reset…** first checks fresh earned-reset details.
 When details are available, you select a reset and review its exact effect before confirmation.
 **No, go back** is the safe default and cancellation before confirmation sends no mutation.
@@ -93,7 +109,7 @@ Successful, already-completed, not-needed, and no-credit outcomes are reported s
 
 ## ⚙️ Settings
 
-Choose **Settings** in `/usage` to edit Codex Fast mode, the Codex reset countdown, and the Fireworks account selector through Pi's settings-list interaction in TUI mode.
+Choose **Settings** in `/usage` to edit Codex Fast mode and the Codex reset countdown through Pi's settings-list interaction in TUI mode.
 RPC mode reports the active manual settings path instead of opening terminal UI.
 
 These preferences live in `pi-usage.json` under Pi's user agent directory, normally `~/.pi/agent/pi-usage.json`.
@@ -104,19 +120,9 @@ Malformed or invalid files remain untouched.
 A failed save restores the prior displayed and effective value, while shutdown waits for queued writes.
 Separate Pi processes are not mutually locked.
 
-### Fireworks account
-
-A Fireworks key that can see one account needs no setting.
-For a key that can see several accounts, choose **Fireworks account** in the TUI Settings screen, or set the exact visible account slug in `pi-usage.json` and run `/reload`:
-
-```json
-{
-  "fireworksAccountId": "acme"
-}
-```
-
-The `fireworksAccountId` setting is validated as a URL-safe account slug and then checked against the official account listing before billing data is requested.
-Submit a blank value from the TUI input, or remove the JSON field and run `/reload`, to restore single-account auto-selection.
+Target selections are stored only as IDs in the provider-neutral `selectedTargets` object in this file and are managed through `/usage`, not the Settings screen.
+The former `fireworksAccountId` field remains read-compatible: it supplies `selectedTargets.fireworks` in memory only when the generic value is absent.
+A successful explicit Fireworks account selection writes the generic field and removes the legacy field atomically; ordinary reads do not rewrite the file.
 
 ### Codex Fast mode
 
@@ -279,7 +285,8 @@ DeepSeek Harness `cd5ef8148158c3a752a658978873241fdf8e2bbc` reports only per-req
 - Statusline example: `fireworks USD 12.345678901`
 
 The extension queries the fixed endpoints only when the selected model origin is `https://api.fireworks.ai` and any resolved-auth origin override, when present, has the same official origin.
-The account slug is discovered through the documented account listing; a key that can see several accounts must set `fireworksAccountId` in `pi-usage.json` to one of the listed account slugs, and the slug must remain visible to the key.
+The account slug is discovered through the documented account listing.
+One visible account is selected automatically; several visible accounts use the remembered selection or ask through `/usage`, and a disappeared selection returns **Selection required** without a billing request.
 Monetary `units` and `nanos` values are summed exactly with integer arithmetic and stay exact through display.
 Fireworks does not expose credit balance, spend caps, per-window quota, or reset times through its API, so `pi-usage` does not claim those Fireworks capabilities; the web console remains the authoritative balance source.
 Rated line items may differ from the final invoice once credits or adjustments are applied.
@@ -390,8 +397,8 @@ Only the official `api.z.ai` and `open.bigmodel.cn` origins are queried; other o
 `Current` identifies the provider and credential used by Pi's selected model.
 `Configured` identifies runtime auth for another supported provider, not an active provider.
 
-The extension does not enumerate multiple accounts inside one provider and does not switch accounts.
-Account selection remains owned by Pi or an account-management extension.
+The extension selects one provider target for one query and never flattens targets into provider rows or aggregates every visible target.
+Provider adapters own target discovery and validation; core owns one-target selection, persistence, cache identity, cancellation, and UI.
 A compatible credential owner may offer the verified active named account through the versioned process-local protocol without exposing its account label or storage.
 Without such an owner, `pi-usage` retains its standalone Pi `auth.json` behavior.
 An older or incompatible owner degrades to the existing authentication-unavailable result when the stored login does not match runtime auth.
@@ -457,7 +464,7 @@ An absent or incompatible peer preserves standalone fallback and fail-closed mis
 - Credentials resolved for custom provider base URLs are never forwarded to the providers' official usage endpoints; effective auth origin validation requires Pi 0.81.0 or newer.
 - Provider reports are snapshots and may themselves be delayed by the provider.
 - DeepSeek reports current API balance only; it does not expose historical usage, quota windows, reset times, or account-wide token totals through the balance endpoint.
-- Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and keys that can see several accounts must set `fireworksAccountId` in `pi-usage.json`.
+- Fireworks reports rated 30-day spend only; credit balance and spend caps are visible only in the Fireworks web console, and `/usage` must select one visible account before querying a multi-account key.
 - Moonshot AI reports current API balance only; it does not expose historical spend, aggregate token usage, quota windows, or reset times through the balance endpoint.
 - Vercel AI Gateway reports current team credits and lifetime spend only; Custom Reporting and request-rate counters are not queried.
 - MiniMax Token Plan field semantics have changed over time; contradictory counts and percentages are reported as unavailable rather than guessed.
@@ -484,6 +491,7 @@ packages/pi-usage/
 │   ├── codex-fast-runtime.ts # Fast command, persistence lifecycle, and request hooks
 │   ├── settings.ts    # Validated user settings and atomic persistence
 │   ├── usage-helpers.ts # Small orchestration helpers
+│   ├── usage-targets.ts # Provider-neutral target resolution and safe picker descriptors
 │   ├── query.ts       # Runtime auth resolution and bounded provider queries
 │   ├── oauth-credential-source.ts # Ephemeral OAuth candidate collection
 │   ├── codex-resets.ts # Codex reset auth, API contracts, and normalization

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -95,7 +95,7 @@ The current provider then offers **Select &lt;target&gt;…**, while a ready cur
 
 Selecting another provider may open one Pi target prompt after that provider is queried lazily.
 Cancelling the prompt changes nothing.
-An explicit selection is saved first, then auth and targets are resolved again before billing is queried.
+Auth and target membership are revalidated before an explicit selection is saved, then both are resolved again before billing is queried.
 **View all configured providers…** never opens nested target prompts: unresolved providers remain visible with guidance to view them individually.
 Background status refresh also stays non-interactive and shows `selection required` until `/usage` completes the choice.
 Fireworks accounts are the first implementation of this provider-neutral flow.

--- a/packages/pi-usage/src/core.ts
+++ b/packages/pi-usage/src/core.ts
@@ -54,13 +54,39 @@ export class UsageCache {
 }
 
 export function fingerprintResolvedAuth(
-	auth: { apiKey?: string; headers?: Record<string, string> },
+	auth: {
+		apiKey?: string;
+		headers?: Record<string, string | null>;
+		baseUrl?: string;
+		env?: Record<string, string>;
+		source?: string;
+		providerAuth?: {
+			apiKey?: string;
+			headers?: Record<string, string | null>;
+			baseUrl?: string;
+		};
+	},
 	salt: Uint8Array,
 ): string {
 	const headers = Object.entries(auth.headers ?? {})
 		.map(([name, value]) => [name.toLowerCase(), value] as const)
 		.sort(([left], [right]) => left.localeCompare(right));
-	const canonical = JSON.stringify({ apiKey: auth.apiKey ?? "", headers });
+	const env = Object.entries(auth.env ?? {}).sort(([left], [right]) => left.localeCompare(right));
+	const providerHeaders = Object.entries(auth.providerAuth?.headers ?? {})
+		.map(([name, value]) => [name.toLowerCase(), value] as const)
+		.sort(([left], [right]) => left.localeCompare(right));
+	const canonical = JSON.stringify({
+		apiKey: auth.apiKey ?? "",
+		headers,
+		baseUrl: auth.baseUrl ?? "",
+		env,
+		source: auth.source ?? "",
+		providerAuth: {
+			apiKey: auth.providerAuth?.apiKey ?? "",
+			headers: providerHeaders,
+			baseUrl: auth.providerAuth?.baseUrl ?? "",
+		},
+	});
 	return createHmac("sha256", salt).update(canonical).digest("hex");
 }
 

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -94,6 +94,9 @@ export function formatProviderStates(states: readonly ProviderUsageState[]): str
 		.map((state) => {
 			if (state.status === "ready") return formatUsageReport(state.report, state.displayState);
 			const label = state.displayState === "current" ? "Current" : "Configured";
+			if (state.status === "selection-required") {
+				return `${state.providerName} · ${label}\nSelection required: choose this provider's ${state.singularLabel} by viewing it individually.`;
+			}
 			const status =
 				state.status === "auth-unavailable"
 					? "Authentication unavailable"

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -68,6 +68,7 @@ export type {
 	UsageSettings,
 	UsageSettingsRuntime,
 	UsageSettingsState,
+	UsageTargetPublicationCheck,
 } from "./settings.js";
 export {
 	createUsageSettingsRuntime,
@@ -92,6 +93,7 @@ export type {
 	UsageModel,
 	UsageProviderAdapter,
 	UsageProviderTarget,
+	UsageQuerySettings,
 	UsageReport,
 	UsageRequestGuard,
 	UsageSemantics,

--- a/packages/pi-usage/src/index.ts
+++ b/packages/pi-usage/src/index.ts
@@ -36,6 +36,7 @@ export { normalizeBasetenBillingUsagePayload } from "./providers/baseten.js";
 export { normalizeCodexBackendPayload } from "./providers/codex.js";
 export { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
 export {
+	createFireworksAdapter,
 	normalizeFireworksAccountsPayload,
 	normalizeFireworksBillingSummaryPayload,
 } from "./providers/fireworks.js";
@@ -90,13 +91,23 @@ export type {
 	UsageMetric,
 	UsageModel,
 	UsageProviderAdapter,
-	UsageQuerySettings,
+	UsageProviderTarget,
 	UsageReport,
+	UsageRequestGuard,
 	UsageSemantics,
 	UsageSemanticsKind,
+	UsageTargetResolver,
 	UsageUnit,
 	VercelAIGatewayCreditsPayload,
 	XaiBillingPayload,
 	XaiUserPayload,
 } from "./types.js";
 export { default } from "./usage.js";
+export type { UsageTargetResolution, UsageTargetSelectOptions } from "./usage-targets.js";
+export {
+	createUsageTargetSelectOptions,
+	isBoundedTargetId,
+	listUsageTargets,
+	normalizeUsageTargets,
+	resolveUsageTarget,
+} from "./usage-targets.js";

--- a/packages/pi-usage/src/providers/fireworks.ts
+++ b/packages/pi-usage/src/providers/fireworks.ts
@@ -2,7 +2,9 @@ import { sanitizeDisplayText } from "../core.js";
 import type {
 	FireworksAccountsPayload,
 	FireworksBillingSummaryPayload,
+	ResolvedUsageAuth,
 	UsageMetric,
+	UsageProviderAdapter,
 	UsageReport,
 } from "../types.js";
 
@@ -14,6 +16,9 @@ const INT64_MIN = -(2n ** 63n);
 const INT64_MAX = 2n ** 63n - 1n;
 const MAX_UNITS_CHARS = 20;
 const MAX_NANOS_CHARS = 11;
+const FIREWORKS_BILLING_SUMMARY_ORIGIN = "https://api.fireworks.ai";
+const FIREWORKS_SPEND_WINDOW_DAYS = 30;
+const FIREWORKS_MAX_ACCOUNT_PAGES = 5;
 
 const SERIES_KEYS = ["serverless", "dedicated", "training", "other"] as const;
 type SeriesKey = (typeof SERIES_KEYS)[number];
@@ -51,6 +56,77 @@ export function normalizeFireworksAccountsPayload(payload: FireworksAccountsPayl
 		accounts.push(accountId);
 	}
 	return accounts;
+}
+
+type FetchProviderJson = (
+	url: string,
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+	description: string,
+	request?: { redirect?: RequestRedirect },
+) => Promise<Record<string, unknown>>;
+
+export function createFireworksAdapter(fetchProviderJson: FetchProviderJson): UsageProviderAdapter {
+	return {
+		id: "fireworks",
+		displayName: "Fireworks",
+		semantics: { kind: "api-key", label: "Fireworks API spend" },
+		targets: {
+			singularLabel: "account",
+			pluralLabel: "accounts",
+			async list(auth, signal, timeoutMs, guard) {
+				const startedAt = Date.now();
+				const accounts: string[] = [];
+				let pageToken: string | undefined;
+				for (let page = 0; page < FIREWORKS_MAX_ACCOUNT_PAGES; page += 1) {
+					await guard();
+					const payload = (await fetchProviderJson(
+						fireworksAccountsUrl(pageToken),
+						auth,
+						signal,
+						remainingTimeout(timeoutMs, startedAt, "fetching Fireworks accounts"),
+						"Fireworks accounts endpoint",
+						{ redirect: "error" },
+					)) as FireworksAccountsPayload;
+					await guard();
+					for (const accountId of normalizeFireworksAccountsPayload(payload)) {
+						if (accounts.includes(accountId)) {
+							throw new Error(`Fireworks accounts listing repeated ${accountId}.`);
+						}
+						accounts.push(accountId);
+					}
+					pageToken = fireworksNextPageToken(payload.nextPageToken);
+					if (!pageToken) break;
+				}
+				if (pageToken) {
+					throw new Error(
+						`Fireworks account listing exceeded ${FIREWORKS_MAX_ACCOUNT_PAGES} pages.`,
+					);
+				}
+				return accounts.map((id) => ({ id, label: id }));
+			},
+		},
+		async query(auth, signal, timeoutMs, guard, targetId) {
+			if (!guard) throw new Error("Fireworks API spend requires request-boundary revalidation.");
+			if (!isFireworksAccountId(targetId)) {
+				throw new Error("Fireworks billing requires a safe selected account slug.");
+			}
+			const startedAt = Date.now();
+			await guard();
+			const billingWindowAt = Date.now();
+			const payload = (await fetchProviderJson(
+				fireworksBillingSummaryUrl(targetId, billingWindowAt),
+				auth,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "fetching Fireworks rated spend"),
+				"Fireworks billing summary endpoint",
+				{ redirect: "error" },
+			)) as FireworksBillingSummaryPayload;
+			await guard();
+			return normalizeFireworksBillingSummaryPayload(payload, targetId, Date.now());
+		},
+	};
 }
 
 export function normalizeFireworksBillingSummaryPayload(
@@ -190,6 +266,42 @@ function formatMoneyAmount(amount: bigint): string {
 	const units = magnitude / NANOS_PER_UNIT;
 	const nanos = (magnitude % NANOS_PER_UNIT).toString().padStart(9, "0").replace(/0+$/u, "");
 	return `${negative ? "-" : ""}${units.toString()}${nanos ? `.${nanos}` : ""}`;
+}
+
+function fireworksAccountsUrl(pageToken: string | undefined): string {
+	const url = new URL("/v1/accounts", FIREWORKS_BILLING_SUMMARY_ORIGIN);
+	url.searchParams.set("pageSize", "200");
+	if (pageToken !== undefined) url.searchParams.set("pageToken", pageToken);
+	return url.toString();
+}
+
+function fireworksNextPageToken(value: unknown): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "string" || !value || value.length > 512) {
+		throw new Error("Fireworks accounts listing returned an invalid page token.");
+	}
+	return value;
+}
+
+function fireworksBillingSummaryUrl(accountId: string, startedAt: number): string {
+	const dayMs = 24 * 60 * 60 * 1000;
+	const dayFloor = (time: number) => `${new Date(time).toISOString().slice(0, 10)}T00:00:00Z`;
+	const url = new URL(
+		`/v1/accounts/${accountId}/billing/summary`,
+		FIREWORKS_BILLING_SUMMARY_ORIGIN,
+	);
+	url.searchParams.set(
+		"startTime",
+		dayFloor(startedAt - (FIREWORKS_SPEND_WINDOW_DAYS - 1) * dayMs),
+	);
+	url.searchParams.set("endTime", dayFloor(startedAt + dayMs));
+	return url.toString();
+}
+
+function remainingTimeout(timeoutMs: number, startedAt: number, description: string): number {
+	const remaining = timeoutMs - (Date.now() - startedAt);
+	if (remaining <= 0) throw new Error(`Timed out while ${description}.`);
+	return remaining;
 }
 
 function asObject(value: unknown): Record<string, unknown> | undefined {

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -37,6 +37,7 @@ import type {
 	PiModel,
 	ResolvedUsageAuth,
 	UsageProviderAdapter,
+	UsageQuerySettings,
 	UsageReport,
 	UsageRequestGuard,
 	VercelAIGatewayCreditsPayload,
@@ -46,6 +47,7 @@ import type {
 	ZaiQuotaPayload,
 	ZaiSubscriptionPayload,
 } from "./types.js";
+import { resolveUsageTarget } from "./usage-targets.js";
 
 const BASETEN_BILLING_USAGE_URL = "https://api.baseten.co/v1/billing/usage_summary";
 const BASETEN_USAGE_WINDOW_DAYS = 30;
@@ -503,10 +505,46 @@ export async function queryProviderUsage(
 	signal: AbortSignal,
 	timeoutMs: number,
 	guard?: UsageRequestGuard,
-	targetId?: string,
+	targetOrSettings?: string | Readonly<UsageQuerySettings>,
 ): Promise<UsageReport> {
+	const startedAt = Date.now();
+	let targetId =
+		typeof targetOrSettings === "string"
+			? targetOrSettings
+			: adapter.id === "fireworks"
+				? targetOrSettings?.fireworksAccountId
+				: undefined;
+	let resolvedLegacyFireworksTarget = false;
 	try {
-		return await adapter.query(auth, signal, timeoutMs, guard, targetId);
+		if (
+			adapter.id === "fireworks" &&
+			typeof targetOrSettings !== "string" &&
+			adapter.targets &&
+			guard
+		) {
+			const target = await resolveUsageTarget(
+				adapter,
+				auth,
+				targetId,
+				signal,
+				remainingTimeout(timeoutMs, startedAt, "resolving the Fireworks account"),
+				guard,
+			);
+			if (target.kind === "selection-required") {
+				throw new Error("Fireworks account selection is required.");
+			}
+			targetId = target.targetId;
+			resolvedLegacyFireworksTarget = true;
+		}
+		return await adapter.query(
+			auth,
+			signal,
+			resolvedLegacyFireworksTarget
+				? remainingTimeout(timeoutMs, startedAt, `querying ${adapter.displayName} usage`)
+				: timeoutMs,
+			guard,
+			targetId,
+		);
 	} catch (error) {
 		if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
 		throw new Error(redactUsageError(errorMessage(error), auth.secrets));

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -1,3 +1,5 @@
+// This module intentionally keeps adapter transport beside resolved-auth and origin validation;
+// separating that security boundary would duplicate request and redaction policy across providers.
 import { randomBytes } from "node:crypto";
 import { type ExtensionContext, readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { errorMessage, fingerprintResolvedAuth, redactUsageError } from "./core.js";
@@ -8,11 +10,7 @@ import {
 import { normalizeBasetenBillingUsagePayload } from "./providers/baseten.js";
 import { normalizeCodexBackendPayload } from "./providers/codex.js";
 import { normalizeDeepSeekBalancePayload } from "./providers/deepseek.js";
-import {
-	isFireworksAccountId,
-	normalizeFireworksAccountsPayload,
-	normalizeFireworksBillingSummaryPayload,
-} from "./providers/fireworks.js";
+import { createFireworksAdapter } from "./providers/fireworks.js";
 import { normalizeGitHubCopilotUsagePayload } from "./providers/github-copilot.js";
 import { normalizeKimiCodingUsagePayload } from "./providers/kimi-coding.js";
 import {
@@ -30,8 +28,6 @@ import type {
 	BasetenBillingUsagePayload,
 	CodexBackendPayload,
 	DeepSeekBalancePayload,
-	FireworksAccountsPayload,
-	FireworksBillingSummaryPayload,
 	GitHubCopilotUsagePayload,
 	KimiCodingUsagePayload,
 	MiniMaxUsagePayload,
@@ -41,8 +37,8 @@ import type {
 	PiModel,
 	ResolvedUsageAuth,
 	UsageProviderAdapter,
-	UsageQuerySettings,
 	UsageReport,
+	UsageRequestGuard,
 	VercelAIGatewayCreditsPayload,
 	XaiBillingPayload,
 	XaiUserPayload,
@@ -55,9 +51,6 @@ const BASETEN_BILLING_USAGE_URL = "https://api.baseten.co/v1/billing/usage_summa
 const BASETEN_USAGE_WINDOW_DAYS = 30;
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance";
-const FIREWORKS_BILLING_SUMMARY_ORIGIN = "https://api.fireworks.ai";
-const FIREWORKS_SPEND_WINDOW_DAYS = 30;
-const FIREWORKS_MAX_ACCOUNT_PAGES = 5;
 const GITHUB_COPILOT_USAGE_URL = "https://api.github.com/copilot_internal/user";
 const OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key";
 const VERCEL_AI_GATEWAY_CREDITS_URL = "https://ai-gateway.vercel.sh/v1/credits";
@@ -83,8 +76,6 @@ const MAX_SUCCESS_BODY_BYTES = 64 * 1024;
 const MAX_ERROR_BODY_BYTES = 4 * 1024;
 
 export const AUTH_FINGERPRINT_SALT = randomBytes(32);
-
-export type UsageRequestGuard = () => Promise<void>;
 
 export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 	{
@@ -201,35 +192,7 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 			return normalizeVercelAIGatewayCreditsPayload(payload, Date.now());
 		},
 	},
-	{
-		id: "fireworks",
-		displayName: "Fireworks",
-		semantics: { kind: "api-key", label: "Fireworks API spend" },
-		async query(auth, signal, timeoutMs, guard, settings) {
-			if (!guard) throw new Error("Fireworks API spend requires request-boundary revalidation.");
-			const startedAt = Date.now();
-			await guard();
-			const accountId = await resolveFireworksAccountId(
-				auth,
-				signal,
-				remainingTimeout(timeoutMs, startedAt, "resolving the Fireworks account"),
-				guard,
-				settings?.fireworksAccountId,
-			);
-			await guard();
-			const billingWindowAt = Date.now();
-			const payload = (await fetchProviderJson(
-				fireworksBillingSummaryUrl(accountId, billingWindowAt),
-				auth,
-				signal,
-				remainingTimeout(timeoutMs, startedAt, "fetching Fireworks rated spend"),
-				"Fireworks billing summary endpoint",
-				{ redirect: "error" },
-			)) as FireworksBillingSummaryPayload;
-			await guard();
-			return normalizeFireworksBillingSummaryPayload(payload, accountId, Date.now());
-		},
-	},
+	createFireworksAdapter(fetchProviderJson),
 	{
 		id: "opencode-go",
 		displayName: "OpenCode Go",
@@ -402,6 +365,12 @@ export async function resolveUsageAuth(
 	if (!model) return undefined;
 	// SAFETY: Pi exposes the required auth methods at runtime, and checks below narrow them before use.
 	const registry = ctx.modelRegistry as unknown as UsageAuthRegistry;
+	const provider = registry.getProvider?.(adapter.id);
+	if (provider?.baseUrl && !hasOfficialUrlOrigin(provider.baseUrl, adapter.id)) {
+		throw new Error(
+			`${adapter.displayName} usage cannot send an overridden provider credential to the official usage endpoint.`,
+		);
+	}
 	let modelAuth: RequestAuth | undefined;
 	const currentModel = ctx.model?.provider === adapter.id ? ctx.model : undefined;
 	const resolveCurrentModelAuth = async (): Promise<RequestAuth | undefined> => {
@@ -429,8 +398,46 @@ export async function resolveUsageAuth(
 	// Providers with credential-change retries read selected-model auth last so a rotation during
 	// provider-origin validation cannot leave the earlier credential queued for the usage request.
 	if (resolveSelectedAuthLast) modelAuth = await resolveCurrentModelAuth();
+	if (modelAuth?.baseUrl && !hasOfficialUrlOrigin(modelAuth.baseUrl, adapter.id)) {
+		throw new Error(
+			`${adapter.displayName} usage cannot send model-resolved proxy credentials to the official usage endpoint.`,
+		);
+	}
 	const auth = modelAuth ?? providerResult?.auth;
 	if (!auth) return undefined;
+	const finalize = (resolved: ResolvedUsageAuth): ResolvedUsageAuth => {
+		const preservedAuth = { ...(providerResult?.auth ?? auth) };
+		const env = providerResult?.env ?? modelAuth?.env;
+		const source = providerResult?.source;
+		const effectiveBaseUrl =
+			modelAuth?.baseUrl ?? providerResult?.auth.baseUrl ?? provider?.baseUrl ?? model.baseUrl;
+		const redactionInputs = [
+			preservedAuth.apiKey,
+			...Object.values(preservedAuth.headers ?? {}),
+			...Object.values(env ?? {}),
+			modelAuth?.apiKey,
+			...Object.values(modelAuth?.headers ?? {}),
+		].filter((value): value is string => typeof value === "string" && value.length > 0);
+		return {
+			...resolved,
+			auth: preservedAuth,
+			...(env ? { env: { ...env } } : {}),
+			...(source ? { source } : {}),
+			effectiveBaseUrl,
+			secrets: [...new Set([...resolved.secrets, ...redactionInputs])],
+			fingerprint: fingerprintResolvedAuth(
+				{
+					apiKey: resolved.apiKey,
+					headers: resolved.headers,
+					baseUrl: effectiveBaseUrl,
+					env,
+					source,
+					providerAuth: preservedAuth,
+				},
+				salt,
+			),
+		};
+	};
 	if (adapter.id === "github-copilot") {
 		const offered = candidateReader
 			? candidateReader(ctx, adapter.id)
@@ -438,12 +445,14 @@ export async function resolveUsageAuth(
 		if (!offered.ok) {
 			throw new Error("GitHub Copilot OAuth credential discovery failed closed.");
 		}
-		return resolveGitHubCopilotUsageAuth(
-			auth,
-			model,
-			salt,
-			offered.candidates,
-			offered.offeredCount === 0,
+		return finalize(
+			resolveGitHubCopilotUsageAuth(
+				auth,
+				model,
+				salt,
+				offered.candidates,
+				offered.offeredCount === 0,
+			),
 		);
 	}
 	if (adapter.id === "xai") {
@@ -451,7 +460,7 @@ export async function resolveUsageAuth(
 			? candidateReader(ctx, adapter.id)
 			: fallbackOAuthCredentialCandidates(adapter.id, credentialReader);
 		if (!offered.ok) throw new Error("xAI OAuth credential discovery failed closed.");
-		return resolveXaiUsageAuth(auth, model, salt, offered.candidates);
+		return finalize(resolveXaiUsageAuth(auth, model, salt, offered.candidates));
 	}
 	if (adapter.id === "deepseek") {
 		const resolvedAuthorization = authorizationFrom(auth);
@@ -459,10 +468,10 @@ export async function resolveUsageAuth(
 		if (!access) throw new Error("DeepSeek API balance requires Bearer authentication.");
 		const authorization = `Bearer ${access}`;
 		const headers = { Authorization: authorization };
-		return {
+		return finalize({
 			apiKey: access,
 			headers,
-			fingerprint: fingerprintResolvedAuth({ headers }, salt),
+			fingerprint: "",
 			secrets: [
 				access,
 				auth.apiKey,
@@ -471,7 +480,7 @@ export async function resolveUsageAuth(
 				authorization,
 			].filter((value): value is string => Boolean(value)),
 			model,
-		};
+		});
 	}
 	const authorization = authorizationFrom(auth);
 	if (!authorization) return undefined;
@@ -479,13 +488,13 @@ export async function resolveUsageAuth(
 	const secrets = [auth.apiKey, headerValue(auth.headers, "Authorization"), authorization].filter(
 		(value): value is string => Boolean(value),
 	);
-	return {
+	return finalize({
 		apiKey: auth.apiKey,
 		headers,
-		fingerprint: fingerprintResolvedAuth({ headers }, salt),
+		fingerprint: "",
 		secrets,
 		model,
-	};
+	});
 }
 
 export async function queryProviderUsage(
@@ -494,10 +503,10 @@ export async function queryProviderUsage(
 	signal: AbortSignal,
 	timeoutMs: number,
 	guard?: UsageRequestGuard,
-	settings?: Readonly<UsageQuerySettings>,
+	targetId?: string,
 ): Promise<UsageReport> {
 	try {
-		return await adapter.query(auth, signal, timeoutMs, guard, settings);
+		return await adapter.query(auth, signal, timeoutMs, guard, targetId);
 	} catch (error) {
 		if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
 		throw new Error(redactUsageError(errorMessage(error), auth.secrets));
@@ -696,17 +705,22 @@ async function readBoundedResponse(
 type RequestAuth = {
 	apiKey?: string;
 	headers?: Record<string, string | null>;
+	baseUrl?: string;
+	env?: Record<string, string>;
 };
 
 type StoredCredentialReader = (providerId: string) => unknown;
 
 type UsageAuthRegistry = {
+	getProvider?(providerId: string): { baseUrl?: string } | undefined;
 	getApiKeyAndHeaders?(
 		model: PiModel,
 	): Promise<({ ok: true } & RequestAuth) | { ok: false; error: string }>;
 	getProviderAuth?(providerId: string): Promise<
 		| {
-				auth: RequestAuth & { baseUrl?: string };
+				auth: RequestAuth;
+				env?: Record<string, string>;
+				source?: string;
 		  }
 		| undefined
 	>;
@@ -902,7 +916,7 @@ function hasOfficialUrlOrigin(value: string, providerId: string): boolean {
 		}
 		if (providerId === "openai-codex") return url.origin === "https://chatgpt.com";
 		if (providerId === "deepseek") return url.origin === "https://api.deepseek.com";
-		if (providerId === "fireworks") return url.origin === FIREWORKS_BILLING_SUMMARY_ORIGIN;
+		if (providerId === "fireworks") return url.origin === "https://api.fireworks.ai";
 		if (providerId === "openrouter") return url.origin === "https://openrouter.ai";
 		if (providerId === "vercel-ai-gateway") return url.origin === "https://ai-gateway.vercel.sh";
 		if (providerId === "opencode-go") return url.origin === "https://opencode.ai";
@@ -1012,98 +1026,6 @@ function remainingTimeout(
 	const remaining = timeoutMs - (Date.now() - startedAt);
 	if (remaining <= 0) throw new Error(`Timed out while ${description}.`);
 	return remaining;
-}
-
-// Fireworks requires an account slug for its billing endpoints; discover it through the
-// documented account listing, requiring an explicit slug when a key can see several accounts.
-async function resolveFireworksAccountId(
-	auth: ResolvedUsageAuth,
-	signal: AbortSignal,
-	timeoutMs: number,
-	guard: () => Promise<void>,
-	configuredAccountId: string | undefined,
-): Promise<string> {
-	if (configuredAccountId !== undefined && !isFireworksAccountId(configuredAccountId)) {
-		throw new Error("The Fireworks account setting was not a safe account slug.");
-	}
-	const startedAt = Date.now();
-	const accounts: string[] = [];
-	let pageToken: string | undefined;
-	for (let page = 0; page < FIREWORKS_MAX_ACCOUNT_PAGES; page += 1) {
-		await guard();
-		const payload = (await fetchProviderJson(
-			fireworksAccountsUrl(pageToken),
-			auth,
-			signal,
-			remainingTimeout(timeoutMs, startedAt, "fetching Fireworks accounts"),
-			"Fireworks accounts endpoint",
-			{ redirect: "error" },
-		)) as FireworksAccountsPayload;
-		for (const accountId of normalizeFireworksAccountsPayload(
-			payload as FireworksAccountsPayload,
-		)) {
-			if (accounts.includes(accountId)) {
-				throw new Error(`Fireworks accounts listing repeated ${accountId}.`);
-			}
-			accounts.push(accountId);
-			if (configuredAccountId === accountId) return accountId;
-		}
-		pageToken = fireworksNextPageToken(payload.nextPageToken);
-		if (!pageToken) break;
-	}
-	if (pageToken) {
-		throw new Error(
-			configuredAccountId
-				? `The configured Fireworks account was not found within the first ${FIREWORKS_MAX_ACCOUNT_PAGES} listing pages.`
-				: `Fireworks account listing exceeded ${FIREWORKS_MAX_ACCOUNT_PAGES} pages; set fireworksAccountId in pi-usage.json to an account returned in those pages.`,
-		);
-	}
-	if (accounts.length === 0) {
-		throw new Error("Fireworks account discovery returned no accounts for this API key.");
-	}
-	if (configuredAccountId) {
-		throw new Error(
-			"The configured Fireworks account does not match an account visible to this API key.",
-		);
-	}
-	if (accounts.length === 1) return accounts[0] as string;
-	const preview = accounts.slice(0, 8).join(", ");
-	const suffix = accounts.length > 8 ? ` …and ${accounts.length - 8} more` : "";
-	throw new Error(
-		`The Fireworks key can see ${accounts.length} accounts (${preview}${suffix}); set fireworksAccountId in pi-usage.json to one of them.`,
-	);
-}
-
-function fireworksAccountsUrl(pageToken: string | undefined): string {
-	const url = new URL("/v1/accounts", FIREWORKS_BILLING_SUMMARY_ORIGIN);
-	url.searchParams.set("pageSize", "200");
-	if (pageToken !== undefined) url.searchParams.set("pageToken", pageToken);
-	return url.toString();
-}
-
-function fireworksNextPageToken(value: unknown): string | undefined {
-	if (value === undefined || value === null) return undefined;
-	if (typeof value !== "string" || !value || value.length > 512) {
-		throw new Error("Fireworks accounts listing returned an invalid page token.");
-	}
-	return value;
-}
-
-function fireworksBillingSummaryUrl(accountId: string, startedAt: number): string {
-	const dayMs = 24 * 60 * 60 * 1000;
-	const dayFloor = (time: number) => `${new Date(time).toISOString().slice(0, 10)}T00:00:00Z`;
-	const url = new URL(
-		`/v1/accounts/${accountId}/billing/summary`,
-		FIREWORKS_BILLING_SUMMARY_ORIGIN,
-	);
-	// The endpoint aggregates by UTC date; endTime is exclusive, so the window includes today
-	// plus the preceding 29 dates.
-	url.searchParams.set(
-		"startTime",
-		dayFloor(startedAt - (FIREWORKS_SPEND_WINDOW_DAYS - 1) * dayMs),
-	);
-	url.searchParams.set("endTime", dayFloor(startedAt + dayMs));
-	return url.toString();
 }
 
 function zaiOrigin(baseUrl: string | undefined): string {

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -29,6 +29,8 @@ export interface UsageSettingsState {
 	issue?: string;
 }
 
+export type UsageTargetPublicationCheck = () => Promise<void>;
+
 export interface UsageSettingsRuntime {
 	get(): Readonly<UsageSettingsState>;
 	reload(signal?: AbortSignal): Promise<Readonly<UsageSettingsState>>;
@@ -40,6 +42,7 @@ export interface UsageSettingsRuntime {
 		providerId: string,
 		targetId: string,
 		signal?: AbortSignal,
+		checkPublishedSelection?: UsageTargetPublicationCheck,
 	): Promise<Readonly<UsageSettingsState>>;
 	flush(): Promise<void>;
 }
@@ -180,16 +183,37 @@ export function createUsageSettingsRuntime(
 				state = saved;
 				return structuredClone(state);
 			}),
-		updateSelectedTarget: (providerId, targetId, signal) =>
+		updateSelectedTarget: (providerId, targetId, signal, checkPublishedSelection) =>
 			enqueue(async () => {
-				const saved = await saveUsageTargetSelection(
+				const transaction = await saveUsageTargetSelection(
 					path,
 					providerId,
 					targetId,
 					operations,
 					signal,
 				);
-				state = saved;
+				try {
+					await checkPublishedSelection?.();
+					throwIfAborted(signal);
+				} catch (error) {
+					try {
+						await restoreUsageSettingsState(
+							path,
+							transaction.saved,
+							transaction.previous,
+							operations,
+						);
+						state = transaction.previous;
+					} catch (rollbackError) {
+						state = await loadUsageSettings(path);
+						throw new AggregateError(
+							[error, rollbackError],
+							"Target selection changed after publication and pi-usage.json rollback failed",
+						);
+					}
+					throw error;
+				}
+				state = transaction.saved;
 				return structuredClone(state);
 			}),
 		flush: () => queue,
@@ -221,11 +245,12 @@ async function saveUsageTargetSelection(
 	targetId: string,
 	operations: UsageSettingsFileOperations,
 	signal?: AbortSignal,
-): Promise<UsageSettingsState> {
+): Promise<{ saved: UsageSettingsState; previous: UsageSettingsState }> {
 	if (!isProviderId(providerId) || !isBoundedTargetId(targetId)) {
 		throw new Error("Refusing to save an invalid usage target selection");
 	}
-	return saveUsageSettingsDocument(
+	const previous = await loadUsageSettings(path, signal);
+	const saved = await saveUsageSettingsDocument(
 		path,
 		(document) => {
 			document.selectedTargets = {
@@ -236,7 +261,9 @@ async function saveUsageTargetSelection(
 		},
 		operations,
 		signal,
+		previous,
 	);
+	return { saved, previous };
 }
 
 async function saveUsageSettingsDocument(
@@ -244,10 +271,14 @@ async function saveUsageSettingsDocument(
 	mutate: (document: Record<string, unknown>) => void,
 	operations: UsageSettingsFileOperations,
 	signal?: AbortSignal,
+	expected?: UsageSettingsState,
 ): Promise<UsageSettingsState> {
 	const latest = await loadUsageSettings(path, signal);
 	if (latest.kind === "invalid") {
 		throw new Error("Cannot overwrite an invalid pi-usage.json; repair it and reload first");
+	}
+	if (expected && !sameUsageSettingsDocument(latest, expected)) {
+		throw new Error("pi-usage.json changed while saving; retry the action");
 	}
 	const document = { ...latest.document };
 	mutate(document);
@@ -279,6 +310,44 @@ async function saveUsageSettingsDocument(
 		await rm(temporaryPath, { force: true }).catch(() => undefined);
 	}
 	return { kind: "loaded", path, settings, document };
+}
+
+async function restoreUsageSettingsState(
+	path: string,
+	published: UsageSettingsState,
+	previous: UsageSettingsState,
+	operations: UsageSettingsFileOperations,
+): Promise<void> {
+	if (previous.kind === "missing") {
+		const current = await loadUsageSettings(path);
+		if (!sameUsageSettingsDocument(current, published)) {
+			throw new Error("pi-usage.json changed before target selection rollback");
+		}
+		await rm(path);
+		return;
+	}
+	if (previous.kind !== "loaded" || !previous.document) {
+		throw new Error("Cannot restore invalid prior pi-usage.json settings");
+	}
+	await saveUsageSettingsDocument(
+		path,
+		(document) => {
+			for (const key of Object.keys(document)) delete document[key];
+			Object.assign(document, previous.document);
+		},
+		operations,
+		undefined,
+		published,
+	);
+}
+
+function sameUsageSettingsDocument(
+	left: Pick<UsageSettingsState, "kind" | "document">,
+	right: Pick<UsageSettingsState, "kind" | "document">,
+): boolean {
+	return (
+		left.kind === right.kind && JSON.stringify(left.document) === JSON.stringify(right.document)
+	);
 }
 
 async function chmodPrivate(path: string): Promise<void> {

--- a/packages/pi-usage/src/settings.ts
+++ b/packages/pi-usage/src/settings.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { isFireworksAccountId } from "./providers/fireworks.js";
+import { isBoundedTargetId } from "./usage-targets.js";
 
 export const USAGE_SETTINGS_FILE = "pi-usage.json";
 export const MAX_USAGE_SETTINGS_BYTES = 64 * 1024;
@@ -11,12 +12,13 @@ export const MAX_USAGE_SETTINGS_BYTES = 64 * 1024;
 export interface UsageSettings {
 	codexFastMode: boolean;
 	codexStatusResetCountdown: boolean;
-	fireworksAccountId?: string;
+	selectedTargets: Record<string, string>;
 }
 
 export const DEFAULT_USAGE_SETTINGS: Readonly<UsageSettings> = Object.freeze({
 	codexFastMode: false,
 	codexStatusResetCountdown: true,
+	selectedTargets: Object.freeze({}),
 });
 
 export interface UsageSettingsState {
@@ -32,6 +34,11 @@ export interface UsageSettingsRuntime {
 	reload(signal?: AbortSignal): Promise<Readonly<UsageSettingsState>>;
 	update(
 		patch: Partial<UsageSettings>,
+		signal?: AbortSignal,
+	): Promise<Readonly<UsageSettingsState>>;
+	updateSelectedTarget(
+		providerId: string,
+		targetId: string,
 		signal?: AbortSignal,
 	): Promise<Readonly<UsageSettingsState>>;
 	flush(): Promise<void>;
@@ -68,6 +75,12 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 	) {
 		return undefined;
 	}
+	const selectedTargets = normalizeSelectedTargets(value.selectedTargets);
+	if (Object.hasOwn(value, "selectedTargets") && !selectedTargets) return undefined;
+	const effectiveTargets = { ...(selectedTargets ?? {}) };
+	if (!effectiveTargets.fireworks && isFireworksAccountId(value.fireworksAccountId)) {
+		effectiveTargets.fireworks = value.fireworksAccountId;
+	}
 	return {
 		codexFastMode:
 			typeof value.codexFastMode === "boolean"
@@ -77,9 +90,7 @@ export function normalizeUsageSettings(value: unknown): UsageSettings | undefine
 			typeof value.codexStatusResetCountdown === "boolean"
 				? value.codexStatusResetCountdown
 				: DEFAULT_USAGE_SETTINGS.codexStatusResetCountdown,
-		...(isFireworksAccountId(value.fireworksAccountId)
-			? { fireworksAccountId: value.fireworksAccountId }
-			: {}),
+		selectedTargets: effectiveTargets,
 	};
 }
 
@@ -169,6 +180,18 @@ export function createUsageSettingsRuntime(
 				state = saved;
 				return structuredClone(state);
 			}),
+		updateSelectedTarget: (providerId, targetId, signal) =>
+			enqueue(async () => {
+				const saved = await saveUsageTargetSelection(
+					path,
+					providerId,
+					targetId,
+					operations,
+					signal,
+				);
+				state = saved;
+				return structuredClone(state);
+			}),
 		flush: () => queue,
 	};
 }
@@ -179,15 +202,55 @@ async function saveUsageSettingsPatch(
 	operations: UsageSettingsFileOperations,
 	signal?: AbortSignal,
 ): Promise<UsageSettingsState> {
+	return saveUsageSettingsDocument(
+		path,
+		(document) => {
+			for (const [key, value] of Object.entries(patch)) {
+				if (value === undefined) delete document[key];
+				else document[key] = value;
+			}
+		},
+		operations,
+		signal,
+	);
+}
+
+async function saveUsageTargetSelection(
+	path: string,
+	providerId: string,
+	targetId: string,
+	operations: UsageSettingsFileOperations,
+	signal?: AbortSignal,
+): Promise<UsageSettingsState> {
+	if (!isProviderId(providerId) || !isBoundedTargetId(targetId)) {
+		throw new Error("Refusing to save an invalid usage target selection");
+	}
+	return saveUsageSettingsDocument(
+		path,
+		(document) => {
+			document.selectedTargets = {
+				...(normalizeSelectedTargets(document.selectedTargets) ?? {}),
+				[providerId]: targetId,
+			};
+			if (providerId === "fireworks") delete document.fireworksAccountId;
+		},
+		operations,
+		signal,
+	);
+}
+
+async function saveUsageSettingsDocument(
+	path: string,
+	mutate: (document: Record<string, unknown>) => void,
+	operations: UsageSettingsFileOperations,
+	signal?: AbortSignal,
+): Promise<UsageSettingsState> {
 	const latest = await loadUsageSettings(path, signal);
 	if (latest.kind === "invalid") {
 		throw new Error("Cannot overwrite an invalid pi-usage.json; repair it and reload first");
 	}
 	const document = { ...latest.document };
-	for (const [key, value] of Object.entries(patch)) {
-		if (value === undefined) delete document[key];
-		else document[key] = value;
-	}
+	mutate(document);
 	const settings = normalizeUsageSettings(document);
 	if (!settings) throw new Error("Refusing to save invalid pi-usage settings");
 	const directory = dirname(path);
@@ -232,4 +295,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
 	return error instanceof Error && "code" in error;
+}
+
+function normalizeSelectedTargets(value: unknown): Record<string, string> | undefined {
+	if (value === undefined) return {};
+	if (!isRecord(value)) return undefined;
+	const targets: Record<string, string> = {};
+	for (const [providerId, targetId] of Object.entries(value)) {
+		if (!isProviderId(providerId) || !isBoundedTargetId(targetId)) return undefined;
+		targets[providerId] = targetId;
+	}
+	return targets;
+}
+
+function isProviderId(value: string): boolean {
+	return /^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u.test(value);
 }

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -63,6 +63,10 @@ export interface ResolvedUsageAuth {
 	effectiveBaseUrl?: string;
 }
 
+export interface UsageQuerySettings {
+	fireworksAccountId?: string;
+}
+
 export type UsageRequestGuard = () => Promise<void>;
 
 export interface UsageProviderTarget {

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -53,10 +53,33 @@ export interface ResolvedUsageAuth {
 	fingerprint: string;
 	secrets: string[];
 	model: PiModel;
+	auth?: {
+		apiKey?: string;
+		headers?: Record<string, string | null>;
+		baseUrl?: string;
+	};
+	env?: Record<string, string>;
+	source?: string;
+	effectiveBaseUrl?: string;
 }
 
-export interface UsageQuerySettings {
-	fireworksAccountId?: string;
+export type UsageRequestGuard = () => Promise<void>;
+
+export interface UsageProviderTarget {
+	id: string;
+	label: string;
+	description?: string;
+}
+
+export interface UsageTargetResolver {
+	singularLabel: string;
+	pluralLabel: string;
+	list(
+		auth: ResolvedUsageAuth,
+		signal: AbortSignal,
+		timeoutMs: number,
+		guard: UsageRequestGuard,
+	): Promise<readonly UsageProviderTarget[]>;
 }
 
 export interface UsageProviderAdapter {
@@ -64,12 +87,13 @@ export interface UsageProviderAdapter {
 	displayName: string;
 	semantics: UsageSemantics;
 	publishesStatusline?: boolean;
+	targets?: UsageTargetResolver;
 	query(
 		auth: ResolvedUsageAuth,
 		signal: AbortSignal,
 		timeoutMs: number,
-		guard?: () => Promise<void>,
-		settings?: Readonly<UsageQuerySettings>,
+		guard?: UsageRequestGuard,
+		targetId?: string,
 	): Promise<UsageReport>;
 }
 
@@ -80,6 +104,15 @@ export type ProviderUsageState =
 			displayState: UsageDisplayState;
 			status: "ready";
 			report: UsageReport;
+	  }
+	| {
+			providerId: string;
+			providerName: string;
+			displayState: UsageDisplayState;
+			status: "selection-required";
+			singularLabel: string;
+			pluralLabel: string;
+			choices: readonly UsageProviderTarget[];
 	  }
 	| {
 			providerId: string;

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -11,16 +11,12 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import { errorMessage } from "./core.js";
-import { isFireworksAccountId } from "./providers/fireworks.js";
-import type { UsageSettings, UsageSettingsRuntime } from "./settings.js";
+import type { UsageSettingsRuntime } from "./settings.js";
 
-const AUTO = "Auto";
-const EDIT = "Edit…";
 const OFF = "Off";
 const ON = "On";
 
-type UsageSettingId = keyof UsageSettings;
-type SettingsScreenResult = { changed: boolean; editFireworksAccount: boolean };
+type UsageSettingId = "codexFastMode" | "codexStatusResetCountdown";
 
 export async function showUsageSettings(
 	ctx: ExtensionCommandContext,
@@ -33,187 +29,96 @@ export async function showUsageSettings(
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${settingsRuntime.get().path}`, "info");
 		return false;
 	}
-	let changed = false;
-	while (!parentSignal.aborted && isCurrent()) {
-		const result = await showSettingsList(ctx, settingsRuntime, parentSignal, isCurrent, onApplied);
-		if (!result) return changed;
-		changed ||= result.changed;
-		if (!result.editFireworksAccount) return changed;
-		changed ||= await editFireworksAccount(
-			ctx,
-			settingsRuntime,
-			parentSignal,
-			isCurrent,
-			onApplied,
-		);
-	}
-	return changed;
-}
+	return (
+		(await ctx.ui.custom<boolean>((tui, theme, _keybindings, done) => {
+			const localController = new AbortController();
+			const signal = AbortSignal.any([parentSignal, localController.signal]);
+			let changed = false;
+			let closing = false;
+			let saveQueue = Promise.resolve();
+			const state = settingsRuntime.get();
+			const items: SettingItem[] = [
+				{
+					id: "codexFastMode",
+					label: "Codex Fast mode",
+					description: "Use faster Codex routing at increased plan allowance consumption.",
+					currentValue: state.settings.codexFastMode ? ON : OFF,
+					values: [OFF, ON],
+				},
+				{
+					id: "codexStatusResetCountdown",
+					label: "Codex reset countdown",
+					description: "Show time remaining until each Codex usage limit resets.",
+					currentValue: state.settings.codexStatusResetCountdown ? ON : OFF,
+					values: [OFF, ON],
+				},
+			];
+			const container = new Container();
+			container.addChild(new Text(theme.fg("accent", theme.bold("pi-usage Settings")), 1, 1));
 
-async function showSettingsList(
-	ctx: ExtensionCommandContext,
-	settingsRuntime: UsageSettingsRuntime,
-	parentSignal: AbortSignal,
-	isCurrent: () => boolean,
-	onApplied: (id: UsageSettingId) => void,
-): Promise<SettingsScreenResult | undefined> {
-	return ctx.ui.custom<SettingsScreenResult>((tui, theme, _keybindings, done) => {
-		const localController = new AbortController();
-		const signal = AbortSignal.any([parentSignal, localController.signal]);
-		let changed = false;
-		let closing = false;
-		let saveQueue = Promise.resolve();
-		const state = settingsRuntime.get();
-		const fireworksValue = state.settings.fireworksAccountId ?? AUTO;
-		const items: SettingItem[] = [
-			{
-				id: "codexFastMode",
-				label: "Codex Fast mode",
-				description: "Use faster Codex routing at increased plan allowance consumption.",
-				currentValue: state.settings.codexFastMode ? ON : OFF,
-				values: [OFF, ON],
-			},
-			{
-				id: "codexStatusResetCountdown",
-				label: "Codex reset countdown",
-				description: "Show time remaining until each Codex usage limit resets.",
-				currentValue: state.settings.codexStatusResetCountdown ? ON : OFF,
-				values: [OFF, ON],
-			},
-			{
-				id: "fireworksAccountId",
-				label: "Fireworks account",
-				description: "Select Edit to enter a visible account slug, or submit blank to clear it.",
-				currentValue: fireworksValue,
-				values: state.settings.fireworksAccountId
-					? [state.settings.fireworksAccountId, EDIT]
-					: [AUTO, EDIT],
-			},
-		];
-		const container = new Container();
-		container.addChild(new Text(theme.fg("accent", theme.bold("pi-usage Settings")), 1, 1));
-
-		let settingsList: SettingsList;
-		const cancel = () => {
-			if (closing) return;
-			closing = true;
-			localController.abort();
-			done({ changed, editFireworksAccount: false });
-		};
-		const queueUpdate = (
-			id: UsageSettingId,
-			requested: UsageSettings[UsageSettingId],
-			display: string,
-		) => {
-			saveQueue = saveQueue.then(async () => {
-				const previous = settingsRuntime.get().settings[id];
-				if (settingsRuntime.get().kind === "invalid") {
-					settingsList.updateValue(id, displaySetting(id, previous));
-					if (!signal.aborted && isCurrent()) {
-						ctx.ui.notify("Repair pi-usage.json and reload before changing settings.", "error");
-						tui.requestRender();
-					}
-					return;
-				}
-				try {
-					await settingsRuntime.update({ [id]: requested }, signal);
-				} catch (error) {
-					if (signal.aborted || !isCurrent()) return;
-					settingsList.updateValue(id, displaySetting(id, previous));
-					ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
-					tui.requestRender();
-					return;
-				}
-				if (previous !== requested) {
-					changed = true;
-					onApplied(id);
-				}
-				if (signal.aborted || !isCurrent()) return;
-				settingsList.updateValue(id, display);
-				tui.requestRender();
-			});
-		};
-		settingsList = new SettingsList(
-			items,
-			items.length + 2,
-			getSettingsListTheme(),
-			(id, value) => {
-				if (closing || signal.aborted || !isCurrent()) return;
-				if (id === "fireworksAccountId") {
-					if (value === EDIT) {
-						saveQueue = saveQueue.then(() => {
-							if (closing || signal.aborted || !isCurrent()) return;
-							closing = true;
-							done({ changed, editFireworksAccount: true });
-						});
-					}
-					return;
-				}
-				const settingId = id as "codexFastMode" | "codexStatusResetCountdown";
-				queueUpdate(settingId, value !== OFF, value);
-			},
-			cancel,
-		);
-		container.addChild(settingsList);
-
-		parentSignal.addEventListener("abort", cancel, { once: true });
-		return {
-			render: (width: number) => container.render(width),
-			invalidate: () => container.invalidate(),
-			handleInput(data: string) {
+			let settingsList: SettingsList;
+			const cancel = () => {
 				if (closing) return;
-				if (matchesKey(data, Key.ctrl("c"))) cancel();
-				else settingsList.handleInput(data);
-				tui.requestRender();
-			},
-			dispose() {
+				closing = true;
 				localController.abort();
-				parentSignal.removeEventListener("abort", cancel);
-			},
-		};
-	});
-}
+				done(changed);
+			};
+			const queueUpdate = (id: UsageSettingId, requested: boolean, display: string) => {
+				saveQueue = saveQueue.then(async () => {
+					const previous = settingsRuntime.get().settings[id];
+					if (settingsRuntime.get().kind === "invalid") {
+						settingsList.updateValue(id, previous ? ON : OFF);
+						if (!signal.aborted && isCurrent()) {
+							ctx.ui.notify("Repair pi-usage.json and reload before changing settings.", "error");
+							tui.requestRender();
+						}
+						return;
+					}
+					try {
+						await settingsRuntime.update({ [id]: requested }, signal);
+					} catch (error) {
+						if (signal.aborted || !isCurrent()) return;
+						settingsList.updateValue(id, previous ? ON : OFF);
+						ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
+						tui.requestRender();
+						return;
+					}
+					if (previous !== requested) {
+						changed = true;
+						onApplied(id);
+					}
+					if (signal.aborted || !isCurrent()) return;
+					settingsList.updateValue(id, display);
+					tui.requestRender();
+				});
+			};
+			settingsList = new SettingsList(
+				items,
+				items.length + 2,
+				getSettingsListTheme(),
+				(id, value) => {
+					if (closing || signal.aborted || !isCurrent()) return;
+					queueUpdate(id as UsageSettingId, value !== OFF, value);
+				},
+				cancel,
+			);
+			container.addChild(settingsList);
 
-async function editFireworksAccount(
-	ctx: ExtensionCommandContext,
-	settingsRuntime: UsageSettingsRuntime,
-	signal: AbortSignal,
-	isCurrent: () => boolean,
-	onApplied: (id: UsageSettingId) => void,
-): Promise<boolean> {
-	while (!signal.aborted && isCurrent()) {
-		const state = settingsRuntime.get();
-		if (state.kind === "invalid") {
-			ctx.ui.notify("Repair pi-usage.json and reload before changing settings.", "error");
-			return false;
-		}
-		const entered = await ctx.ui.input(
-			"Fireworks account slug · submit blank for Auto",
-			state.settings.fireworksAccountId ?? "Example: acme",
-			{ signal },
-		);
-		if (signal.aborted || !isCurrent() || entered === undefined) return false;
-		const normalized = entered.trim();
-		const requested = normalized || undefined;
-		if (requested !== undefined && !isFireworksAccountId(requested)) {
-			ctx.ui.notify("Enter a URL-safe Fireworks account slug.", "warning");
-			continue;
-		}
-		if (requested === state.settings.fireworksAccountId) return false;
-		try {
-			await settingsRuntime.update({ fireworksAccountId: requested }, signal);
-		} catch (error) {
-			if (signal.aborted || !isCurrent()) return false;
-			ctx.ui.notify(`Could not save pi-usage.json: ${errorMessage(error)}`, "error");
-			return false;
-		}
-		onApplied("fireworksAccountId");
-		return true;
-	}
-	return false;
-}
-
-function displaySetting(id: UsageSettingId, value: UsageSettings[UsageSettingId]): string {
-	if (id === "fireworksAccountId") return typeof value === "string" ? value : AUTO;
-	return value ? ON : OFF;
+			parentSignal.addEventListener("abort", cancel, { once: true });
+			return {
+				render: (width: number) => container.render(width),
+				invalidate: () => container.invalidate(),
+				handleInput(data: string) {
+					if (closing) return;
+					if (matchesKey(data, Key.ctrl("c"))) cancel();
+					else settingsList.handleInput(data);
+					tui.requestRender();
+				},
+				dispose() {
+					localController.abort();
+					parentSignal.removeEventListener("abort", cancel);
+				},
+			};
+		})) ?? false
+	);
 }

--- a/packages/pi-usage/src/usage-targets.ts
+++ b/packages/pi-usage/src/usage-targets.ts
@@ -36,10 +36,12 @@ export async function resolveUsageTarget(
 		throw new Error(`The remembered ${adapter.targets.singularLabel} identifier was invalid.`);
 	}
 	const choices = await listUsageTargets(adapter, auth, signal, timeoutMs, guard);
-	if (choices.length === 1) return { kind: "selected", targetId: choices[0]?.id };
-	if (rememberedTargetId && choices.some((choice) => choice.id === rememberedTargetId)) {
-		return { kind: "selected", targetId: rememberedTargetId };
+	if (rememberedTargetId) {
+		return choices.some((choice) => choice.id === rememberedTargetId)
+			? { kind: "selected", targetId: rememberedTargetId }
+			: { kind: "selection-required", choices };
 	}
+	if (choices.length === 1) return { kind: "selected", targetId: choices[0]?.id };
 	return { kind: "selection-required", choices };
 }
 
@@ -51,9 +53,16 @@ export async function listUsageTargets(
 	guard: UsageRequestGuard,
 ): Promise<readonly UsageProviderTarget[]> {
 	if (!adapter.targets) return [];
+	const startedAt = Date.now();
 	await guard();
-	const listed = await adapter.targets.list(auth, signal, timeoutMs, guard);
+	const listed = await adapter.targets.list(
+		auth,
+		signal,
+		remainingTargetTimeout(timeoutMs, startedAt),
+		guard,
+	);
 	await guard();
+	remainingTargetTimeout(timeoutMs, startedAt);
 	const choices = normalizeUsageTargets(listed);
 	if (choices.length === 0) {
 		throw new Error(`${adapter.targets.pluralLabel} discovery returned no choices.`);
@@ -113,6 +122,12 @@ export function createUsageTargetSelectOptions(
 		return option;
 	});
 	return { options, targetIdFor: (option) => ids.get(option) };
+}
+
+function remainingTargetTimeout(timeoutMs: number, startedAt: number): number {
+	const remaining = timeoutMs - (Date.now() - startedAt);
+	if (remaining <= 0) throw new Error("Timed out while discovering provider targets.");
+	return remaining;
 }
 
 export function isBoundedTargetId(value: unknown): value is string {

--- a/packages/pi-usage/src/usage-targets.ts
+++ b/packages/pi-usage/src/usage-targets.ts
@@ -1,0 +1,128 @@
+import { sanitizeDisplayText } from "./core.js";
+import type {
+	ResolvedUsageAuth,
+	UsageProviderAdapter,
+	UsageProviderTarget,
+	UsageRequestGuard,
+} from "./types.js";
+
+const MAX_TARGETS = 1_000;
+const MAX_TARGET_ID_CHARS = 256;
+const MAX_TARGET_LABEL_CHARS = 120;
+const MAX_TARGET_DESCRIPTION_CHARS = 180;
+
+export type UsageTargetResolution =
+	| { kind: "selected"; targetId?: string }
+	| {
+			kind: "selection-required";
+			choices: readonly UsageProviderTarget[];
+	  };
+
+export interface UsageTargetSelectOptions {
+	options: readonly string[];
+	targetIdFor(option: string): string | undefined;
+}
+
+export async function resolveUsageTarget(
+	adapter: UsageProviderAdapter,
+	auth: ResolvedUsageAuth,
+	rememberedTargetId: string | undefined,
+	signal: AbortSignal,
+	timeoutMs: number,
+	guard: UsageRequestGuard,
+): Promise<UsageTargetResolution> {
+	if (!adapter.targets) return { kind: "selected" };
+	if (rememberedTargetId !== undefined && !isBoundedTargetId(rememberedTargetId)) {
+		throw new Error(`The remembered ${adapter.targets.singularLabel} identifier was invalid.`);
+	}
+	const choices = await listUsageTargets(adapter, auth, signal, timeoutMs, guard);
+	if (choices.length === 1) return { kind: "selected", targetId: choices[0]?.id };
+	if (rememberedTargetId && choices.some((choice) => choice.id === rememberedTargetId)) {
+		return { kind: "selected", targetId: rememberedTargetId };
+	}
+	return { kind: "selection-required", choices };
+}
+
+export async function listUsageTargets(
+	adapter: UsageProviderAdapter,
+	auth: ResolvedUsageAuth,
+	signal: AbortSignal,
+	timeoutMs: number,
+	guard: UsageRequestGuard,
+): Promise<readonly UsageProviderTarget[]> {
+	if (!adapter.targets) return [];
+	await guard();
+	const listed = await adapter.targets.list(auth, signal, timeoutMs, guard);
+	await guard();
+	const choices = normalizeUsageTargets(listed);
+	if (choices.length === 0) {
+		throw new Error(`${adapter.targets.pluralLabel} discovery returned no choices.`);
+	}
+	return choices;
+}
+
+export function normalizeUsageTargets(
+	targets: readonly UsageProviderTarget[],
+): readonly UsageProviderTarget[] {
+	if (!Array.isArray(targets)) throw new Error("Target discovery did not return a choices array.");
+	if (targets.length > MAX_TARGETS) {
+		throw new Error(`Target discovery exceeded ${MAX_TARGETS} choices.`);
+	}
+	const seen = new Set<string>();
+	return targets.map((target) => {
+		if (!target || typeof target !== "object" || Array.isArray(target)) {
+			throw new Error("Target discovery returned an invalid choice.");
+		}
+		const { id, label, description } = target as Partial<UsageProviderTarget>;
+		if (!isBoundedTargetId(id)) throw new Error("Target discovery returned an invalid ID.");
+		if (seen.has(id)) throw new Error(`Target discovery repeated ${id}.`);
+		seen.add(id);
+		if (typeof label !== "string") {
+			throw new Error("Target discovery returned an invalid display label.");
+		}
+		if (description !== undefined && typeof description !== "string") {
+			throw new Error("Target discovery returned an invalid description.");
+		}
+		const safeLabel = sanitizeDisplayText(label, MAX_TARGET_LABEL_CHARS);
+		if (!safeLabel) throw new Error("Target discovery returned an empty display label.");
+		const safeDescription = description
+			? sanitizeDisplayText(description, MAX_TARGET_DESCRIPTION_CHARS)
+			: undefined;
+		return { id, label: safeLabel, ...(safeDescription ? { description: safeDescription } : {}) };
+	});
+}
+
+export function createUsageTargetSelectOptions(
+	targets: readonly UsageProviderTarget[],
+): UsageTargetSelectOptions {
+	const normalized = normalizeUsageTargets(targets);
+	const ids = new Map<string, string>();
+	const options = normalized.map((target) => {
+		const base = target.description ? `${target.label} — ${target.description}` : target.label;
+		let option = base;
+		if (ids.has(option)) {
+			const safeId = sanitizeDisplayText(target.id, 80) || "target";
+			option = `${base} · ${safeId}`;
+			let duplicate = 2;
+			while (ids.has(option)) {
+				option = `${base} · ${safeId} (${duplicate})`;
+				duplicate += 1;
+			}
+		}
+		ids.set(option, target.id);
+		return option;
+	});
+	return { options, targetIdFor: (option) => ids.get(option) };
+}
+
+export function isBoundedTargetId(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value.length <= MAX_TARGET_ID_CHARS &&
+		![...value].some((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+		})
+	);
+}

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -37,7 +37,11 @@ import {
 	queryProviderUsage,
 	resolveUsageAuth,
 } from "./query.js";
-import { createUsageSettingsRuntime, type UsageSettingsRuntime } from "./settings.js";
+import {
+	createUsageSettingsRuntime,
+	type UsageSettingsRuntime,
+	type UsageSettingsState,
+} from "./settings.js";
 import type {
 	PiModel,
 	ProviderUsageState,
@@ -87,6 +91,10 @@ type QueryOutcome = {
 	authState?: "unavailable";
 	rememberedTargetId?: string;
 };
+
+class UsageTargetSelectionChangedError extends Error {
+	override readonly name = "UsageTargetSelectionChangedError";
+}
 
 type StableCurrent = {
 	outcome: QueryOutcome;
@@ -767,7 +775,11 @@ export default function usageExtension(
 			const actionableTargetState = (): ProviderUsageState | undefined => {
 				if (visibleStates.length !== 1) return undefined;
 				const state = visibleStates[0];
-				return state && adapterForProvider(state.providerId)?.targets ? state : undefined;
+				return state &&
+					(state.status === "ready" || state.status === "selection-required") &&
+					adapterForProvider(state.providerId)?.targets
+					? state
+					: undefined;
 			};
 			const promptForTarget = async (
 				state: ProviderUsageState,
@@ -829,14 +841,49 @@ export default function usageExtension(
 					);
 					return false;
 				}
-				const saved = await runMenuOperation(
-					ctx,
-					`Saving ${adapter.targets.singularLabel}…`,
-					controller.signal,
-					(signal) => settingsRuntime.updateSelectedTarget(adapter.id, targetId, signal),
-				);
-				if (!saved || controller.signal.aborted || statusGeneration !== menuGeneration)
+				let saved: Readonly<UsageSettingsState> | undefined;
+				try {
+					saved = await runMenuOperation(
+						ctx,
+						`Saving ${adapter.targets.singularLabel}…`,
+						controller.signal,
+						(signal) =>
+							settingsRuntime.updateSelectedTarget(adapter.id, targetId, signal, async () => {
+								let published: Awaited<ReturnType<typeof loadTargetChoices>>;
+								try {
+									published = await loadTargetChoices(ctx, adapter, signal);
+								} catch (error) {
+									if (
+										signal.aborted ||
+										controller.signal.aborted ||
+										statusGeneration !== menuGeneration ||
+										isStaleExtensionContextError(error)
+									) {
+										throw error;
+									}
+									throw new UsageTargetSelectionChangedError();
+								}
+								if (
+									published.fingerprint !== snapshot.fingerprint ||
+									!published.choices.some((choice) => choice.id === targetId)
+								) {
+									throw new UsageTargetSelectionChangedError();
+								}
+							}),
+					);
+				} catch (error) {
+					if (error instanceof UsageTargetSelectionChangedError) {
+						ctx.ui.notify(
+							`${providerDisplayName(ctx, adapter.id)} ${adapter.targets.pluralLabel} changed; choose again.`,
+							"warning",
+						);
+						return false;
+					}
+					throw error;
+				}
+				if (!saved || controller.signal.aborted || statusGeneration !== menuGeneration) {
 					return false;
+				}
 				invalidateProviderState(adapter.id);
 				return true;
 			};

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -54,6 +54,11 @@ import {
 	setBoundedMap,
 } from "./usage-helpers.js";
 import { showUsageSettings } from "./usage-settings-ui.js";
+import {
+	createUsageTargetSelectOptions,
+	listUsageTargets,
+	resolveUsageTarget,
+} from "./usage-targets.js";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const STATUS_COUNTDOWN_REFRESH_MS = 60 * 1000;
@@ -80,6 +85,7 @@ type QueryOutcome = {
 	state: ProviderUsageState;
 	fingerprint?: string;
 	authState?: "unavailable";
+	rememberedTargetId?: string;
 };
 
 type StableCurrent = {
@@ -174,7 +180,11 @@ export default function usageExtension(
 			if (
 				safeSetStatus(
 					ctx,
-					outcome.state.status === "auth-unavailable" ? "auth unavailable" : "usage error",
+					outcome.state.status === "auth-unavailable"
+						? "auth unavailable"
+						: outcome.state.status === "selection-required"
+							? "selection required"
+							: "usage error",
 				)
 			) {
 				if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
@@ -248,10 +258,10 @@ export default function usageExtension(
 		const expectedSessionGeneration = sessionGeneration;
 		const expectedSessionId = ctx.sessionManager.getSessionId();
 		const expectedModelIdentity = modelIdentity(ctx.model);
-		const expectedFireworksAccountId =
-			adapter.id === "fireworks" ? settingsRuntime.get().settings.fireworksAccountId : undefined;
-		const querySettings =
-			adapter.id === "fireworks" ? { fireworksAccountId: expectedFireworksAccountId } : undefined;
+		const expectedTargetId = adapter.targets
+			? settingsRuntime.get().settings.selectedTargets[adapter.id]
+			: undefined;
+		const providerName = providerDisplayName(ctx, adapter.id);
 		let auth: ResolvedUsageAuth | undefined;
 		try {
 			auth = await awaitWithDeadline(
@@ -268,32 +278,33 @@ export default function usageExtension(
 			return {
 				state: {
 					providerId: adapter.id,
-					providerName: adapter.displayName,
+					providerName,
 					displayState,
 					status: isTimeoutError(error) ? "query-failed" : "auth-unavailable",
 					message: errorMessage(error),
 				},
 			};
 		}
-		const requiresRequestBoundaryGuard = [
-			"baseten",
-			"deepseek",
-			"fireworks",
-			"minimax",
-			"minimax-cn",
-			"moonshotai",
-			"moonshotai-cn",
-			"vercel-ai-gateway",
-			"xai",
-			"zai",
-			"zai-coding-cn",
-		].includes(adapter.id);
+		const requiresRequestBoundaryGuard =
+			adapter.targets !== undefined ||
+			[
+				"baseten",
+				"deepseek",
+				"minimax",
+				"minimax-cn",
+				"moonshotai",
+				"moonshotai-cn",
+				"vercel-ai-gateway",
+				"xai",
+				"zai",
+				"zai-coding-cn",
+			].includes(adapter.id);
 		const requestContextChanged = () =>
 			expectedSessionGeneration !== sessionGeneration ||
 			ctx.sessionManager.getSessionId() !== expectedSessionId ||
 			modelIdentity(ctx.model) !== expectedModelIdentity ||
-			(adapter.id === "fireworks" &&
-				settingsRuntime.get().settings.fireworksAccountId !== expectedFireworksAccountId);
+			(adapter.targets !== undefined &&
+				settingsRuntime.get().settings.selectedTargets[adapter.id] !== expectedTargetId);
 		if (requiresRequestBoundaryGuard && requestContextChanged()) throw abortError();
 		if (!auth) {
 			if (displayState === "current") {
@@ -302,101 +313,142 @@ export default function usageExtension(
 			return {
 				state: {
 					providerId: adapter.id,
-					providerName: adapter.displayName,
+					providerName,
 					displayState,
 					status: "auth-unavailable",
-					message: `No runtime credential is configured for ${adapter.displayName}.`,
+					message: `No runtime credential is configured for ${providerName}.`,
 				},
 				authState: "unavailable",
 			};
 		}
-		const queryFingerprint =
-			adapter.id === "fireworks"
-				? `${auth.fingerprint}:account:${expectedFireworksAccountId ?? "auto"}`
-				: auth.fingerprint;
-		if (displayState === "current") {
-			transitionCurrentIdentity(`${adapter.id}:${queryFingerprint}`, adapter.id);
-		}
-
-		const cached = !force ? cache.get(adapter.id, queryFingerprint) : undefined;
-		if (cached) {
-			return {
-				state: {
-					providerId: adapter.id,
-					providerName: adapter.displayName,
-					displayState,
-					status: "ready",
-					report: cached,
-				},
-				fingerprint: auth.fingerprint,
-			};
-		}
-
-		const failureKey = `${adapter.id}:${queryFingerprint}`;
-		const previousFailure = failureBackoff.get(failureKey);
-		if (!force && previousFailure && previousFailure.until > Date.now()) {
-			return {
-				state: {
-					providerId: adapter.id,
-					providerName: adapter.displayName,
-					displayState,
-					status: "query-failed",
-					message: previousFailure.message,
-				},
-				fingerprint: auth.fingerprint,
-			};
-		}
-		failureBackoff.delete(failureKey);
-		querySequence += 1;
-		const queryId = querySequence;
-		setBoundedMap(latestQueries, failureKey, queryId, MAX_ACCOUNT_STATES);
-
 		let retryableAuthChanged = false;
+		const guard = async () => {
+			if (signal.aborted || requestContextChanged()) throw abortError();
+			if (!requiresRequestBoundaryGuard) return;
+			const revalidated = await awaitWithDeadline(
+				resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
+				signal,
+				Math.max(1, deadlineAt - Date.now()),
+				`revalidating ${providerName} runtime auth`,
+			);
+			if (signal.aborted || requestContextChanged()) throw abortError();
+			if (revalidated?.fingerprint !== auth.fingerprint) {
+				if (["deepseek", "minimax", "minimax-cn"].includes(adapter.id)) {
+					retryableAuthChanged = true;
+					throw new Error(`${providerName} runtime credential changed during the usage query.`);
+				}
+				throw abortError();
+			}
+		};
+		let queryFingerprint = adapter.targets
+			? `${auth.fingerprint}:target:${expectedTargetId ?? "unresolved"}`
+			: auth.fingerprint;
+		let failureKey = `${adapter.id}:${queryFingerprint}`;
+		let queryId: number | undefined;
 		try {
-			const remainingMs = Math.max(1, deadlineAt - Date.now());
-			const guard = requiresRequestBoundaryGuard
-				? async () => {
-						if (signal.aborted || requestContextChanged()) throw abortError();
-						const revalidated = await awaitWithDeadline(
-							resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
-							signal,
-							Math.max(1, deadlineAt - Date.now()),
-							`revalidating ${adapter.displayName} runtime auth`,
-						);
-						if (signal.aborted || requestContextChanged()) throw abortError();
-						if (revalidated?.fingerprint !== auth.fingerprint) {
-							if (["deepseek", "minimax", "minimax-cn"].includes(adapter.id)) {
-								retryableAuthChanged = true;
-								throw new Error(
-									`${adapter.displayName} runtime credential changed during the usage query.`,
-								);
-							}
-							throw abortError();
-						}
-					}
-				: undefined;
+			const previousDiscoveryFailure = failureBackoff.get(failureKey);
+			if (!force && previousDiscoveryFailure && previousDiscoveryFailure.until > Date.now()) {
+				return {
+					state: {
+						providerId: adapter.id,
+						providerName,
+						displayState,
+						status: "query-failed",
+						message: previousDiscoveryFailure.message,
+					},
+					fingerprint: auth.fingerprint,
+					rememberedTargetId: expectedTargetId,
+				};
+			}
+			const target = await resolveUsageTarget(
+				adapter,
+				auth,
+				expectedTargetId,
+				signal,
+				Math.max(1, deadlineAt - Date.now()),
+				guard,
+			);
+			if (target.kind === "selection-required") {
+				if (displayState === "current") {
+					transitionCurrentIdentity(`${adapter.id}:${queryFingerprint}`, adapter.id);
+				}
+				return {
+					state: {
+						providerId: adapter.id,
+						providerName,
+						displayState,
+						status: "selection-required",
+						singularLabel: adapter.targets?.singularLabel ?? "target",
+						pluralLabel: adapter.targets?.pluralLabel ?? "targets",
+						choices: target.choices,
+					},
+					fingerprint: auth.fingerprint,
+					rememberedTargetId: expectedTargetId,
+				};
+			}
+			queryFingerprint = adapter.targets
+				? `${auth.fingerprint}:target:${target.targetId ?? "none"}`
+				: auth.fingerprint;
+			failureKey = `${adapter.id}:${queryFingerprint}`;
+			if (displayState === "current") {
+				transitionCurrentIdentity(`${adapter.id}:${queryFingerprint}`, adapter.id);
+			}
+			const cached = !force ? cache.get(adapter.id, queryFingerprint) : undefined;
+			if (cached) {
+				return {
+					state: {
+						providerId: adapter.id,
+						providerName,
+						displayState,
+						status: "ready",
+						report: cached,
+					},
+					fingerprint: auth.fingerprint,
+					rememberedTargetId: expectedTargetId,
+				};
+			}
+			const previousFailure = failureBackoff.get(failureKey);
+			if (!force && previousFailure && previousFailure.until > Date.now()) {
+				return {
+					state: {
+						providerId: adapter.id,
+						providerName,
+						displayState,
+						status: "query-failed",
+						message: previousFailure.message,
+					},
+					fingerprint: auth.fingerprint,
+					rememberedTargetId: expectedTargetId,
+				};
+			}
+			failureBackoff.delete(failureKey);
+			querySequence += 1;
+			queryId = querySequence;
+			setBoundedMap(latestQueries, failureKey, queryId, MAX_ACCOUNT_STATES);
 			const report = await queryProviderUsage(
 				adapter,
 				auth,
 				signal,
-				remainingMs,
-				guard,
-				querySettings,
+				Math.max(1, deadlineAt - Date.now()),
+				requiresRequestBoundaryGuard ? guard : undefined,
+				target.targetId,
 			);
-			if (guard) await guard();
+			if (requiresRequestBoundaryGuard) await guard();
+			const effectiveReport = { ...report, providerName };
 			if (latestQueries.get(failureKey) === queryId) {
-				cache.set(adapter.id, queryFingerprint, report);
+				cache.set(adapter.id, queryFingerprint, effectiveReport);
 				failureBackoff.delete(failureKey);
 			}
 			return {
 				state: {
 					providerId: adapter.id,
-					providerName: adapter.displayName,
+					providerName,
 					displayState,
 					status: "ready",
-					report,
+					report: effectiveReport,
 				},
 				fingerprint: auth.fingerprint,
+				rememberedTargetId: expectedTargetId,
 			};
 		} catch (error) {
 			if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
@@ -407,7 +459,9 @@ export default function usageExtension(
 				!requestContextChanged() &&
 				Date.now() < deadlineAt
 			) {
-				if (latestQueries.get(failureKey) === queryId) latestQueries.delete(failureKey);
+				if (queryId !== undefined && latestQueries.get(failureKey) === queryId) {
+					latestQueries.delete(failureKey);
+				}
 				return queryAdapterState(
 					ctx,
 					adapter,
@@ -423,7 +477,7 @@ export default function usageExtension(
 			for (const [key, failure] of failureBackoff) {
 				if (failure.until <= now) failureBackoff.delete(key);
 			}
-			if (latestQueries.get(failureKey) === queryId) {
+			if (queryId === undefined || latestQueries.get(failureKey) === queryId) {
 				setBoundedMap(
 					failureBackoff,
 					failureKey,
@@ -434,14 +488,53 @@ export default function usageExtension(
 			return {
 				state: {
 					providerId: adapter.id,
-					providerName: adapter.displayName,
+					providerName,
 					displayState,
 					status: "query-failed",
 					message,
 				},
 				fingerprint: auth.fingerprint,
+				rememberedTargetId: expectedTargetId,
 			};
 		}
+	};
+
+	const loadTargetChoices = async (
+		ctx: ExtensionContext,
+		adapter: UsageProviderAdapter,
+		signal: AbortSignal,
+	) => {
+		if (!adapter.targets) return [];
+		const expectedSessionGeneration = sessionGeneration;
+		const expectedSessionId = ctx.sessionManager.getSessionId();
+		const expectedModel = modelIdentity(ctx.model);
+		const expectedTargetId = settingsRuntime.get().settings.selectedTargets[adapter.id];
+		const deadlineAt = Date.now() + DEFAULT_TIMEOUT_MS;
+		const changed = () =>
+			expectedSessionGeneration !== sessionGeneration ||
+			ctx.sessionManager.getSessionId() !== expectedSessionId ||
+			modelIdentity(ctx.model) !== expectedModel ||
+			settingsRuntime.get().settings.selectedTargets[adapter.id] !== expectedTargetId;
+		const auth = await awaitWithDeadline(
+			resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
+			signal,
+			Math.max(1, deadlineAt - Date.now()),
+			`resolving ${providerDisplayName(ctx, adapter.id)} runtime auth`,
+		);
+		if (!auth || signal.aborted || changed()) throw abortError();
+		const guard = async () => {
+			if (signal.aborted || changed()) throw abortError();
+			const revalidated = await awaitWithDeadline(
+				resolveUsageAuth(ctx, adapter, undefined, credentialReader, credentialCandidates),
+				signal,
+				Math.max(1, deadlineAt - Date.now()),
+				`revalidating ${providerDisplayName(ctx, adapter.id)} runtime auth`,
+			);
+			if (signal.aborted || changed() || revalidated?.fingerprint !== auth.fingerprint) {
+				throw abortError();
+			}
+		};
+		return listUsageTargets(adapter, auth, signal, Math.max(1, deadlineAt - Date.now()), guard);
 	};
 
 	const queryCurrentState = async (
@@ -558,6 +651,10 @@ export default function usageExtension(
 			return false;
 		}
 		const adapter = adapterForProvider(model?.provider);
+		const selectionStillCurrent =
+			!adapter?.targets ||
+			settingsRuntime.get().settings.selectedTargets[adapter.id] === outcome.rememberedTargetId;
+		if (!selectionStillCurrent) return false;
 		if (outcome.authState === "unavailable") {
 			if (!adapter) return false;
 			try {
@@ -570,6 +667,9 @@ export default function usageExtension(
 				return (
 					generation === statusGeneration &&
 					modelIdentity(ctx.model) === modelIdentity(model) &&
+					(!adapter.targets ||
+						settingsRuntime.get().settings.selectedTargets[adapter.id] ===
+							outcome.rememberedTargetId) &&
 					auth === undefined
 				);
 			} catch (error) {
@@ -589,6 +689,9 @@ export default function usageExtension(
 			return (
 				generation === statusGeneration &&
 				modelIdentity(ctx.model) === modelIdentity(model) &&
+				(!adapter.targets ||
+					settingsRuntime.get().settings.selectedTargets[adapter.id] ===
+						outcome.rememberedTargetId) &&
 				auth?.fingerprint === outcome.fingerprint
 			);
 		} catch (error) {
@@ -654,6 +757,52 @@ export default function usageExtension(
 			let redemptionId: string | undefined;
 			let resetOutcome: CodexResetOutcome | undefined;
 			let resetFailure: string | undefined;
+			const actionableTargetState = (): ProviderUsageState | undefined => {
+				if (visibleStates.length !== 1) return undefined;
+				const state = visibleStates[0];
+				return state && adapterForProvider(state.providerId)?.targets ? state : undefined;
+			};
+			const promptForTarget = async (state: ProviderUsageState): Promise<boolean> => {
+				const adapter = adapterForProvider(state.providerId);
+				if (!adapter?.targets) return false;
+				const choices =
+					state.status === "selection-required"
+						? state.choices
+						: await runMenuOperation(
+								ctx,
+								`Loading ${adapter.targets.pluralLabel}…`,
+								controller.signal,
+								(signal) => loadTargetChoices(ctx, adapter, signal),
+							);
+				if (!choices || controller.signal.aborted || statusGeneration !== menuGeneration) {
+					return false;
+				}
+				const selectOptions = createUsageTargetSelectOptions(choices);
+				const selected = await ctx.ui.select(
+					`Select ${adapter.targets.singularLabel} for ${providerDisplayName(ctx, adapter.id)}`,
+					[...selectOptions.options],
+					{ signal: controller.signal },
+				);
+				if (
+					selected === undefined ||
+					controller.signal.aborted ||
+					statusGeneration !== menuGeneration
+				) {
+					return false;
+				}
+				const targetId = selectOptions.targetIdFor(selected);
+				if (!targetId) return false;
+				const saved = await runMenuOperation(
+					ctx,
+					`Saving ${adapter.targets.singularLabel}…`,
+					controller.signal,
+					(signal) => settingsRuntime.updateSelectedTarget(adapter.id, targetId, signal),
+				);
+				if (!saved || controller.signal.aborted || statusGeneration !== menuGeneration)
+					return false;
+				invalidateProviderState(adapter.id);
+				return true;
+			};
 			const { defineMenu, runMenu } = await import("@narumitw/pi-tui-kit");
 			if (controller.signal.aborted || statusGeneration !== menuGeneration) return;
 			type Screen =
@@ -666,6 +815,7 @@ export default function usageExtension(
 			type Action =
 				| "refresh"
 				| "settings"
+				| "target"
 				| "toggle-fast"
 				| "another"
 				| "all"
@@ -681,6 +831,8 @@ export default function usageExtension(
 				screens: {
 					main: () => {
 						const fastAvailability = fastRuntime.availability(ctx.model);
+						const targetState = actionableTargetState();
+						const targetAdapter = adapterForProvider(targetState?.providerId);
 						const fastLines =
 							fastAvailability.kind === "available"
 								? [`Fast mode: ${fastAvailability.enabled ? "On" : "Off"}`, FAST_USAGE_WARNING]
@@ -694,6 +846,15 @@ export default function usageExtension(
 							items: [
 								{ id: "refresh", label: REFRESH_CURRENT, action: "refresh" },
 								{ id: "settings", label: SETTINGS, action: "settings" },
+								...(targetState && targetAdapter?.targets
+									? [
+											{
+												id: "target",
+												label: `${targetState.status === "selection-required" ? "Select" : "Change"} ${targetAdapter.targets.singularLabel}…`,
+												action: "target" as const,
+											},
+										]
+									: []),
 								...(fastAvailability.kind === "available"
 									? [
 											{
@@ -735,7 +896,7 @@ export default function usageExtension(
 							.filter((adapter) => adapter.id !== ctx.model?.provider)
 							.map((adapter) => ({
 								id: adapter.id,
-								label: adapter.displayName,
+								label: providerDisplayName(ctx, adapter.id),
 								action: "provider" as const,
 							})),
 						hint: "back",
@@ -799,6 +960,57 @@ export default function usageExtension(
 					}),
 				},
 				actions: {
+					target: async () => {
+						const targetState = actionableTargetState();
+						if (!targetState) return { kind: "rejected" };
+						try {
+							if (!(await promptForTarget(targetState))) return { kind: "stay" };
+							const adapter = adapterForProvider(targetState.providerId);
+							if (!adapter) return { kind: "rejected" };
+							if (targetState.providerId === ctx.model?.provider) {
+								const refreshed = await queryStableCurrent(
+									ctx,
+									true,
+									controller,
+									`Checking ${providerDisplayName(ctx, adapter.id)} usage…`,
+								);
+								if (!refreshed) return { kind: "stay" };
+								stableCurrent = refreshed;
+								current = refreshed.outcome;
+								visibleStates = [current.state];
+								publishStableCurrent(ctx, refreshed);
+								return { kind: "stay" };
+							}
+							const outcome = await runMenuOperation(
+								ctx,
+								`Checking ${providerDisplayName(ctx, adapter.id)} usage…`,
+								controller.signal,
+								(signal) => queryAdapterState(ctx, adapter, "configured", true, signal),
+							);
+							if (!outcome) return { kind: "stay" };
+							const revalidated = await queryStableCurrent(
+								ctx,
+								false,
+								controller,
+								"Revalidating current usage…",
+							);
+							if (!revalidated) return { kind: "stay" };
+							stableCurrent = revalidated;
+							current = revalidated.outcome;
+							visibleStates = [
+								outcome.state.providerId === current.state.providerId
+									? current.state
+									: { ...outcome.state, displayState: "configured" },
+							];
+							return { kind: "stay" };
+						} catch (error) {
+							if (isAbortError(error) || isStaleExtensionContextError(error)) {
+								return { kind: "stay" };
+							}
+							ctx.ui.notify(`Could not select target: ${errorMessage(error)}`, "error");
+							return { kind: "stay" };
+						}
+					},
 					settings: async () => {
 						await showUsageSettings(
 							ctx,
@@ -1023,13 +1235,23 @@ export default function usageExtension(
 							(candidate) => candidate.id === itemId && candidate.id !== ctx.model?.provider,
 						);
 						if (!adapter) return { kind: "back" };
-						const outcome = await runMenuOperation(
+						let outcome = await runMenuOperation(
 							ctx,
-							`Checking ${adapter.displayName} usage…`,
+							`Checking ${providerDisplayName(ctx, adapter.id)} usage…`,
 							controller.signal,
 							(signal) => queryAdapterState(ctx, adapter, "configured", false, signal),
 						);
 						if (!outcome) return { kind: "back" };
+						if (outcome.state.status === "selection-required") {
+							if (!(await promptForTarget(outcome.state))) return { kind: "back" };
+							outcome = await runMenuOperation(
+								ctx,
+								`Checking ${providerDisplayName(ctx, adapter.id)} usage…`,
+								controller.signal,
+								(signal) => queryAdapterState(ctx, adapter, "configured", true, signal),
+							);
+							if (!outcome) return { kind: "back" };
+						}
 						const revalidated = await queryStableCurrent(
 							ctx,
 							false,
@@ -1076,7 +1298,7 @@ export default function usageExtension(
 							const adapter = adapters[index] as UsageProviderAdapter;
 							return {
 								providerId: adapter.id,
-								providerName: adapter.displayName,
+								providerName: providerDisplayName(ctx, adapter.id),
 								displayState: "configured",
 								status: "query-failed",
 								message: errorMessage(result.reason),

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -504,7 +504,7 @@ export default function usageExtension(
 		adapter: UsageProviderAdapter,
 		signal: AbortSignal,
 	) => {
-		if (!adapter.targets) return [];
+		if (!adapter.targets) throw new Error("Provider does not support usage targets.");
 		const expectedSessionGeneration = sessionGeneration;
 		const expectedSessionId = ctx.sessionManager.getSessionId();
 		const expectedModel = modelIdentity(ctx.model);
@@ -534,7 +534,14 @@ export default function usageExtension(
 				throw abortError();
 			}
 		};
-		return listUsageTargets(adapter, auth, signal, Math.max(1, deadlineAt - Date.now()), guard);
+		const choices = await listUsageTargets(
+			adapter,
+			auth,
+			signal,
+			Math.max(1, deadlineAt - Date.now()),
+			guard,
+		);
+		return { choices, fingerprint: auth.fingerprint };
 	};
 
 	const queryCurrentState = async (
@@ -762,22 +769,27 @@ export default function usageExtension(
 				const state = visibleStates[0];
 				return state && adapterForProvider(state.providerId)?.targets ? state : undefined;
 			};
-			const promptForTarget = async (state: ProviderUsageState): Promise<boolean> => {
+			const promptForTarget = async (
+				state: ProviderUsageState,
+				stateFingerprint?: string,
+			): Promise<boolean> => {
 				const adapter = adapterForProvider(state.providerId);
 				if (!adapter?.targets) return false;
-				const choices =
-					state.status === "selection-required"
-						? state.choices
+				const expectedRememberedTargetId =
+					settingsRuntime.get().settings.selectedTargets[adapter.id];
+				const snapshot =
+					state.status === "selection-required" && stateFingerprint
+						? { choices: state.choices, fingerprint: stateFingerprint }
 						: await runMenuOperation(
 								ctx,
 								`Loading ${adapter.targets.pluralLabel}…`,
 								controller.signal,
 								(signal) => loadTargetChoices(ctx, adapter, signal),
 							);
-				if (!choices || controller.signal.aborted || statusGeneration !== menuGeneration) {
+				if (!snapshot || controller.signal.aborted || statusGeneration !== menuGeneration) {
 					return false;
 				}
-				const selectOptions = createUsageTargetSelectOptions(choices);
+				const selectOptions = createUsageTargetSelectOptions(snapshot.choices);
 				const selected = await ctx.ui.select(
 					`Select ${adapter.targets.singularLabel} for ${providerDisplayName(ctx, adapter.id)}`,
 					[...selectOptions.options],
@@ -786,12 +798,37 @@ export default function usageExtension(
 				if (
 					selected === undefined ||
 					controller.signal.aborted ||
-					statusGeneration !== menuGeneration
+					statusGeneration !== menuGeneration ||
+					settingsRuntime.get().settings.selectedTargets[adapter.id] !== expectedRememberedTargetId
 				) {
 					return false;
 				}
 				const targetId = selectOptions.targetIdFor(selected);
 				if (!targetId) return false;
+				const revalidated = await runMenuOperation(
+					ctx,
+					`Revalidating ${adapter.targets.singularLabel}…`,
+					controller.signal,
+					(signal) => loadTargetChoices(ctx, adapter, signal),
+				);
+				if (
+					!revalidated ||
+					controller.signal.aborted ||
+					statusGeneration !== menuGeneration ||
+					settingsRuntime.get().settings.selectedTargets[adapter.id] !== expectedRememberedTargetId
+				) {
+					return false;
+				}
+				if (
+					revalidated.fingerprint !== snapshot.fingerprint ||
+					!revalidated.choices.some((choice) => choice.id === targetId)
+				) {
+					ctx.ui.notify(
+						`${providerDisplayName(ctx, adapter.id)} ${adapter.targets.pluralLabel} changed; choose again.`,
+						"warning",
+					);
+					return false;
+				}
 				const saved = await runMenuOperation(
 					ctx,
 					`Saving ${adapter.targets.singularLabel}…`,
@@ -964,7 +1001,11 @@ export default function usageExtension(
 						const targetState = actionableTargetState();
 						if (!targetState) return { kind: "rejected" };
 						try {
-							if (!(await promptForTarget(targetState))) return { kind: "stay" };
+							const stateFingerprint =
+								targetState === current.state ? current.fingerprint : undefined;
+							if (!(await promptForTarget(targetState, stateFingerprint))) {
+								return { kind: "stay" };
+							}
 							const adapter = adapterForProvider(targetState.providerId);
 							if (!adapter) return { kind: "rejected" };
 							if (targetState.providerId === ctx.model?.provider) {
@@ -1243,7 +1284,9 @@ export default function usageExtension(
 						);
 						if (!outcome) return { kind: "back" };
 						if (outcome.state.status === "selection-required") {
-							if (!(await promptForTarget(outcome.state))) return { kind: "back" };
+							if (!(await promptForTarget(outcome.state, outcome.fingerprint))) {
+								return { kind: "back" };
+							}
 							outcome = await runMenuOperation(
 								ctx,
 								`Checking ${providerDisplayName(ctx, adapter.id)} usage…`,

--- a/packages/pi-usage/test/baseten.test.ts
+++ b/packages/pi-usage/test/baseten.test.ts
@@ -128,7 +128,7 @@ test("Baseten runtime auth accepts only official inference or management origins
 	});
 	const auth = await resolveUsageAuth(officialContext, adapter);
 	assert.deepEqual(auth?.headers, { Authorization: "Bearer current-baseten-key" });
-	assert.ok(!auth?.secrets.includes("must-not-send"));
+	assert.ok(auth?.secrets.includes("must-not-send"));
 
 	const fetchMock = vi.spyOn(globalThis, "fetch");
 	try {

--- a/packages/pi-usage/test/codex-fast-menu.test.ts
+++ b/packages/pi-usage/test/codex-fast-menu.test.ts
@@ -21,7 +21,7 @@ function runtime(kind: UsageSettingsState["kind"] = "loaded") {
 	let state: UsageSettingsState = {
 		kind,
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: false, codexStatusResetCountdown: false },
+		settings: { codexFastMode: false, codexStatusResetCountdown: false, selectedTargets: {} },
 		...(kind === "invalid" ? { issue: "bad file" } : { document: {} }),
 	};
 	const patches: unknown[] = [];
@@ -39,6 +39,9 @@ function runtime(kind: UsageSettingsState["kind"] = "loaded") {
 				document: { ...state.document, ...patch },
 			};
 			return structuredClone(state);
+		},
+		async updateSelectedTarget() {
+			throw new Error("target selection is not used in Codex Fast menu tests");
 		},
 		async flush() {},
 	};

--- a/packages/pi-usage/test/codex-fast-runtime.test.ts
+++ b/packages/pi-usage/test/codex-fast-runtime.test.ts
@@ -32,6 +32,7 @@ function memoryRuntime(
 		settings: {
 			codexFastMode: options.enabled ?? false,
 			codexStatusResetCountdown: false,
+			selectedTargets: {},
 		},
 		...(options.kind === "invalid" ? { issue: "bad file" } : { document: {} }),
 	};
@@ -58,6 +59,9 @@ function memoryRuntime(
 				document: { ...state.document, ...patch },
 			};
 			return structuredClone(state);
+		},
+		async updateSelectedTarget() {
+			throw new Error("target selection is not used in Codex Fast tests");
 		},
 		async flush() {
 			flushes += 1;
@@ -312,7 +316,7 @@ test("session replacement aborts stale loads and accepted writes before UI publi
 	releaseLoad({
 		kind: "loaded",
 		path: "/tmp/pi-usage.json",
-		settings: { codexFastMode: true, codexStatusResetCountdown: false },
+		settings: { codexFastMode: true, codexStatusResetCountdown: false, selectedTargets: {} },
 		document: { codexFastMode: true },
 	});
 	await pendingLoad;

--- a/packages/pi-usage/test/core.test.ts
+++ b/packages/pi-usage/test/core.test.ts
@@ -154,14 +154,31 @@ test("runtime auth rejects proxy origins and forwards only adapter-approved head
 		/proxy-resolved.*official/iu,
 	);
 
+	const { ctx: providerOverrideContext } = createMockContext({
+		model: officialModel,
+		modelRegistry: {
+			getProvider: () => ({ baseUrl: "https://proxy.example.test/v1" }),
+			getProviderAuth: async () => ({ auth: { apiKey: "must-not-send" } }),
+			getAvailable: () => [officialModel],
+			getAll: () => [officialModel],
+		},
+	});
+	await assert.rejects(
+		() => resolveUsageAuth(providerOverrideContext, adapter),
+		/overridden provider credential.*official/iu,
+	);
+
 	const { ctx: officialContext } = createMockContext({
 		model: officialModel,
 		modelRegistry: {
+			getProvider: () => ({ baseUrl: "https://openrouter.ai/api/v1" }),
 			getProviderAuth: async () => ({
 				auth: {
 					apiKey: "official-key",
 					headers: { "X-Proxy-Secret": "must-not-leak", "X-Title": "private-title" },
 				},
+				env: { OPENROUTER_ACCOUNT: "account-a" },
+				source: "test credential",
 			}),
 			getAvailable: () => [officialModel],
 			getAll: () => [officialModel],
@@ -169,6 +186,29 @@ test("runtime auth rejects proxy origins and forwards only adapter-approved head
 	});
 	const auth = await resolveUsageAuth(officialContext, adapter);
 	assert.deepEqual(auth?.headers, { Authorization: "Bearer official-key" });
+	assert.deepEqual(auth?.auth, {
+		apiKey: "official-key",
+		headers: { "X-Proxy-Secret": "must-not-leak", "X-Title": "private-title" },
+	});
+	assert.deepEqual(auth?.env, { OPENROUTER_ACCOUNT: "account-a" });
+	assert.equal(auth?.source, "test credential");
+	assert.equal(auth?.effectiveBaseUrl, "https://openrouter.ai/api/v1");
+
+	const { ctx: rotatedEnvContext } = createMockContext({
+		model: officialModel,
+		modelRegistry: {
+			getProvider: () => ({ baseUrl: "https://openrouter.ai/api/v1" }),
+			getProviderAuth: async () => ({
+				auth: { apiKey: "official-key" },
+				env: { OPENROUTER_ACCOUNT: "account-b" },
+				source: "test credential",
+			}),
+			getAvailable: () => [officialModel],
+			getAll: () => [officialModel],
+		},
+	});
+	const rotatedEnv = await resolveUsageAuth(rotatedEnvContext, adapter);
+	assert.notEqual(rotatedEnv?.fingerprint, auth?.fingerprint);
 
 	const { ctx: modelScopedContext } = createMockContext({
 		model: officialModel,
@@ -189,7 +229,7 @@ test("runtime auth rejects proxy origins and forwards only adapter-approved head
 	const modelScopedAuth = await resolveUsageAuth(modelScopedContext, adapter);
 	assert.deepEqual(modelScopedAuth?.headers, { Authorization: "Bearer current-model-key" });
 	assert.ok(modelScopedAuth?.secrets.includes("Bearer current-model-key"));
-	assert.ok(!modelScopedAuth?.secrets.includes("must-not-leak"));
+	assert.ok(modelScopedAuth?.secrets.includes("must-not-leak"));
 
 	const { ctx: modelKeyContext } = createMockContext({
 		model: officialModel,

--- a/packages/pi-usage/test/deepseek.test.ts
+++ b/packages/pi-usage/test/deepseek.test.ts
@@ -217,7 +217,7 @@ test("DeepSeek runtime auth accepts only official model and resolved-auth origin
 	});
 	const auth = await resolveUsageAuth(officialContext, adapter);
 	assert.deepEqual(auth?.headers, { Authorization: "Bearer current-deepseek-key" });
-	assert.ok(!auth?.secrets.includes("must-not-send"));
+	assert.ok(auth?.secrets.includes("must-not-send"));
 
 	const fetchMock = vi.spyOn(globalThis, "fetch");
 	try {

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -12,6 +12,7 @@ import {
 	resolveUsageTarget,
 	SUPPORTED_ADAPTERS,
 	type UsageProviderAdapter,
+	type UsageQuerySettings,
 } from "../src/index.js";
 
 const FIREWORKS_MODEL = {
@@ -541,6 +542,41 @@ test("Fireworks transport follows opaque pagination tokens across account pages"
 			"https://api.fireworks.ai/v1/accounts?pageSize=200&pageToken=token%2B%2F%3D",
 		);
 		assert.match(requests[2] ?? "", /\/v1\/accounts\/bold\/billing\/summary\?/u);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("queryProviderUsage preserves legacy Fireworks settings and auto-selection", async () => {
+	const requests: string[] = [];
+	const fetchMock = vi.fn(async (input: string | URL | Request) => {
+		const url = String(input);
+		requests.push(url);
+		return url.includes("/v1/accounts?")
+			? new Response(JSON.stringify({ accounts: [accountRow("acme")] }), { status: 200 })
+			: summaryResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const legacySettings: UsageQuerySettings = { fireworksAccountId: "acme" };
+		for (const settings of [legacySettings, undefined]) {
+			const report = await queryProviderUsage(
+				adapter,
+				fireworksAuth(),
+				new AbortController().signal,
+				1_000,
+				async () => undefined,
+				settings,
+			);
+			assert.equal(report.accountLabel, "acme");
+		}
+		assert.equal(requests.filter((url) => url.includes("/v1/accounts?")).length, 2);
+		assert.equal(requests.filter((url) => url.includes("/billing/summary")).length, 2);
+		assert.ok(
+			requests
+				.filter((url) => url.includes("/billing/summary"))
+				.every((url) => /\/v1\/accounts\/acme\/billing\/summary\?/u.test(url)),
+		);
 	} finally {
 		vi.unstubAllGlobals();
 	}

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -9,6 +9,7 @@ import {
 	queryProviderUsage,
 	type ResolvedUsageAuth,
 	resolveUsageAuth,
+	resolveUsageTarget,
 	SUPPORTED_ADAPTERS,
 	type UsageProviderAdapter,
 } from "../src/index.js";
@@ -54,14 +55,23 @@ function fireworksAuth(secret = "fw-test-secret"): ResolvedUsageAuth {
 	};
 }
 
-function queryFireworks(
+async function queryFireworks(
 	signal = new AbortController().signal,
 	timeoutMs = 1_000,
-	fireworksAccountId?: string,
+	rememberedAccountId?: string,
 ) {
-	return queryProviderUsage(adapter, fireworksAuth(), signal, timeoutMs, async () => undefined, {
-		fireworksAccountId,
-	});
+	const auth = fireworksAuth();
+	const guard = async () => undefined;
+	const target = await resolveUsageTarget(
+		adapter,
+		auth,
+		rememberedAccountId,
+		signal,
+		timeoutMs,
+		guard,
+	);
+	if (target.kind === "selection-required") throw new Error("Selection required");
+	return queryProviderUsage(adapter, auth, signal, timeoutMs, guard, target.targetId);
 }
 
 test("Fireworks billing summary sums rated line items exactly per currency and series", () => {
@@ -281,7 +291,8 @@ test("Fireworks runtime auth accepts only official model and resolved-auth origi
 	});
 	const auth = await resolveUsageAuth(officialContext, adapter);
 	assert.deepEqual(auth?.headers, { Authorization: "Bearer fw-current-key" });
-	assert.ok(!auth?.secrets.includes("must-not-send"));
+	assert.equal(auth?.auth?.apiKey, "provider-key");
+	assert.ok(auth?.secrets.includes("must-not-send"));
 
 	const fetchMock = vi.spyOn(globalThis, "fetch");
 	try {
@@ -327,8 +338,9 @@ test("Fireworks transport revalidates before network access and counts it agains
 					new AbortController().signal,
 					5,
 					() => new Promise<void>((resolve) => setTimeout(resolve, 10)),
+					"acme",
 				),
-			/timed out.*resolving the fireworks account/iu,
+			/timed out.*fetching fireworks rated spend/iu,
 		);
 		assert.equal(fetchMock.mock.calls.length, 0);
 	} finally {
@@ -379,6 +391,44 @@ test("Fireworks transport auto-selects a single account and queries only the fix
 		await assert.rejects(() => queryFireworks(), /refused a redirected response/iu);
 	} finally {
 		nowMock.mockRestore();
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Fireworks target discovery aborts its owned request when the flow is cancelled", async () => {
+	const controller = new AbortController();
+	let requestSignal: AbortSignal | undefined;
+	let markStarted: () => void = () => undefined;
+	const started = new Promise<void>((resolve) => {
+		markStarted = resolve;
+	});
+	const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+		requestSignal = init?.signal ?? undefined;
+		markStarted();
+		return new Promise<Response>((_resolve, reject) => {
+			requestSignal?.addEventListener(
+				"abort",
+				() => reject(new DOMException("aborted", "AbortError")),
+				{ once: true },
+			);
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	try {
+		const pending = adapter.targets?.list(
+			fireworksAuth(),
+			controller.signal,
+			1_000,
+			async () => undefined,
+		);
+		assert.ok(pending);
+		await started;
+		controller.abort();
+		await assert.rejects(pending, (error: unknown) => {
+			return error instanceof Error && error.name === "AbortError";
+		});
+		assert.equal(requestSignal?.aborted, true);
+	} finally {
 		vi.unstubAllGlobals();
 	}
 });
@@ -439,7 +489,7 @@ test("Fireworks transport shares one deadline across account pages", async () =>
 	}
 });
 
-test("Fireworks transport stops long account listings after finding the configured account", async () => {
+test("Fireworks target discovery completes pagination before using a remembered account", async () => {
 	const requests: string[] = [];
 	const fetchMock = vi.fn(async (input: string | URL | Request) => {
 		requests.push(String(input));
@@ -449,14 +499,17 @@ test("Fireworks transport stops long account listings after finding the configur
 				{ status: 200 },
 			);
 		}
+		if (requests.length === 2) {
+			return new Response(JSON.stringify({ accounts: [accountRow("beta")] }), { status: 200 });
+		}
 		return summaryResponse();
 	});
 	vi.stubGlobal("fetch", fetchMock);
 	try {
 		const report = await queryFireworks(new AbortController().signal, 1_000, "acme");
 		assert.equal(report.accountLabel, "acme");
-		assert.equal(requests.length, 2);
-		assert.match(requests[1] ?? "", /\/v1\/accounts\/acme\/billing\/summary\?/u);
+		assert.equal(requests.length, 3);
+		assert.match(requests[2] ?? "", /\/v1\/accounts\/acme\/billing\/summary\?/u);
 	} finally {
 		vi.unstubAllGlobals();
 	}
@@ -493,7 +546,7 @@ test("Fireworks transport follows opaque pagination tokens across account pages"
 	}
 });
 
-test("Fireworks transport fails closed for ambiguous, hostile, or unresolvable accounts", async () => {
+test("Fireworks target discovery returns unresolved choices and query validates exact slugs", async () => {
 	const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
 		return new Response(JSON.stringify({ accounts: [accountRow("acme"), accountRow("beta")] }), {
 			status: 200,
@@ -501,18 +554,43 @@ test("Fireworks transport fails closed for ambiguous, hostile, or unresolvable a
 	});
 	vi.stubGlobal("fetch", fetchMock);
 	try {
-		await assert.rejects(
-			() => queryFireworks(),
-			/see 2 accounts \(acme, beta\); set fireworksAccountId in pi-usage\.json/iu,
+		const auth = fireworksAuth();
+		const unresolved = await resolveUsageTarget(
+			adapter,
+			auth,
+			undefined,
+			new AbortController().signal,
+			1_000,
+			async () => undefined,
 		);
+		assert.deepEqual(unresolved, {
+			kind: "selection-required",
+			choices: [
+				{ id: "acme", label: "acme" },
+				{ id: "beta", label: "beta" },
+			],
+		});
 		await assert.rejects(
-			() => queryFireworks(new AbortController().signal, 1_000, "../other"),
-			/account setting was not a safe account slug/iu,
+			() =>
+				queryProviderUsage(
+					adapter,
+					auth,
+					new AbortController().signal,
+					1_000,
+					async () => undefined,
+					"../other",
+				),
+			/safe selected account slug/iu,
 		);
-		await assert.rejects(
-			() => queryFireworks(new AbortController().signal, 1_000, "hidden-account"),
-			/configured Fireworks account does not match an account visible/iu,
+		const stale = await resolveUsageTarget(
+			adapter,
+			auth,
+			"hidden-account",
+			new AbortController().signal,
+			1_000,
+			async () => undefined,
 		);
+		assert.equal(stale.kind, "selection-required");
 	} finally {
 		vi.unstubAllGlobals();
 	}

--- a/packages/pi-usage/test/kimi-coding.test.ts
+++ b/packages/pi-usage/test/kimi-coding.test.ts
@@ -303,7 +303,7 @@ test("Kimi runtime auth accepts fresh OAuth and API-key bearers only at the offi
 	});
 	const oauth = await resolveUsageAuth(oauthContext, adapter);
 	assert.deepEqual(oauth?.headers, { Authorization: "Bearer oauth-access" });
-	assert.ok(!oauth?.secrets.includes("do-not-send"));
+	assert.ok(oauth?.secrets.includes("do-not-send"));
 
 	const { ctx: apiKeyContext } = createMockContext({
 		model: KIMI_MODEL,

--- a/packages/pi-usage/test/moonshot.test.ts
+++ b/packages/pi-usage/test/moonshot.test.ts
@@ -233,7 +233,7 @@ test("Moonshot runtime auth keeps Global and China credentials on their official
 			});
 			const auth = await resolveUsageAuth(ctx, adapter);
 			assert.deepEqual(auth?.headers, { Authorization: `Bearer ${providerId}-key` });
-			assert.ok(!auth?.secrets.includes("must-not-send"));
+			assert.ok(auth?.secrets.includes("must-not-send"));
 
 			for (const [modelBaseUrl, authBaseUrl, pattern] of [
 				["https://proxy.example.test/v1", undefined, /custom.*official/iu],

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -166,6 +166,51 @@ test("target saves preserve unknown fields and legacy Fireworks data for other p
 	});
 });
 
+test("failed post-publication target checks restore the exact prior settings state", async () => {
+	const path = await tempSettingsPath();
+	await writeFile(path, '{"fireworksAccountId":"acme","future":"kept"}\n');
+	const runtime = createUsageSettingsRuntime(path);
+	await runtime.reload();
+	let observedPublishedDocument: unknown;
+
+	await assert.rejects(
+		runtime.updateSelectedTarget("fireworks", "beta", undefined, async () => {
+			observedPublishedDocument = JSON.parse(await readFile(path, "utf8"));
+			throw new Error("credential rotated");
+		}),
+		/credential rotated/,
+	);
+
+	assert.deepEqual(observedPublishedDocument, {
+		selectedTargets: { fireworks: "beta" },
+		future: "kept",
+	});
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+		fireworksAccountId: "acme",
+		future: "kept",
+	});
+	assert.equal(runtime.get().settings.selectedTargets.fireworks, "acme");
+	assert.deepEqual(
+		(await readdir(join(path, ".."))).filter((name) => name.endsWith(".tmp")),
+		[],
+	);
+
+	const missingPath = await tempSettingsPath();
+	const missingRuntime = createUsageSettingsRuntime(missingPath);
+	await assert.rejects(
+		missingRuntime.updateSelectedTarget("fireworks", "beta", undefined, async () => {
+			assert.equal(
+				(await loadUsageSettings(missingPath)).settings.selectedTargets.fireworks,
+				"beta",
+			);
+			throw new Error("membership changed");
+		}),
+		/membership changed/,
+	);
+	assert.equal((await loadUsageSettings(missingPath)).kind, "missing");
+	assert.equal(missingRuntime.get().kind, "missing");
+});
+
 test("serialized updates reread the latest document and leave no temporary files", async () => {
 	const path = await tempSettingsPath();
 	await writeFile(path, '{"codexFastMode":false,"external":"first"}\n');

--- a/packages/pi-usage/test/settings.test.ts
+++ b/packages/pi-usage/test/settings.test.ts
@@ -39,17 +39,35 @@ test("normalizes owned settings and ignores the retired xAI field", () => {
 	assert.deepEqual(normalizeUsageSettings({ codexFastMode: true }), {
 		codexFastMode: true,
 		codexStatusResetCountdown: true,
+		selectedTargets: {},
 	});
 	assert.deepEqual(normalizeUsageSettings({ fireworksAccountId: "acme-prod" }), {
 		codexFastMode: false,
 		codexStatusResetCountdown: true,
-		fireworksAccountId: "acme-prod",
+		selectedTargets: { fireworks: "acme-prod" },
 	});
+	assert.deepEqual(
+		normalizeUsageSettings({
+			fireworksAccountId: "legacy",
+			selectedTargets: { fireworks: "current", custom: "project-1" },
+		}),
+		{
+			codexFastMode: false,
+			codexStatusResetCountdown: true,
+			selectedTargets: { fireworks: "current", custom: "project-1" },
+		},
+	);
 	assert.deepEqual(normalizeUsageSettings({ xaiUsage: false }), DEFAULT_USAGE_SETTINGS);
 	assert.deepEqual(normalizeUsageSettings({ xaiUsage: "retired" }), DEFAULT_USAGE_SETTINGS);
 	assert.equal(normalizeUsageSettings({ codexFastMode: "true" }), undefined);
 	assert.equal(normalizeUsageSettings({ fireworksAccountId: "../other" }), undefined);
 	assert.equal(normalizeUsageSettings({ fireworksAccountId: "" }), undefined);
+	assert.equal(normalizeUsageSettings({ selectedTargets: [] }), undefined);
+	assert.equal(normalizeUsageSettings({ selectedTargets: { provider: "" } }), undefined);
+	assert.equal(
+		normalizeUsageSettings({ selectedTargets: { provider: "x".repeat(257) } }),
+		undefined,
+	);
 	assert.equal(normalizeUsageSettings([]), undefined);
 });
 
@@ -66,7 +84,7 @@ test("missing loads are side-effect free and valid loads preserve unknown fields
 	const loaded = await loadUsageSettings(path);
 	assert.equal(loaded.kind, "loaded");
 	assert.equal(loaded.settings.codexFastMode, true);
-	assert.equal(loaded.settings.fireworksAccountId, "acme");
+	assert.equal(loaded.settings.selectedTargets.fireworks, "acme");
 	assert.equal(loaded.document?.xaiUsage, false);
 	assert.equal(loaded.document?.future, "kept");
 });
@@ -116,14 +134,36 @@ test("the first explicit save creates a private file and preserves unknown field
 	if (process.platform !== "win32") assert.equal((await stat(path)).mode & 0o777, 0o600);
 });
 
-test("clearing the Fireworks account removes only its owned field", async () => {
+test("an explicit Fireworks selection atomically migrates the legacy field", async () => {
 	const path = await tempSettingsPath();
 	await writeFile(path, '{"fireworksAccountId":"acme","future":"kept"}\n');
 	const runtime = createUsageSettingsRuntime(path);
 	await runtime.reload();
-	await runtime.update({ fireworksAccountId: undefined });
-	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { future: "kept" });
-	assert.equal(runtime.get().settings.fireworksAccountId, undefined);
+	assert.equal(runtime.get().settings.selectedTargets.fireworks, "acme");
+	assert.equal(JSON.parse(await readFile(path, "utf8")).fireworksAccountId, "acme");
+
+	await runtime.updateSelectedTarget("fireworks", "beta");
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+		selectedTargets: { fireworks: "beta" },
+		future: "kept",
+	});
+	assert.equal(runtime.get().settings.selectedTargets.fireworks, "beta");
+});
+
+test("target saves preserve unknown fields and legacy Fireworks data for other providers", async () => {
+	const path = await tempSettingsPath();
+	await writeFile(
+		path,
+		'{"fireworksAccountId":"acme","selectedTargets":{"other":"old"},"future":"kept"}\n',
+	);
+	const runtime = createUsageSettingsRuntime(path);
+	await runtime.reload();
+	await runtime.updateSelectedTarget("other", "new");
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+		fireworksAccountId: "acme",
+		selectedTargets: { other: "new" },
+		future: "kept",
+	});
 });
 
 test("serialized updates reread the latest document and leave no temporary files", async () => {
@@ -196,10 +236,37 @@ test("failed saves retain prior runtime state, clean up, and do not poison retri
 	assert.equal(runtime.get().settings.codexFastMode, true);
 });
 
+test("failed explicit target migration keeps legacy data and allows a retry", async () => {
+	const path = await tempSettingsPath();
+	await writeFile(path, '{"fireworksAccountId":"acme","future":"kept"}\n');
+	let rejectRename = true;
+	const runtime = createUsageSettingsRuntime({
+		path,
+		operations: {
+			rename: async (source, destination) => {
+				if (rejectRename) throw new Error("rename rejected");
+				await rename(source, destination);
+			},
+		},
+	});
+	await runtime.reload();
+	await assert.rejects(runtime.updateSelectedTarget("fireworks", "beta"), /rename rejected/);
+	assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+		fireworksAccountId: "acme",
+		future: "kept",
+	});
+	assert.equal(runtime.get().settings.selectedTargets.fireworks, "acme");
+
+	rejectRename = false;
+	await runtime.updateSelectedTarget("fireworks", "beta");
+	assert.equal(runtime.get().settings.selectedTargets.fireworks, "beta");
+});
+
 test("normalizes the Codex reset countdown status preference", () => {
 	assert.deepEqual(normalizeUsageSettings({ codexStatusResetCountdown: false }), {
 		codexFastMode: false,
 		codexStatusResetCountdown: false,
+		selectedTargets: {},
 	});
 	assert.equal(normalizeUsageSettings({ codexStatusResetCountdown: "false" }), undefined);
 });

--- a/packages/pi-usage/test/usage-targets.test.ts
+++ b/packages/pi-usage/test/usage-targets.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import {
 	createUsageTargetSelectOptions,
+	listUsageTargets,
 	type ResolvedUsageAuth,
 	resolveUsageTarget,
 	type UsageProviderAdapter,
@@ -92,6 +93,17 @@ test("provider-neutral resolution handles one account and remembered organizatio
 			["org-a", "org-b"],
 		);
 	}
+
+	const rotatedAccount = targetAdapter("rotated-account", "account", "accounts", [
+		{ id: "new-account", label: "New account" },
+	]);
+	assert.deepEqual(
+		await resolveUsageTarget(rotatedAccount, auth, "old-account", signal, 1_000, guard),
+		{
+			kind: "selection-required",
+			choices: [{ id: "new-account", label: "New account" }],
+		},
+	);
 });
 
 test("a second fake provider proves project selection and zero-target failure are generic", async () => {
@@ -113,6 +125,40 @@ test("a second fake provider proves project selection and zero-target failure ar
 		resolveUsageTarget(empty, auth, undefined, signal, 1_000, guard),
 		/workspaces discovery returned no choices/iu,
 	);
+});
+
+test("target discovery subtracts guard time from the adapter deadline", async () => {
+	let now = 1_000;
+	const nowMock = vi.spyOn(Date, "now").mockImplementation(() => now);
+	const adapter = targetAdapter("deadline-provider", "project", "projects", [
+		{ id: "project", label: "Project" },
+	]);
+	let receivedTimeout: number | undefined;
+	let listCalls = 0;
+	if (!adapter.targets) assert.fail("target adapter must expose targets");
+	adapter.targets.list = async (_auth, _signal, timeoutMs) => {
+		listCalls += 1;
+		receivedTimeout = timeoutMs;
+		return [{ id: "project", label: "Project" }];
+	};
+	try {
+		await listUsageTargets(adapter, auth, signal, 100, async () => {
+			now += 40;
+		});
+		assert.equal(receivedTimeout, 60);
+
+		now = 2_000;
+		listCalls = 0;
+		await assert.rejects(
+			listUsageTargets(adapter, auth, signal, 100, async () => {
+				now += 100;
+			}),
+			/Timed out while discovering provider targets/iu,
+		);
+		assert.equal(listCalls, 0);
+	} finally {
+		nowMock.mockRestore();
+	}
 });
 
 test("target descriptors sanitize terminal input, stay bounded, and reject duplicate IDs", async () => {

--- a/packages/pi-usage/test/usage-targets.test.ts
+++ b/packages/pi-usage/test/usage-targets.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	createUsageTargetSelectOptions,
+	type ResolvedUsageAuth,
+	resolveUsageTarget,
+	type UsageProviderAdapter,
+	type UsageProviderTarget,
+} from "../src/index.js";
+
+const auth: ResolvedUsageAuth = {
+	headers: { Authorization: "Bearer test" },
+	fingerprint: "auth",
+	secrets: ["test"],
+	model: {
+		id: "model",
+		name: "Model",
+		provider: "fake",
+		baseUrl: "https://example.test",
+	} as never,
+};
+
+function targetAdapter(
+	id: string,
+	singularLabel: string,
+	pluralLabel: string,
+	targets: readonly UsageProviderTarget[],
+): UsageProviderAdapter {
+	return {
+		id,
+		displayName: id,
+		semantics: { kind: "project", label: `${singularLabel} usage` },
+		targets: {
+			singularLabel,
+			pluralLabel,
+			async list() {
+				return targets;
+			},
+		},
+		async query(_auth, _signal, _timeoutMs, _guard, targetId) {
+			return {
+				providerId: id,
+				providerName: id,
+				capturedAt: 0,
+				source: "fake",
+				semantics: { kind: "project", label: `${singularLabel} usage` },
+				accountLabel: targetId,
+				buckets: [],
+				metrics: [],
+			};
+		},
+	};
+}
+
+const signal = new AbortController().signal;
+const guard = async () => undefined;
+
+test("provider-neutral resolution handles one account and remembered organizations", async () => {
+	const accountAdapter = targetAdapter("accounts-provider", "account", "accounts", [
+		{ id: "account-1", label: "Primary" },
+	]);
+	assert.deepEqual(
+		await resolveUsageTarget(accountAdapter, auth, undefined, signal, 1_000, guard),
+		{ kind: "selected", targetId: "account-1" },
+	);
+
+	const organizationAdapter = targetAdapter(
+		"organizations-provider",
+		"organization",
+		"organizations",
+		[
+			{ id: "org-a", label: "Alpha" },
+			{ id: "org-b", label: "Beta" },
+		],
+	);
+	assert.deepEqual(
+		await resolveUsageTarget(organizationAdapter, auth, "org-b", signal, 1_000, guard),
+		{ kind: "selected", targetId: "org-b" },
+	);
+	const stale = await resolveUsageTarget(
+		organizationAdapter,
+		auth,
+		"org-gone",
+		signal,
+		1_000,
+		guard,
+	);
+	assert.equal(stale.kind, "selection-required");
+	if (stale.kind === "selection-required") {
+		assert.deepEqual(
+			stale.choices.map((choice) => choice.id),
+			["org-a", "org-b"],
+		);
+	}
+});
+
+test("a second fake provider proves project selection and zero-target failure are generic", async () => {
+	const projects = targetAdapter("projects-provider", "project", "projects", [
+		{ id: "project-a", label: "Shared" },
+		{ id: "project-b", label: "Shared" },
+	]);
+	const unresolved = await resolveUsageTarget(projects, auth, undefined, signal, 1_000, guard);
+	assert.equal(unresolved.kind, "selection-required");
+	if (unresolved.kind === "selection-required") {
+		const options = createUsageTargetSelectOptions(unresolved.choices);
+		assert.equal(new Set(options.options).size, 2);
+		assert.equal(options.targetIdFor(options.options[0] ?? ""), "project-a");
+		assert.equal(options.targetIdFor(options.options[1] ?? ""), "project-b");
+	}
+
+	const empty = targetAdapter("empty-provider", "workspace", "workspaces", []);
+	await assert.rejects(
+		resolveUsageTarget(empty, auth, undefined, signal, 1_000, guard),
+		/workspaces discovery returned no choices/iu,
+	);
+});
+
+test("target descriptors sanitize terminal input, stay bounded, and reject duplicate IDs", async () => {
+	const hostile = targetAdapter("hostile-provider", "team", "teams", [
+		{
+			id: "team-a",
+			label: `Alpha\u001b[31m${"x".repeat(200)}`,
+			description: "Line\nTwo",
+		},
+		{ id: "team-b", label: "Alpha" },
+	]);
+	const result = await resolveUsageTarget(hostile, auth, undefined, signal, 1_000, guard);
+	assert.equal(result.kind, "selection-required");
+	if (result.kind === "selection-required") {
+		assert.ok(result.choices.every((choice) => !choice.label.includes("\u001b")));
+		assert.ok(result.choices.every((choice) => choice.label.length <= 120));
+		assert.equal(result.choices[0]?.description, "Line Two");
+	}
+
+	const malformed = targetAdapter("malformed-provider", "team", "teams", [
+		{ id: "team", label: 42 } as unknown as UsageProviderTarget,
+	]);
+	await assert.rejects(
+		resolveUsageTarget(malformed, auth, undefined, signal, 1_000, guard),
+		/invalid display label/iu,
+	);
+
+	const duplicate = targetAdapter("duplicate-provider", "team", "teams", [
+		{ id: "same", label: "One" },
+		{ id: "same", label: "Two" },
+	]);
+	await assert.rejects(
+		resolveUsageTarget(duplicate, auth, undefined, signal, 1_000, guard),
+		/repeated same/iu,
+	);
+});

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -104,6 +104,7 @@ function memorySettingsRuntime(
 		document?: Record<string, unknown>;
 		failUpdates?: boolean;
 		kind?: UsageSettingsState["kind"];
+		afterTargetWrite?: () => void;
 	} = {},
 ): { runtime: UsageSettingsRuntime; state: () => UsageSettingsState } {
 	const kind = options.kind ?? "loaded";
@@ -144,15 +145,19 @@ function memorySettingsRuntime(
 			};
 			return structuredClone(state);
 		},
-		updateSelectedTarget: async (providerId, targetId, signal) => {
+		updateSelectedTarget: async (providerId, targetId, signal, checkPublishedSelection) => {
 			signal?.throwIfAborted();
 			if (options.failUpdates) throw new Error("disk full");
 			const selectedTargets = { ...state.settings.selectedTargets, [providerId]: targetId };
-			state = {
+			const next = {
 				...state,
 				settings: { ...state.settings, selectedTargets },
 				document: { ...state.document, selectedTargets },
 			};
+			options.afterTargetWrite?.();
+			await checkPublishedSelection?.();
+			signal?.throwIfAborted();
+			state = next;
 			return structuredClone(state);
 		},
 		flush: async () => undefined,
@@ -561,6 +566,35 @@ test("explicit all-provider query retains DeepSeek balance, Kimi, and partial fa
 	assert.deepEqual(deepSeekFetchedKeys, ["Bearer deepseek-key"]);
 	assert.match(titles[1] ?? "", /query failed/i);
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
+});
+
+test("auth-unavailable target providers do not expose a no-op target action", async () => {
+	const options: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: memorySettingsRuntime().runtime });
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: fireworksModel,
+		select: async (_title: string, choices: string[]) => {
+			options.push(...choices);
+			return "Close";
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: false, error: "missing" }),
+			getProviderAuth: async () => undefined,
+			getAvailable: () => [fireworksModel],
+			getAll: () => [fireworksModel],
+			getProviderDisplayName: testProviderDisplayName,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.ok(options.includes("Close"));
+	assert.ok(!options.some((option) => /^(Select|Change) account…$/u.test(option)));
 });
 
 test("View all renders unresolved target providers without opening a nested picker", async (t) => {
@@ -1185,7 +1219,7 @@ test("current unresolved Fireworks usage prompts once, persists, and re-queries 
 
 	assert.equal(settings.state().settings.selectedTargets.fireworks, "beta");
 	assert.equal(statuses.get("usage"), "fireworks USD 2");
-	assert.equal(requests.filter((url) => url.includes("/v1/accounts?")).length, 3);
+	assert.equal(requests.filter((url) => url.includes("/v1/accounts?")).length, 4);
 	const billingRequests = requests.filter((url) => url.includes("/billing/summary"));
 	assert.equal(billingRequests.length, 1);
 	assert.match(billingRequests[0] ?? "", /\/accounts\/beta\/billing\/summary/u);
@@ -1253,6 +1287,62 @@ test("auth rotation while the target picker is open prevents stale selection per
 	activeKey = "fw-b";
 	resolveTarget("beta");
 	await pending;
+
+	assert.deepEqual(settings.state().settings.selectedTargets, {});
+	assert.equal(requests.filter((request) => request.url.includes("/billing/summary")).length, 0);
+	assert.ok(requests.some((request) => request.authorization === "Bearer fw-a"));
+	assert.ok(requests.some((request) => request.authorization === "Bearer fw-b"));
+	assert.match(notifications.at(-1)?.message ?? "", /accounts changed; choose again/iu);
+});
+
+test("auth rotation during target settings publication rolls back the selection", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activeKey = "fw-a";
+	const requests: Array<{ url: string; authorization: string }> = [];
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		const authorization = new Headers(init?.headers).get("authorization") ?? "";
+		requests.push({ url, authorization });
+		if (url.includes("/v1/accounts?")) {
+			return new Response(
+				JSON.stringify({ accounts: [{ name: "accounts/acme" }, { name: "accounts/beta" }] }),
+				{ status: 200 },
+			);
+		}
+		return new Response(JSON.stringify({ lineItems: [] }), { status: 200 });
+	};
+	const settings = memorySettingsRuntime({
+		afterTargetWrite: () => {
+			activeKey = "fw-b";
+		},
+	});
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	let rootSelections = 0;
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: fireworksModel,
+		select: async (title: string) => {
+			if (title.startsWith("Select account for Fireworks")) return "beta";
+			rootSelections += 1;
+			return rootSelections === 1 ? "Select account…" : "Close";
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: activeKey }),
+			getProviderAuth: async () => ({ auth: { apiKey: activeKey } }),
+			getAvailable: () => [fireworksModel],
+			getAll: () => [fireworksModel],
+			getProviderDisplayName: testProviderDisplayName,
+		},
+	});
+
+	await command.handler("", ctx);
 
 	assert.deepEqual(settings.state().settings.selectedTargets, {});
 	assert.equal(requests.filter((request) => request.url.includes("/billing/summary")).length, 0);

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -1185,13 +1185,80 @@ test("current unresolved Fireworks usage prompts once, persists, and re-queries 
 
 	assert.equal(settings.state().settings.selectedTargets.fireworks, "beta");
 	assert.equal(statuses.get("usage"), "fireworks USD 2");
-	assert.equal(requests.filter((url) => url.includes("/v1/accounts?")).length, 2);
+	assert.equal(requests.filter((url) => url.includes("/v1/accounts?")).length, 3);
 	const billingRequests = requests.filter((url) => url.includes("/billing/summary"));
 	assert.equal(billingRequests.length, 1);
 	assert.match(billingRequests[0] ?? "", /\/accounts\/beta\/billing\/summary/u);
 	assert.ok(titles.some((title) => /Selection required/iu.test(title)));
 	await command.handler("", ctx);
 	assert.ok(selectedOptions.flat().some((option) => /Change account…/u.test(option)));
+});
+
+test("auth rotation while the target picker is open prevents stale selection persistence", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	let activeKey = "fw-a";
+	const requests: Array<{ url: string; authorization: string }> = [];
+	globalThis.fetch = async (input, init) => {
+		const url = String(input);
+		const authorization = new Headers(init?.headers).get("authorization") ?? "";
+		requests.push({ url, authorization });
+		if (url.includes("/v1/accounts?")) {
+			const accounts =
+				authorization === "Bearer fw-a"
+					? [{ name: "accounts/acme" }, { name: "accounts/beta" }]
+					: [{ name: "accounts/beta" }, { name: "accounts/gamma" }];
+			return new Response(JSON.stringify({ accounts }), { status: 200 });
+		}
+		return new Response(JSON.stringify({ lineItems: [] }), { status: 200 });
+	};
+	const settings = memorySettingsRuntime();
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	let rootSelections = 0;
+	let resolveTarget!: (value: string) => void;
+	let markTargetStarted: () => void = () => undefined;
+	const targetStarted = new Promise<void>((resolve) => {
+		markTargetStarted = resolve;
+	});
+	const { ctx, notifications } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: fireworksModel,
+		select: async (title: string) => {
+			if (title.startsWith("Select account for Fireworks")) {
+				markTargetStarted();
+				return new Promise<string>((resolve) => {
+					resolveTarget = resolve;
+				});
+			}
+			rootSelections += 1;
+			return rootSelections === 1 ? "Select account…" : "Close";
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: activeKey }),
+			getProviderAuth: async () => ({ auth: { apiKey: activeKey } }),
+			getAvailable: () => [fireworksModel],
+			getAll: () => [fireworksModel],
+			getProviderDisplayName: testProviderDisplayName,
+		},
+	});
+
+	const pending = command.handler("", ctx);
+	await targetStarted;
+	activeKey = "fw-b";
+	resolveTarget("beta");
+	await pending;
+
+	assert.deepEqual(settings.state().settings.selectedTargets, {});
+	assert.equal(requests.filter((request) => request.url.includes("/billing/summary")).length, 0);
+	assert.ok(requests.some((request) => request.authorization === "Bearer fw-a"));
+	assert.ok(requests.some((request) => request.authorization === "Bearer fw-b"));
+	assert.match(notifications.at(-1)?.message ?? "", /accounts changed; choose again/iu);
 });
 
 test("cancelling the target picker leaves selection and billing untouched", async (t) => {

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -72,6 +72,21 @@ const fireworksModel = {
 	baseUrl: "https://api.fireworks.ai/inference",
 };
 
+function testProviderDisplayName(provider: string): string {
+	return (
+		{
+			"openai-codex": "OpenAI Codex",
+			openrouter: "OpenRouter",
+			deepseek: "DeepSeek",
+			"kimi-coding": "Kimi For Coding",
+			fireworks: "Fireworks",
+			minimax: "MiniMax",
+			xai: "xAI",
+			zai: "Z.AI",
+		}[provider] ?? provider
+	);
+}
+
 function codexAccessToken(accountId: string): string {
 	const payload = Buffer.from(
 		JSON.stringify({
@@ -85,6 +100,7 @@ function memorySettingsRuntime(
 	options: {
 		codexStatusResetCountdown?: boolean;
 		fireworksAccountId?: string;
+		selectedTargets?: Record<string, string>;
 		document?: Record<string, unknown>;
 		failUpdates?: boolean;
 		kind?: UsageSettingsState["kind"];
@@ -97,16 +113,20 @@ function memorySettingsRuntime(
 		settings: {
 			codexFastMode: false,
 			codexStatusResetCountdown: options.codexStatusResetCountdown ?? false,
-			...(options.fireworksAccountId ? { fireworksAccountId: options.fireworksAccountId } : {}),
+			selectedTargets: {
+				...(options.fireworksAccountId ? { fireworks: options.fireworksAccountId } : {}),
+				...options.selectedTargets,
+			},
 		},
 		...(kind === "invalid"
 			? { issue: "invalid test settings" }
 			: {
 					document: {
 						codexFastMode: false,
-						...(options.fireworksAccountId
-							? { fireworksAccountId: options.fireworksAccountId }
-							: {}),
+						selectedTargets: {
+							...(options.fireworksAccountId ? { fireworks: options.fireworksAccountId } : {}),
+							...options.selectedTargets,
+						},
 						...options.document,
 					},
 				}),
@@ -121,6 +141,17 @@ function memorySettingsRuntime(
 				...state,
 				settings: { ...state.settings, ...patch },
 				document: { ...state.document, ...patch },
+			};
+			return structuredClone(state);
+		},
+		updateSelectedTarget: async (providerId, targetId, signal) => {
+			signal?.throwIfAborted();
+			if (options.failUpdates) throw new Error("disk full");
+			const selectedTargets = { ...state.settings.selectedTargets, [providerId]: targetId };
+			state = {
+				...state,
+				settings: { ...state.settings, selectedTargets },
+				document: { ...state.document, selectedTargets },
 			};
 			return structuredClone(state);
 		},
@@ -245,7 +276,7 @@ test("/usage automatically queries the current runtime account and shows state p
 			getAvailable: () => [openRouterModel],
 			getAll: () => [openRouterModel, codexModel],
 			getProviderAuthStatus: (provider: string) => ({ configured: provider === "openrouter" }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -357,7 +388,7 @@ test("current Codex usage can redeem a selected reset and refresh account state"
 			getAvailable: () => [codexModel],
 			getAll: () => [codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -430,7 +461,7 @@ test("Codex reset confirmation defaults to cancellation and sends no mutation", 
 			getAvailable: () => [codexModel],
 			getAll: () => [codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -514,7 +545,7 @@ test("explicit all-provider query retains DeepSeek balance, Kimi, and partial fa
 				configured: configured.has(provider),
 				source: "stored",
 			}),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -530,6 +561,58 @@ test("explicit all-provider query retains DeepSeek balance, Kimi, and partial fa
 	assert.deepEqual(deepSeekFetchedKeys, ["Bearer deepseek-key"]);
 	assert.match(titles[1] ?? "", /query failed/i);
 	assert.equal(statuses.get("usage"), "openrouter $75.00 left");
+});
+
+test("View all renders unresolved target providers without opening a nested picker", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const requests: string[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input);
+		requests.push(url);
+		if (url.includes("/v1/accounts?")) {
+			return new Response(
+				JSON.stringify({ accounts: [{ name: "accounts/acme" }, { name: "accounts/beta" }] }),
+				{ status: 200 },
+			);
+		}
+		return usageFetch(input);
+	};
+	const choices = ["View all configured providers…", "Close"];
+	const titles: string[] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: memorySettingsRuntime().runtime });
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: openRouterModel,
+		select: async (title: string) => {
+			titles.push(title);
+			return choices.shift();
+		},
+		modelRegistry: {
+			getProviderAuth: async (providerId: string) => ({
+				auth: {
+					apiKey: `${providerId}-key`,
+					...(providerId === "fireworks" ? { baseUrl: fireworksModel.baseUrl } : {}),
+				},
+			}),
+			getAvailable: () => [openRouterModel, fireworksModel],
+			getAll: () => [openRouterModel, fireworksModel],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: testProviderDisplayName,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.match(titles.at(-1) ?? "", /Fireworks · Configured\nSelection required/iu);
+	assert.ok(!titles.some((title) => title.startsWith("Select account for Fireworks")));
+	assert.equal(requests.filter((url) => url.includes("/billing/summary")).length, 0);
 });
 
 test("another-provider queries show only the selected provider and preserve current status", async (t) => {
@@ -557,7 +640,7 @@ test("another-provider queries show only the selected provider and preserve curr
 			getAvailable: () => [openRouterModel, codexModel],
 			getAll: () => [openRouterModel, codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -629,7 +712,7 @@ test("current auth appearance during a command is revalidated before display", a
 			getAvailable: () => [openRouterModel],
 			getAll: () => [openRouterModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -702,7 +785,7 @@ test("TUI usage queries complete through the loader before opening the menu", as
 			getAvailable: () => [openRouterModel],
 			getAll: () => [openRouterModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -810,7 +893,7 @@ test("session shutdown aborts usage action and provider selectors", async (t) =>
 			getAvailable: () => [openRouterModel, codexModel],
 			getAll: () => [openRouterModel, codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -867,6 +950,7 @@ test("current Kimi usage follows account changes and clears status on model repl
 			}),
 			getAvailable: () => [kimiModel],
 			getAll: () => [kimiModel],
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -998,7 +1082,11 @@ test("current Fireworks usage receives its guard and settings-backed account sel
 				lineItems: [
 					{
 						series: "SERVERLESS",
-						totalCost: { currencyCode: "USD", units: "1", nanos: 0 },
+						totalCost: {
+							currencyCode: "USD",
+							units: url.includes("/accounts/beta/") ? "1" : "3",
+							nanos: 0,
+						},
 					},
 				],
 			}),
@@ -1025,11 +1113,132 @@ test("current Fireworks usage receives its guard and settings-backed account sel
 	await settle();
 
 	assert.equal(statuses.get("usage"), "fireworks USD 1");
+	await settings.runtime.updateSelectedTarget("fireworks", "acme");
+	mock.events.get("turn_start")?.[0]?.({}, ctx);
+	await settle();
+	await settle();
+	assert.equal(statuses.get("usage"), "fireworks USD 3");
 	const billingRequests = requests.filter((url) => url.includes("/billing/summary"));
-	assert.ok(billingRequests.length > 0);
-	assert.ok(billingRequests.every((url) => url.includes("/accounts/beta/billing/summary")));
+	assert.ok(billingRequests.some((url) => url.includes("/accounts/beta/billing/summary")));
+	assert.ok(billingRequests.some((url) => url.includes("/accounts/acme/billing/summary")));
 	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 	assert.equal(statuses.get("usage"), undefined);
+});
+
+test("current unresolved Fireworks usage prompts once, persists, and re-queries fresh targets", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const requests: string[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input);
+		requests.push(url);
+		if (url.includes("/v1/accounts?")) {
+			return new Response(
+				JSON.stringify({ accounts: [{ name: "accounts/acme" }, { name: "accounts/beta" }] }),
+				{ status: 200 },
+			);
+		}
+		return new Response(
+			JSON.stringify({
+				lineItems: [
+					{
+						series: "SERVERLESS",
+						totalCost: { currencyCode: "USD", units: "2", nanos: 0 },
+					},
+				],
+			}),
+			{ status: 200 },
+		);
+	};
+	const settings = memorySettingsRuntime();
+	const menuChoices = ["Select account…", "Close"];
+	const titles: string[] = [];
+	const selectedOptions: string[][] = [];
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: fireworksModel,
+		select: async (title: string, options: string[]) => {
+			titles.push(title);
+			selectedOptions.push(options);
+			if (title.startsWith("Select account for Fireworks")) return "beta";
+			return menuChoices.shift();
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "fw-key" }),
+			getProviderAuth: async () => ({
+				auth: { apiKey: "fw-key", baseUrl: fireworksModel.baseUrl },
+			}),
+			getAvailable: () => [fireworksModel],
+			getAll: () => [fireworksModel],
+			getProviderDisplayName: testProviderDisplayName,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.equal(settings.state().settings.selectedTargets.fireworks, "beta");
+	assert.equal(statuses.get("usage"), "fireworks USD 2");
+	assert.equal(requests.filter((url) => url.includes("/v1/accounts?")).length, 2);
+	const billingRequests = requests.filter((url) => url.includes("/billing/summary"));
+	assert.equal(billingRequests.length, 1);
+	assert.match(billingRequests[0] ?? "", /\/accounts\/beta\/billing\/summary/u);
+	assert.ok(titles.some((title) => /Selection required/iu.test(title)));
+	await command.handler("", ctx);
+	assert.ok(selectedOptions.flat().some((option) => /Change account…/u.test(option)));
+});
+
+test("cancelling the target picker leaves selection and billing untouched", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	const requests: string[] = [];
+	globalThis.fetch = async (input) => {
+		const url = String(input);
+		requests.push(url);
+		return new Response(
+			JSON.stringify({ accounts: [{ name: "accounts/acme" }, { name: "accounts/beta" }] }),
+			{ status: 200 },
+		);
+	};
+	const settings = memorySettingsRuntime();
+	const mock = createMockPi();
+	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
+	const command = mock.commands.get("usage");
+	assert.ok(command);
+	let menuSelection = true;
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: fireworksModel,
+		select: async (title: string) => {
+			if (title.startsWith("Select account for Fireworks")) return undefined;
+			if (menuSelection) {
+				menuSelection = false;
+				return "Select account…";
+			}
+			return "Close";
+		},
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "fw-key" }),
+			getProviderAuth: async () => ({ auth: { apiKey: "fw-key" } }),
+			getAvailable: () => [fireworksModel],
+			getAll: () => [fireworksModel],
+			getProviderDisplayName: testProviderDisplayName,
+		},
+	});
+
+	await command.handler("", ctx);
+
+	assert.deepEqual(settings.state().settings.selectedTargets, {});
+	assert.equal(requests.filter((url) => url.includes("/billing/summary")).length, 0);
 });
 
 test("Fireworks waits for settings reload and cancels a replaced reload before refreshing", async (t) => {
@@ -1077,7 +1286,7 @@ test("Fireworks waits for settings reload and cancels a replaced reload before r
 				);
 			});
 		}
-		return settings.runtime.update({ fireworksAccountId: "beta" }, signal);
+		return settings.runtime.updateSelectedTarget("fireworks", "beta", signal);
 	};
 	const mock = createMockPi();
 	usageExtension(mock.pi, { settingsRuntime: settings.runtime });
@@ -1103,7 +1312,7 @@ test("Fireworks waits for settings reload and cancels a replaced reload before r
 	await settle();
 	await settle();
 
-	assert.equal(settings.state().settings.fireworksAccountId, "beta");
+	assert.equal(settings.state().settings.selectedTargets.fireworks, "beta");
 	assert.equal(statuses.get("usage"), "fireworks USD 1");
 	const billingRequests = requests.filter((url) => url.includes("/billing/summary"));
 	assert.ok(billingRequests.length > 0);
@@ -1418,7 +1627,7 @@ test("a current command supersedes an older automatic query for the same provide
 			getAvailable: () => [openRouterModel],
 			getAll: () => [openRouterModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -1467,7 +1676,7 @@ test("cross-provider results revalidate which account is Current before display"
 			getAvailable: () => [openRouterModel, codexModel],
 			getAll: () => [openRouterModel, codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -1554,7 +1763,7 @@ test("Codex reset countdown repaints locally and stops across replacement and sh
 			getAvailable: () => [codexModel],
 			getAll: () => [codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -1621,7 +1830,7 @@ test("Codex reset countdown ignores a stale extension context", async (t) => {
 			getAvailable: () => [codexModel],
 			getAll: () => [codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -1698,7 +1907,7 @@ test("a slow command cannot overwrite status after the selected model changes", 
 			getAvailable: () => [openRouterModel, codexModel],
 			getAll: () => [openRouterModel, codexModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -1763,7 +1972,7 @@ test("statusline follows runtime auth changes and clears for unsupported selecte
 			getAvailable: () => [openRouterModel],
 			getAll: () => [openRouterModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -1992,7 +2201,7 @@ test("xAI account changes after the final adapter guard prevent configured publi
 			getAvailable: () => [openRouterModel, xaiModel],
 			getAll: () => [openRouterModel, xaiModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -2057,7 +2266,7 @@ test("xAI appears as a configured provider without changing current status", asy
 			getAvailable: () => [openRouterModel, xaiModel],
 			getAll: () => [openRouterModel, xaiModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -2091,7 +2300,7 @@ test("the Settings menu action gives RPC mode the active manual settings path", 
 			getAvailable: () => [openRouterModel],
 			getAll: () => [openRouterModel],
 			getProviderAuthStatus: () => ({ configured: true }),
-			getProviderDisplayName: (provider: string) => provider,
+			getProviderDisplayName: testProviderDisplayName,
 		},
 	});
 
@@ -2172,181 +2381,8 @@ test("the TUI SettingsList describes and applies usage preferences immediately",
 		),
 	);
 	assert.ok(renderedSettings.some((frame) => /Use faster Codex routing/.test(frame)));
-	assert.ok(renderedSettings.some((frame) => /Fireworks account/.test(frame)));
+	assert.doesNotMatch(renderedSettings.join("\n"), /Fireworks account/u);
 	assert.doesNotMatch(renderedSettings.join("\n"), /xAI|warning|undocumented|experimental/iu);
-});
-
-test("the TUI Settings flow edits and clears the Fireworks account", async () => {
-	for (const [initial, entered, expected] of [
-		[undefined, "acme-prod", "acme-prod"],
-		["acme-prod", "   ", undefined],
-	] as const) {
-		const settings = memorySettingsRuntime({ fireworksAccountId: initial });
-		let customCalls = 0;
-		const applied: string[] = [];
-		const { ctx } = createMockContext({
-			hasUI: true,
-			mode: "tui",
-			input: async () => entered,
-			custom: async (factory: unknown) =>
-				new Promise<unknown>((resolve) => {
-					customCalls += 1;
-					let component: {
-						dispose?(): void;
-						handleInput(data: string): void;
-						render(width: number): string[];
-					};
-					const done = (value: unknown) => {
-						component.dispose?.();
-						resolve(value);
-					};
-					component = (
-						factory as (
-							tui: { requestRender(): void },
-							theme: {
-								bold(text: string): string;
-								fg(_color: string, text: string): string;
-							},
-							keybindings: object,
-							done: (value: unknown) => void,
-						) => typeof component
-					)({ requestRender() {} }, { bold: (text) => text, fg: (_color, text) => text }, {}, done);
-					if (customCalls === 1) {
-						component.handleInput("\u001b[B");
-						component.handleInput("\u001b[B");
-						component.handleInput("\r");
-					} else {
-						component.handleInput("\u0003");
-					}
-				}),
-		});
-
-		const changed = await showUsageSettings(
-			ctx,
-			settings.runtime,
-			new AbortController().signal,
-			() => true,
-			(id) => applied.push(id),
-		);
-
-		assert.equal(changed, true);
-		assert.equal(settings.state().settings.fireworksAccountId, expected);
-		assert.deepEqual(applied, ["fireworksAccountId"]);
-		assert.equal(customCalls, 2);
-	}
-});
-
-test("the Fireworks settings input retries validation and rolls back save failures", async () => {
-	for (const failUpdates of [false, true]) {
-		const settings = memorySettingsRuntime({ failUpdates });
-		const inputs = ["../unsafe", "acme"];
-		let customCalls = 0;
-		const { ctx, notifications } = createMockContext({
-			hasUI: true,
-			mode: "tui",
-			input: async () => inputs.shift(),
-			custom: async (factory: unknown) =>
-				new Promise<unknown>((resolve) => {
-					customCalls += 1;
-					let component: {
-						dispose?(): void;
-						handleInput(data: string): void;
-					};
-					const done = (value: unknown) => {
-						component.dispose?.();
-						resolve(value);
-					};
-					component = (
-						factory as (
-							tui: { requestRender(): void },
-							theme: {
-								bold(text: string): string;
-								fg(_color: string, text: string): string;
-							},
-							keybindings: object,
-							done: (value: unknown) => void,
-						) => typeof component
-					)({ requestRender() {} }, { bold: (text) => text, fg: (_color, text) => text }, {}, done);
-					if (customCalls === 1) {
-						component.handleInput("\u001b[B");
-						component.handleInput("\u001b[B");
-						component.handleInput("\r");
-					} else {
-						component.handleInput("\u0003");
-					}
-				}),
-		});
-
-		const changed = await showUsageSettings(
-			ctx,
-			settings.runtime,
-			new AbortController().signal,
-			() => true,
-			() => undefined,
-		);
-
-		assert.equal(changed, !failUpdates);
-		assert.equal(settings.state().settings.fireworksAccountId, failUpdates ? undefined : "acme");
-		assert.match(notifications[0]?.message ?? "", /URL-safe Fireworks account slug/iu);
-		if (failUpdates) assert.match(notifications[1]?.message ?? "", /disk full/iu);
-	}
-});
-
-test("parent cancellation aborts the Fireworks settings input without saving", async () => {
-	const settings = memorySettingsRuntime();
-	const parentController = new AbortController();
-	let markInputStarted: () => void = () => undefined;
-	const inputStarted = new Promise<void>((resolve) => {
-		markInputStarted = resolve;
-	});
-	const { ctx } = createMockContext({
-		hasUI: true,
-		mode: "tui",
-		input: async (_title: string, _placeholder: string, options: { signal: AbortSignal }) => {
-			markInputStarted();
-			return new Promise<undefined>((resolve) => {
-				options.signal.addEventListener("abort", () => resolve(undefined), { once: true });
-			});
-		},
-		custom: async (factory: unknown) =>
-			new Promise<unknown>((resolve) => {
-				let component: {
-					dispose?(): void;
-					handleInput(data: string): void;
-				};
-				const done = (value: unknown) => {
-					component.dispose?.();
-					resolve(value);
-				};
-				component = (
-					factory as (
-						tui: { requestRender(): void },
-						theme: {
-							bold(text: string): string;
-							fg(_color: string, text: string): string;
-						},
-						keybindings: object,
-						done: (value: unknown) => void,
-					) => typeof component
-				)({ requestRender() {} }, { bold: (text) => text, fg: (_color, text) => text }, {}, done);
-				component.handleInput("\u001b[B");
-				component.handleInput("\u001b[B");
-				component.handleInput("\r");
-			}),
-	});
-
-	const pending = showUsageSettings(
-		ctx,
-		settings.runtime,
-		parentController.signal,
-		() => true,
-		() => assert.fail("cancelled input must not apply"),
-	);
-	await inputStarted;
-	parentController.abort();
-
-	assert.equal(await pending, false);
-	assert.equal(settings.state().settings.fireworksAccountId, undefined);
 });
 
 test("Ctrl+C hard-cancels Settings before conflicting configurable actions", async (t) => {
@@ -2408,6 +2444,7 @@ test("Ctrl+C hard-cancels Settings before conflicting configurable actions", asy
 	assert.deepEqual(settings.state().settings, {
 		codexFastMode: false,
 		codexStatusResetCountdown: false,
+		selectedTargets: {},
 	});
 	assert.equal(applied, 0);
 });

--- a/packages/pi-usage/test/vercel-ai-gateway.test.ts
+++ b/packages/pi-usage/test/vercel-ai-gateway.test.ts
@@ -105,7 +105,7 @@ test("Vercel AI Gateway runtime auth accepts only the official model and auth or
 	});
 	const auth = await resolveUsageAuth(officialContext, adapter);
 	assert.deepEqual(auth?.headers, { Authorization: "Bearer current-vercel-key" });
-	assert.ok(!auth?.secrets.includes("must-not-send"));
+	assert.ok(auth?.secrets.includes("must-not-send"));
 
 	const fetchMock = vi.spyOn(globalThis, "fetch");
 	try {


### PR DESCRIPTION
## Summary

- add a provider-neutral target resolver, guarded cache identity, and one-off `ctx.ui.select()` flow for accounts, organizations, projects, teams, or workspaces
- move Fireworks account discovery into its adapter, auto-select one account, remember explicit multi-account choices, and migrate the legacy setting atomically
- keep Settings limited to Codex preferences, make View all and background status non-interactive, and document the Provider → Target behavior
- add a patch Changeset plus contract, transport, settings, cache, menu, and lifecycle coverage

## Verification

- `npm --workspace @narumitw/pi-usage run check`
- `npx vitest run packages/pi-usage/test --reporter=dot` — 221 tests passed
- `npm run check`
- `npm test` — 3,422 tests passed
- `npm run package:pack -- usage` — 32 expected files, including `dist/index.ts`, README, manifest, and license
- bounded offline RPC load: `pi --mode rpc --offline --no-session --no-extensions --no-skills -e ./packages/pi-usage` — generated entry loaded and `get_state` succeeded
- reviewed against `docs/extension-conventions.md` and `docs/extension-settings.md`; cancellation, disposal, replacement, shutdown, stale auth/model/selection, atomic writes, rollback, invalid-file protection, and unknown-field preservation were audited

## Risks and unverified paths

- No live Fireworks credential was used. Fixed-origin pagination and billing behavior are covered deterministically, and the built package was loaded through Pi.
- The pre-existing OAuth credential-source fallback remains unchanged for compatibility; the new target flow uses Pi's public resolved-auth and model-registry APIs and adds no direct credential or environment reads.
