### PR TITLE
fix(pi-worktree): normalize cwd comparison in writeTargetSession for Windows

### DIFF
--- a/.changeset/fix-pi-worktree-windows-path.md
+++ b/.changeset/fix-pi-worktree-windows-path.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-worktree": patch
+---
+
+Normalize the cwd comparison in `writeTargetSession` so `/worktree` workspace switching works on Windows, where Git reports forward-slash paths but session headers store backslashes.

--- a/packages/pi-worktree/src/session.ts
+++ b/packages/pi-worktree/src/session.ts
@@ -1,4 +1,5 @@
 import { existsSync, writeFileSync } from "node:fs";
+import { resolve as normalizeTargetPath } from "node:path";
 import type { ExtensionCommandContext, SessionEntry } from "@earendil-works/pi-coding-agent";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { stripTerminalControls } from "./git.js";
@@ -92,7 +93,10 @@ function writeTargetSession(
 		mode: 0o600,
 	});
 	const verified = SessionManager.open(targetFile);
-	if (verified.getCwd() !== targetPath || verified.getLeafId() !== expectedLeaf) {
+	if (
+		normalizeTargetPath(verified.getCwd()) !== normalizeTargetPath(targetPath) ||
+		verified.getLeafId() !== expectedLeaf
+	) {
 		throw new Error("Pi could not verify the target session cwd and active branch.");
 	}
 	return targetFile;


### PR DESCRIPTION
## Summary

On Windows, `/worktree` workspace switching always fails with:

```
Could not switch Pi workspace to D:/workspace/projects/frontend-web-excel/.pi-worktrees. The worktree was retained. Retry from /worktree. Pi could not verify the target session cwd and active branch.
```

The Git worktree itself is created successfully; only the Pi session-switch step fails. The failure is deterministic — every retry fails at the same check.

## Root Cause

1. `switchToWorktree()` receives `targetPath` from `git worktree list --porcelain` output. On Windows, Git emits **forward-slash** paths (`D:/workspace/projects/...`).
2. `writeTargetSession()` calls `SessionManager.create(targetPath)`. Internally, Pi stores `cwd = resolvePath(cwd)` (i.e. `path.resolve()`), which normalizes to **backslashes** on win32 (`D:\workspace\projects\...`). This is what gets written into the session header.
3. Verification then compares strictly — `packages/pi-worktree/src/session.ts`:
   ```ts
   if (verified.getCwd() !== targetPath || verified.getLeafId() !== expectedLeaf) {
   ```
   A backslash form and a forward-slash form are **never equal on Windows**, so the switch always throws.

## Fix

Normalize both sides before comparing in `writeTargetSession()` (`packages/pi-worktree/src/session.ts`) using `node:path`:

```ts
import { resolve as normalizeTargetPath } from "node:path";
// ...
if (
    normalizeTargetPath(verified.getCwd()) !== normalizeTargetPath(targetPath) ||
    verified.getLeafId() !== expectedLeaf
) {
    throw new Error("Pi could not verify the target session cwd and active branch.");
}
```

On win32, `path.resolve()` canonicalizes both paths to the same backslash form; on POSIX the comparison is unchanged in effect (both sides already use the platform separator).

## Verification

- `npm run check` for `packages/pi-worktree` passes (build + biome + `tsc --noEmit`).
- All pi-worktree tests pass (11 files / 94 tests).
- The win32 separator mismatch cannot be reproduced on POSIX CI, so the behavior fix is validated by root-cause analysis plus a report from a Windows 11 machine (`pi 0.84.3`, `@narumitw/pi-worktree 0.51.6`): after normalization, the workspace switch succeeds in both the create-and-switch and switch flows; only the cwd comparison was broken — `getLeafId()` already matched.

## Changeset

Adds a `patch` changeset for `@narumitw/pi-worktree`.
