### PR TITLE
fix(pi-usage): render MiniMax Token Plan zero-quota rows with percent fallback and surface real refresh errors

### DIFF
--- a/.changeset/minimax-percent-fallback.md
+++ b/.changeset/minimax-percent-fallback.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Render MiniMax Token Plan rows with zero countable quota as percent-based buckets (the API uses `*_remaining_percent` as the canonical indicator) instead of throwing or hiding the row, and surface the actual refresh error in the status chip instead of swallowing it.

--- a/.changeset/minimax-percent-fallback.md
+++ b/.changeset/minimax-percent-fallback.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-usage": patch
 ---
 
-Render MiniMax Token Plan rows with zero countable quota as percent-based buckets (the API uses `*_remaining_percent` as the canonical indicator) instead of throwing or hiding the row, and surface the actual refresh error in the status chip instead of swallowing it.
+Render MiniMax Token Plan rows with zero countable quota as percent-based buckets, fall back to the general group in the status chip, and show query-failed messages in the chip.

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -364,9 +364,11 @@ function formatMiniMaxReport(lines: string[], report: UsageReport): void {
 		const value =
 			bucket.period === "unlimited"
 				? "unlimited"
-				: bucket.limit && bucket.remaining !== undefined
-					? `${bucket.remaining} of ${bucket.limit} left · ${percentRemaining(bucket)}%${reset}`
-					: "unavailable";
+				: bucket.unit === "percent" && bucket.remaining !== undefined
+					? `${bucket.remaining}% remaining${reset}`
+					: bucket.limit && bucket.remaining !== undefined
+						? `${bucket.remaining} of ${bucket.limit} left · ${percentRemaining(bucket)}%${reset}`
+						: "unavailable";
 		lines.push(`${`${bucket.label}:`.padEnd(VALUE_COLUMN)}${value}`);
 	}
 }
@@ -386,6 +388,10 @@ function formatMiniMaxStatusline(report: UsageReport, model?: UsageModel): strin
 		const window = formatWindowLabel(bucket.windowMinutes, fallback, true);
 		if (bucket.period === "unlimited") {
 			parts.push(`unlimited ${window}`);
+			continue;
+		}
+		if (bucket.unit === "percent" && bucket.remaining !== undefined) {
+			parts.push(`${bucket.remaining}% ${window}`);
 			continue;
 		}
 		if (!bucket.limit || bucket.remaining === undefined) continue;

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -366,7 +366,7 @@ function formatMiniMaxReport(lines: string[], report: UsageReport): void {
 				? "unlimited"
 				: bucket.unit === "percent" && bucket.remaining !== undefined
 					? `${bucket.remaining}% remaining${reset}`
-					: bucket.limit && bucket.remaining !== undefined
+					: bucket.limit !== undefined && bucket.remaining !== undefined
 						? `${bucket.remaining} of ${bucket.limit} left · ${percentRemaining(bucket)}%${reset}`
 						: "unavailable";
 		lines.push(`${`${bucket.label}:`.padEnd(VALUE_COLUMN)}${value}`);
@@ -394,7 +394,7 @@ function formatMiniMaxStatusline(report: UsageReport, model?: UsageModel): strin
 			parts.push(`${bucket.remaining}% ${window}`);
 			continue;
 		}
-		if (!bucket.limit || bucket.remaining === undefined) continue;
+		if (bucket.limit === undefined || bucket.remaining === undefined) continue;
 		parts.push(`${percentRemaining(bucket)}% ${window}`);
 	}
 	return parts.length > 1 ? parts.join(" ") : undefined;
@@ -409,37 +409,32 @@ function selectMiniMaxGroup(report: UsageReport, model?: UsageModel): string | u
 		),
 	];
 	if (groups.length <= 1) return groups[0];
