### PR TITLE
feat(codex-compact): support Responses compaction APIs

### DIFF
--- a/.changeset/bright-responses-compact.md
+++ b/.changeset/bright-responses-compact.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-codex-compact": minor
+---
+
+Add Remote V2 and unary Responses Compact routing for OpenAI Codex, OpenAI, Azure OpenAI, and compatible custom providers while preserving existing checkpoints.

--- a/docs/implementation-notes/codex-compaction-mechanism.md
+++ b/docs/implementation-notes/codex-compaction-mechanism.md
@@ -788,29 +788,57 @@ The transferable design is the checkpoint protocol rather than any one summary p
 9. **Do not infer losslessness from persistence.** An exactly replayable summary checkpoint can still
    omit critical task state, so long conversations and repeated compactions remain accuracy risks.
 
+## Current protocol addendum
+
+Research date: 2026-09-03.
+
+The current `~/workspace/codex` checkout at commit `36984da4` retains both remote protocols:
+
+- `codex-api/src/endpoint/compact.rs` implements unary `POST responses/compact`;
+- `core/src/compact_remote_v2_attempt.rs` appends `ResponseItem::CompactionTrigger {}` to a normal Responses request;
+- `model-provider/src/provider.rs` marks OpenAI and Azure Responses providers as Remote V2-capable;
+- `features/src/lib.rs` keeps `remote_compaction_v2` stable and enabled by default.
+
+The installed OpenAI SDK `6.40.0` also publishes the official `responses.compact()` client plus
+`ResponseCompactParams`, `CompactedResponse`, `ResponseCompactionItem`, and
+`ResponseInputItem.CompactionTrigger` types. Its unary response contract returns retained user
+messages followed by one opaque compaction item and includes compaction usage. This official OpenAI
+surface is distinct from undocumented Codex-backend metadata, headers, and lifecycle behavior.
+
+The installed Pi provider interface has no first-class compact method. It does expose public
+`onPayload`, injected `fetch`, credentials, provider headers and environment, timeout, retry, and
+cancellation options. Deterministic adapter tests verify that the built-in Codex, OpenAI, and Azure
+Responses adapters each expose one HTTP Responses request and accept a compaction-only or synthetic
+completed SSE response. That public bridge is the supported package boundary; custom adapters that
+do not honor it fail closed to Pi-native compaction.
+
 ## Current Pi extension boundary
 
 The external Codex research above remains pinned, while this section describes the maintained repository extension boundary and must be reconciled when that package changes.
 
 This repository contains
 [`packages/pi-codex-compact`](../../packages/pi-codex-compact/README.md), a stable Pi extension that
-detects remote-compaction support from the active model's `openai-codex-responses` API capability.
-It implements the Remote V2 wire path inside Pi's public extension boundary:
+supports `openai-codex-responses`, `openai-responses`, and `azure-openai-responses`. It selects Remote
+V2 or unary Responses Compact automatically and permits an explicit protocol choice:
 
-- add `compaction_trigger` to an extension-owned Codex Responses request;
-- validate and persist the opaque `compaction` item in versioned `CompactionEntry.details`;
+- expand a prior compatible checkpoint in the provider-built input;
+- either append one final `compaction_trigger` to a normal Responses SSE request or rewrite the same-origin `/responses` request to unary `/responses/compact`;
+- validate one bounded opaque `compaction` item and protocol-approved retained user messages;
+- persist a version 2 checkpoint while reading version 1 Codex checkpoints without rewriting sessions;
 - identify the fallback summary from the active entry's persisted `CompactionEntry.summary` rather than regenerated prose;
-- collapse that summary and its fingerprint-verified kept suffix to a marker;
+- collapse that summary and its fingerprint-verified kept suffix to one deterministic marker;
 - replace that marker with bounded remote replacement history in `before_provider_request`;
-- fall back to native Pi compaction for other model APIs or Remote V2 failure.
+- fall back to native Pi compaction for unsupported APIs or remote failure.
 
 The package deliberately keeps Pi's threshold, `/compact`, overflow retry, append-only session tree,
 and `CompactionEntry` publication. A TUI control menu, opened with `/codex-compact`, provides
 manual compaction and writes bounded user options to `pi-codex-compact.json`.
 
 This is payload replay, not full Codex-core parity. A pure Pi extension cannot own Codex's context
