### PR TITLE
fix(pi-usage): reject contradictory zero-total counts

### DIFF
--- a/.changeset/minimax-percent-fallback.md
+++ b/.changeset/minimax-percent-fallback.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-usage": patch
 ---
 
-Render MiniMax Token Plan rows with zero countable quota as percent-based buckets, fall back to the general group in the status chip, and show query-failed messages in the chip.
+Render consistent MiniMax Token Plan rows with zero countable quota as percent-based buckets, reject contradictory zero-total counts, fall back to the general group in the status chip, and show query-failed messages in the chip.

--- a/packages/pi-usage/src/providers/minimax.ts
+++ b/packages/pi-usage/src/providers/minimax.ts
@@ -152,18 +152,21 @@ function normalizeWindow(row: Record<string, unknown>, fields: WindowFields): Us
 	}
 	const total = nonnegativeInteger(row[fields.totalField], fields.totalField);
 	const count = nonnegativeInteger(row[fields.countField], fields.countField);
-	if (total === 0 && percent === undefined) {
-		throw new Error(`MiniMax Token Plan ${fields.label} returned no quota and no percent.`);
-	}
-	// Token Plan reports remaining_percent as the quota even when counts are 0.
 	if (total === 0) {
+		if (count !== 0) {
+			throw new Error(`MiniMax Token Plan ${fields.label} counts were inconsistent.`);
+		}
+		if (percent === undefined) {
+			throw new Error(`MiniMax Token Plan ${fields.label} returned no quota and no percent.`);
+		}
+		// Token Plan reports remaining_percent as the quota when both counts are 0.
 		return {
 			id: fields.id,
 			label: fields.label,
 			groupId: fields.groupId,
 			groupLabel: fields.groupLabel,
-			remaining: percent as number,
-			used: 100 - (percent as number),
+			remaining: percent,
+			used: 100 - percent,
 			limit: 0,
 			unit: "percent",
 			windowMinutes,

--- a/packages/pi-usage/test/minimax.test.ts
+++ b/packages/pi-usage/test/minimax.test.ts
@@ -390,6 +390,26 @@ test("MiniMax Token Plan rejects rows with zero total and no usable percent", ()
 	);
 });
 
+test("MiniMax Token Plan rejects zero totals with nonzero counts even when percent is valid", () => {
+	const base = quotaPayload().model_remains[0];
+	const payload = {
+		base_resp: { status_code: 0, status_msg: "success" },
+		model_remains: [
+			{
+				...base,
+				model_name: "general",
+				current_interval_total_count: 0,
+				current_interval_usage_count: 1,
+				current_interval_remaining_percent: 38,
+			},
+		],
+	};
+	assert.throws(
+		() => normalizeMiniMaxUsagePayload("minimax", "token-plan", payload, 0),
+		/counts were inconsistent/iu,
+	);
+});
+
 test("MiniMax Token Plan keeps mixed rows where one window is zero-total and the other has counts", () => {
 	const base = quotaPayload().model_remains[0];
 	const payload = {


### PR DESCRIPTION
## Summary

- reject MiniMax Token Plan windows whose count is nonzero while total is zero
- preserve percent-only buckets only for the observed consistent `0/0` count shape
- add regression coverage and update the existing unreleased Changeset

Follow-up to #1169.

## Verification

- `npx vitest run packages/pi-usage/test/minimax.test.ts packages/pi-usage/test/usage.test.ts` — 67 passed
- `npm run check` — passed
- `PI_EXTENSIONS_TEST_BASE=main PI_EXTENSIONS_BUILD_READY=1 npm test` — 285 passed

## Semantic audit

- MiniMax zero-total rows remain fail-closed when counts contradict each other or percent is absent.
- Valid zero-total `0/0` percent rows and count-based rows retain the behavior merged in #1169.
- No settings, lifecycle, package metadata, entrypoint, dependency, or runtime-loading behavior changed; no additional Pi load smoke was required.