-	if (model?.provider !== report.providerId) return undefined;
-	const modelKeys = [model.id, model.name]
-		.map(normalizeMiniMaxModelKey)
-		.filter((key): key is string => key !== undefined);
-	const candidates = groups.map((group) => {
-		const bucket = report.buckets.find((candidate) => candidate.groupId === group);
-		const patterns = [bucket?.groupLabel, ...(bucket?.modelKeys ?? []), group]
+	if (model && model.provider !== report.providerId) return undefined;
+	if (model) {
+		const modelKeys = [model.id, model.name]
 			.map(normalizeMiniMaxModelKey)
 			.filter((key): key is string => key !== undefined);
-		return { group, patterns };
-	});
-	const exact = candidates.find(({ patterns }) =>
-		patterns.some((pattern) => !pattern.includes("*") && modelKeys.includes(pattern)),
-	);
-	if (exact) return exact.group;
-	const wildcard = candidates.find(({ patterns }) =>
-		patterns.some(
-			(pattern) =>
-				pattern.includes("*") && modelKeys.some((key) => wildcardKeyMatches(pattern, key)),
-		),
-	);
-	if (wildcard) return wildcard.group;
-	// Fallback: no model-specific match. Prefer the "general" group when present —
-	// it is the MiniMax Token Plan catch-all bucket that applies across models
-	// (e.g. for users on a Coding Plan where specific model rows are 0/0). Matches
-	// the prior local usage extension's behavior of always showing "general".
-	// If no "general" group exists, return undefined so callers can hide the chip
-	// rather than guess.
-	const general = candidates.find((candidate) => candidate.group === "general");
-	if (general) return general.group;
-	return undefined;
+		const candidates = groups.map((group) => {
+			const bucket = report.buckets.find((candidate) => candidate.groupId === group);
+			const patterns = [bucket?.groupLabel, ...(bucket?.modelKeys ?? []), group]
+				.map(normalizeMiniMaxModelKey)
+				.filter((key): key is string => key !== undefined);
+			return { group, patterns };
+		});
+		const exact = candidates.find(({ patterns }) =>
+			patterns.some((pattern) => !pattern.includes("*") && modelKeys.includes(pattern)),
+		);
+		if (exact) return exact.group;
+		const wildcard = candidates.find(({ patterns }) =>
+			patterns.some(
+				(pattern) =>
+					pattern.includes("*") && modelKeys.some((key) => wildcardKeyMatches(pattern, key)),
+			),
+		);
+		if (wildcard) return wildcard.group;
+	}
+	// Prefer the Coding Plan catch-all over hiding the chip.
+	return groups.find((group) => group === "general");
 }
 
 function normalizeMiniMaxModelKey(value: string | undefined): string | undefined {

--- a/packages/pi-usage/src/format.ts
+++ b/packages/pi-usage/src/format.ts
@@ -424,12 +424,22 @@ function selectMiniMaxGroup(report: UsageReport, model?: UsageModel): string | u
 		patterns.some((pattern) => !pattern.includes("*") && modelKeys.includes(pattern)),
 	);
 	if (exact) return exact.group;
-	return candidates.find(({ patterns }) =>
+	const wildcard = candidates.find(({ patterns }) =>
 		patterns.some(
 			(pattern) =>
 				pattern.includes("*") && modelKeys.some((key) => wildcardKeyMatches(pattern, key)),
 		),
-	)?.group;
+	);
+	if (wildcard) return wildcard.group;
+	// Fallback: no model-specific match. Prefer the "general" group when present —
+	// it is the MiniMax Token Plan catch-all bucket that applies across models
+	// (e.g. for users on a Coding Plan where specific model rows are 0/0). Matches
+	// the prior local usage extension's behavior of always showing "general".
+	// If no "general" group exists, return undefined so callers can hide the chip
+	// rather than guess.
+	const general = candidates.find((candidate) => candidate.group === "general");
+	if (general) return general.group;
+	return undefined;
 }
 
 function normalizeMiniMaxModelKey(value: string | undefined): string | undefined {

--- a/packages/pi-usage/src/providers/minimax.ts
+++ b/packages/pi-usage/src/providers/minimax.ts
@@ -152,6 +152,28 @@ function normalizeWindow(row: Record<string, unknown>, fields: WindowFields): Us
 	}
 	const total = nonnegativeInteger(row[fields.totalField], fields.totalField);
 	const count = nonnegativeInteger(row[fields.countField], fields.countField);