-window generations, exact pre-turn and mid-turn continuation state, pending-input boundary,
-provider `comp_hash` compatibility checks, request lineage headers, or prompt-cache window identity.
-Checkpoint replay requires the exact model ID and an active model with the
-`openai-codex-responses` API capability; stored provider provenance does not gate replay.
-Full resume history also requires the extension and a working route for that API.
+window generations, summary-free token-budget reset, exact pre-turn and mid-turn continuation state,
+pending-input boundary, provider `comp_hash` compatibility checks, request lineage headers, or
+prompt-cache window identity. Pi's public `getAllTools()` metadata also omits the optional
+`constrainedSampling` field, so Remote V2 can preserve exposed tool order and schema fields but not
+that field. Checkpoint replay requires the exact model ID and API label; stored provider provenance
+does not gate replay. Full resume history also requires the extension and a working route for that
+API and protocol.

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -2,17 +2,18 @@
 
 [![npm](https://img.shields.io/npm/v/@narumitw/pi-codex-compact)](https://www.npmjs.com/package/@narumitw/pi-codex-compact) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
-Use Codex Remote Compaction V2 in Pi for models that use the `openai-codex-responses` API.
+Use Responses compaction in Pi through Remote Compaction V2 or the unary `responses/compact` API.
 The extension stores an opaque server-generated checkpoint and replays it in later compatible requests instead of generating a local plaintext summary.
 Pi still decides when compaction runs and keeps its normal `/compact`, threshold, overflow, and session-publication behavior.
 
 ## ✨ Features
 
-- Uses the active Codex Responses provider and credentials without persisting secrets or request headers.
+- Supports `openai-codex-responses`, `openai-responses`, and `azure-openai-responses`.
+- Uses Remote V2 or same-origin unary `responses/compact` through the active provider and credentials.
 - Handles manual, threshold, and overflow compaction through Pi's existing lifecycle.
 - Validates and persists one bounded opaque checkpoint that survives compatible reloads, resumes, and forks.
 - Replays the latest checkpoint while preserving newer conversation and extension context.
-- Supports repeated compaction by carrying the previous checkpoint into the next request.
+- Supports repeated and cross-protocol compaction by carrying the previous checkpoint forward.
 - Falls back to Pi's native plaintext compaction on non-cancellation failures.
 - Provides `/codex-compact` for effective-route status, settings, and manual compaction.
 
@@ -38,7 +39,7 @@ pi -e ./packages/pi-codex-compact
 ```
 
 The package declares `dist/index.ts`, so build a local checkout before loading its package directory.
-Loading the package enables Remote V2 with the documented defaults.
+Loading the package enables automatic Responses compaction routing with the documented defaults.
 Do not load a global npm installation and the local workspace at the same time.
 
 Pi extensions run with your user permissions.
@@ -46,13 +47,14 @@ Review third-party extension source before installing it.
 
 ## 🚀 Quick start
 
-1. Sign in through Pi's built-in OpenAI Codex provider, or configure a custom provider that routes to a compatible Codex backend.
-2. Select a model whose API is `openai-codex-responses`.
+1. Sign in through Pi's built-in OpenAI, OpenAI Codex, or Azure OpenAI provider, or configure a compatible custom provider.
+2. Select a model using `openai-codex-responses`, `openai-responses`, or `azure-openai-responses`.
 3. Work normally.
    Pi's automatic compaction and built-in `/compact` continue to operate.
 4. Run `/codex-compact` to inspect the effective route or choose **Compact now**.
 5. After compaction, continue the session normally; compatible requests replay the opaque checkpoint.
 
+With the default `auto` protocol, Codex Responses uses Remote V2 while OpenAI and Azure OpenAI Responses use unary `responses/compact`.
 When the active model uses another API, compaction remains entirely Pi-native.
 
 ## 💬 Commands
@@ -61,7 +63,7 @@ When the active model uses another API, compaction remains entirely Pi-native.
 /codex-compact
 ```
 
-In TUI mode, the menu shows whether Remote V2 is enabled, the active model, and whether manual compaction will use **Codex Remote V2** or **Pi native**.
+In TUI mode, the menu shows whether remote compaction is enabled, the protocol setting, the active model, and whether manual compaction will use **Responses Remote V2**, **Responses Compact API**, or **Pi native**.
 It contains:
 
 ```text
@@ -73,9 +75,10 @@ Close
 **Compact now** closes the menu before asking Pi to compact the active session.
 Escape or Ctrl+C closes without compacting, and an obsolete menu cannot trigger work after session replacement or shutdown.
 **Settings** opens the bounded settings editor.
-In non-TUI modes, the command reports the manual settings path instead of opening custom UI or compacting.
+In RPC mode, the command reports the manual settings path instead of opening custom UI or compacting.
+Print and JSON modes remain silent because they have no command-result channel that can safely replace their normal output.
 
-Pi's built-in `/compact` remains available and follows the same extension hook when the active model uses `openai-codex-responses`.
+Pi's built-in `/compact` remains available and follows the same extension hook for all three supported Responses APIs.
 
 ## ⚙️ Settings
 
@@ -91,6 +94,7 @@ There is no environment-variable or project-level override.
 ```json
 {
   "enabled": true,
+  "protocol": "auto",
   "requestTimeoutMs": 300000,
   "maxRetries": 2,
   "replacementTokenBudget": 64000,
@@ -100,11 +104,12 @@ There is no environment-variable or project-level override.
 
 | Setting | Default | Accepted values | Behavior | Recommendation |
 | --- | ---: | --- | --- | --- |
-| `enabled` | `true` | Boolean | Attempt Remote V2 when the active model uses `openai-codex-responses`. | Keep enabled unless diagnosing provider behavior. |
+| `enabled` | `true` | Boolean | Attempt a supported remote compaction route. | Keep enabled unless diagnosing provider behavior. |
+| `protocol` | `"auto"` | `"auto"`, `"remote-v2"`, or `"responses-compact"` | Select by API or force one remote protocol. | Keep `auto`; force a route only when diagnosing a compatible backend. |
 | `requestTimeoutMs` | `300000` | Integer from 30,000 to 600,000 ms | Bound one extension-owned remote request. | Keep five minutes; increase only for a consistently slow connection. |
 | `maxRetries` | `2` | Integer from 0 to 2 | Retry transient provider transport failures before Pi fallback. | Keep two; use zero when diagnosing the first failure. |
 | `replacementTokenBudget` | `64000` | Integer from 8,000 to 128,000 tokens | Bound approximate retained user-message text beside the opaque item. | Keep 64K; lower it to reduce session size or raise it only when recent user context is being lost. |
-| `notifyOnFallback` | `true` | Boolean | Warn when Remote V2 fails and Pi-native compaction takes over. | Keep enabled so silent fallback does not hide protocol or entitlement problems. |
+| `notifyOnFallback` | `true` | Boolean | Warn when remote compaction fails and Pi-native compaction takes over. | Keep enabled so silent fallback does not hide protocol or entitlement problems. |
 
 Missing fields use defaults.
 Settings reload on every `session_start`, including `/reload`, resume, and fork.
@@ -121,34 +126,41 @@ This extension does **not** read `~/.codex/config.toml`.
 
 | Codex setting | Extension behavior |
 | --- | --- |
-| `features.remote_compaction_v2` | Conceptually corresponds to this extension's `enabled`; it is not imported. |
+| `features.remote_compaction_v2` | Conceptually corresponds to `protocol: "remote-v2"`; it is not imported. |
 | `model_auto_compact_token_limit` | Not duplicated. Pi's own compaction threshold remains authoritative. |
 | `model_auto_compact_token_limit_scope` | Not supported; Pi extensions do not own Codex's compact-window lineage. |
-| `compact_prompt` / `experimental_compact_prompt_file` | Not used by Remote V2, whose opaque checkpoint is generated by the server. |
+| `compact_prompt` / `experimental_compact_prompt_file` | Not used by either remote protocol, whose opaque checkpoint is generated by the server. |
 | `features.token_budget` | Not supported; token-budget context reset is a different experimental strategy. |
 
 ## ✅ Requirements and compatibility
 
 - Pi APIs compatible with the package's declared peer dependencies.
-- API `openai-codex-responses` on the active model.
-- A built-in or custom provider that routes that API to a backend supporting `compaction_trigger` and opaque `compaction` replay.
-- Working credentials and Remote V2 entitlement for that backend.
+- One of `openai-codex-responses`, `openai-responses`, or `azure-openai-responses` on the active model.
+- A provider whose HTTP Responses adapter honors Pi's public `onPayload` and injected `fetch` options.
+- A backend supporting the selected protocol and opaque `compaction` replay.
+- Working credentials and any required compaction entitlement.
 
-The built-in `openai-codex` provider is supported, and a custom provider or proxy is eligible when its model explicitly uses `openai-codex-responses`.
-Generic `openai-responses`, `azure-openai-responses`, GitHub Copilot, and other merely Responses-compatible API labels are not eligible.
-The extension does not probe provider capabilities before compaction; a provider that declares `openai-codex-responses` owns compatible routing, authentication, request transforms, SSE transport, and opaque replay.
-A failed Remote V2 compaction attempt falls back to Pi native, but an ordinary request cannot transparently recover after an incompatible provider has already received an existing opaque checkpoint.
+| Model API | `auto` route | Other selectable route |
+| --- | --- | --- |
+| `openai-codex-responses` | Responses Remote V2 | Responses Compact API |
+| `openai-responses` | Responses Compact API | Responses Remote V2 |
+| `azure-openai-responses` | Responses Compact API | Responses Remote V2 |
+
+The installed built-in adapters are covered by deterministic transport tests.
+A custom provider or proxy is eligible when its model explicitly uses one of these APIs, but its backend still owns compatible routing, authentication, request transforms, and opaque replay.
+The extension does not send a separate capability probe or automatically retry a failed billable request through the other protocol.
+A failed remote attempt falls back to Pi native, but an ordinary request cannot transparently recover after an incompatible provider has already received an existing opaque checkpoint.
 Provider provenance is stored for diagnosis but is not a replay gate.
-Switching providers can replay a checkpoint only when the API and exact model ID still match; switching model IDs leaves Pi's visible fallback marker plus retained recent messages in context.
+Switching providers can replay a checkpoint only when the API label and exact model ID still match; switching APIs or model IDs leaves Pi's visible fallback marker plus retained recent messages in context.
 
 ## 🔄 How it works
 
 1. Pi prepares compaction and selects the recent message suffix it will retain.
 2. If an earlier compatible checkpoint is present, the extension identifies its boundary from the summary persisted on the active `CompactionEntry` and validates the retained suffix fingerprints.
-3. It projects that checkpoint into the current Responses input, appends exactly one final `compaction_trigger`, and sends a normal authenticated Codex Responses SSE request with cache retention disabled.
-4. It requires a completed response containing exactly one non-empty opaque `compaction` item.
-5. It constructs bounded replacement history from recent raw user-role Responses items followed by the opaque item.
-6. It stores that history and fingerprints of Pi's retained suffix in versioned `CompactionEntry.details`.
+3. Remote V2 projects that checkpoint into a normal Responses SSE request and appends exactly one final `compaction_trigger`.
+4. Unary compact captures the provider-built payload and authentication, rewrites only the same-origin `/responses` path to `/responses/compact`, and requests JSON without making a normal inference call.
+5. It requires one bounded non-empty opaque `compaction` item; unary output may precede it only with user-role retained messages.
+6. It constructs bounded replacement history and stores it with Pi suffix fingerprints in versioned `CompactionEntry.details`.
 7. On later compatible requests, it replaces an exactly validated marker with the persisted replacement history immediately before provider dispatch.
 
 The persisted entry remains the summary identity source, so replay does not depend on the wording generated by the currently installed extension version.
@@ -156,14 +168,14 @@ If persisted summary identity, fingerprints, model identity, payload shape, or m
 
 ## 🔒 Security and privacy
 
-Remote compaction sends the active conversation context, system prompt, and active tool schemas to the configured backend used by the selected Codex Responses provider.
+Remote compaction sends the active conversation context and system prompt to the configured Responses backend; Remote V2 also sends active tool schemas.
 The Pi session stores the producing provider ID, encrypted compaction item, and bounded recent user-role Responses items.
 It does not store credentials, authorization headers, or request headers in checkpoint details.
 
 | Boundary | Limit |
 | --- | ---: |
-| Observed SSE stream | 8 MiB |
-| Serialized opaque compaction item | 2 MiB |
+| Observed SSE stream or unary JSON response | 8 MiB |
+| Serialized opaque compaction item or retained output item | 2 MiB |
 | Persisted replacement history | 8 MiB |
 | Retained user text | 64K approximate tokens by default; configurable from 8K to 128K |
 | Settings file | 64 KiB |
@@ -176,11 +188,11 @@ These hard byte ceilings are intentionally not configurable.
 
 ## 🚧 Limitations
 
-- The wire contract is undocumented and can change independently of Pi or this package.
-  Keep backups of important sessions.
-- Full older history depends on this extension, the `openai-codex-responses` API, the exact checkpoint model ID, and a provider route whose backend accepts the opaque item.
+- Codex Remote V2 remains an undocumented hosted contract and can change independently of Pi or this package; keep backups of important sessions.
+- Full older history depends on this extension, the checkpoint API label, the exact checkpoint model ID, and a provider route whose backend accepts the opaque item.
   Removing the extension exposes only the portability fallback marker and Pi-retained recent messages.
 - The package does not reproduce Codex core's context-window UUID/number lineage, previous-model compatibility fallback, exact pre-turn ordering, or exact mid-turn model-session ownership.
+- Pi's public `getAllTools()` metadata does not expose `constrainedSampling`; Remote V2 preserves active tool order, names, descriptions, and parameter schemas but cannot reproduce that optional field.
 - Remote failure falls back to Pi's plaintext summary, so a session can contain both remote opaque and native compaction entries over time.
 - Settings concurrency is coordinated only within one Pi process; separate processes rely on the final conflict check.
 
@@ -218,10 +230,14 @@ See [`docs/implementation-notes/codex-compaction-mechanism.md`](../../docs/imple
 ```text
 src/index.ts          Thin Pi entrypoint
 src/codex-compact.ts  Pi lifecycle, command, provider projection, and fallback
-src/remote.ts         Provider stream invocation, auth payload, timeout, and retry controls
-src/protocol.ts       Bounded SSE parsing and Remote V2 payload/output validation
+src/remote.ts         Protocol dispatch
+src/remote-v2.ts      Remote V2 provider stream and SSE inspection
+src/remote-compact.ts Unary Compact API bridge and usage normalization
+src/remote-shared.ts  Shared provider completion handling
+src/remote-types.ts   Protocol-neutral request and response types
+src/protocol.ts       Bounded SSE/JSON parsing and payload/output validation
 src/checkpoint.ts     Replacement history, fingerprints, persistence, and replay projection
-src/model-api.ts      Codex Responses API detection for Remote V2 eligibility
+src/model-api.ts      Responses API and protocol route selection
 src/settings.ts       Global settings validation and atomic persistence
 src/settings-menu.ts  First-use manual compaction and settings TUI
 
@@ -233,7 +249,7 @@ test/                 Protocol, checkpoint, lifecycle, remote, settings, menu, a
 
 ## 🔎 Keywords
 
-Pi extension, Pi coding agent, OpenAI Codex, custom provider, proxy, Remote Compaction V2, opaque checkpoint, Responses API, context compaction.
+Pi extension, Pi coding agent, OpenAI Codex, Azure OpenAI, custom provider, proxy, Remote Compaction V2, Responses Compact API, opaque checkpoint, Responses API, context compaction.
 
 ## 📄 License
 

--- a/packages/pi-codex-compact/README.md
+++ b/packages/pi-codex-compact/README.md
@@ -76,7 +76,7 @@ Close
 Escape or Ctrl+C closes without compacting, and an obsolete menu cannot trigger work after session replacement or shutdown.
 **Settings** opens the bounded settings editor.
 In RPC mode, the command reports the manual settings path instead of opening custom UI or compacting.
-Print and JSON modes remain silent because they have no command-result channel that can safely replace their normal output.
+Print and JSON modes reject the command explicitly because they cannot open the menu or safely replace their normal output with an interactive result.
 
 Pi's built-in `/compact` remains available and follows the same extension hook for all three supported Responses APIs.
 

--- a/packages/pi-codex-compact/benchmark/run.mjs
+++ b/packages/pi-codex-compact/benchmark/run.mjs
@@ -635,7 +635,7 @@ async function compactArm({ arm, isCancelled, sessionState }) {
 	assertSessionReady({ arm, extensionErrors, isCancelled, operation: "compaction" });
 	const isCodexCheckpoint =
 		compaction.details?.kind === "pi-codex-remote-compaction" &&
-		compaction.details?.protocol === "remote-compaction-v2";
+		compaction.details?.protocol === "remote-v2";
 	if (arm === "codex" && !isCodexCheckpoint) {
 		throw new Error(
 			"Codex arm did not produce a Remote V2 checkpoint; refusing to report a Pi fallback as Codex",

--- a/packages/pi-codex-compact/package.json
+++ b/packages/pi-codex-compact/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@narumitw/pi-codex-compact",
 	"version": "0.51.3",
-	"description": "Codex Remote Compaction V2 for compatible Pi providers.",
+	"description": "Responses compaction protocols for compatible Pi providers.",
 	"type": "module",
 	"license": "MIT",
 	"private": false,

--- a/packages/pi-codex-compact/src/checkpoint.ts
+++ b/packages/pi-codex-compact/src/checkpoint.ts
@@ -1,23 +1,29 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { CompactionEntry, SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { RemoteCompactionProtocol, ResponsesCompactionApi } from "./model-api.js";
+import { RESPONSES_COMPACTION_APIS } from "./model-api.js";
 import { type JsonObject, validateCompactionItem } from "./protocol.js";
 
 export const CHECKPOINT_KIND = "pi-codex-remote-compaction";
-export const CHECKPOINT_VERSION = 1;
+export const CHECKPOINT_VERSION = 2;
 export const REPLACEMENT_TOKEN_BUDGET = 64_000;
 export const REPLACEMENT_BYTE_BUDGET = 8 * 1024 * 1024;
 const MAX_MEDIA_ITEM_BYTES = 2 * 1024 * 1024;
+const MAX_CHECKPOINT_DETAILS_BYTES = 10 * 1024 * 1024;
+const MAX_CHECKPOINT_ID_LENGTH = 128;
 const MAX_PROVIDER_ID_LENGTH = 256;
+const MAX_MODEL_ID_LENGTH = 512;
+const MAX_KEPT_FINGERPRINTS = 100_000;
 
 export interface CodexCheckpointDetails {
 	kind: typeof CHECKPOINT_KIND;
 	version: typeof CHECKPOINT_VERSION;
 	checkpointId: string;
 	provider: string;
-	api: "openai-codex-responses";
+	api: ResponsesCompactionApi;
 	modelId: string;
-	protocol: "remote-compaction-v2";
+	protocol: RemoteCompactionProtocol;
 	replacementHistory: JsonObject[];
 	keptMessageFingerprints: string[];
 	createdAt: string;
@@ -51,14 +57,14 @@ export function checkpointMarker(checkpointId: string): string {
 	return [
 		`[PI_CODEX_REMOTE_CHECKPOINT:${checkpointId}]`,
 		"Opaque checkpoint injection failed. Do not infer missing history; tell the user to re-enable",
-		"@narumitw/pi-codex-compact with a model using the openai-codex-responses API.",
+		"@narumitw/pi-codex-compact with the same model and Responses API.",
 	].join(" ");
 }
 
 export function fallbackSummary(checkpointId: string): string {
 	return [
-		`OpenAI Codex Remote Compaction V2 checkpoint ${checkpointId} stores the older history opaquely.`,
-		"Full replay requires @narumitw/pi-codex-compact and the same model through a compatible Codex Responses provider.",
+		`Responses compaction checkpoint ${checkpointId} stores the older history opaquely.`,
+		"Full replay requires @narumitw/pi-codex-compact and the same model through a compatible Responses provider.",
 		"Without them, only Pi's retained recent messages remain available.",
 	].join(" ");
 }
@@ -73,20 +79,36 @@ function markerMessage(checkpointId: string, timestamp: number): AgentMessage {
 
 export function parseCheckpointDetails(value: unknown): CodexCheckpointDetails | undefined {
 	if (!isObject(value)) return undefined;
+	try {
+		if (serializedBytes(value) > MAX_CHECKPOINT_DETAILS_BYTES) return undefined;
+	} catch {
+		return undefined;
+	}
+	const isVersionOne =
+		value.version === 1 &&
+		value.api === "openai-codex-responses" &&
+		value.protocol === "remote-compaction-v2";
+	const isVersionTwo =
+		value.version === CHECKPOINT_VERSION &&
+		RESPONSES_COMPACTION_APIS.includes(value.api as ResponsesCompactionApi) &&
+		(value.protocol === "remote-v2" || value.protocol === "responses-compact");
 	if (
 		value.kind !== CHECKPOINT_KIND ||
-		value.version !== CHECKPOINT_VERSION ||
+		(!isVersionOne && !isVersionTwo) ||
 		typeof value.checkpointId !== "string" ||
 		value.checkpointId.length < 8 ||
+		value.checkpointId.length > MAX_CHECKPOINT_ID_LENGTH ||
 		typeof value.provider !== "string" ||
 		value.provider.length === 0 ||
 		value.provider.length > MAX_PROVIDER_ID_LENGTH ||
-		value.api !== "openai-codex-responses" ||
 		typeof value.modelId !== "string" ||
-		value.protocol !== "remote-compaction-v2" ||
+		value.modelId.length === 0 ||
+		value.modelId.length > MAX_MODEL_ID_LENGTH ||
 		!Array.isArray(value.replacementHistory) ||
 		!Array.isArray(value.keptMessageFingerprints) ||
-		typeof value.createdAt !== "string"
+		value.keptMessageFingerprints.length > MAX_KEPT_FINGERPRINTS ||
+		typeof value.createdAt !== "string" ||
+		value.createdAt.length > 64
 	) {
 		return undefined;
 	}
@@ -106,7 +128,18 @@ export function parseCheckpointDetails(value: unknown): CodexCheckpointDetails |
 	} catch {
 		return undefined;
 	}
-	return structuredClone(value) as unknown as CodexCheckpointDetails;
+	return {
+		kind: CHECKPOINT_KIND,
+		version: CHECKPOINT_VERSION,
+		checkpointId: value.checkpointId,
+		provider: value.provider,
+		api: isVersionOne ? "openai-codex-responses" : (value.api as ResponsesCompactionApi),
+		modelId: value.modelId,
+		protocol: isVersionOne ? "remote-v2" : (value.protocol as RemoteCompactionProtocol),
+		replacementHistory: structuredClone(value.replacementHistory),
+		keptMessageFingerprints: [...value.keptMessageFingerprints],
+		createdAt: value.createdAt,
+	};
 }
 
 export function latestCheckpoint(entries: readonly SessionEntry[]):
@@ -258,7 +291,9 @@ export function buildReplacementHistory(
 
 export function createCheckpointDetails(input: {
 	provider: string;
+	api: ResponsesCompactionApi;
 	modelId: string;
+	protocol: RemoteCompactionProtocol;
 	replacementHistory: JsonObject[];
 	keptMessages: readonly AgentMessage[];
 	checkpointId?: string;
@@ -269,9 +304,9 @@ export function createCheckpointDetails(input: {
 		version: CHECKPOINT_VERSION,
 		checkpointId: input.checkpointId ?? randomUUID(),
 		provider: input.provider,
-		api: "openai-codex-responses",
+		api: input.api,
 		modelId: input.modelId,
-		protocol: "remote-compaction-v2",
+		protocol: input.protocol,
 		replacementHistory: structuredClone(input.replacementHistory),
 		keptMessageFingerprints: input.keptMessages.map(fingerprintMessage),
 		createdAt: input.createdAt ?? new Date().toISOString(),

--- a/packages/pi-codex-compact/src/codex-compact.ts
+++ b/packages/pi-codex-compact/src/codex-compact.ts
@@ -18,7 +18,7 @@ import {
 	latestCheckpoint,
 	projectCheckpointContext,
 } from "./checkpoint.js";
-import { usesCodexResponsesApi } from "./model-api.js";
+import { resolveCompactionRoute, usesResponsesCompactionApi } from "./model-api.js";
 import { hasCheckpointMarker, rewriteCheckpointMarker } from "./protocol.js";
 import { requestRemoteCompaction } from "./remote.js";
 import {
@@ -27,6 +27,7 @@ import {
 	type CodexCompactSettingsState,
 	createCodexCompactSettingsRuntime,
 } from "./settings.js";
+import { terminalText } from "./terminal.js";
 
 const STATUS_KEY = "codex-compact";
 
@@ -37,8 +38,10 @@ function activeCheckpoint(ctx: ExtensionContext) {
 function isCheckpointCompatible(
 	details: CodexCheckpointDetails,
 	model: Model<Api> | undefined,
-): model is Model<"openai-codex-responses"> {
-	return usesCodexResponsesApi(model) && model.id === details.modelId;
+): boolean {
+	return (
+		usesResponsesCompactionApi(model) && model.api === details.api && model.id === details.modelId
+	);
 }
 
 function keptMessages(event: SessionBeforeCompactEvent): AgentMessage[] {
@@ -54,27 +57,31 @@ function keptMessages(event: SessionBeforeCompactEvent): AgentMessage[] {
 }
 
 function activeTools(pi: ExtensionAPI): Tool[] {
-	const enabled = new Set(pi.getActiveTools());
-	return pi
-		.getAllTools()
-		.filter((tool) => enabled.has(tool.name))
-		.map((tool) => ({
-			name: tool.name,
-			description: tool.description,
-			parameters: tool.parameters,
-		}));
+	const available = new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
+	return pi.getActiveTools().flatMap((name) => {
+		const tool = available.get(name);
+		return tool
+			? [
+					{
+						name: tool.name,
+						description: tool.description,
+						parameters: tool.parameters,
+					},
+				]
+			: [];
+	});
 }
 
 function projectedCurrentMessages(
 	event: SessionBeforeCompactEvent,
-	model: Model<"openai-codex-responses">,
+	model: Model<Api>,
 ): { messages: AgentMessage[]; prior?: CodexCheckpointDetails } {
 	const leafId = event.branchEntries.at(-1)?.id ?? null;
 	const session = buildSessionContext(event.branchEntries, leafId);
 	const prior = latestCheckpoint(event.branchEntries);
 	if (!prior) return { messages: session.messages };
-	if (prior.details.modelId !== model.id) {
-		throw new Error("The active opaque checkpoint belongs to a different Codex model");
+	if (prior.details.api !== model.api || prior.details.modelId !== model.id) {
+		throw new Error("The active opaque checkpoint belongs to a different Responses model");
 	}
 	const projected = projectCheckpointContext(session.messages, prior.details, prior.entry.summary);
 	if (!projected) {
@@ -89,8 +96,8 @@ function notifyFailure(
 	settings: CodexCompactSettings,
 ): void {
 	if (!ctx.hasUI || !settings.notifyOnFallback) return;
-	const message = error instanceof Error ? error.message : String(error);
-	ctx.ui.notify(`Codex remote compaction failed; using Pi compaction. ${message}`, "warning");
+	const message = terminalText(error instanceof Error ? error.message : String(error));
+	ctx.ui.notify(`Responses compaction failed; using Pi compaction. ${message}`, "warning");
 }
 
 function sessionStillOwned(ctx: ExtensionContext, sessionId: string, signal: AbortSignal): boolean {
@@ -102,18 +109,25 @@ async function compactRemotely(
 	event: SessionBeforeCompactEvent,
 	ctx: ExtensionContext,
 	settings: CodexCompactSettings,
+	ownerSignal: AbortSignal,
 	fetch?: typeof globalThis.fetch,
 ) {
 	const model = ctx.model;
-	if (!settings.enabled || !usesCodexResponsesApi(model)) return undefined;
+	const route = resolveCompactionRoute(model, settings);
+	if (route.kind === "native" || !usesResponsesCompactionApi(model)) return undefined;
+	const signal = AbortSignal.any([event.signal, ownerSignal]);
+	if (signal.aborted) return { cancel: true };
 	const sessionId = ctx.sessionManager.getSessionId();
-	ctx.ui.setStatus(STATUS_KEY, "Codex remote compaction…");
+	ctx.ui.setStatus(
+		STATUS_KEY,
+		route.protocol === "remote-v2" ? "Responses Remote V2…" : "Responses Compact API…",
+	);
 	try {
 		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-		if (!sessionStillOwned(ctx, sessionId, event.signal)) return { cancel: true };
+		if (!sessionStillOwned(ctx, sessionId, signal)) return { cancel: true };
 		if (!auth.ok) throw new Error(auth.error);
 		const provider = ctx.modelRegistry.getProvider(model.provider);
-		if (!provider) throw new Error("The active Codex Responses provider is unavailable");
+		if (!provider) throw new Error("The active Responses provider is unavailable");
 		const current = projectedCurrentMessages(event, model);
 		const context: Context = {
 			systemPrompt: ctx.getSystemPrompt(),
@@ -124,10 +138,11 @@ async function compactRemotely(
 			provider,
 			model,
 			context,
+			protocol: route.protocol,
 			apiKey: auth.apiKey,
 			headers: auth.headers,
 			env: auth.env,
-			signal: event.signal,
+			signal,
 			priorCheckpoint: current.prior
 				? {
 						marker: checkpointMarker(current.prior.checkpointId),
@@ -138,13 +153,17 @@ async function compactRemotely(
 			maxRetries: settings.maxRetries,
 			fetch,
 		});
-		if (!sessionStillOwned(ctx, sessionId, event.signal)) return { cancel: true };
-		const replacementHistory = buildReplacementHistory(response.promptInput, response.item, {
-			tokenBudget: settings.replacementTokenBudget,
-		});
+		if (!sessionStillOwned(ctx, sessionId, signal)) return { cancel: true };
+		const replacementHistory = buildReplacementHistory(
+			response.compactedOutput?.slice(0, -1) ?? response.promptInput,
+			response.item,
+			{ tokenBudget: settings.replacementTokenBudget },
+		);
 		const details = createCheckpointDetails({
 			provider: model.provider,
+			api: route.api,
 			modelId: model.id,
+			protocol: route.protocol,
 			replacementHistory,
 			keptMessages: keptMessages(event),
 		});
@@ -158,7 +177,7 @@ async function compactRemotely(
 			},
 		};
 	} catch (error) {
-		if (event.signal.aborted || ctx.sessionManager.getSessionId() !== sessionId) {
+		if (signal.aborted || ctx.sessionManager.getSessionId() !== sessionId) {
 			return { cancel: true };
 		}
 		notifyFailure(ctx, error, settings);
@@ -178,8 +197,9 @@ export function createCodexCompactExtension(
 		let generation = 0;
 
 		pi.registerCommand("codex-compact", {
-			description: "Compact now or configure Codex Remote Compaction V2",
-			handler: async (_args, ctx) => {
+			description: "Compact now or configure Responses compaction",
+			handler: async (args, ctx) => {
+				if (args.trim()) throw new Error("Usage: /codex-compact");
 				const ownerGeneration = generation;
 				const controller = sessionController;
 				const { showCodexCompactMenu } = await import("./settings-menu.js");
@@ -205,7 +225,7 @@ export function createCodexCompactExtension(
 				if (sessionController.signal.aborted || ownerGeneration !== generation) return;
 				if (ctx.hasUI) {
 					ctx.ui.notify(
-						`Could not load pi-codex-compact.json; using defaults. ${error instanceof Error ? error.message : String(error)}`,
+						`Could not load pi-codex-compact.json; using defaults. ${terminalText(error instanceof Error ? error.message : String(error))}`,
 						"warning",
 					);
 				}
@@ -220,14 +240,21 @@ export function createCodexCompactExtension(
 			}
 			if (ctx.hasUI && state.kind === "invalid") {
 				ctx.ui.notify(
-					`Invalid pi-codex-compact.json; using defaults without overwriting it. ${state.issue}`,
+					`Invalid pi-codex-compact.json; using defaults without overwriting it. ${terminalText(state.issue ?? "unknown validation error")}`,
 					"warning",
 				);
 			}
 		});
 
 		pi.on("session_before_compact", (event, ctx) =>
-			compactRemotely(pi, event, ctx, settingsRuntime.get().settings, options.fetch),
+			compactRemotely(
+				pi,
+				event,
+				ctx,
+				settingsRuntime.get().settings,
+				sessionController.signal,
+				options.fetch,
+			),
 		);
 
 		pi.on("context", (event, ctx) => {
@@ -260,7 +287,7 @@ export function createCodexCompactExtension(
 			providerWarnings.add(key);
 			if (ctx.hasUI) {
 				ctx.ui.notify(
-					"The active Codex checkpoint cannot replay on this model; Pi will expose only its fallback marker and retained recent messages.",
+					"The active Responses checkpoint cannot replay on this model; Pi will expose only its fallback marker and retained recent messages.",
 					"warning",
 				);
 			}

--- a/packages/pi-codex-compact/src/model-api.ts
+++ b/packages/pi-codex-compact/src/model-api.ts
@@ -1,8 +1,48 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { hasApi } from "@earendil-works/pi-ai";
 
-export function usesCodexResponsesApi(
+export const RESPONSES_COMPACTION_APIS = [
+	"openai-codex-responses",
+	"openai-responses",
+	"azure-openai-responses",
+] as const;
+
+export type ResponsesCompactionApi = (typeof RESPONSES_COMPACTION_APIS)[number];
+export type RemoteCompactionProtocol = "remote-v2" | "responses-compact";
+export type RemoteCompactionProtocolSetting = "auto" | RemoteCompactionProtocol;
+
+export type CompactionRoute =
+	| { kind: "remote"; protocol: RemoteCompactionProtocol; api: ResponsesCompactionApi }
+	| { kind: "native"; reason: string };
+
+export function usesResponsesCompactionApi(
 	model: Model<Api> | undefined,
-): model is Model<"openai-codex-responses"> {
-	return model !== undefined && hasApi(model, "openai-codex-responses");
+): model is Model<ResponsesCompactionApi> {
+	return model !== undefined && RESPONSES_COMPACTION_APIS.some((api) => hasApi(model, api));
+}
+
+export function resolveCompactionRouteForApi(
+	api: Api | undefined,
+	options: { enabled: boolean; protocol: RemoteCompactionProtocolSetting },
+): CompactionRoute {
+	if (!options.enabled) return { kind: "native", reason: "remote compaction is disabled" };
+	if (!api) return { kind: "native", reason: "no active model" };
+	if (!RESPONSES_COMPACTION_APIS.includes(api as ResponsesCompactionApi)) {
+		return { kind: "native", reason: `API ${api} does not support Responses compaction` };
+	}
+	const supportedApi = api as ResponsesCompactionApi;
+	const protocol =
+		options.protocol === "auto"
+			? supportedApi === "openai-codex-responses"
+				? "remote-v2"
+				: "responses-compact"
+			: options.protocol;
+	return { kind: "remote", protocol, api: supportedApi };
+}
+
+export function resolveCompactionRoute(
+	model: Model<Api> | undefined,
+	options: { enabled: boolean; protocol: RemoteCompactionProtocolSetting },
+): CompactionRoute {
+	return resolveCompactionRouteForApi(model?.api, options);
 }

--- a/packages/pi-codex-compact/src/protocol.ts
+++ b/packages/pi-codex-compact/src/protocol.ts
@@ -1,4 +1,5 @@
 export const MAX_SSE_BYTES = 8 * 1024 * 1024;
+export const MAX_COMPACT_JSON_BYTES = 8 * 1024 * 1024;
 export const MAX_COMPACTION_ITEM_BYTES = 2 * 1024 * 1024;
 
 export type JsonObject = Record<string, unknown>;
@@ -45,6 +46,12 @@ export function validateCompactionItem(
 export interface CollectedCompaction {
 	item: JsonObject;
 	completedResponse?: JsonObject;
+}
+
+export interface CollectedCompactResponse {
+	item: JsonObject;
+	output: JsonObject[];
+	response: JsonObject;
 }
 
 function compactionItemsFromEvent(event: JsonObject): unknown[] {
@@ -156,6 +163,116 @@ export async function collectCompactionSse(
 	return { item: [...items.values()][0], completedResponse };
 }
 
+function isRetainedCompactMessage(value: unknown): value is JsonObject {
+	return (
+		isObject(value) &&
+		value.role === "user" &&
+		(value.type === undefined || value.type === "message") &&
+		Array.isArray(value.content) &&
+		value.content.every(
+			(part) => isObject(part) && (part.type === "input_text" || part.type === "input_image"),
+		)
+	);
+}
+
+export function validateCompactedResponse(
+	value: unknown,
+	options: { maxBytes?: number; maxItemBytes?: number } = {},
+): CollectedCompactResponse {
+	if (!isObject(value) || !Array.isArray(value.output)) {
+		throw new CodexCompactionProtocolError("Responses Compact returned an invalid response object");
+	}
+	const maxBytes = options.maxBytes ?? MAX_COMPACT_JSON_BYTES;
+	const maxItemBytes = options.maxItemBytes ?? MAX_COMPACTION_ITEM_BYTES;
+	if (byteLength(value) > maxBytes) {
+		throw new CodexCompactionProtocolError("Responses Compact response exceeded the size limit");
+	}
+	if (value.output.length === 0) {
+		throw new CodexCompactionProtocolError("Responses Compact returned no output items");
+	}
+	const output = value.output.map((item) => {
+		if (!isObject(item)) {
+			throw new CodexCompactionProtocolError("Responses Compact returned a non-object output item");
+		}
+		if (byteLength(item) > maxItemBytes) {
+			throw new CodexCompactionProtocolError(
+				"Responses Compact output item exceeded the size limit",
+			);
+		}
+		return structuredClone(item);
+	});
+	const compactionItems = output.filter((item) => item.type === "compaction");
+	if (compactionItems.length !== 1 || output.at(-1)?.type !== "compaction") {
+		throw new CodexCompactionProtocolError(
+			"Responses Compact must return retained messages followed by one compaction item",
+		);
+	}
+	for (const item of output.slice(0, -1)) {
+		if (!isRetainedCompactMessage(item)) {
+			throw new CodexCompactionProtocolError(
+				"Responses Compact returned an unsupported retained output item",
+			);
+		}
+	}
+	const item = validateCompactionItem(output.at(-1), maxItemBytes);
+	return { item, output: [...output.slice(0, -1), item], response: structuredClone(value) };
+}
+
+export async function collectCompactResponse(
+	response: Response,
+	options: { signal?: AbortSignal; maxBytes?: number; maxItemBytes?: number } = {},
+): Promise<CollectedCompactResponse> {
+	const maxBytes = options.maxBytes ?? MAX_COMPACT_JSON_BYTES;
+	const declaredLength = Number(response.headers.get("content-length"));
+	if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+		throw new CodexCompactionProtocolError("Responses Compact response exceeded the size limit");
+	}
+	if (!response.body) {
+		throw new CodexCompactionProtocolError("Responses Compact response did not contain a body");
+	}
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let bytes = 0;
+	const onAbort = () => {
+		void reader.cancel(new DOMException("Compaction aborted", "AbortError")).catch(() => undefined);
+	};
+	options.signal?.addEventListener("abort", onAbort, { once: true });
+	try {
+		while (true) {
+			if (options.signal?.aborted) throw new DOMException("Compaction aborted", "AbortError");
+			const { done, value } = await reader.read();
+			if (done) break;
+			bytes += value.byteLength;
+			if (bytes > maxBytes) {
+				throw new CodexCompactionProtocolError(
+					"Responses Compact response exceeded the size limit",
+				);
+			}
+			chunks.push(value);
+		}
+		if (options.signal?.aborted) throw new DOMException("Compaction aborted", "AbortError");
+	} catch (error) {
+		await reader.cancel(error).catch(() => undefined);
+		throw error;
+	} finally {
+		options.signal?.removeEventListener("abort", onAbort);
+		reader.releaseLock();
+	}
+	const body = new Uint8Array(bytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(new TextDecoder().decode(body));
+	} catch {
+		throw new CodexCompactionProtocolError("Responses Compact returned malformed JSON");
+	}
+	return validateCompactedResponse(parsed, options);
+}
+
 function markerTextFromItem(item: unknown): string | undefined {
 	if (!isObject(item) || item.role !== "user" || !Array.isArray(item.content)) return undefined;
 	if (item.content.length !== 1) return undefined;
@@ -205,14 +322,24 @@ export function appendCompactionTrigger(payload: unknown): JsonObject {
 	return { ...payload, input: [...payload.input, { type: "compaction_trigger" }] };
 }
 
+export function expandRemoteCompactionPayload(
+	payload: unknown,
+	checkpoint?: { marker: string; replacementHistory: readonly unknown[] },
+): JsonObject {
+	if (checkpoint) {
+		return rewriteCheckpointMarker(payload, checkpoint.marker, checkpoint.replacementHistory);
+	}
+	if (!isObject(payload) || !Array.isArray(payload.input)) {
+		throw new CodexCompactionProtocolError("Responses payload is missing an input array");
+	}
+	return structuredClone(payload);
+}
+
 export function prepareRemoteCompactionPayload(
 	payload: unknown,
 	checkpoint?: { marker: string; replacementHistory: readonly unknown[] },
 ): JsonObject {
-	const expanded = checkpoint
-		? rewriteCheckpointMarker(payload, checkpoint.marker, checkpoint.replacementHistory)
-		: payload;
-	return appendCompactionTrigger(expanded);
+	return appendCompactionTrigger(expandRemoteCompactionPayload(payload, checkpoint));
 }
 
 export function hasCheckpointMarker(payload: unknown, marker: string): boolean {

--- a/packages/pi-codex-compact/src/protocol.ts
+++ b/packages/pi-codex-compact/src/protocol.ts
@@ -252,7 +252,11 @@ export async function collectCompactResponse(
 	const maxBytes = options.maxBytes ?? MAX_COMPACT_JSON_BYTES;
 	const declaredLength = Number(response.headers.get("content-length"));
 	if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-		throw new CodexCompactionProtocolError("Responses Compact response exceeded the size limit");
+		const error = new CodexCompactionProtocolError(
+			"Responses Compact response exceeded the size limit",
+		);
+		await response.body?.cancel(error).catch(() => undefined);
+		throw error;
 	}
 	if (!response.body) {
 		throw new CodexCompactionProtocolError("Responses Compact response did not contain a body");

--- a/packages/pi-codex-compact/src/protocol.ts
+++ b/packages/pi-codex-compact/src/protocol.ts
@@ -163,15 +163,42 @@ export async function collectCompactionSse(
 	return { item: [...items.values()][0], completedResponse };
 }
 
+function isRetainedCompactContent(value: unknown): value is JsonObject {
+	if (!isObject(value)) return false;
+	if (value.type === "input_text") return typeof value.text === "string";
+	if (value.type !== "input_image") return false;
+	if (
+		value.detail !== undefined &&
+		value.detail !== null &&
+		value.detail !== "auto" &&
+		value.detail !== "low" &&
+		value.detail !== "high" &&
+		value.detail !== "original"
+	) {
+		return false;
+	}
+	if (
+		(value.file_id !== undefined && value.file_id !== null && typeof value.file_id !== "string") ||
+		(value.image_url !== undefined &&
+			value.image_url !== null &&
+			typeof value.image_url !== "string")
+	) {
+		return false;
+	}
+	return (
+		(typeof value.file_id === "string" && value.file_id.length > 0) ||
+		(typeof value.image_url === "string" && value.image_url.length > 0)
+	);
+}
+
 function isRetainedCompactMessage(value: unknown): value is JsonObject {
 	return (
 		isObject(value) &&
 		value.role === "user" &&
 		(value.type === undefined || value.type === "message") &&
 		Array.isArray(value.content) &&
-		value.content.every(
-			(part) => isObject(part) && (part.type === "input_text" || part.type === "input_image"),
-		)
+		value.content.length > 0 &&
+		value.content.every(isRetainedCompactContent)
 	);
 }
 

--- a/packages/pi-codex-compact/src/remote-compact.ts
+++ b/packages/pi-codex-compact/src/remote-compact.ts
@@ -85,6 +85,17 @@ function mergedHeaders(input: string | URL | Request, init?: RequestInit): Heade
 	return headers;
 }
 
+function mergedSignal(
+	input: string | URL | Request,
+	init: RequestInit | undefined,
+	ownerSignal: AbortSignal,
+): AbortSignal {
+	const signals = [ownerSignal];
+	if (input instanceof Request) signals.push(input.signal);
+	if (init?.signal) signals.push(init.signal);
+	return signals.length === 1 ? ownerSignal : AbortSignal.any(signals);
+}
+
 function nonRetryableBridgeFailure(error: unknown): Response {
 	const message = error instanceof Error ? error.message : String(error);
 	return Response.json(
@@ -204,17 +215,17 @@ export async function requestResponsesCompact(
 			bridgeError = error;
 			return nonRetryableBridgeFailure(error);
 		}
+		const signal = mergedSignal(input, init, request.signal);
 		const response = await baseFetch(compactUrl, {
 			...init,
 			method: "POST",
 			headers: mergedHeaders(input, init),
 			body: JSON.stringify(preparedPayload),
+			signal,
 		});
 		if (!response.ok) return response;
 		try {
-			const result = await collectCompactResponse(response, {
-				signal: init?.signal ?? request.signal,
-			});
+			const result = await collectCompactResponse(response, { signal });
 			successfulResponses += 1;
 			if (successfulResponses !== 1) {
 				throw new CodexCompactionProtocolError(

--- a/packages/pi-codex-compact/src/remote-compact.ts
+++ b/packages/pi-codex-compact/src/remote-compact.ts
@@ -192,6 +192,7 @@ export async function requestResponsesCompact(
 	let sentInput: JsonObject[] | undefined;
 	let compactResult: CollectedCompactResponse | undefined;
 	let bridgeError: unknown;
+	let dispatchInFlight = false;
 	let successfulResponses = 0;
 	const baseFetch = request.fetch ?? globalThis.fetch;
 	const bridgeFetch: typeof globalThis.fetch = async (input, init) => {
@@ -199,6 +200,12 @@ export async function requestResponsesCompact(
 		if (successfulResponses > 0) {
 			bridgeError = new CodexCompactionProtocolError(
 				"Provider dispatched again after Responses Compact succeeded",
+			);
+			return nonRetryableBridgeFailure(bridgeError);
+		}
+		if (dispatchInFlight) {
+			bridgeError = new CodexCompactionProtocolError(
+				"Provider dispatched overlapping Responses Compact requests",
 			);
 			return nonRetryableBridgeFailure(bridgeError);
 		}
@@ -216,27 +223,32 @@ export async function requestResponsesCompact(
 			return nonRetryableBridgeFailure(error);
 		}
 		const signal = mergedSignal(input, init, request.signal);
-		const response = await baseFetch(compactUrl, {
-			...init,
-			method: "POST",
-			headers: mergedHeaders(input, init),
-			body: JSON.stringify(preparedPayload),
-			signal,
-		});
-		if (!response.ok) return response;
+		dispatchInFlight = true;
 		try {
-			const result = await collectCompactResponse(response, { signal });
-			successfulResponses += 1;
-			if (successfulResponses !== 1) {
-				throw new CodexCompactionProtocolError(
-					"Provider returned more than one successful Responses Compact response",
-				);
+			const response = await baseFetch(compactUrl, {
+				...init,
+				method: "POST",
+				headers: mergedHeaders(input, init),
+				body: JSON.stringify(preparedPayload),
+				signal,
+			});
+			if (!response.ok) return response;
+			try {
+				const result = await collectCompactResponse(response, { signal });
+				successfulResponses += 1;
+				if (successfulResponses !== 1) {
+					throw new CodexCompactionProtocolError(
+						"Provider returned more than one successful Responses Compact response",
+					);
+				}
+				compactResult = result;
+				return syntheticCompletion(result, preparedPayload);
+			} catch (error) {
+				bridgeError = error;
+				return nonRetryableBridgeFailure(error);
 			}
-			compactResult = result;
-			return syntheticCompletion(result, preparedPayload);
-		} catch (error) {
-			bridgeError = error;
-			return nonRetryableBridgeFailure(error);
+		} finally {
+			dispatchInFlight = false;
 		}
 	};
 

--- a/packages/pi-codex-compact/src/remote-compact.ts
+++ b/packages/pi-codex-compact/src/remote-compact.ts
@@ -1,0 +1,275 @@
+import type { Usage } from "@earendil-works/pi-ai";
+import type { ResponsesCompactionApi } from "./model-api.js";
+import {
+	CodexCompactionProtocolError,
+	type CollectedCompactResponse,
+	collectCompactResponse,
+	expandRemoteCompactionPayload,
+	type JsonObject,
+} from "./protocol.js";
+import { collectProviderUsage } from "./remote-shared.js";
+import {
+	abortError,
+	assertPreparedInput,
+	isJsonObject,
+	type RemoteCompactionRequest,
+	type RemoteCompactionResponse,
+} from "./remote-types.js";
+
+const OFFICIAL_COMPACT_FIELDS = [
+	"model",
+	"input",
+	"instructions",
+	"previous_response_id",
+	"prompt_cache_key",
+	"prompt_cache_retention",
+	"service_tier",
+] as const;
+
+const CODEX_COMPACT_FIELDS = [
+	"model",
+	"input",
+	"instructions",
+	"tools",
+	"parallel_tool_calls",
+	"reasoning",
+	"service_tier",
+	"prompt_cache_key",
+	"text",
+	"access_programs",
+] as const;
+
+function compactPayload(payload: JsonObject, api: ResponsesCompactionApi): JsonObject {
+	const fields = api === "openai-codex-responses" ? CODEX_COMPACT_FIELDS : OFFICIAL_COMPACT_FIELDS;
+	const result: JsonObject = {};
+	for (const field of fields) {
+		if (Object.hasOwn(payload, field) && payload[field] !== undefined) {
+			result[field] = structuredClone(payload[field]);
+		}
+	}
+	if (typeof result.model !== "string" || result.model.length === 0) {
+		throw new CodexCompactionProtocolError("Responses payload is missing a model");
+	}
+	assertPreparedInput(result);
+	return result;
+}
+
+function requestUrl(input: string | URL | Request): URL {
+	return new URL(input instanceof Request ? input.url : String(input));
+}
+
+export function responsesCompactUrl(input: string | URL | Request): URL {
+	const original = requestUrl(input);
+	if (!original.pathname.endsWith("/responses")) {
+		throw new CodexCompactionProtocolError(
+			"Provider request URL does not end with the Responses endpoint",
+		);
+	}
+	const compact = new URL(original);
+	compact.pathname = `${compact.pathname}/compact`;
+	if (compact.origin !== original.origin) {
+		throw new CodexCompactionProtocolError("Responses Compact URL changed origin");
+	}
+	return compact;
+}
+
+function mergedHeaders(input: string | URL | Request, init?: RequestInit): Headers {
+	const headers = new Headers(input instanceof Request ? input.headers : undefined);
+	new Headers(init?.headers).forEach((value, name) => {
+		headers.set(name, value);
+	});
+	headers.delete("content-encoding");
+	headers.delete("content-length");
+	headers.set("accept", "application/json");
+	headers.set("content-type", "application/json");
+	return headers;
+}
+
+function nonRetryableBridgeFailure(error: unknown): Response {
+	const message = error instanceof Error ? error.message : String(error);
+	return Response.json(
+		{
+			error: {
+				message,
+				type: "invalid_request_error",
+				code: "invalid_compact_response",
+			},
+		},
+		{ status: 400 },
+	);
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function optionalUsageDetail(details: unknown, field: string): number {
+	if (details === undefined || details === null) return 0;
+	if (!isJsonObject(details)) {
+		throw new CodexCompactionProtocolError("Responses Compact response has invalid usage details");
+	}
+	const value = details[field];
+	if (value === undefined || value === null) return 0;
+	if (!nonNegativeInteger(value)) {
+		throw new CodexCompactionProtocolError(
+			`Responses Compact response has invalid usage detail ${field}`,
+		);
+	}
+	return value;
+}
+
+function validatedUsage(response: JsonObject): JsonObject {
+	const usage = response.usage;
+	if (!isJsonObject(usage)) {
+		throw new CodexCompactionProtocolError("Responses Compact response is missing usage");
+	}
+	for (const field of ["input_tokens", "output_tokens", "total_tokens"] as const) {
+		if (!nonNegativeInteger(usage[field])) {
+			throw new CodexCompactionProtocolError(`Responses Compact response has invalid ${field}`);
+		}
+	}
+	const inputTokens = usage.input_tokens as number;
+	const outputTokens = usage.output_tokens as number;
+	const totalTokens = usage.total_tokens as number;
+	const cachedTokens = optionalUsageDetail(usage.input_tokens_details, "cached_tokens");
+	const cacheWriteTokens = optionalUsageDetail(usage.input_tokens_details, "cache_write_tokens");
+	const reasoningTokens = optionalUsageDetail(usage.output_tokens_details, "reasoning_tokens");
+	if (cachedTokens + cacheWriteTokens > inputTokens || reasoningTokens > outputTokens) {
+		throw new CodexCompactionProtocolError(
+			"Responses Compact response has inconsistent usage details",
+		);
+	}
+	if (totalTokens !== inputTokens + outputTokens) {
+		throw new CodexCompactionProtocolError(
+			"Responses Compact response has inconsistent total usage",
+		);
+	}
+	return structuredClone(usage);
+}
+
+function syntheticCompletion(result: CollectedCompactResponse, payload: JsonObject): Response {
+	const completed = {
+		id: typeof result.response.id === "string" ? result.response.id : "resp_pi_compact_bridge",
+		object: "response",
+		created_at:
+			typeof result.response.created_at === "number"
+				? result.response.created_at
+				: Math.floor(Date.now() / 1000),
+		status: "completed",
+		model: payload.model,
+		output: [],
+		parallel_tool_calls: false,
+		tool_choice: "auto",
+		tools: [],
+		usage: validatedUsage(result.response),
+	};
+	const events = [
+		{ type: "response.created", response: { ...completed, status: "in_progress" } },
+		{ type: "response.completed", response: completed },
+	];
+	return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+export async function requestResponsesCompact(
+	request: RemoteCompactionRequest,
+): Promise<RemoteCompactionResponse> {
+	if (request.signal.aborted) throw abortError();
+	let preparedPayload: JsonObject | undefined;
+	let sentInput: JsonObject[] | undefined;
+	let compactResult: CollectedCompactResponse | undefined;
+	let bridgeError: unknown;
+	let successfulResponses = 0;
+	const baseFetch = request.fetch ?? globalThis.fetch;
+	const bridgeFetch: typeof globalThis.fetch = async (input, init) => {
+		if (request.signal.aborted) throw abortError();
+		if (successfulResponses > 0) {
+			bridgeError = new CodexCompactionProtocolError(
+				"Provider dispatched again after Responses Compact succeeded",
+			);
+			return nonRetryableBridgeFailure(bridgeError);
+		}
+		if (!preparedPayload) {
+			bridgeError = new CodexCompactionProtocolError(
+				"Provider dispatched before exposing its request payload",
+			);
+			return nonRetryableBridgeFailure(bridgeError);
+		}
+		let compactUrl: URL;
+		try {
+			compactUrl = responsesCompactUrl(input);
+		} catch (error) {
+			bridgeError = error;
+			return nonRetryableBridgeFailure(error);
+		}
+		const response = await baseFetch(compactUrl, {
+			...init,
+			method: "POST",
+			headers: mergedHeaders(input, init),
+			body: JSON.stringify(preparedPayload),
+		});
+		if (!response.ok) return response;
+		try {
+			const result = await collectCompactResponse(response, {
+				signal: init?.signal ?? request.signal,
+			});
+			successfulResponses += 1;
+			if (successfulResponses !== 1) {
+				throw new CodexCompactionProtocolError(
+					"Provider returned more than one successful Responses Compact response",
+				);
+			}
+			compactResult = result;
+			return syntheticCompletion(result, preparedPayload);
+		} catch (error) {
+			bridgeError = error;
+			return nonRetryableBridgeFailure(error);
+		}
+	};
+
+	const stream = request.provider.stream(request.model, request.context, {
+		apiKey: request.apiKey,
+		headers: request.headers,
+		env: request.env,
+		signal: request.signal,
+		transport: "sse",
+		cacheRetention: "none",
+		timeoutMs: request.requestTimeoutMs ?? 5 * 60 * 1000,
+		maxRetries: request.maxRetries ?? 2,
+		fetch: bridgeFetch,
+		onPayload: (payload) => {
+			if (preparedPayload) {
+				throw new CodexCompactionProtocolError(
+					"Provider exposed more than one compaction request payload",
+				);
+			}
+			const expanded = expandRemoteCompactionPayload(payload, request.priorCheckpoint);
+			preparedPayload = compactPayload(expanded, request.model.api);
+			sentInput = assertPreparedInput(preparedPayload);
+			return expanded;
+		},
+	});
+
+	let usage: Usage;
+	try {
+		usage = await collectProviderUsage(stream, request.signal);
+	} catch (error) {
+		if (bridgeError) throw bridgeError;
+		throw error;
+	}
+	if (request.signal.aborted) throw abortError();
+	if (bridgeError) throw bridgeError;
+	if (!preparedPayload || !sentInput || !compactResult || successfulResponses !== 1) {
+		throw new CodexCompactionProtocolError(
+			"Provider did not complete exactly one Responses Compact request",
+		);
+	}
+	return {
+		item: compactResult.item,
+		promptInput: sentInput,
+		compactedOutput: compactResult.output,
+		usage,
+	};
+}

--- a/packages/pi-codex-compact/src/remote-shared.ts
+++ b/packages/pi-codex-compact/src/remote-shared.ts
@@ -1,0 +1,19 @@
+import type { AssistantMessageEventStream, Usage } from "@earendil-works/pi-ai";
+import { abortError } from "./remote-types.js";
+
+export async function collectProviderUsage(
+	stream: AssistantMessageEventStream,
+	signal: AbortSignal,
+): Promise<Usage> {
+	let usage: Usage | undefined;
+	for await (const event of stream) {
+		if (signal.aborted) throw abortError();
+		if (event.type === "error") {
+			throw new Error(event.error.errorMessage ?? "Responses compaction request failed");
+		}
+		if (event.type === "done") usage = event.message.usage;
+	}
+	if (signal.aborted) throw abortError();
+	if (!usage) throw new Error("Responses provider stream ended without completion usage");
+	return usage;
+}

--- a/packages/pi-codex-compact/src/remote-types.ts
+++ b/packages/pi-codex-compact/src/remote-types.ts
@@ -1,0 +1,45 @@
+import type { Context, Model, Provider, ProviderHeaders, Usage } from "@earendil-works/pi-ai";
+import type { RemoteCompactionProtocol, ResponsesCompactionApi } from "./model-api.js";
+import type { JsonObject } from "./protocol.js";
+
+export interface PriorCheckpointPayload {
+	marker: string;
+	replacementHistory: readonly unknown[];
+}
+
+export interface RemoteCompactionRequest {
+	provider: Provider;
+	model: Model<ResponsesCompactionApi>;
+	context: Context;
+	protocol: RemoteCompactionProtocol;
+	apiKey?: string;
+	headers?: ProviderHeaders;
+	env?: Record<string, string>;
+	signal: AbortSignal;
+	priorCheckpoint?: PriorCheckpointPayload;
+	requestTimeoutMs?: number;
+	maxRetries?: number;
+	fetch?: typeof globalThis.fetch;
+}
+
+export interface RemoteCompactionResponse {
+	item: JsonObject;
+	promptInput: JsonObject[];
+	compactedOutput?: JsonObject[];
+	usage: Usage;
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function abortError(): DOMException {
+	return new DOMException("Compaction aborted", "AbortError");
+}
+
+export function assertPreparedInput(payload: JsonObject): JsonObject[] {
+	if (!Array.isArray(payload.input) || !payload.input.every(isJsonObject)) {
+		throw new Error("Prepared compaction payload has invalid input items");
+	}
+	return structuredClone(payload.input);
+}

--- a/packages/pi-codex-compact/src/remote-v2.ts
+++ b/packages/pi-codex-compact/src/remote-v2.ts
@@ -1,0 +1,70 @@
+import {
+	CodexCompactionProtocolError,
+	type CollectedCompaction,
+	collectCompactionSse,
+	prepareRemoteCompactionPayload,
+} from "./protocol.js";
+import { collectProviderUsage } from "./remote-shared.js";
+import {
+	abortError,
+	assertPreparedInput,
+	type RemoteCompactionRequest,
+	type RemoteCompactionResponse,
+} from "./remote-types.js";
+
+export async function requestRemoteCompactionV2(
+	request: RemoteCompactionRequest,
+): Promise<RemoteCompactionResponse> {
+	if (request.signal.aborted) throw abortError();
+	let sentInput: ReturnType<typeof assertPreparedInput> | undefined;
+	const inspections: Promise<
+		{ ok: true; value: CollectedCompaction } | { ok: false; error: unknown }
+	>[] = [];
+	const baseFetch = request.fetch ?? globalThis.fetch;
+	const inspectedFetch: typeof globalThis.fetch = async (input, init) => {
+		const response = await baseFetch(input, init);
+		if (!response.ok || !response.body) return response;
+		const [providerBody, inspectionBody] = response.body.tee();
+		const inspection = collectCompactionSse(inspectionBody, { signal: request.signal }).then(
+			(value) => ({ ok: true as const, value }),
+			(error: unknown) => ({ ok: false as const, error }),
+		);
+		inspections.push(inspection);
+		return new Response(providerBody, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	};
+
+	const stream = request.provider.stream(request.model, request.context, {
+		apiKey: request.apiKey,
+		headers: request.headers,
+		env: request.env,
+		signal: request.signal,
+		transport: "sse",
+		cacheRetention: "none",
+		timeoutMs: request.requestTimeoutMs ?? 5 * 60 * 1000,
+		maxRetries: request.maxRetries ?? 2,
+		fetch: inspectedFetch,
+		onPayload: (payload) => {
+			const prepared = prepareRemoteCompactionPayload(payload, request.priorCheckpoint);
+			sentInput = assertPreparedInput(prepared).slice(0, -1);
+			return prepared;
+		},
+	});
+
+	const usage = await collectProviderUsage(stream, request.signal);
+	if (!sentInput) {
+		throw new CodexCompactionProtocolError("Provider did not expose a request payload");
+	}
+	if (inspections.length !== 1) {
+		throw new CodexCompactionProtocolError(
+			`Provider exposed ${inspections.length} successful SSE responses; expected exactly one`,
+		);
+	}
+	const inspection = await inspections[0];
+	if (request.signal.aborted) throw abortError();
+	if (!inspection.ok) throw inspection.error;
+	return { item: inspection.value.item, promptInput: sentInput, usage };
+}

--- a/packages/pi-codex-compact/src/remote.ts
+++ b/packages/pi-codex-compact/src/remote.ts
@@ -1,117 +1,17 @@
-import type { Context, Model, Provider, ProviderHeaders, Usage } from "@earendil-works/pi-ai";
-import {
-	CodexCompactionProtocolError,
-	type CollectedCompaction,
-	collectCompactionSse,
-	type JsonObject,
-	prepareRemoteCompactionPayload,
-} from "./protocol.js";
+import { requestResponsesCompact } from "./remote-compact.js";
+import type { RemoteCompactionRequest, RemoteCompactionResponse } from "./remote-types.js";
+import { requestRemoteCompactionV2 } from "./remote-v2.js";
 
-interface PriorCheckpointPayload {
-	marker: string;
-	replacementHistory: readonly unknown[];
-}
+export type {
+	PriorCheckpointPayload,
+	RemoteCompactionRequest,
+	RemoteCompactionResponse,
+} from "./remote-types.js";
 
-export interface RemoteCompactionRequest {
-	provider: Provider;
-	model: Model<"openai-codex-responses">;
-	context: Context;
-	apiKey?: string;
-	headers?: ProviderHeaders;
-	env?: Record<string, string>;
-	signal: AbortSignal;
-	priorCheckpoint?: PriorCheckpointPayload;
-	requestTimeoutMs?: number;
-	maxRetries?: number;
-	fetch?: typeof globalThis.fetch;
-}
-
-export interface RemoteCompactionResponse {
-	item: JsonObject;
-	promptInput: JsonObject[];
-	usage: Usage;
-}
-
-const EMPTY_USAGE: Usage = {
-	input: 0,
-	output: 0,
-	cacheRead: 0,
-	cacheWrite: 0,
-	totalTokens: 0,
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
-
-function isObject(value: unknown): value is JsonObject {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function abortError(): DOMException {
-	return new DOMException("Compaction aborted", "AbortError");
-}
-
-export async function requestRemoteCompaction(
+export function requestRemoteCompaction(
 	request: RemoteCompactionRequest,
 ): Promise<RemoteCompactionResponse> {
-	if (request.signal.aborted) throw abortError();
-	let sentInput: JsonObject[] | undefined;
-	const inspections: Promise<
-		{ ok: true; value: CollectedCompaction } | { ok: false; error: unknown }
-	>[] = [];
-	const baseFetch = request.fetch ?? globalThis.fetch;
-	const inspectedFetch: typeof globalThis.fetch = async (input, init) => {
-		const response = await baseFetch(input, init);
-		if (!response.ok || !response.body) return response;
-		const [providerBody, inspectionBody] = response.body.tee();
-		const inspection = collectCompactionSse(inspectionBody, { signal: request.signal }).then(
-			(value) => ({ ok: true as const, value }),
-			(error: unknown) => ({ ok: false as const, error }),
-		);
-		inspections.push(inspection);
-		return new Response(providerBody, {
-			status: response.status,
-			statusText: response.statusText,
-			headers: response.headers,
-		});
-	};
-
-	const stream = request.provider.stream(request.model, request.context, {
-		apiKey: request.apiKey,
-		headers: request.headers,
-		env: request.env,
-		signal: request.signal,
-		transport: "sse",
-		cacheRetention: "none",
-		timeoutMs: request.requestTimeoutMs ?? 5 * 60 * 1000,
-		maxRetries: request.maxRetries ?? 2,
-		fetch: inspectedFetch,
-		onPayload: (payload) => {
-			const prepared = prepareRemoteCompactionPayload(payload, request.priorCheckpoint);
-			if (!Array.isArray(prepared.input) || !prepared.input.every(isObject)) {
-				throw new CodexCompactionProtocolError(
-					"Prepared compaction payload has invalid input items",
-				);
-			}
-			sentInput = structuredClone(prepared.input.slice(0, -1)) as JsonObject[];
-			return prepared;
-		},
-	});
-
-	let usage = EMPTY_USAGE;
-	for await (const event of stream) {
-		if (request.signal.aborted) throw abortError();
-		if (event.type === "error") {
-			throw new Error(event.error.errorMessage ?? "Codex remote compaction request failed");
-		}
-		if (event.type === "done") usage = event.message.usage;
-	}
-	if (request.signal.aborted) throw abortError();
-	if (!sentInput)
-		throw new CodexCompactionProtocolError("Provider did not expose a request payload");
-	if (inspections.length === 0) {
-		throw new CodexCompactionProtocolError("Provider response did not expose an SSE body");
-	}
-	const inspection = await inspections.at(-1);
-	if (request.signal.aborted) throw abortError();
-	if (!inspection?.ok) throw inspection?.error ?? new Error("Remote compaction inspection failed");
-	return { item: inspection.value.item, promptInput: sentInput, usage };
+	return request.protocol === "responses-compact"
+		? requestResponsesCompact(request)
+		: requestRemoteCompactionV2(request);
 }

--- a/packages/pi-codex-compact/src/settings-menu.ts
+++ b/packages/pi-codex-compact/src/settings-menu.ts
@@ -218,14 +218,12 @@ export async function showCodexCompactMenu(
 	ctx: ExtensionCommandContext,
 	owner: SettingsMenuOwner,
 ): Promise<void> {
-	if (ctx.mode !== "tui") {
-		if (ctx.mode === "rpc" && ctx.hasUI) {
-			ctx.ui.notify(
-				`Edit Responses compaction settings at ${safeText(runtime.get().path)}.`,
-				"info",
-			);
-		}
+	if (ctx.mode === "rpc" && ctx.hasUI) {
+		ctx.ui.notify(`Edit Responses compaction settings at ${safeText(runtime.get().path)}.`, "info");
 		return;
+	}
+	if (ctx.mode !== "tui") {
+		throw new Error("/codex-compact requires TUI or RPC UI support");
 	}
 	const { runMenu } = await import("@narumitw/pi-tui-kit");
 	if (owner.signal.aborted || !owner.isCurrent()) return;

--- a/packages/pi-codex-compact/src/settings-menu.ts
+++ b/packages/pi-codex-compact/src/settings-menu.ts
@@ -1,16 +1,19 @@
+import type { Api } from "@earendil-works/pi-ai";
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { MenuDefinition } from "@narumitw/pi-tui-kit";
-import { usesCodexResponsesApi } from "./model-api.js";
+import { resolveCompactionRouteForApi } from "./model-api.js";
 import type {
 	CodexCompactSettings,
 	CodexCompactSettingsRuntime,
 	CodexCompactSettingsState,
 } from "./settings.js";
+import { terminalText as safeText } from "./terminal.js";
 
 type Screen = "main" | "settings" | "invalid";
 type Action =
 	| "compact-now"
 	| "set-enabled"
+	| "set-protocol"
 	| "set-timeout"
 	| "set-retries"
 	| "set-retention"
@@ -23,14 +26,7 @@ export interface SettingsMenuOwner {
 
 interface CompactMenuStatus {
 	model: string;
-	remoteEligible: boolean;
-}
-
-function safeText(value: string): string {
-	return Array.from(value, (character) => {
-		const codePoint = character.codePointAt(0) ?? 0;
-		return codePoint < 32 || (codePoint >= 127 && codePoint <= 159) ? " " : character;
-	}).join("");
+	api?: Api;
 }
 
 function timeoutLabel(milliseconds: number): string {
@@ -41,6 +37,17 @@ function retentionLabel(tokens: number): string {
 	return `${tokens / 1000}K tokens`;
 }
 
+function protocolLabel(protocol: CodexCompactSettings["protocol"]): string {
+	switch (protocol) {
+		case "auto":
+			return "Auto";
+		case "remote-v2":
+			return "Remote V2";
+		case "responses-compact":
+			return "Responses Compact";
+	}
+}
+
 async function update(
 	runtime: CodexCompactSettingsRuntime,
 	ctx: ExtensionCommandContext,
@@ -49,7 +56,8 @@ async function update(
 ) {
 	try {
 		await runtime.update(patch, signal);
-		ctx.ui.notify("Codex compaction settings saved.", "info");
+		if (signal.aborted) return { kind: "rejected" as const };
+		ctx.ui.notify("Responses compaction settings saved.", "info");
 		return { kind: "stay" as const };
 	} catch (error) {
 		if (signal.aborted) return { kind: "rejected" as const };
@@ -70,9 +78,10 @@ export function createCodexCompactMenu(
 		screens: {
 			main: ({ state }) => ({
 				kind: "actions",
-				title: "Codex Remote Compaction",
+				title: "Responses Compaction",
 				lines: [
-					`Remote V2: ${state.settings.enabled ? "On" : "Off"}`,
+					`Remote compaction: ${state.settings.enabled ? "On" : "Off"}`,
+					`Protocol setting: ${protocolLabel(state.settings.protocol)}`,
 					`Active model: ${safeText(options.status?.model ?? "none")}`,
 					`Compact route: ${safeText(compactRoute(state, options.status))}`,
 				],
@@ -97,16 +106,24 @@ export function createCodexCompactMenu(
 			}),
 			settings: ({ state }) => ({
 				kind: "settings",
-				title: "Codex Remote Compaction Settings",
+				title: "Responses Compaction Settings",
 				lines: [`User settings · ${safeText(state.path)}`],
 				items: [
 					{
 						id: "enabled",
 						label: "Remote compaction",
-						description: "Use Codex Remote V2 when the model uses openai-codex-responses.",
+						description: "Use a supported Responses compaction protocol.",
 						currentValue: state.settings.enabled ? "On" : "Off",
 						values: ["On", "Off"],
 						action: "set-enabled",
+					},
+					{
+						id: "protocol",
+						label: "Protocol",
+						description: "Choose automatically or force one supported remote protocol.",
+						currentValue: protocolLabel(state.settings.protocol),
+						values: ["Auto", "Remote V2", "Responses Compact"],
+						action: "set-protocol",
 					},
 					{
 						id: "requestTimeoutMs",
@@ -135,7 +152,7 @@ export function createCodexCompactMenu(
 					{
 						id: "notifyOnFallback",
 						label: "Fallback notifications",
-						description: "Warn when Remote V2 fails and native Pi compaction takes over.",
+						description: "Warn when remote compaction fails and Pi native takes over.",
 						currentValue: state.settings.notifyOnFallback ? "On" : "Off",
 						values: ["On", "Off"],
 						action: "set-notify",
@@ -160,6 +177,20 @@ export function createCodexCompactMenu(
 			},
 			"set-enabled": ({ ctx, value, signal }) =>
 				update(runtime, ctx, { enabled: value === "On" }, signal),
+			"set-protocol": ({ ctx, value, signal }) =>
+				update(
+					runtime,
+					ctx,
+					{
+						protocol:
+							value === "Remote V2"
+								? "remote-v2"
+								: value === "Responses Compact"
+									? "responses-compact"
+									: "auto",
+					},
+					signal,
+				),
 			"set-timeout": ({ ctx, value, signal }) =>
 				update(
 					runtime,
@@ -188,7 +219,12 @@ export async function showCodexCompactMenu(
 	owner: SettingsMenuOwner,
 ): Promise<void> {
 	if (ctx.mode !== "tui") {
-		ctx.ui.notify(`Edit Codex compaction settings at ${safeText(runtime.get().path)}.`, "info");
+		if (ctx.mode === "rpc" && ctx.hasUI) {
+			ctx.ui.notify(
+				`Edit Responses compaction settings at ${safeText(runtime.get().path)}.`,
+				"info",
+			);
+		}
 		return;
 	}
 	const { runMenu } = await import("@narumitw/pi-tui-kit");
@@ -222,7 +258,7 @@ export function compactMenuStatus(ctx: ExtensionCommandContext): CompactMenuStat
 	const model = ctx.model;
 	return {
 		model: model ? `${model.provider}/${model.id}` : "none",
-		remoteEligible: usesCodexResponsesApi(model),
+		api: model?.api,
 	};
 }
 
@@ -230,6 +266,7 @@ function compactRoute(
 	state: Readonly<CodexCompactSettingsState>,
 	status: CompactMenuStatus | undefined,
 ): string {
-	if (!state.settings.enabled) return "Pi native (Remote V2 off)";
-	return status?.remoteEligible ? "Codex Remote V2" : "Pi native (requires openai-codex-responses)";
+	const route = resolveCompactionRouteForApi(status?.api, state.settings);
+	if (route.kind === "native") return `Pi native (${route.reason})`;
+	return route.protocol === "remote-v2" ? "Responses Remote V2" : "Responses Compact API";
 }

--- a/packages/pi-codex-compact/src/settings.ts
+++ b/packages/pi-codex-compact/src/settings.ts
@@ -3,12 +3,14 @@ import { constants } from "node:fs";
 import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { RemoteCompactionProtocolSetting } from "./model-api.js";
 
 export const CODEX_COMPACT_SETTINGS_FILE = "pi-codex-compact.json";
 export const MAX_SETTINGS_BYTES = 64 * 1024;
 
 export interface CodexCompactSettings {
 	enabled: boolean;
+	protocol: RemoteCompactionProtocolSetting;
 	requestTimeoutMs: number;
 	maxRetries: number;
 	replacementTokenBudget: number;
@@ -17,6 +19,7 @@ export interface CodexCompactSettings {
 
 export const DEFAULT_CODEX_COMPACT_SETTINGS: Readonly<CodexCompactSettings> = Object.freeze({
 	enabled: true,
+	protocol: "auto",
 	requestTimeoutMs: 300_000,
 	maxRetries: 2,
 	replacementTokenBudget: 64_000,
@@ -60,6 +63,14 @@ function validInteger(value: unknown, minimum: number, maximum: number): value i
 export function normalizeCodexCompactSettings(value: unknown): CodexCompactSettings | undefined {
 	if (!isRecord(value)) return undefined;
 	if (Object.hasOwn(value, "enabled") && typeof value.enabled !== "boolean") return undefined;
+	if (
+		Object.hasOwn(value, "protocol") &&
+		value.protocol !== "auto" &&
+		value.protocol !== "remote-v2" &&
+		value.protocol !== "responses-compact"
+	) {
+		return undefined;
+	}
 	if (Object.hasOwn(value, "notifyOnFallback") && typeof value.notifyOnFallback !== "boolean") {
 		return undefined;
 	}
@@ -76,6 +87,10 @@ export function normalizeCodexCompactSettings(value: unknown): CodexCompactSetti
 	return {
 		enabled:
 			typeof value.enabled === "boolean" ? value.enabled : DEFAULT_CODEX_COMPACT_SETTINGS.enabled,
+		protocol:
+			value.protocol === "remote-v2" || value.protocol === "responses-compact"
+				? value.protocol
+				: DEFAULT_CODEX_COMPACT_SETTINGS.protocol,
 		requestTimeoutMs:
 			typeof value.requestTimeoutMs === "number"
 				? value.requestTimeoutMs

--- a/packages/pi-codex-compact/src/terminal.ts
+++ b/packages/pi-codex-compact/src/terminal.ts
@@ -1,0 +1,6 @@
+export function terminalText(value: string): string {
+	return Array.from(value, (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return codePoint < 32 || (codePoint >= 127 && codePoint <= 159) ? " " : character;
+	}).join("");
+}

--- a/packages/pi-codex-compact/test/checkpoint.test.ts
+++ b/packages/pi-codex-compact/test/checkpoint.test.ts
@@ -34,7 +34,9 @@ function checkpoint(
 ) {
 	return createCheckpointDetails({
 		provider,
+		api: "openai-codex-responses",
 		modelId: "gpt-5.6",
+		protocol: "remote-v2",
 		replacementHistory: [rawUser("old"), opaque],
 		keptMessages: kept,
 		checkpointId: id,
@@ -136,11 +138,30 @@ test("validates versioned details and rejects malformed or unbounded persisted d
 	const customProvider = checkpoint([], "checkpoint-custom", "company-codex-proxy");
 	assert.deepEqual(parseCheckpointDetails(details), details);
 	assert.deepEqual(parseCheckpointDetails(customProvider), customProvider);
-	assert.equal(parseCheckpointDetails({ ...details, version: 2 }), undefined);
+	assert.deepEqual(
+		parseCheckpointDetails({
+			...details,
+			version: 1,
+			protocol: "remote-compaction-v2",
+		}),
+		details,
+	);
+	assert.equal(parseCheckpointDetails({ ...details, version: 3 }), undefined);
+	assert.equal(parseCheckpointDetails({ ...details, checkpointId: "x".repeat(129) }), undefined);
 	assert.equal(parseCheckpointDetails({ ...details, provider: "" }), undefined);
 	assert.equal(parseCheckpointDetails({ ...details, provider: "x".repeat(257) }), undefined);
+	assert.equal(parseCheckpointDetails({ ...details, modelId: "" }), undefined);
+	assert.equal(parseCheckpointDetails({ ...details, modelId: "x".repeat(513) }), undefined);
 	assert.equal(parseCheckpointDetails({ ...details, replacementHistory: [] }), undefined);
 	assert.equal(parseCheckpointDetails({ ...details, keptMessageFingerprints: ["bad"] }), undefined);
+	const cyclic: Record<string, unknown> = { ...details };
+	cyclic.self = cyclic;
+	assert.equal(parseCheckpointDetails(cyclic), undefined);
+	for (const api of ["openai-responses", "azure-openai-responses"] as const) {
+		for (const protocol of ["remote-v2", "responses-compact"] as const) {
+			assert.equal(parseCheckpointDetails({ ...details, api, protocol })?.api, api);
+		}
+	}
 	assert.doesNotMatch(JSON.stringify(details), /token|authorization|header/i);
 });
 

--- a/packages/pi-codex-compact/test/lifecycle.test.ts
+++ b/packages/pi-codex-compact/test/lifecycle.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import {
+	type Api,
+	type Context,
 	createAssistantMessageEventStream,
 	type Model,
 	type OpenAICodexResponsesOptions,
@@ -8,7 +10,11 @@ import {
 import type { SessionBeforeCompactEvent, SessionEntry } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import { createCheckpointDetails, parseCheckpointDetails } from "../src/checkpoint.js";
+import {
+	createCheckpointDetails,
+	fallbackSummary,
+	parseCheckpointDetails,
+} from "../src/checkpoint.js";
 import { createCodexCompactExtension } from "../src/codex-compact.js";
 import {
 	type CodexCompactSettingsRuntime,
@@ -60,8 +66,10 @@ function settingsRuntime(overrides = {}): CodexCompactSettingsRuntime {
 
 function fakeProvider(
 	onOptions?: (options: OpenAICodexResponsesOptions) => void,
-	providerModel: Model<"openai-codex-responses"> = model,
+	providerModel: Model<Api> = model,
 	onPreparedPayload?: (payload: unknown) => void,
+	protocol: "remote-v2" | "responses-compact" = "remote-v2",
+	onContext?: (context: Context) => void,
 ): Provider {
 	return {
 		id: providerModel.provider,
@@ -69,6 +77,7 @@ function fakeProvider(
 		auth: {} as Provider["auth"],
 		getModels: () => [providerModel],
 		stream(activeModel, context, options) {
+			onContext?.(context);
 			const codexOptions = options as OpenAICodexResponsesOptions;
 			onOptions?.(codexOptions);
 			const stream = createAssistantMessageEventStream();
@@ -83,10 +92,15 @@ function fakeProvider(
 					});
 					const payload = await options?.onPayload?.({ model: activeModel.id, input }, activeModel);
 					onPreparedPayload?.(payload);
-					assert.deepEqual((payload as { input: unknown[] }).input.at(-1), {
-						type: "compaction_trigger",
+					const payloadInput = (payload as { input: Array<Record<string, unknown>> }).input;
+					assert.equal(
+						payloadInput.at(-1)?.type === "compaction_trigger",
+						protocol === "remote-v2",
+					);
+					const response = await options?.fetch?.("https://example.test/responses", {
+						method: "POST",
+						signal: options?.signal,
 					});
-					const response = await options?.fetch?.("https://example.test", { method: "POST" });
 					await response?.text();
 					const message = {
 						role: "assistant" as const,
@@ -156,6 +170,8 @@ function branch(): SessionEntry[] {
 function event(
 	signal = new AbortController().signal,
 	branchEntries = branch(),
+	reason: SessionBeforeCompactEvent["reason"] = "manual",
+	willRetry = false,
 ): SessionBeforeCompactEvent {
 	return {
 		type: "session_before_compact",
@@ -169,8 +185,8 @@ function event(
 			settings: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 },
 		},
 		branchEntries,
-		reason: "manual",
-		willRetry: false,
+		reason,
+		willRetry,
 		signal,
 	};
 }
@@ -182,6 +198,25 @@ function sseResponse() {
 	);
 }
 
+function compactJsonResponse() {
+	return Response.json({
+		id: "resp_compact",
+		object: "response.compaction",
+		created_at: 1,
+		output: [
+			{ role: "user", content: [{ type: "input_text", text: "retained" }] },
+			{ type: "compaction", encrypted_content: "opaque-openai" },
+		],
+		usage: {
+			input_tokens: 20,
+			input_tokens_details: { cached_tokens: 0 },
+			output_tokens: 1,
+			output_tokens_details: { reasoning_tokens: 0 },
+			total_tokens: 21,
+		},
+	});
+}
+
 function legacyFallbackSummary(checkpointId: string): string {
 	return [
 		`OpenAI Codex Remote Compaction V2 checkpoint ${checkpointId} stores the older history opaquely.`,
@@ -189,6 +224,21 @@ function legacyFallbackSummary(checkpointId: string): string {
 		"Without them, only Pi's retained recent messages remain available.",
 	].join(" ");
 }
+
+test("command rejects undocumented arguments in every mode", async () => {
+	const mock = createMockPi();
+	createCodexCompactExtension({ settingsRuntime: settingsRuntime() })(mock.pi);
+	const command = mock.commands.get("codex-compact");
+	assert.ok(command);
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		await assert.rejects(
+			async () => {
+				await command.handler("unexpected", createMockContext({ mode }).ctx);
+			},
+			{ message: "Usage: /codex-compact" },
+		);
+	}
+});
 
 test("custom Codex Responses providers compact and replay by API and exact model ID", async () => {
 	const mock = createMockPi();
@@ -200,7 +250,7 @@ test("custom Codex Responses providers compact and replay by API and exact model
 	);
 	assert.equal(
 		mock.commands.get("codex-compact")?.description,
-		"Compact now or configure Codex Remote Compaction V2",
+		"Compact now or configure Responses compaction",
 	);
 	const handler = mock.events.get("session_before_compact")?.[0];
 	assert.ok(handler);
@@ -304,13 +354,232 @@ test("custom Codex Responses providers compact and replay by API and exact model
 	assert.equal(await contextHandler?.(contextEvent, differentApi), undefined);
 });
 
-test("repeated compaction projects a checkpoint using its persisted legacy summary", async () => {
+test("generic OpenAI Responses compacts through the unary endpoint", async () => {
+	const mock = createMockPi();
+	const openAIModel = {
+		...model,
+		api: "openai-responses" as const,
+		provider: "company-openai-proxy",
+		baseUrl: "https://example.test",
+	};
+	createCodexCompactExtension({
+		settingsRuntime: settingsRuntime(),
+		fetch: async (input, init) => {
+			assert.equal(String(input), "https://example.test/responses/compact");
+			assert.equal(new Headers(init?.headers).get("content-encoding"), null);
+			return compactJsonResponse();
+		},
+	})(mock.pi);
+	const handler = mock.events.get("session_before_compact")?.[0];
+	const entries = branch();
+	const { ctx, notifications, statuses } = createMockContext({
+		model: openAIModel,
+		getSystemPrompt: () => "system",
+		sessionManager: { getSessionId: () => "session", getBranch: () => entries },
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "fixture" }),
+			getProvider: () => fakeProvider(undefined, openAIModel, undefined, "responses-compact"),
+		},
+		hasUI: true,
+	});
+
+	const result = (await handler?.(event(), ctx)) as {
+		compaction: { details: unknown; usage: unknown };
+	};
+	const details = parseCheckpointDetails(result.compaction.details);
+	assert.ok(details);
+	assert.equal(details.api, "openai-responses");
+	assert.equal(details.protocol, "responses-compact");
+	assert.deepEqual(result.compaction.usage, usage);
+	assert.deepEqual(notifications, []);
+	assert.equal(statuses.get("codex-compact"), undefined);
+});
+
+test("manual, threshold, and overflow compaction preserve Pi preparation boundaries", async () => {
+	for (const [reason, willRetry] of [
+		["manual", false],
+		["threshold", false],
+		["overflow", true],
+	] as const) {
+		const mock = createMockPi();
+		createCodexCompactExtension({
+			settingsRuntime: settingsRuntime(),
+			fetch: async () => sseResponse(),
+		})(mock.pi);
+		const handler = mock.events.get("session_before_compact")?.[0];
+		const { ctx } = createMockContext({
+			model,
+			getSystemPrompt: () => "system",
+			sessionManager: { getSessionId: () => "session", getBranch: () => branch() },
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => ({ ok: true }),
+				getProvider: () => fakeProvider(),
+			},
+		});
+		const compactEvent = event(new AbortController().signal, branch(), reason, willRetry);
+		if (reason === "overflow") {
+			compactEvent.preparation.isSplitTurn = true;
+			compactEvent.preparation.turnPrefixMessages = [
+				{ role: "user", content: [{ type: "text", text: "split prefix" }], timestamp: 1 },
+			];
+		}
+		const result = (await handler?.(compactEvent, ctx)) as {
+			compaction: { firstKeptEntryId: string; tokensBefore: number };
+		};
+		assert.equal(result.compaction.firstKeptEntryId, compactEvent.preparation.firstKeptEntryId);
+		assert.equal(result.compaction.tokensBefore, compactEvent.preparation.tokensBefore);
+	}
+});
+
+test("remote requests preserve ordered active tool fields exposed by Pi", async () => {
+	const constrainedSampling = { type: "json_schema" as const, strict: "require" as const };
+	const mock = createMockPi({
+		activeTools: ["second", "first"],
+		allTools: [
+			{
+				name: "first",
+				description: "first tool",
+				parameters: { type: "object" },
+				constrainedSampling,
+			},
+			{
+				name: "second",
+				description: "second tool",
+				parameters: { type: "object" },
+			},
+		],
+	});
+	let observed: Context | undefined;
+	createCodexCompactExtension({
+		settingsRuntime: settingsRuntime(),
+		fetch: async () => sseResponse(),
+	})(mock.pi);
+	const handler = mock.events.get("session_before_compact")?.[0];
+	const { ctx } = createMockContext({
+		model,
+		getSystemPrompt: () => "system",
+		sessionManager: { getSessionId: () => "session", getBranch: () => branch() },
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true }),
+			getProvider: () =>
+				fakeProvider(undefined, model, undefined, "remote-v2", (context) => {
+					observed = context;
+				}),
+		},
+	});
+
+	await handler?.(event(), ctx);
+	assert.deepEqual(observed?.tools, [
+		{
+			name: "second",
+			description: "second tool",
+			parameters: { type: "object" },
+		},
+		{
+			name: "first",
+			description: "first tool",
+			parameters: { type: "object" },
+		},
+	]);
+});
+
+test("checkpoint projection is idempotent and preserves ordinary request prefixes", async () => {
 	const mock = createMockPi();
 	const entries = branch();
 	const kept = entries[1].type === "message" ? entries[1].message : assert.fail("kept message");
 	const details = createCheckpointDetails({
 		provider: model.provider,
+		api: model.api,
 		modelId: model.id,
+		protocol: "remote-v2",
+		replacementHistory: [
+			{ role: "user", content: [{ type: "input_text", text: "older context" }] },
+			{ type: "compaction", encrypted_content: "prior-opaque" },
+		],
+		keptMessages: [kept],
+		checkpointId: "prefix-checkpoint",
+		createdAt: "2026-01-01T00:00:02.000Z",
+	});
+	const summary = fallbackSummary(details.checkpointId);
+	const checkpointEntry = {
+		type: "compaction" as const,
+		id: "compact",
+		parentId: "assistant",
+		timestamp: "2026-01-01T00:00:02.000Z",
+		summary,
+		firstKeptEntryId: "assistant",
+		tokensBefore: 123,
+		details,
+	};
+	createCodexCompactExtension({ settingsRuntime: settingsRuntime() })(mock.pi);
+	const { ctx } = createMockContext({
+		model,
+		sessionManager: {
+			getSessionId: () => "session",
+			getBranch: () => [...entries, checkpointEntry],
+		},
+	});
+	const contextHandler = mock.events.get("context")?.[0];
+	const payloadHandler = mock.events.get("before_provider_request")?.[0];
+	const summaryMessage = {
+		role: "compactionSummary" as const,
+		summary,
+		tokensBefore: 123,
+		timestamp: 3,
+	};
+	const later = {
+		role: "user" as const,
+		content: [{ type: "text" as const, text: "later" }],
+		timestamp: 4,
+	};
+	const contextEvent = {
+		type: "context" as const,
+		messages: [summaryMessage, kept, later],
+	};
+	const firstProjection = (await contextHandler?.(contextEvent, ctx)) as {
+		messages: Array<{ content: Array<{ text: string }> }>;
+	};
+	assert.deepEqual(await contextHandler?.(contextEvent, ctx), firstProjection);
+	const marker = firstProjection.messages[0].content[0].text;
+	const firstPayload = {
+		input: [
+			{ role: "user", content: [{ type: "input_text", text: marker }] },
+			{ role: "user", content: [{ type: "input_text", text: "later" }] },
+		],
+	};
+	const first = (await payloadHandler?.(
+		{ type: "before_provider_request", payload: firstPayload },
+		ctx,
+	)) as { input: unknown[] };
+	const second = (await payloadHandler?.(
+		{
+			type: "before_provider_request",
+			payload: {
+				...firstPayload,
+				input: [
+					...firstPayload.input,
+					{ role: "user", content: [{ type: "input_text", text: "new tail" }] },
+				],
+			},
+		},
+		ctx,
+	)) as { input: unknown[] };
+	assert.deepEqual(second.input.slice(0, first.input.length), first.input);
+	assert.equal(
+		await payloadHandler?.({ type: "before_provider_request", payload: first }, ctx),
+		undefined,
+	);
+});
+
+test("repeated compaction projects a persisted legacy summary across protocols", async () => {
+	const mock = createMockPi();
+	const entries = branch();
+	const kept = entries[1].type === "message" ? entries[1].message : assert.fail("kept message");
+	const details = createCheckpointDetails({
+		provider: model.provider,
+		api: model.api,
+		modelId: model.id,
+		protocol: "remote-v2",
 		replacementHistory: [
 			{ role: "user", content: [{ type: "input_text", text: "older context" }] },
 			{ type: "compaction", encrypted_content: "prior-opaque" },
@@ -333,8 +602,8 @@ test("repeated compaction projects a checkpoint using its persisted legacy summa
 	const repeatedBranch = [...entries, checkpointEntry];
 	let preparedPayload: unknown;
 	createCodexCompactExtension({
-		settingsRuntime: settingsRuntime(),
-		fetch: async () => sseResponse(),
+		settingsRuntime: settingsRuntime({ protocol: "responses-compact" }),
+		fetch: async () => compactJsonResponse(),
 	})(mock.pi);
 	const handler = mock.events.get("session_before_compact")?.[0];
 	const { ctx, notifications, statuses } = createMockContext({
@@ -347,9 +616,14 @@ test("repeated compaction projects a checkpoint using its persisted legacy summa
 		modelRegistry: {
 			getApiKeyAndHeaders: async () => ({ ok: true }),
 			getProvider: () =>
-				fakeProvider(undefined, model, (payload) => {
-					preparedPayload = payload;
-				}),
+				fakeProvider(
+					undefined,
+					model,
+					(payload) => {
+						preparedPayload = payload;
+					},
+					"responses-compact",
+				),
 		},
 		hasUI: true,
 	});
@@ -357,8 +631,10 @@ test("repeated compaction projects a checkpoint using its persisted legacy summa
 	const result = (await handler?.(event(new AbortController().signal, repeatedBranch), ctx)) as {
 		compaction: { details: unknown };
 	};
-	assert.ok(parseCheckpointDetails(result.compaction.details));
-	assert.deepEqual((preparedPayload as { input: unknown[] }).input.at(-2), {
+	const parsed = parseCheckpointDetails(result.compaction.details);
+	assert.ok(parsed);
+	assert.equal(parsed.protocol, "responses-compact");
+	assert.deepEqual((preparedPayload as { input: unknown[] }).input.at(-1), {
 		type: "compaction",
 		encrypted_content: "prior-opaque",
 	});
@@ -423,6 +699,47 @@ test("session lifecycle reloads settings and drops stale reload continuations", 
 	assert.equal(statuses.get("codex-compact"), undefined);
 });
 
+test("session shutdown aborts an in-flight remote compaction and clears its status", async () => {
+	const mock = createMockPi();
+	let requestStarted!: () => void;
+	const ready = new Promise<void>((resolve) => {
+		requestStarted = resolve;
+	});
+	createCodexCompactExtension({
+		settingsRuntime: settingsRuntime(),
+		fetch: async (_input, init) => {
+			requestStarted();
+			return new Promise<Response>((_resolve, reject) => {
+				if (init?.signal?.aborted) {
+					reject(new DOMException("aborted", "AbortError"));
+					return;
+				}
+				init?.signal?.addEventListener(
+					"abort",
+					() => reject(new DOMException("aborted", "AbortError")),
+					{ once: true },
+				);
+			});
+		},
+	})(mock.pi);
+	const handler = mock.events.get("session_before_compact")?.[0];
+	const shutdown = mock.events.get("session_shutdown")?.[0];
+	const { ctx, statuses } = createMockContext({
+		model,
+		getSystemPrompt: () => "system",
+		sessionManager: { getSessionId: () => "session", getBranch: () => branch() },
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "fixture" }),
+			getProvider: () => fakeProvider(),
+		},
+	});
+	const pending = handler?.(event(), ctx);
+	await ready;
+	await shutdown?.({ type: "session_shutdown", reason: "reload" }, ctx);
+	assert.deepEqual(await pending, { cancel: true });
+	assert.equal(statuses.get("codex-compact"), undefined);
+});
+
 test("disabled, wrong-API, remote-failed, auth-failed, and aborted paths remain safe", async () => {
 	const run = async (options: {
 		settings?: CodexCompactSettingsRuntime;
@@ -458,7 +775,7 @@ test("disabled, wrong-API, remote-failed, auth-failed, and aborted paths remain 
 	assert.equal(
 		(
 			await run({
-				model: { ...model, provider: "openai", api: "openai-responses" },
+				model: { ...model, provider: "anthropic", api: "anthropic-messages" },
 			})
 		).result,
 		undefined,

--- a/packages/pi-codex-compact/test/lifecycle.test.ts
+++ b/packages/pi-codex-compact/test/lifecycle.test.ts
@@ -240,6 +240,18 @@ test("command rejects undocumented arguments in every mode", async () => {
 	}
 });
 
+test("command rejects no-argument use in print and JSON modes", async () => {
+	const mock = createMockPi();
+	createCodexCompactExtension({ settingsRuntime: settingsRuntime() })(mock.pi);
+	const command = mock.commands.get("codex-compact");
+	assert.ok(command);
+	for (const mode of ["print", "json"] as const) {
+		await assert.rejects(async () => {
+			await command.handler("", createMockContext({ mode, hasUI: false }).ctx);
+		}, /requires TUI or RPC UI support/);
+	}
+});
+
 test("custom Codex Responses providers compact and replay by API and exact model ID", async () => {
 	const mock = createMockPi();
 	const customModel = { ...model, provider: "company-codex-proxy" };

--- a/packages/pi-codex-compact/test/model-api.test.ts
+++ b/packages/pi-codex-compact/test/model-api.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, test } from "vitest";
+import { resolveCompactionRoute, usesResponsesCompactionApi } from "../src/model-api.js";
+
+function model(api: Api, provider = "custom"): Model<Api> {
+	return {
+		id: "gpt-5.4",
+		name: "GPT-5.4",
+		api,
+		provider,
+		baseUrl: "https://example.test/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 10_000,
+	};
+}
+
+describe("Responses compaction route selection", () => {
+	test("auto preserves Codex V2 and uses unary compact for OpenAI and Azure", () => {
+		assert.deepEqual(
+			resolveCompactionRoute(model("openai-codex-responses"), {
+				enabled: true,
+				protocol: "auto",
+			}),
+			{ kind: "remote", protocol: "remote-v2", api: "openai-codex-responses" },
+		);
+		assert.deepEqual(
+			resolveCompactionRoute(model("openai-responses"), {
+				enabled: true,
+				protocol: "auto",
+			}),
+			{ kind: "remote", protocol: "responses-compact", api: "openai-responses" },
+		);
+		assert.deepEqual(
+			resolveCompactionRoute(model("azure-openai-responses"), {
+				enabled: true,
+				protocol: "auto",
+			}),
+			{ kind: "remote", protocol: "responses-compact", api: "azure-openai-responses" },
+		);
+	});
+
+	test("forced protocols apply to every characterized Responses adapter", () => {
+		for (const api of [
+			"openai-codex-responses",
+			"openai-responses",
+			"azure-openai-responses",
+		] as const) {
+			assert.deepEqual(
+				resolveCompactionRoute(model(api, "company-proxy"), {
+					enabled: true,
+					protocol: "remote-v2",
+				}),
+				{ kind: "remote", protocol: "remote-v2", api },
+			);
+			assert.deepEqual(
+				resolveCompactionRoute(model(api, "company-proxy"), {
+					enabled: true,
+					protocol: "responses-compact",
+				}),
+				{ kind: "remote", protocol: "responses-compact", api },
+			);
+		}
+	});
+
+	test("disabled, missing, and unsupported models stay Pi native", () => {
+		assert.deepEqual(
+			resolveCompactionRoute(model("openai-responses"), {
+				enabled: false,
+				protocol: "auto",
+			}),
+			{ kind: "native", reason: "remote compaction is disabled" },
+		);
+		assert.deepEqual(resolveCompactionRoute(undefined, { enabled: true, protocol: "auto" }), {
+			kind: "native",
+			reason: "no active model",
+		});
+		assert.deepEqual(
+			resolveCompactionRoute(model("anthropic-messages"), {
+				enabled: true,
+				protocol: "remote-v2",
+			}),
+			{
+				kind: "native",
+				reason: "API anthropic-messages does not support Responses compaction",
+			},
+		);
+		assert.equal(usesResponsesCompactionApi(model("openai-responses")), true);
+		assert.equal(usesResponsesCompactionApi(model("github-copilot")), false);
+	});
+});

--- a/packages/pi-codex-compact/test/protocol.test.ts
+++ b/packages/pi-codex-compact/test/protocol.test.ts
@@ -213,14 +213,21 @@ test("rejects unsafe, malformed, oversized, and aborted unary compact responses"
 		collectCompactResponse(new Response("{invalid", { status: 200 })),
 		/malformed JSON/,
 	);
+	let oversizedBodyCancelled = false;
 	await assert.rejects(
 		collectCompactResponse(
-			new Response(JSON.stringify({ output: [item] }), {
-				headers: { "content-length": "9000000" },
-			}),
+			new Response(
+				new ReadableStream<Uint8Array>({
+					cancel(reason) {
+						oversizedBodyCancelled = reason instanceof CodexCompactionProtocolError;
+					},
+				}),
+				{ headers: { "content-length": "9000000" } },
+			),
 		),
 		/response exceeded/,
 	);
+	assert.equal(oversizedBodyCancelled, true);
 	await assert.rejects(
 		collectCompactResponse(Response.json({ output: [item] }), { maxBytes: 10 }),
 		/response exceeded/,

--- a/packages/pi-codex-compact/test/protocol.test.ts
+++ b/packages/pi-codex-compact/test/protocol.test.ts
@@ -179,12 +179,31 @@ test("rejects unsafe, malformed, oversized, and aborted unary compact responses"
 		() => validateCompactedResponse({ output: [{ type: "compaction_trigger" }, item] }),
 		/unsupported retained/,
 	);
-	assert.throws(
-		() =>
-			validateCompactedResponse({
-				output: [{ role: "user", content: [{ type: "input_file", file_data: "opaque" }] }, item],
-			}),
-		/unsupported retained/,
+	for (const retained of [
+		{ role: "user", content: [] },
+		{ role: "user", content: [{ type: "input_text" }] },
+		{ role: "user", content: [{ type: "input_text", text: 42 }] },
+		{ role: "user", content: [{ type: "input_image", detail: "auto" }] },
+		{ role: "user", content: [{ type: "input_image", image_url: 42 }] },
+		{ role: "user", content: [{ type: "input_image", image_url: "image", detail: "huge" }] },
+		{ role: "user", content: [{ type: "input_file", file_data: "opaque" }] },
+	]) {
+		assert.throws(
+			() => validateCompactedResponse({ output: [retained, item] }),
+			/unsupported retained/,
+		);
+	}
+	assert.doesNotThrow(() =>
+		validateCompactedResponse({
+			output: [
+				{
+					role: "user",
+					type: "message",
+					content: [{ type: "input_image", file_id: "file_fixture", detail: "auto" }],
+				},
+				item,
+			],
+		}),
 	);
 	assert.throws(
 		() => validateCompactedResponse({ output: [item] }, { maxBytes: 10 }),

--- a/packages/pi-codex-compact/test/protocol.test.ts
+++ b/packages/pi-codex-compact/test/protocol.test.ts
@@ -4,8 +4,11 @@ import {
 	appendCompactionTrigger,
 	CodexCompactionProtocolError,
 	collectCompactionSse,
+	collectCompactResponse,
+	expandRemoteCompactionPayload,
 	prepareRemoteCompactionPayload,
 	rewriteCheckpointMarker,
+	validateCompactedResponse,
 } from "../src/protocol.js";
 
 const encoder = new TextEncoder();
@@ -36,13 +39,16 @@ test("collects one compaction from fragmented CRLF SSE and deduplicates complete
 	assert.ok(result.completedResponse);
 });
 
-test("joins multiline data fields and ignores unrelated events", async () => {
-	const outputItem = JSON.stringify({
-		type: "response.output_item.done",
-		item: { type: "compaction", encrypted_content: "opaque" },
-	});
+test("joins multiline data fields and ignores unrelated output items", async () => {
+	const message = { type: "message", role: "assistant", content: [] };
+	const item = { type: "compaction", encrypted_content: "opaque" };
+	const outputItem = JSON.stringify({ type: "response.output_item.done", item });
 	const stream = fragmentedStream(
-		`data: ${outputItem}\n\ndata: {"type":"response.completed",\ndata: "response":{"output":[]}}\n\n`,
+		[
+			`data: ${JSON.stringify({ type: "response.output_item.done", item: message })}\n\n`,
+			`data: ${outputItem}\n\n`,
+			`data: {"type":"response.completed",\ndata: "response":{"output":[${JSON.stringify(message)},${JSON.stringify(item)}]}}\n\n`,
+		].join(""),
 		3,
 	);
 	const result = await collectCompactionSse(stream);
@@ -142,6 +148,89 @@ test("rewrites exactly one marker and appends exactly one final trigger", () => 
 		{ type: "compaction_trigger" },
 	]);
 	assert.equal(payload.input.length, 2, "does not mutate caller payload");
+});
+
+test("validates bounded unary compact output and response streaming", async () => {
+	const value = {
+		id: "resp_compact",
+		object: "response.compaction",
+		output: [
+			{ role: "user", content: [{ type: "input_text", text: "retained" }] },
+			{ type: "compaction", encrypted_content: "opaque" },
+		],
+		usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+	};
+	const validated = validateCompactedResponse(value);
+	assert.equal(validated.item.encrypted_content, "opaque");
+	assert.equal(validated.output.length, 2);
+	const collected = await collectCompactResponse(Response.json(value));
+	assert.deepEqual(collected.output, validated.output);
+});
+
+test("rejects unsafe, malformed, oversized, and aborted unary compact responses", async () => {
+	const item = { type: "compaction", encrypted_content: "opaque" };
+	assert.throws(() => validateCompactedResponse({ output: [] }), /no output/);
+	assert.throws(() => validateCompactedResponse({ output: [item, item] }), /followed by one/);
+	assert.throws(
+		() => validateCompactedResponse({ output: [{ role: "developer", content: [] }, item] }),
+		/unsupported retained/,
+	);
+	assert.throws(
+		() => validateCompactedResponse({ output: [{ type: "compaction_trigger" }, item] }),
+		/unsupported retained/,
+	);
+	assert.throws(
+		() =>
+			validateCompactedResponse({
+				output: [{ role: "user", content: [{ type: "input_file", file_data: "opaque" }] }, item],
+			}),
+		/unsupported retained/,
+	);
+	assert.throws(
+		() => validateCompactedResponse({ output: [item] }, { maxBytes: 10 }),
+		/response exceeded/,
+	);
+	await assert.rejects(
+		collectCompactResponse(new Response("{invalid", { status: 200 })),
+		/malformed JSON/,
+	);
+	await assert.rejects(
+		collectCompactResponse(
+			new Response(JSON.stringify({ output: [item] }), {
+				headers: { "content-length": "9000000" },
+			}),
+		),
+		/response exceeded/,
+	);
+	await assert.rejects(
+		collectCompactResponse(Response.json({ output: [item] }), { maxBytes: 10 }),
+		/response exceeded/,
+	);
+	await assert.rejects(
+		collectCompactResponse(Response.json({ output: [item] }), { maxItemBytes: 10 }),
+		/output item exceeded/,
+	);
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		collectCompactResponse(Response.json({ output: [item] }), { signal: controller.signal }),
+		/aborted/i,
+	);
+});
+
+test("expands checkpoint payloads without mutating or adding a trigger", () => {
+	const payload = {
+		model: "gpt",
+		input: [{ role: "user", content: [{ type: "input_text", text: "checkpoint" }] }],
+	};
+	const expanded = expandRemoteCompactionPayload(payload, {
+		marker: "checkpoint",
+		replacementHistory: [{ type: "compaction", encrypted_content: "prior" }],
+	});
+	assert.deepEqual(expanded.input, [{ type: "compaction", encrypted_content: "prior" }]);
+	assert.deepEqual(payload.input, [
+		{ role: "user", content: [{ type: "input_text", text: "checkpoint" }] },
+	]);
 });
 
 test("payload validators reject malformed inputs, missing/duplicate markers, and duplicate triggers", () => {

--- a/packages/pi-codex-compact/test/provider-adapters.test.ts
+++ b/packages/pi-codex-compact/test/provider-adapters.test.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import type {
+	Api,
+	AssistantMessageEventStream,
+	Model,
+	Provider,
+	Usage,
+} from "@earendil-works/pi-ai";
+import { describe, test } from "vitest";
+
+const PROVIDER_MODULES = {
+	"openai-responses": {
+		specifier: "@earendil-works/pi-ai/providers/openai",
+		factory: "openaiProvider",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		expectedUrl: "https://api.openai.com/v1/responses",
+		bodyKind: "string",
+		contentEncoding: null,
+		credentialHeader: "authorization",
+	},
+	"azure-openai-responses": {
+		specifier: "@earendil-works/pi-ai/providers/azure-openai-responses",
+		factory: "azureOpenAIResponsesProvider",
+		provider: "azure-openai-responses",
+		baseUrl: "https://example.openai.azure.com/openai/v1",
+		expectedUrl: "https://example.openai.azure.com/openai/v1/responses?api-version=v1",
+		bodyKind: "string",
+		contentEncoding: null,
+		credentialHeader: "api-key",
+	},
+	"openai-codex-responses": {
+		specifier: "@earendil-works/pi-ai/providers/openai-codex",
+		factory: "openaiCodexProvider",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api/codex",
+		expectedUrl: "https://chatgpt.com/backend-api/codex/responses",
+		bodyKind: "object",
+		contentEncoding: "zstd",
+		credentialHeader: "authorization",
+	},
+} as const;
+
+type SupportedApi = keyof typeof PROVIDER_MODULES;
+
+const COMPACTION_ITEM = {
+	id: "cmp_adapter_fixture",
+	type: "compaction",
+	encrypted_content: "opaque",
+};
+
+const RESPONSE_USAGE = {
+	input_tokens: 10,
+	input_tokens_details: { cached_tokens: 3 },
+	output_tokens: 2,
+	output_tokens_details: { reasoning_tokens: 1 },
+	total_tokens: 12,
+};
+
+function codexToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: "acct_fixture" },
+		}),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+function apiKey(api: SupportedApi): string {
+	return api === "openai-codex-responses" ? codexToken() : "fixture-key";
+}
+
+function modelFor(api: SupportedApi): Model<Api> {
+	const fixture = PROVIDER_MODULES[api];
+	return {
+		id: "gpt-5.4",
+		name: "GPT-5.4 fixture",
+		api,
+		provider: fixture.provider,
+		baseUrl: fixture.baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 1 },
+		contextWindow: 100_000,
+		maxTokens: 10_000,
+	};
+}
+
+async function providerFor(api: SupportedApi): Promise<Provider> {
+	const fixture = PROVIDER_MODULES[api];
+	// Pi can misresolve static API/provider subpath imports, so keep this variable-specifier import.
+	const module = (await import(fixture.specifier)) as Record<string, () => Provider>;
+	const factory = module[fixture.factory];
+	assert.ok(factory, `missing ${fixture.factory}`);
+	return factory();
+}
+
+function responseObject(output: unknown[]) {
+	return {
+		id: "resp_adapter_fixture",
+		object: "response",
+		created_at: 1,
+		status: "completed",
+		model: "gpt-5.4",
+		output,
+		parallel_tool_calls: true,
+		tool_choice: "auto",
+		tools: [],
+		usage: RESPONSE_USAGE,
+	};
+}
+
+function responseSse(output: unknown[]): Response {
+	const completed = responseObject(output);
+	const events = [
+		{ type: "response.created", response: { ...completed, status: "in_progress", output: [] } },
+		...output.flatMap((item, output_index) => [
+			{ type: "response.output_item.added", output_index, item },
+			{ type: "response.output_item.done", output_index, item },
+		]),
+		{ type: "response.completed", response: completed },
+	];
+	return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+async function collectDone(stream: AssistantMessageEventStream): Promise<Usage> {
+	let usage: Usage | undefined;
+	for await (const event of stream) {
+		if (event.type === "error") throw new Error(event.error.errorMessage);
+		if (event.type === "done") usage = event.message.usage;
+	}
+	assert.ok(usage, "provider stream did not complete");
+	return usage;
+}
+
+async function collectFailure(stream: AssistantMessageEventStream): Promise<string> {
+	let message: string | undefined;
+	for await (const event of stream) {
+		if (event.type === "error") message = event.error.errorMessage;
+	}
+	assert.ok(message, "provider stream did not fail");
+	return message;
+}
+
+function context() {
+	return {
+		systemPrompt: "system",
+		messages: [
+			{
+				role: "user" as const,
+				content: [{ type: "text" as const, text: "hello" }],
+				timestamp: 1,
+			},
+		],
+		tools: [],
+	};
+}
+
+for (const api of Object.keys(PROVIDER_MODULES) as SupportedApi[]) {
+	describe(api, () => {
+		test("exposes one HTTP Responses request and accepts a V2 compaction-only SSE", async () => {
+			const fixture = PROVIDER_MODULES[api];
+			const provider = await providerFor(api);
+			const model = modelFor(api);
+			let payload: Record<string, unknown> | undefined;
+			let fetches = 0;
+			const stream = provider.stream(
+				model,
+				{
+					systemPrompt: "system",
+					messages: [{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 }],
+					tools: [],
+				},
+				{
+					apiKey: apiKey(api),
+					transport: "sse",
+					cacheRetention: "none",
+					maxRetries: 0,
+					onPayload(value) {
+						assert.ok(typeof value === "object" && value !== null && !Array.isArray(value));
+						payload = value as Record<string, unknown>;
+						assert.ok(Array.isArray(payload.input));
+						return {
+							...payload,
+							input: [...payload.input, { type: "compaction_trigger" }],
+						};
+					},
+					fetch: async (input, init) => {
+						fetches += 1;
+						assert.equal(String(input), fixture.expectedUrl);
+						assert.equal(typeof init?.body, fixture.bodyKind);
+						assert.equal(
+							new Headers(init?.headers).get("content-encoding"),
+							fixture.contentEncoding,
+						);
+						return responseSse([COMPACTION_ITEM]);
+					},
+				},
+			);
+
+			const usage = await collectDone(stream);
+			assert.equal(fetches, 1);
+			assert.ok(payload);
+			assert.equal(usage.totalTokens, 12);
+		});
+
+		test("accepts a synthetic completion after a same-origin compact URL rewrite", async () => {
+			const provider = await providerFor(api);
+			const model = modelFor(api);
+			let payload: Record<string, unknown> | undefined;
+			let rewrittenUrl: string | undefined;
+			let compactHeaders: Headers | undefined;
+			const stream = provider.stream(
+				model,
+				{
+					systemPrompt: "system",
+					messages: [{ role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 }],
+					tools: [],
+				},
+				{
+					apiKey: apiKey(api),
+					transport: "sse",
+					cacheRetention: "none",
+					maxRetries: 0,
+					onPayload(value) {
+						assert.ok(typeof value === "object" && value !== null && !Array.isArray(value));
+						payload = value as Record<string, unknown>;
+						return value;
+					},
+					fetch: async (input, init) => {
+						const original = new URL(String(input));
+						const compact = new URL(original);
+						compact.pathname = `${compact.pathname.replace(/\/$/, "")}/compact`;
+						assert.equal(compact.origin, original.origin);
+						rewrittenUrl = compact.toString();
+						compactHeaders = new Headers(init?.headers);
+						compactHeaders.delete("content-encoding");
+						compactHeaders.delete("content-length");
+						return responseSse([]);
+					},
+				},
+			);
+
+			const usage = await collectDone(stream);
+			assert.ok(payload);
+			assert.equal(
+				rewrittenUrl,
+				`${PROVIDER_MODULES[api].expectedUrl.replace(/\/responses(?=\?|$)/, "/responses/compact")}`,
+			);
+			assert.equal(compactHeaders?.has("content-encoding"), false);
+			assert.equal(compactHeaders?.has(PROVIDER_MODULES[api].credentialHeader), true);
+			if (api === "openai-codex-responses") {
+				assert.equal(compactHeaders?.get("chatgpt-account-id"), "acct_fixture");
+			}
+			assert.equal(usage.input, 7);
+			assert.equal(usage.cacheRead, 3);
+			assert.equal(usage.output, 2);
+		});
+
+		test("honors one bounded provider retry", async () => {
+			const provider = await providerFor(api);
+			const model = modelFor(api);
+			let fetches = 0;
+			const stream = provider.stream(model, context(), {
+				apiKey: apiKey(api),
+				transport: "sse",
+				cacheRetention: "none",
+				maxRetries: 1,
+				fetch: async () => {
+					fetches += 1;
+					if (fetches === 1) {
+						return new Response("temporary unavailable", {
+							status: 503,
+							headers: { "retry-after": "0" },
+						});
+					}
+					return responseSse([]);
+				},
+			});
+
+			await collectDone(stream);
+			assert.equal(fetches, 2);
+		});
+
+		test("forwards cancellation to the HTTP request", async () => {
+			const provider = await providerFor(api);
+			const model = modelFor(api);
+			const controller = new AbortController();
+			controller.abort();
+			let fetches = 0;
+			const stream = provider.stream(model, context(), {
+				apiKey: apiKey(api),
+				transport: "sse",
+				cacheRetention: "none",
+				maxRetries: 0,
+				signal: controller.signal,
+				fetch: async () => {
+					fetches += 1;
+					throw new Error("aborted request should not dispatch");
+				},
+			});
+
+			assert.match(await collectFailure(stream), /abort/i);
+			assert.equal(fetches, 0);
+		});
+	});
+}

--- a/packages/pi-codex-compact/test/remote-compact.test.ts
+++ b/packages/pi-codex-compact/test/remote-compact.test.ts
@@ -286,7 +286,7 @@ test("unary compact retries transient HTTP failures but not malformed successful
 	);
 });
 
-test("unary compact rejects duplicate provider dispatch without a second external request", async () => {
+test("unary compact rejects overlapping provider dispatch without a second external request", async () => {
 	const model = modelFor("openai-responses");
 	const provider: Provider = {
 		id: model.provider,
@@ -298,8 +298,10 @@ test("unary compact rejects duplicate provider dispatch without a second externa
 			void (async () => {
 				try {
 					await options?.onPayload?.({ model: activeModel.id, input: [] }, activeModel);
-					await options?.fetch?.("https://example.test/v1/responses", { method: "POST" });
-					await options?.fetch?.("https://example.test/v1/responses", { method: "POST" });
+					await Promise.all([
+						options?.fetch?.("https://example.test/v1/responses", { method: "POST" }),
+						options?.fetch?.("https://example.test/v1/responses", { method: "POST" }),
+					]);
 					const message = {
 						role: "assistant" as const,
 						content: [],
@@ -344,7 +346,7 @@ test("unary compact rejects duplicate provider dispatch without a second externa
 				return compactResponse();
 			},
 		}),
-		/dispatched again/,
+		/overlapping/,
 	);
 	assert.equal(externalRequests, 1);
 });

--- a/packages/pi-codex-compact/test/remote-compact.test.ts
+++ b/packages/pi-codex-compact/test/remote-compact.test.ts
@@ -349,6 +349,90 @@ test("unary compact rejects duplicate provider dispatch without a second externa
 	assert.equal(externalRequests, 1);
 });
 
+test("unary compact preserves cancellation carried by a Request input", async () => {
+	const model = modelFor("openai-responses");
+	const provider: Provider = {
+		id: model.provider,
+		name: "Request input fixture",
+		auth: {} as Provider["auth"],
+		getModels: () => [model],
+		stream(activeModel, _context, options) {
+			const stream = createAssistantMessageEventStream();
+			void (async () => {
+				try {
+					await options?.onPayload?.({ model: activeModel.id, input: [] }, activeModel);
+					await options?.fetch?.(
+						new Request("https://example.test/v1/responses", {
+							method: "POST",
+							signal: options.signal,
+						}),
+					);
+					assert.fail("Aborted bridge request unexpectedly completed");
+				} catch (error) {
+					const message = {
+						role: "assistant" as const,
+						content: [],
+						api: activeModel.api,
+						provider: activeModel.provider,
+						model: activeModel.id,
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error" as const,
+						errorMessage: error instanceof Error ? error.message : String(error),
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "error", reason: "error", error: message });
+					stream.end(message);
+				}
+			})();
+			return stream;
+		},
+		streamSimple() {
+			throw new Error("not used");
+		},
+	};
+	const controller = new AbortController();
+	let requestStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		requestStarted = resolve;
+	});
+	let forwardedSignal: AbortSignal | undefined;
+	const pending = requestRemoteCompaction({
+		provider,
+		model,
+		context: context(),
+		protocol: "responses-compact",
+		apiKey: "fixture",
+		signal: controller.signal,
+		maxRetries: 0,
+		fetch: async (_input, init) => {
+			forwardedSignal = init?.signal ?? undefined;
+			requestStarted();
+			return new Promise<Response>((_resolve, reject) => {
+				if (forwardedSignal?.aborted) {
+					reject(new DOMException("Compaction aborted", "AbortError"));
+					return;
+				}
+				forwardedSignal?.addEventListener(
+					"abort",
+					() => reject(new DOMException("Compaction aborted", "AbortError")),
+					{ once: true },
+				);
+			});
+		},
+	});
+	await started;
+	controller.abort();
+	await assert.rejects(pending, /aborted/i);
+	assert.equal(forwardedSignal?.aborted, true);
+});
+
 test("unary compact aborts stalled response parsing without publishing output", async () => {
 	const api = "openai-responses";
 	const provider = await providerFor(api);

--- a/packages/pi-codex-compact/test/remote-compact.test.ts
+++ b/packages/pi-codex-compact/test/remote-compact.test.ts
@@ -1,0 +1,385 @@
+import assert from "node:assert/strict";
+import {
+	type Context,
+	createAssistantMessageEventStream,
+	type Model,
+	type Provider,
+} from "@earendil-works/pi-ai";
+import { describe, test } from "vitest";
+import type { ResponsesCompactionApi } from "../src/model-api.js";
+import { requestRemoteCompaction } from "../src/remote.js";
+import { responsesCompactUrl } from "../src/remote-compact.js";
+
+const PROVIDER_MODULES = {
+	"openai-responses": {
+		specifier: "@earendil-works/pi-ai/providers/openai",
+		factory: "openaiProvider",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		compactUrl: "https://api.openai.com/v1/responses/compact",
+	},
+	"azure-openai-responses": {
+		specifier: "@earendil-works/pi-ai/providers/azure-openai-responses",
+		factory: "azureOpenAIResponsesProvider",
+		provider: "azure-openai-responses",
+		baseUrl: "https://example.openai.azure.com/openai/v1",
+		compactUrl: "https://example.openai.azure.com/openai/v1/responses/compact?api-version=v1",
+	},
+	"openai-codex-responses": {
+		specifier: "@earendil-works/pi-ai/providers/openai-codex",
+		factory: "openaiCodexProvider",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api/codex",
+		compactUrl: "https://chatgpt.com/backend-api/codex/responses/compact",
+	},
+} as const;
+
+const COMPACTION_ITEM = {
+	id: "cmp_remote_fixture",
+	type: "compaction",
+	encrypted_content: "opaque",
+};
+
+const RAW_USAGE = {
+	input_tokens: 10,
+	input_tokens_details: { cached_tokens: 3 },
+	output_tokens: 2,
+	output_tokens_details: { reasoning_tokens: 1 },
+	total_tokens: 12,
+};
+
+function codexToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({
+			"https://api.openai.com/auth": { chatgpt_account_id: "acct_fixture" },
+		}),
+	).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+function apiKey(api: ResponsesCompactionApi): string {
+	return api === "openai-codex-responses" ? codexToken() : "fixture-key";
+}
+
+function modelFor(api: ResponsesCompactionApi): Model<ResponsesCompactionApi> {
+	const fixture = PROVIDER_MODULES[api];
+	return {
+		id: "gpt-5.4",
+		name: "GPT-5.4 fixture",
+		api,
+		provider: fixture.provider,
+		baseUrl: fixture.baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 1 },
+		contextWindow: 100_000,
+		maxTokens: 10_000,
+	};
+}
+
+async function providerFor(api: ResponsesCompactionApi): Promise<Provider> {
+	const fixture = PROVIDER_MODULES[api];
+	// Pi can misresolve static API/provider subpath imports, so keep this variable-specifier import.
+	const module = (await import(fixture.specifier)) as Record<string, () => Provider>;
+	const factory = module[fixture.factory];
+	assert.ok(factory, `missing ${fixture.factory}`);
+	return factory();
+}
+
+function context(text = "current"): Context {
+	return {
+		systemPrompt: "system",
+		messages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],
+		tools: [],
+	};
+}
+
+function compactResponse(
+	output: unknown[] = [
+		{ role: "user", content: [{ type: "input_text", text: "retained" }] },
+		COMPACTION_ITEM,
+	],
+): Response {
+	return Response.json({
+		id: "resp_compact_fixture",
+		object: "response.compaction",
+		created_at: 1,
+		output,
+		usage: RAW_USAGE,
+	});
+}
+
+for (const api of Object.keys(PROVIDER_MODULES) as ResponsesCompactionApi[]) {
+	describe(`${api} unary compact bridge`, () => {
+		test("makes one authenticated same-origin request and returns provider-normalized usage", async () => {
+			const fixture = PROVIDER_MODULES[api];
+			const provider = await providerFor(api);
+			const model = modelFor(api);
+			let fetches = 0;
+			let requestBody: Record<string, unknown> | undefined;
+			const result = await requestRemoteCompaction({
+				provider,
+				model,
+				context: context(),
+				protocol: "responses-compact",
+				apiKey: apiKey(api),
+				signal: new AbortController().signal,
+				maxRetries: 0,
+				fetch: async (input, init) => {
+					fetches += 1;
+					assert.equal(String(input), fixture.compactUrl);
+					assert.equal(new URL(String(input)).origin, new URL(fixture.baseUrl).origin);
+					const headers = new Headers(init?.headers);
+					assert.equal(headers.get("content-encoding"), null);
+					assert.equal(headers.get("content-type"), "application/json");
+					assert.equal(
+						headers.has(api === "azure-openai-responses" ? "api-key" : "authorization"),
+						true,
+					);
+					if (api === "openai-codex-responses") {
+						assert.equal(headers.get("chatgpt-account-id"), "acct_fixture");
+					}
+					assert.equal(typeof init?.body, "string");
+					requestBody = JSON.parse(String(init?.body));
+					return compactResponse();
+				},
+			});
+
+			assert.equal(fetches, 1);
+			assert.ok(requestBody);
+			assert.equal(requestBody.stream, undefined);
+			assert.equal(requestBody.store, undefined);
+			assert.equal(requestBody.include, undefined);
+			assert.ok(Array.isArray(requestBody.input));
+			assert.equal(result.item.encrypted_content, "opaque");
+			assert.equal(result.compactedOutput?.at(-1)?.type, "compaction");
+			assert.equal(result.promptInput.length > 0, true);
+			assert.deepEqual(
+				{
+					input: result.usage.input,
+					cacheRead: result.usage.cacheRead,
+					output: result.usage.output,
+					totalTokens: result.usage.totalTokens,
+				},
+				{ input: 7, cacheRead: 3, output: 2, totalTokens: 12 },
+			);
+		});
+	});
+}
+
+test("unary compact expands a previous checkpoint without adding a trigger", async () => {
+	const api = "openai-responses";
+	const provider = await providerFor(api);
+	let body: Record<string, unknown> | undefined;
+	await requestRemoteCompaction({
+		provider,
+		model: modelFor(api),
+		context: context("checkpoint marker"),
+		protocol: "responses-compact",
+		apiKey: apiKey(api),
+		signal: new AbortController().signal,
+		priorCheckpoint: {
+			marker: "checkpoint marker",
+			replacementHistory: [{ type: "compaction", encrypted_content: "prior" }],
+		},
+		fetch: async (_input, init) => {
+			body = JSON.parse(String(init?.body));
+			return compactResponse();
+		},
+	});
+
+	assert.ok(body);
+	assert.equal(
+		(body.input as Array<Record<string, unknown>>).some(
+			(item) => item.type === "compaction" && item.encrypted_content === "prior",
+		),
+		true,
+	);
+	assert.equal(
+		(body.input as Array<Record<string, unknown>>).some(
+			(item) =>
+				item.type === "compaction_trigger" || JSON.stringify(item).includes("checkpoint marker"),
+		),
+		false,
+	);
+});
+
+test("unary compact retries transient HTTP failures but not malformed successful bodies", async () => {
+	const api = "openai-responses";
+	const provider = await providerFor(api);
+	let fetches = 0;
+	await requestRemoteCompaction({
+		provider,
+		model: modelFor(api),
+		context: context(),
+		protocol: "responses-compact",
+		apiKey: apiKey(api),
+		signal: new AbortController().signal,
+		maxRetries: 1,
+		fetch: async () => {
+			fetches += 1;
+			return fetches === 1
+				? new Response("temporary", { status: 503, headers: { "retry-after": "0" } })
+				: compactResponse();
+		},
+	});
+	assert.equal(fetches, 2);
+
+	fetches = 0;
+	await assert.rejects(
+		requestRemoteCompaction({
+			provider,
+			model: modelFor(api),
+			context: context(),
+			protocol: "responses-compact",
+			apiKey: apiKey(api),
+			signal: new AbortController().signal,
+			maxRetries: 2,
+			fetch: async () => {
+				fetches += 1;
+				return new Response("{invalid", { status: 200 });
+			},
+		}),
+		/malformed JSON/,
+	);
+	assert.equal(fetches, 1);
+
+	fetches = 0;
+	await assert.rejects(
+		requestRemoteCompaction({
+			provider,
+			model: modelFor(api),
+			context: context(),
+			protocol: "responses-compact",
+			apiKey: apiKey(api),
+			signal: new AbortController().signal,
+			maxRetries: 2,
+			fetch: async () => {
+				fetches += 1;
+				return Response.json({ output: [COMPACTION_ITEM] });
+			},
+		}),
+		/missing usage/,
+	);
+	assert.equal(fetches, 1);
+
+	await assert.rejects(
+		requestRemoteCompaction({
+			provider,
+			model: modelFor(api),
+			context: context(),
+			protocol: "responses-compact",
+			apiKey: apiKey(api),
+			signal: new AbortController().signal,
+			maxRetries: 0,
+			fetch: async () =>
+				Response.json({
+					id: "resp_bad_usage",
+					output: [COMPACTION_ITEM],
+					usage: {
+						...RAW_USAGE,
+						input_tokens_details: { cached_tokens: 11 },
+					},
+				}),
+		}),
+		/inconsistent usage details/,
+	);
+});
+
+test("unary compact rejects duplicate provider dispatch without a second external request", async () => {
+	const model = modelFor("openai-responses");
+	const provider: Provider = {
+		id: model.provider,
+		name: "duplicate fixture",
+		auth: {} as Provider["auth"],
+		getModels: () => [model],
+		stream(activeModel, _context, options) {
+			const stream = createAssistantMessageEventStream();
+			void (async () => {
+				try {
+					await options?.onPayload?.({ model: activeModel.id, input: [] }, activeModel);
+					await options?.fetch?.("https://example.test/v1/responses", { method: "POST" });
+					await options?.fetch?.("https://example.test/v1/responses", { method: "POST" });
+					const message = {
+						role: "assistant" as const,
+						content: [],
+						api: activeModel.api,
+						provider: activeModel.provider,
+						model: activeModel.id,
+						usage: {
+							input: 7,
+							output: 2,
+							cacheRead: 3,
+							cacheWrite: 0,
+							totalTokens: 12,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop" as const,
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "done", reason: "stop", message });
+					stream.end(message);
+				} catch (error) {
+					stream.end();
+					throw error;
+				}
+			})();
+			return stream;
+		},
+		streamSimple() {
+			throw new Error("not used");
+		},
+	};
+	let externalRequests = 0;
+	await assert.rejects(
+		requestRemoteCompaction({
+			provider,
+			model,
+			context: context(),
+			protocol: "responses-compact",
+			apiKey: "fixture",
+			signal: new AbortController().signal,
+			fetch: async () => {
+				externalRequests += 1;
+				return compactResponse();
+			},
+		}),
+		/dispatched again/,
+	);
+	assert.equal(externalRequests, 1);
+});
+
+test("unary compact aborts stalled response parsing without publishing output", async () => {
+	const api = "openai-responses";
+	const provider = await providerFor(api);
+	const controller = new AbortController();
+	const pending = requestRemoteCompaction({
+		provider,
+		model: modelFor(api),
+		context: context(),
+		protocol: "responses-compact",
+		apiKey: apiKey(api),
+		signal: controller.signal,
+		fetch: async () =>
+			new Response(
+				new ReadableStream<Uint8Array>({
+					start() {
+						queueMicrotask(() => controller.abort());
+					},
+				}),
+				{ status: 200 },
+			),
+	});
+	await assert.rejects(pending, /aborted/i);
+});
+
+test("compact URL rewriting rejects unexpected paths and preserves origin and query", () => {
+	assert.equal(
+		responsesCompactUrl("https://example.test/v1/responses?api-version=v1").toString(),
+		"https://example.test/v1/responses/compact?api-version=v1",
+	);
+	assert.throws(
+		() => responsesCompactUrl("https://attacker.test/v1/chat/completions"),
+		/does not end with the Responses endpoint/,
+	);
+});

--- a/packages/pi-codex-compact/test/remote.test.ts
+++ b/packages/pi-codex-compact/test/remote.test.ts
@@ -115,6 +115,7 @@ test("uses the public provider stream with SSE, bounded retry options, and a fin
 		provider,
 		model,
 		context: { messages: [] } satisfies Context,
+		protocol: "remote-v2",
 		apiKey: "oauth-token",
 		signal: new AbortController().signal,
 		fetch: async () => responseSse(),
@@ -135,6 +136,7 @@ test("expands a previous checkpoint before requesting repeated compaction", asyn
 		provider,
 		model,
 		context: { messages: [] },
+		protocol: "remote-v2",
 		apiKey: "oauth-token",
 		signal: new AbortController().signal,
 		priorCheckpoint: {
@@ -159,6 +161,7 @@ test("propagates abort and malformed remote output", async () => {
 			provider,
 			model,
 			context: { messages: [] },
+			protocol: "remote-v2",
 			apiKey: "oauth-token",
 			signal: controller.signal,
 			fetch: async () => responseSse(),
@@ -170,6 +173,7 @@ test("propagates abort and malformed remote output", async () => {
 			provider,
 			model,
 			context: { messages: [] },
+			protocol: "remote-v2",
 			apiKey: "oauth-token",
 			signal: new AbortController().signal,
 			fetch: async () =>

--- a/packages/pi-codex-compact/test/settings-menu.test.ts
+++ b/packages/pi-codex-compact/test/settings-menu.test.ts
@@ -46,14 +46,17 @@ test("root menu makes manual compaction primary and exposes its effective route"
 	const customContext = createMockContext({ model: customModel }).ctx;
 	assert.deepEqual(compactMenuStatus(customContext), {
 		model: "company-codex-proxy/gpt-5.6",
-		remoteEligible: true,
+		api: "openai-codex-responses",
 	});
-	const ineligibleStatus = compactMenuStatus(
+	const openAIStatus = compactMenuStatus(
 		createMockContext({ model: { ...customModel, api: "openai-responses" } }).ctx,
 	);
-	assert.equal(ineligibleStatus.remoteEligible, false);
+	assert.equal(openAIStatus.api, "openai-responses");
+	const ineligibleStatus = compactMenuStatus(
+		createMockContext({ model: { ...customModel, api: "anthropic-messages" } }).ctx,
+	);
 	const menu = createCodexCompactMenu(current.runtime, {
-		status: { model: "openai-codex/gpt-5.6", remoteEligible: true },
+		status: { model: "openai-codex/gpt-5.6", api: "openai-codex-responses" },
 	});
 	assert.equal(menu.start, "main");
 	const main = resolveMenuScreen(menu, "main", current.runtime.get());
@@ -64,7 +67,7 @@ test("root menu makes manual compaction primary and exposes its effective route"
 		["Compact now", "Settings", "Close"],
 	);
 	assert.match(main.lines?.join("\n") ?? "", /openai-codex\/gpt-5\.6/);
-	assert.match(main.lines?.join("\n") ?? "", /Codex Remote V2/);
+	assert.match(main.lines?.join("\n") ?? "", /Responses Remote V2/);
 	const ineligible = resolveMenuScreen(
 		createCodexCompactMenu(current.runtime, { status: ineligibleStatus }),
 		"main",
@@ -72,14 +75,25 @@ test("root menu makes manual compaction primary and exposes its effective route"
 	);
 	assert.equal(ineligible.kind, "actions");
 	if (ineligible.kind !== "actions") assert.fail("Expected ineligible actions screen");
-	assert.match(ineligible.lines?.join("\n") ?? "", /Pi native \(requires openai-codex-responses\)/);
+	assert.match(
+		ineligible.lines?.join("\n") ?? "",
+		/Pi native \(API anthropic-messages does not support Responses compaction\)/,
+	);
 	const disabled = resolveMenuScreen(menu, "main", {
 		...current.runtime.get(),
 		settings: { ...current.runtime.get().settings, enabled: false },
 	});
 	assert.equal(disabled.kind, "actions");
 	if (disabled.kind !== "actions") assert.fail("Expected disabled actions screen");
-	assert.match(disabled.lines?.join("\n") ?? "", /Pi native \(Remote V2 off\)/);
+	assert.match(disabled.lines?.join("\n") ?? "", /Pi native \(remote compaction is disabled\)/);
+	const openAI = resolveMenuScreen(
+		createCodexCompactMenu(current.runtime, { status: openAIStatus }),
+		"main",
+		current.runtime.get(),
+	);
+	assert.equal(openAI.kind, "actions");
+	if (openAI.kind !== "actions") assert.fail("Expected OpenAI actions screen");
+	assert.match(openAI.lines?.join("\n") ?? "", /Responses Compact API/);
 });
 
 test("settings screen exposes bounded controls and invalid files remain repairable", () => {
@@ -92,6 +106,7 @@ test("settings screen exposes bounded controls and invalid files remain repairab
 		screen.items.map((item) => [item.id, item.currentValue]),
 		[
 			["enabled", "On"],
+			["protocol", "Auto"],
 			["requestTimeoutMs", "5 min"],
 			["maxRetries", "2"],
 			["replacementTokenBudget", "64K tokens"],
@@ -141,17 +156,48 @@ test("menu actions persist exact setting patches", async () => {
 		value,
 	});
 	await menu.actions["set-enabled"](action("Off"));
+	await menu.actions["set-protocol"](action("Responses Compact"));
 	await menu.actions["set-timeout"](action("10 min"));
 	await menu.actions["set-retries"](action("1"));
 	await menu.actions["set-retention"](action("96K tokens"));
 	await menu.actions["set-notify"](action("Off"));
 	assert.deepEqual(memory.patches, [
 		{ enabled: false },
+		{ protocol: "responses-compact" },
 		{ requestTimeoutMs: 600_000 },
 		{ maxRetries: 1 },
 		{ replacementTokenBudget: 96_000 },
 		{ notifyOnFallback: false },
 	]);
+});
+
+test("stale settings saves do not notify through a disposed menu", async () => {
+	const memory = memoryRuntime();
+	let release!: () => void;
+	const blocked = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const runtime: CodexCompactSettingsRuntime = {
+		...memory.runtime,
+		async update(patch) {
+			await blocked;
+			return memory.runtime.update(patch);
+		},
+	};
+	const menu = createCodexCompactMenu(runtime);
+	const controller = new AbortController();
+	const { ctx, notifications } = createMockContext({ mode: "tui" });
+	const pending = menu.actions["set-enabled"]({
+		ctx,
+		state: runtime.get(),
+		signal: controller.signal,
+		itemId: "enabled",
+		value: "Off",
+	});
+	controller.abort();
+	release();
+	assert.deepEqual(await pending, { kind: "rejected" });
+	assert.deepEqual(notifications, []);
 });
 
 test("TUI manual action compacts once after close and reports core errors", async () => {
@@ -199,20 +245,27 @@ test("stale menu ownership cannot trigger delayed manual compaction", async () =
 	assert.equal(compactions, 0);
 });
 
-test("non-TUI command reports the settings path without compacting", async () => {
+test("non-TUI command reports through RPC and remains silent in print mode", async () => {
 	const memory = memoryRuntime();
 	let compactions = 0;
-	const { ctx, notifications } = createMockContext({
-		mode: "print",
-		hasUI: false,
+	const rpc = createMockContext({
+		mode: "rpc",
+		hasUI: true,
 		compact: () => {
 			compactions += 1;
 		},
 	});
-	await showCodexCompactMenu(memory.runtime, ctx, {
+	await showCodexCompactMenu(memory.runtime, rpc.ctx, {
 		signal: new AbortController().signal,
 		isCurrent: () => true,
 	});
-	assert.match(notifications[0]?.message ?? "", /pi-codex-compact\.json/);
+	assert.match(rpc.notifications[0]?.message ?? "", /pi-codex-compact\.json/);
+
+	const print = createMockContext({ mode: "print", hasUI: false });
+	await showCodexCompactMenu(memory.runtime, print.ctx, {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+	});
+	assert.deepEqual(print.notifications, []);
 	assert.equal(compactions, 0);
 });

--- a/packages/pi-codex-compact/test/settings-menu.test.ts
+++ b/packages/pi-codex-compact/test/settings-menu.test.ts
@@ -245,7 +245,7 @@ test("stale menu ownership cannot trigger delayed manual compaction", async () =
 	assert.equal(compactions, 0);
 });
 
-test("non-TUI command reports through RPC and remains silent in print mode", async () => {
+test("non-TUI command reports through RPC and rejects print and JSON modes", async () => {
 	const memory = memoryRuntime();
 	let compactions = 0;
 	const rpc = createMockContext({
@@ -261,11 +261,16 @@ test("non-TUI command reports through RPC and remains silent in print mode", asy
 	});
 	assert.match(rpc.notifications[0]?.message ?? "", /pi-codex-compact\.json/);
 
-	const print = createMockContext({ mode: "print", hasUI: false });
-	await showCodexCompactMenu(memory.runtime, print.ctx, {
-		signal: new AbortController().signal,
-		isCurrent: () => true,
-	});
-	assert.deepEqual(print.notifications, []);
+	for (const mode of ["print", "json"] as const) {
+		const nonInteractive = createMockContext({ mode, hasUI: false });
+		await assert.rejects(
+			showCodexCompactMenu(memory.runtime, nonInteractive.ctx, {
+				signal: new AbortController().signal,
+				isCurrent: () => true,
+			}),
+			/requires TUI or RPC UI support/,
+		);
+		assert.deepEqual(nonInteractive.notifications, []);
+	}
 	assert.equal(compactions, 0);
 });

--- a/packages/pi-codex-compact/test/settings.test.ts
+++ b/packages/pi-codex-compact/test/settings.test.ts
@@ -26,11 +26,20 @@ afterEach(async () => {
 
 test("normalizes defaults and bounded user settings", () => {
 	assert.deepEqual(normalizeCodexCompactSettings({}), DEFAULT_CODEX_COMPACT_SETTINGS);
-	assert.deepEqual(normalizeCodexCompactSettings({ enabled: false, maxRetries: 0 }), {
-		...DEFAULT_CODEX_COMPACT_SETTINGS,
-		enabled: false,
-		maxRetries: 0,
-	});
+	assert.deepEqual(
+		normalizeCodexCompactSettings({
+			enabled: false,
+			protocol: "responses-compact",
+			maxRetries: 0,
+		}),
+		{
+			...DEFAULT_CODEX_COMPACT_SETTINGS,
+			enabled: false,
+			protocol: "responses-compact",
+			maxRetries: 0,
+		},
+	);
+	assert.equal(normalizeCodexCompactSettings({ protocol: "unknown" }), undefined);
 	assert.equal(normalizeCodexCompactSettings({ maxRetries: 3 }), undefined);
 	assert.equal(normalizeCodexCompactSettings({ requestTimeoutMs: 10 }), undefined);
 	assert.equal(normalizeCodexCompactSettings({ replacementTokenBudget: 1_000_000 }), undefined);

--- a/packages/pi-codex-compact/test/terminal.test.ts
+++ b/packages/pi-codex-compact/test/terminal.test.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { terminalText } from "../src/terminal.js";
+
+test("strips terminal controls without mutating printable text", () => {
+	assert.equal(terminalText("model\u001b[31m\nname\u009b"), "model [31m name ");
+	assert.equal(terminalText("openai/gpt-5.4"), "openai/gpt-5.4");
+});


### PR DESCRIPTION
## Summary

- support Remote V2 and unary `responses/compact` across Codex, OpenAI, and Azure Responses APIs
- add protocol routing, bounded JSON/SSE validation, same-origin request bridging, and version 1 checkpoint migration
- preserve Pi compaction lifecycle, settings safety, native fallback, and deterministic checkpoint replay
- update the package menu, documentation, benchmark classification, and release Changeset

## Verification

- `npm run check`
- `npm --workspace @narumitw/pi-codex-compact run check`
- `npx tsc -p tsconfig.test.json`
- `npx vitest run packages/pi-codex-compact/test` — 86 passed
- `node packages/pi-codex-compact/benchmark/self-test.mjs`
- `npm run package:pack -- codex-compact` — 22 expected files; no tests or benchmark artifacts
- offline package-directory Pi load smoke
- live OpenAI Codex Remote V2 compact and checkpoint replay — checkpoint version 2, replay completed
- README heading audit
- PR CI — checks and configured affected test suite passed

## Risks and unverified paths

- OpenAI and Azure live unary smokes were unavailable because those credentials are not configured; deterministic tests exercise their installed real adapters.
- Pi's public `getAllTools()` omits `constrainedSampling`; the package preserves exposed active-tool order, names, descriptions, and schemas and documents this limitation.
- Local unconstrained full `npm test` runs repeatedly hit unrelated 5-second Git/generated-entry timeouts under sustained host load. The same `pi-sync` contract timeout reproduces on an unmodified `origin/main` worktree. Package tests, test TypeScript compilation, root checks, and the PR's configured affected test suite pass.