+	// Total of zero with no usable percent: no quota, no usage — drop the bucket entirely
+	// so it does not surface as a confusing row in /usage or the footer chip.
+	if (total === 0 && percent === undefined) {
+		throw new Error(`MiniMax Token Plan ${fields.label} returned no quota and no percent.`);
+	}
+	// Total of zero but percent available: the API uses percent as the canonical
+	// indicator for these rows (matches the behavior of the prior local usage
+	// extension). Emit a percent-based bucket instead of count-based.
+	if (total === 0) {
+		return {
+			id: fields.id,
+			label: fields.label,
+			groupId: fields.groupId,
+			groupLabel: fields.groupLabel,
+			remaining: percent as number,
+			used: 100 - (percent as number),
+			limit: 0,
+			unit: "percent",
+			windowMinutes,
+			resetsAt,
+		};
+	}
 	const resolved = resolveQuotaCounts(count, total, percent);
 	if (!resolved) throw new Error(`MiniMax Token Plan ${fields.label} counts were inconsistent.`);
 	return {
@@ -171,7 +193,15 @@ function resolveQuotaCounts(
 	total: number,
 	remainingPercent: number | undefined,
 ): Pick<UsageBucket, "used" | "remaining" | "limit"> | undefined {
-	if (total <= 0 || reportedCount > total) return undefined;
+	if (reportedCount > total) return undefined;
+	if (total === 0 && remainingPercent !== undefined) {
+		// No countable quota in this window but the API still reports a meaningful
+		// `*_remaining_percent` (the percent field is the canonical indicator for
+		// Token Plan rows). Defer percent-only rendering to `normalizeWindow` where
+		// it sits next to the existing unlimited branch.
+		return { used: 100 - remainingPercent, remaining: remainingPercent, limit: 0 };
+	}
+	if (total === 0) return undefined;
 	let remaining = reportedCount;
 	if (remainingPercent !== undefined) {
 		const asRemaining = (reportedCount / total) * 100;

--- a/packages/pi-usage/src/providers/minimax.ts
+++ b/packages/pi-usage/src/providers/minimax.ts
@@ -152,14 +152,10 @@ function normalizeWindow(row: Record<string, unknown>, fields: WindowFields): Us
 	}
 	const total = nonnegativeInteger(row[fields.totalField], fields.totalField);
 	const count = nonnegativeInteger(row[fields.countField], fields.countField);
-	// Total of zero with no usable percent: no quota, no usage — drop the bucket entirely
-	// so it does not surface as a confusing row in /usage or the footer chip.
 	if (total === 0 && percent === undefined) {
 		throw new Error(`MiniMax Token Plan ${fields.label} returned no quota and no percent.`);
 	}
-	// Total of zero but percent available: the API uses percent as the canonical
-	// indicator for these rows (matches the behavior of the prior local usage
-	// extension). Emit a percent-based bucket instead of count-based.
+	// Token Plan reports remaining_percent as the quota even when counts are 0.
 	if (total === 0) {
 		return {
 			id: fields.id,
@@ -193,15 +189,7 @@ function resolveQuotaCounts(
 	total: number,
 	remainingPercent: number | undefined,
 ): Pick<UsageBucket, "used" | "remaining" | "limit"> | undefined {
-	if (reportedCount > total) return undefined;
-	if (total === 0 && remainingPercent !== undefined) {
-		// No countable quota in this window but the API still reports a meaningful
-		// `*_remaining_percent` (the percent field is the canonical indicator for
-		// Token Plan rows). Defer percent-only rendering to `normalizeWindow` where
-		// it sits next to the existing unlimited branch.
-		return { used: 100 - remainingPercent, remaining: remainingPercent, limit: 0 };
-	}
-	if (total === 0) return undefined;
+	if (total <= 0 || reportedCount > total) return undefined;
 	let remaining = reportedCount;
 	if (remainingPercent !== undefined) {
 		const asRemaining = (reportedCount / total) * 100;

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -185,14 +185,14 @@ export default function usageExtension(
 			return;
 		}
 		if (outcome.state.status !== "ready") {
-   const chip =
-       outcome.state.status === "auth-unavailable"
-           ? "auth unavailable"
-           : outcome.state.status === "selection-required"
-               ? "selection required"
-               : `usage err: ${outcome.state.message.slice(0, 50)}`;
+			const chip =
+				outcome.state.status === "auth-unavailable"
+					? "auth unavailable"
+					: outcome.state.status === "selection-required"
+						? "selection required"
+						: `usage err: ${outcome.state.message.slice(0, 50)}`;
 
-   if (safeSetStatus(ctx, chip)) {
+			if (safeSetStatus(ctx, chip)) {
 				if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
 			}
 			return;

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -516,7 +516,9 @@ export default function usageExtension(
 	) => {
 		void refreshCurrentStatus(ctx, model, force).catch((error) => {
 			if (isStaleExtensionContextError(error) || isAbortError(error)) return;
-			safeSetStatus(ctx, "usage error");
+			const message = errorMessage(error);
+			console.error("[pi-usage] refresh failed:", message);
+			safeSetStatus(ctx, `usage err: ${message.slice(0, 50)}`);
 		});
 	};
 

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -171,12 +171,11 @@ export default function usageExtension(
 			return;
 		}
 		if (outcome.state.status !== "ready") {
-			if (
-				safeSetStatus(
-					ctx,
-					outcome.state.status === "auth-unavailable" ? "auth unavailable" : "usage error",
-				)
-			) {
+			const chip =
+				outcome.state.status === "auth-unavailable"
+					? "auth unavailable"
+					: `usage err: ${outcome.state.message.slice(0, 50)}`;
+			if (safeSetStatus(ctx, chip)) {
 				if (shouldSchedule && sessionActive) scheduleStatusRefresh(ctx, model);
 			}
 			return;

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -259,10 +259,6 @@ test("MiniMax normalizers reject failed, malformed, or contradictory responses",
 });
 
 test("MiniMax Token Plan renders percent-based buckets when total is zero but percent is valid", () => {
-	// The general row in the user's API has total=0 / usage=0 but reports
-	// meaningful *_remaining_percent values (the API uses percent as the canonical
-	// indicator for Token Plan rows). It must NOT be skipped and must render with
-	// unit="percent".
 	const base = quotaPayload().model_remains[0];
 	const payload = {
 		base_resp: { status_code: 0, status_msg: "success" },
@@ -290,7 +286,6 @@ test("MiniMax Token Plan renders percent-based buckets when total is zero but pe
 		],
 	};
 	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 1_000);
-	// Both rows render: 4 buckets total (2 per row).
 	assert.equal(report.buckets.length, 4);
 	const general = report.buckets.filter((b) => b.groupLabel === "general");
 	const video = report.buckets.filter((b) => b.groupLabel === "video");
@@ -334,10 +329,6 @@ test("MiniMax Token Plan percent-only buckets render with percent and resets, no
 });
 
 test("MiniMax statusline falls back to general group when no model-specific match exists", () => {
-	// A user on a MiniMax Token Plan (Coding Plan) with rows for "general" and
-	// "video" but no model-specific row for their actual model (e.g. MiniMax-M3)
-	// should see the "general" row in the statusline — matches the prior local
-	// usage extension's behavior of preferring general as the catch-all.
 	const base = quotaPayload().model_remains[0];
 	const payload = {
 		base_resp: { status_code: 0, status_msg: "success" },
@@ -366,6 +357,11 @@ test("MiniMax statusline falls back to general group when no model-specific matc
 	};
 	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 1_000);
 	assert.equal(formatUsageStatusline(report, MODELS.minimax), "minimax 38% 5h 32% wk");
+	assert.equal(formatUsageStatusline(report), "minimax 38% 5h 32% wk");
+	assert.equal(
+		formatUsageStatusline(report, { ...MODELS.minimax, provider: "openai-codex" }),
+		undefined,
+	);
 });
 
 test("MiniMax Token Plan rejects rows with zero total and no usable percent", () => {
@@ -415,15 +411,29 @@ test("MiniMax Token Plan keeps mixed rows where one window is zero-total and the
 	assert.equal(report.buckets.length, 2);
 	const interval = report.buckets.find((b) => b.label === "Rolling window");
 	const weekly = report.buckets.find((b) => b.label === "Weekly window");
-	// Rolling: percent-based (percent=0 → 100% used).
 	assert.equal(interval?.unit, "percent");
 	assert.equal(interval?.remaining, 0);
 	assert.equal(interval?.used, 100);
-	// Weekly: count-based.
 	assert.equal(weekly?.unit, "count");
 	assert.equal(weekly?.limit, 1000);
 	assert.equal(weekly?.used, 200);
 	assert.equal(weekly?.remaining, 800);
+});
+
+test("MiniMax Token Plan count buckets with remaining 0 still render", () => {
+	const payload = quotaPayload();
+	payload.model_remains[0] = {
+		...payload.model_remains[0],
+		current_interval_usage_count: 0,
+		current_weekly_usage_count: 0,
+		current_weekly_remaining_percent: 0,
+	};
+	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 1_000);
+	const formatted = formatUsageReport(report, "current");
+	assert.doesNotMatch(formatted, /unavailable/iu);
+	assert.match(formatted, /Rolling window:\s+0 of 1500 left · 0%/u);
+	assert.match(formatted, /Weekly window:\s+0 of 1000 left · 0%/u);
+	assert.equal(formatUsageStatusline(report), "minimax 0% 5h 0% wk");
 });
 
 test("MiniMax runtime auth accepts only its matching official region", async () => {

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -308,6 +308,31 @@ test("MiniMax Token Plan renders percent-based buckets when total is zero but pe
 	assert.equal(generalWeekly?.limit, 0);
 });
 
+test("MiniMax Token Plan percent-only buckets render with percent and resets, not 'unavailable'", () => {
+	const base = quotaPayload().model_remains[0];
+	const payload = {
+		base_resp: { status_code: 0, status_msg: "success" },
+		model_remains: [
+			{
+				...base,
+				model_name: "general",
+				current_interval_total_count: 0,
+				current_interval_usage_count: 0,
+				current_interval_remaining_percent: 38,
+				current_weekly_total_count: 0,
+				current_weekly_usage_count: 0,
+				current_weekly_remaining_percent: 32,
+			},
+		],
+	};
+	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 1_000);
+	const formatted = formatUsageReport(report, "current");
+	assert.doesNotMatch(formatted, /unavailable/iu);
+	assert.match(formatted, /Rolling window:\s+38% remaining/iu);
+	assert.match(formatted, /Weekly window:\s+32% remaining/iu);
+	assert.match(formatted, /\(resets [^)]+\)/u);
+});
+
 test("MiniMax Token Plan rejects rows with zero total and no usable percent", () => {
 	const base = quotaPayload().model_remains[0];
 	const payload = {

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -333,6 +333,41 @@ test("MiniMax Token Plan percent-only buckets render with percent and resets, no
 	assert.match(formatted, /\(resets [^)]+\)/u);
 });
 
+test("MiniMax statusline falls back to general group when no model-specific match exists", () => {
+	// A user on a MiniMax Token Plan (Coding Plan) with rows for "general" and
+	// "video" but no model-specific row for their actual model (e.g. MiniMax-M3)
+	// should see the "general" row in the statusline — matches the prior local
+	// usage extension's behavior of preferring general as the catch-all.
+	const base = quotaPayload().model_remains[0];
+	const payload = {
+		base_resp: { status_code: 0, status_msg: "success" },
+		model_remains: [
+			{
+				...base,
+				model_name: "general",
+				current_interval_total_count: 0,
+				current_interval_usage_count: 0,
+				current_interval_remaining_percent: 38,
+				current_weekly_total_count: 0,
+				current_weekly_usage_count: 0,
+				current_weekly_remaining_percent: 32,
+			},
+			{
+				...base,
+				model_name: "video",
+				current_interval_total_count: 5,
+				current_interval_usage_count: 0,
+				current_interval_remaining_percent: 100,
+				current_weekly_total_count: 35,
+				current_weekly_usage_count: 2,
+				current_weekly_remaining_percent: 94,
+			},
+		],
+	};
+	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 1_000);
+	assert.equal(formatUsageStatusline(report, MODELS.minimax), "minimax 38% 5h 32% wk");
+});
+
 test("MiniMax Token Plan rejects rows with zero total and no usable percent", () => {
 	const base = quotaPayload().model_remains[0];
 	const payload = {

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -258,6 +258,114 @@ test("MiniMax normalizers reject failed, malformed, or contradictory responses",
 	}
 });
 
+test("MiniMax Token Plan renders percent-based buckets when total is zero but percent is valid", () => {
+	// The general row in the user's API has total=0 / usage=0 but reports
+	// meaningful *_remaining_percent values (the API uses percent as the canonical
+	// indicator for Token Plan rows). It must NOT be skipped and must render with
+	// unit="percent".
+	const base = quotaPayload().model_remains[0];
+	const payload = {
+		base_resp: { status_code: 0, status_msg: "success" },
+		model_remains: [
+			{
+				...base,
+				model_name: "general",
+				current_interval_total_count: 0,
+				current_interval_usage_count: 0,
+				current_interval_remaining_percent: 38,
+				current_weekly_total_count: 0,
+				current_weekly_usage_count: 0,
+				current_weekly_remaining_percent: 32,
+			},
+			{
+				...base,
+				model_name: "video",
+				current_interval_total_count: 5,
+				current_interval_usage_count: 0,
+				current_interval_remaining_percent: 100,
+				current_weekly_total_count: 35,
+				current_weekly_usage_count: 2,
+				current_weekly_remaining_percent: 94,
+			},
+		],
+	};
+	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 1_000);
+	// Both rows render: 4 buckets total (2 per row).
+	assert.equal(report.buckets.length, 4);
+	const general = report.buckets.filter((b) => b.groupLabel === "general");
+	const video = report.buckets.filter((b) => b.groupLabel === "video");
+	assert.equal(general.length, 2);
+	assert.equal(video.length, 2);
+	const generalInterval = general.find((b) => b.label === "Rolling window");
+	const generalWeekly = general.find((b) => b.label === "Weekly window");
+	assert.equal(generalInterval?.unit, "percent");
+	assert.equal(generalInterval?.remaining, 38);
+	assert.equal(generalInterval?.used, 62);
+	assert.equal(generalInterval?.limit, 0);
+	assert.equal(generalWeekly?.unit, "percent");
+	assert.equal(generalWeekly?.remaining, 32);
+	assert.equal(generalWeekly?.used, 68);
+	assert.equal(generalWeekly?.limit, 0);
+});
+
+test("MiniMax Token Plan rejects rows with zero total and no usable percent", () => {
+	const base = quotaPayload().model_remains[0];
+	const payload = {
+		base_resp: { status_code: 0, status_msg: "success" },
+		model_remains: [
+			{
+				...base,
+				model_name: "general",
+				current_interval_total_count: 0,
+				current_interval_usage_count: 0,
+				current_interval_remaining_percent: undefined,
+				current_weekly_total_count: 0,
+				current_weekly_usage_count: 0,
+				current_weekly_remaining_percent: undefined,
+			},
+		],
+	};
+	// We strip the undefined percent fields via JSON serialization; the API never
+	// returns them as undefined, but the production code defends against it.
+	const cleaned = JSON.parse(JSON.stringify(payload));
+	assert.throws(
+		() => normalizeMiniMaxUsagePayload("minimax", "token-plan", cleaned, 0),
+		/no quota and no percent/iu,
+	);
+});
+
+test("MiniMax Token Plan keeps mixed rows where one window is zero-total and the other has counts", () => {
+	const base = quotaPayload().model_remains[0];
+	const payload = {
+		base_resp: { status_code: 0, status_msg: "success" },
+		model_remains: [
+			{
+				...base,
+				model_name: "general",
+				current_interval_total_count: 0,
+				current_interval_usage_count: 0,
+				current_interval_remaining_percent: 0,
+				current_weekly_total_count: 1000,
+				current_weekly_usage_count: 200,
+				current_weekly_remaining_percent: 80,
+			},
+		],
+	};
+	const report = normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 1_000);
+	assert.equal(report.buckets.length, 2);
+	const interval = report.buckets.find((b) => b.label === "Rolling window");
+	const weekly = report.buckets.find((b) => b.label === "Weekly window");
+	// Rolling: percent-based (percent=0 → 100% used).
+	assert.equal(interval?.unit, "percent");
+	assert.equal(interval?.remaining, 0);
+	assert.equal(interval?.used, 100);
+	// Weekly: count-based.
+	assert.equal(weekly?.unit, "count");
+	assert.equal(weekly?.limit, 1000);
+	assert.equal(weekly?.used, 200);
+	assert.equal(weekly?.remaining, 800);
+});
+
 test("MiniMax runtime auth accepts only its matching official region", async () => {
 	const fetchMock = vi.spyOn(globalThis, "fetch");
 	try {

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -1228,6 +1228,39 @@ test("MiniMax account rotation at the request boundary retries without querying 
 	assert.equal(statuses.get("usage"), undefined);
 });
 
+test("MiniMax query-failed status chip includes the truncated error message", async (t) => {
+	const originalFetch = globalThis.fetch;
+	t.onTestFinished(() => {
+		globalThis.fetch = originalFetch;
+	});
+	globalThis.fetch = async () =>
+		new Response("nope", { status: 500, statusText: "Internal Server Error" });
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx, statuses } = createMockContext({
+		model: miniMaxModel,
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "sk-cp-test" }),
+			getProviderAuth: async () => ({
+				auth: { apiKey: "sk-cp-test", baseUrl: miniMaxModel.baseUrl },
+			}),
+			getAvailable: () => [miniMaxModel],
+			getAll: () => [miniMaxModel],
+		},
+	});
+
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	await settle();
+	await settle();
+
+	const chip = statuses.get("usage");
+	assert.equal(typeof chip, "string");
+	assert.match(String(chip), /^usage err: MiniMax usage endpoint returned 500 /u);
+	assert.ok(String(chip).length <= "usage err: ".length + 50);
+	mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(statuses.get("usage"), undefined);
+});
+
 test("DeepSeek session replacement aborts a stale balance request before publication", async (t) => {
 	const originalFetch = globalThis.fetch;
 	t.onTestFinished(() => {


### PR DESCRIPTION
# fix(pi-usage): render MiniMax Token Plan zero-quota rows with percent fallback and surface real refresh errors

Fixes #1168

## Problem

`@narumitw/pi-usage` shows `"usage error"` in the footer chip and drops the `general` (Coding Plan) row for `sk-cp-*` MiniMax Token Plan users. MiniMax's `/v1/token_plan/remains` returns `current_interval_total_count: 0` / `current_interval_usage_count: 0` with a valid `*_remaining_percent`. The extension treated that as inconsistent counts and aborted the whole query.

Pi's MiniMax footer already treats `*_remaining_percent` as the quota and always shows the `general` row. This PR matches that.

## Root cause

1. `normalizeWindow` threw when `total === 0`, so a `general` 0/0 row aborted the payload before `video` was processed.
2. After emitting `limit: 0` percent buckets, the report/statusline gates treated `0` as missing and printed `"unavailable"` or hid the chip.
3. `selectMiniMaxGroup` returned `undefined` for models like `MiniMax-M3` that match neither `general` nor `video`.
4. MiniMax normalize throws become `{ status: "query-failed" }` inside `queryAdapterState`. `publishStatus` still mapped that to a generic `"usage error"` chip, so the real message never reached the footer.

## Changes

- `normalizeWindow` emits `unit: "percent"` when `total === 0` and `*_remaining_percent` is present. Mixed windows (one zero-total, one counted) are handled per window. `resolveQuotaCounts` stays count-only; it is not called for `total === 0`.
- Report and statusline render percent buckets as `${remaining}% remaining` / `${remaining}% ${window}`, and treat `limit === 0` remaining-count rows as defined.
- `selectMiniMaxGroup` falls back to `general` when no exact or wildcard model match exists, including callers that omit a model. A model from another provider still hides the chip.
- `publishStatus` puts a truncated `query-failed` message in the chip. The `startStatusRefresh` catch still logs unexpected exceptions.

## Verification

- `npx vitest run packages/pi-usage/test/minimax.test.ts packages/pi-usage/test/usage.test.ts` — 63 passed
- Pre-commit typecheck for `pi-usage` — passed

## Compatibility

- No public API changes.
- Count-based Token Plan rows and `sk-api-*` account-balance are unchanged.

## Unverified paths

- Full interactive TUI footer rendering from a non-interactive shell.
- Other MiniMax key shapes (`sk-api-*`) were not touched.
