### PR TITLE
fix(btw): wait for terminal input drain

### DIFF
--- a/.changeset/quiet-btw-input-drain.md
+++ b/.changeset/quiet-btw-input-drain.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Wait for Pi's terminal input drain before restoring the parent fullscreen TUI after Ctrl+C.

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -159,8 +159,8 @@ Prefer Pi-owned `ctx.ui` flows and one TUI when they can preserve the required s
   The outgoing TUI must consume the triggering input so it cannot reach a stale or unrelated focused component.
   **Verification:** `Test` hard cancellation with the root component focused and again with at least one nested overlay focused, and assert that the owning flow settles in each case.
 - **MUST:** Do not stop or start a shared terminal reentrantly from its active input callback.
-  Keep logical cancellation synchronous, but defer the physical terminal transfer until the triggering callback unwinds when either TUI rebuilds terminal input state during stop or start.
-  **Verification:** `Test` input-dispatch depth and assert that every terminal stop, start, and restored redraw occurs only after the triggering callback returns.
+  Keep logical cancellation synchronous, but wait for the terminal's native input-drain boundary before the physical transfer when the host exposes one; otherwise defer until the triggering callback unwinds.
+  **Verification:** `Test` with a controllable input drain and input-dispatch depth, then assert that every terminal stop, start, and restored redraw occurs only after the applicable boundary settles.
 - **MUST:** After terminal restoration completes, the next separately dispatched input must reach the restored TUI through its normal input pipeline instead of being delivered to the stopped TUI.
   Do not promise replay of bytes already coalesced behind the handoff key in the triggering raw dispatch when Pi exposes no public input-injection API.
   **Verification:** `Test` the first post-restoration printable and viewport inputs and assert that the restored editor and scroll region receive them without another handoff key.
@@ -385,7 +385,7 @@ fragile regular expressions. Until then, label the real verification method hone
 - [ ] For command-surface changes, preserve established routes or explicitly own an approved breaking
       migration, and test every claimed execution mode.
 - [ ] For prompt-cache-sensitive changes, identify each prefix epoch and compare normalized provider-facing inputs across ordinary requests and applicable restoration boundaries.
-- [ ] For shared-terminal handoffs, test hard cancellation under root and nested-overlay focus, same-batch follow-up input, repeated cleanup, and unrelated parent overlays.
+- [ ] For shared-terminal handoffs, test hard cancellation under root and nested-overlay focus, pending input drain, post-restoration input, repeated cleanup, and unrelated parent overlays.
 - [ ] Update focused tests and run the verification method named by each relevant MUST.
 - [ ] Run `npm run check` and `npm test`; add pack or Pi runtime smokes when metadata or loading changed.
 - [ ] Report any skipped check, accepted exception, or follow-up validator opportunity in the change

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -304,6 +304,7 @@ class BtwFullscreenHost<T> implements Component {
 	private fullscreenCreated = false;
 	private fullscreenStopped = false;
 	private parentRestoreQueued = false;
+	private parentRestorePromise: Promise<void> | undefined;
 	private cleanupError: unknown;
 
 	constructor(
@@ -357,8 +358,8 @@ class BtwFullscreenHost<T> implements Component {
 				try {
 					this.hardCancelActiveCustom?.();
 				} finally {
-					// ProcessTerminal.stop() destroys its active input buffer. Defer only the
-					// physical handoff so Windows can finish dispatching this Ctrl+C first.
+					// ProcessTerminal.stop() destroys its active input buffer. Keep cancellation
+					// synchronous, then drain input before the physical Windows terminal handoff.
 					// Pi has no public input injection, so do not replay bytes already coalesced
 					// behind the hard-cancel key.
 					this.queueParentRestore();
@@ -375,7 +376,8 @@ class BtwFullscreenHost<T> implements Component {
 		} catch (error) {
 			this.cleanupError ??= error;
 		}
-		this.restoreParent();
+		if (this.parentRestorePromise) await this.parentRestorePromise;
+		else this.restoreParent();
 		if (this.cleanupError !== undefined) outcome = { kind: "failed", error: this.cleanupError };
 		this.finished = true;
 		this.done(outcome);
@@ -384,7 +386,12 @@ class BtwFullscreenHost<T> implements Component {
 	private queueParentRestore(): void {
 		if (this.parentRestoreQueued || this.parentRestoreAttempted) return;
 		this.parentRestoreQueued = true;
-		queueMicrotask(() => {
+		this.parentRestorePromise = Promise.resolve().then(async () => {
+			try {
+				await this.fullscreen?.terminal.drainInput?.();
+			} catch (error) {
+				this.cleanupError ??= error;
+			}
 			this.parentRestoreQueued = false;
 			this.restoreParent();
 		});

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -207,6 +207,10 @@ class InputHandoffTerminal implements Terminal {
 	private inputHandler: ((data: string) => void) | undefined;
 	private inputDispatchDepth = 0;
 	private nextStopError: Error | undefined;
+	private pendingDrain: Promise<void> | undefined;
+	private resolvePendingDrain: (() => void) | undefined;
+	private rejectPendingDrain: ((error: Error) => void) | undefined;
+	drainCallCount = 0;
 
 	start(onInput: (data: string) => void): void {
 		this.recordLifecycle("start");
@@ -225,6 +229,25 @@ class InputHandoffTerminal implements Terminal {
 		this.nextStopError = error;
 	}
 
+	deferDrain(): void {
+		this.pendingDrain = new Promise<void>((resolve, reject) => {
+			this.resolvePendingDrain = resolve;
+			this.rejectPendingDrain = reject;
+		});
+	}
+
+	resolveDrain(): void {
+		this.resolvePendingDrain?.();
+		this.resolvePendingDrain = undefined;
+		this.rejectPendingDrain = undefined;
+	}
+
+	rejectDrain(error: Error): void {
+		this.rejectPendingDrain?.(error);
+		this.resolvePendingDrain = undefined;
+		this.rejectPendingDrain = undefined;
+	}
+
 	send(data: string): void {
 		const handler = this.inputHandler;
 		if (!handler) return;
@@ -241,7 +264,10 @@ class InputHandoffTerminal implements Terminal {
 		if (this.inputDispatchDepth > 0) this.lifecycleDuringInput.push(event);
 	}
 
-	async drainInput(): Promise<void> {}
+	async drainInput(): Promise<void> {
+		this.drainCallCount += 1;
+		await this.pendingDrain;
+	}
 	write(data: string): void {
 		if (this.inputDispatchDepth > 0) this.outputDuringInput.push(data);
 	}
@@ -465,6 +491,93 @@ async function startClipboardSelection(
 		copyInput: inputForCopyBinding(keybindings),
 	};
 }
+
+test("Ctrl+C waits for terminal input drain before restoring the parent", async () => {
+	const harness = createInputHandoffHarness();
+	harness.terminal.deferDrain();
+	let sideCancelCount = 0;
+	let settled = false;
+	const running = runBtwFullscreen(harness.ctx, (ctx) =>
+		ctx.ui.custom<"closed">((_tui, _theme, _keybindings, done) => ({
+			focused: false,
+			render: () => ["side thread"],
+			handleInput(data: string) {
+				if (data !== "\u0003") return;
+				sideCancelCount += 1;
+				done("closed");
+			},
+			invalidate() {},
+		})),
+	);
+	void running.then(
+		() => {
+			settled = true;
+		},
+		() => {
+			settled = true;
+		},
+	);
+	try {
+		await flushAsyncWork();
+		const lifecycleBeforeCancel = harness.terminal.lifecycle.length;
+
+		harness.terminal.send("\u0003");
+
+		assert.equal(sideCancelCount, 1);
+		await Promise.resolve();
+		assert.equal(harness.terminal.drainCallCount, 1);
+		assert.equal(settled, false);
+		assert.equal(harness.terminal.lifecycle.length, lifecycleBeforeCancel);
+
+		harness.terminal.send("\u0003");
+		await Promise.resolve();
+		assert.equal(sideCancelCount, 1);
+		assert.equal(harness.terminal.drainCallCount, 1);
+		assert.equal(harness.terminal.lifecycle.length, lifecycleBeforeCancel);
+
+		harness.terminal.resolveDrain();
+
+		assert.equal(await running, "closed");
+		assert.deepEqual(harness.terminal.lifecycle.slice(lifecycleBeforeCancel), ["stop", "start"]);
+	} finally {
+		harness.terminal.resolveDrain();
+		await running.catch(() => undefined);
+		harness.parent.stop();
+	}
+});
+
+test("a drainInput failure still restores the parent once and propagates", async () => {
+	const harness = createInputHandoffHarness();
+	harness.terminal.deferDrain();
+	const running = runBtwFullscreen(harness.ctx, (ctx) =>
+		ctx.ui.custom<"closed">((_tui, _theme, _keybindings, done) => ({
+			focused: false,
+			render: () => ["side thread"],
+			handleInput(data: string) {
+				if (data === "\u0003") done("closed");
+			},
+			invalidate() {},
+		})),
+	);
+	try {
+		await flushAsyncWork();
+		const lifecycleBeforeCancel = harness.terminal.lifecycle.length;
+
+		harness.terminal.send("\u0003");
+		await Promise.resolve();
+
+		assert.equal(harness.terminal.drainCallCount, 1);
+		assert.equal(harness.terminal.lifecycle.length, lifecycleBeforeCancel);
+		harness.terminal.rejectDrain(new Error("input drain failed"));
+
+		await assert.rejects(running, /input drain failed/u);
+		assert.deepEqual(harness.terminal.lifecycle.slice(lifecycleBeforeCancel), ["stop", "start"]);
+	} finally {
+		harness.terminal.resolveDrain();
+		await running.catch(() => undefined);
+		harness.parent.stop();
+	}
+});
 
 test("Ctrl+C restores a fullscreen parent only after input dispatch unwinds", async () => {
 	const harness = createInputHandoffHarness(createBtwTestKeybindings(), {


### PR DESCRIPTION
## Summary

- wait for Pi's terminal input drain before transferring the shared terminal back to the parent TUI
- keep Ctrl+C cancellation synchronous while serializing queued and outer cleanup through one restore promise
- cover pending-drain ordering, repeated cancellation, and drain failure recovery
- update the shared-terminal convention and add a patch Changeset

Fixes #1173

## Verification

- `npx --no-install vitest run packages/pi-btw/test/fullscreen-ui.test.ts`: 37 tests passed
- related generated-entry, fullscreen-search, and mouse-wheel tests: 42 tests passed
- `npm --workspace @narumitw/pi-btw run typecheck`
- `npm run check`
- `npm pack --workspace @narumitw/pi-btw --dry-run --json`: 15 files
- package-directory Pi load smoke through the installed CLI bundle: 8 model rows

## Environment limitations

- `npm test` could not start the suite in this Windows tool environment because `spawnSync ... tsc.cmd` returned `EINVAL`.
- Direct pi-btw Vitest execution passed 200 tests; its build-runtime symlink case failed with an unrelated Windows `EPERM`.
- Interactive Windows Terminal rendering and viewport scrolling were not re-smoked because the harness exposes non-TTY stdin/stdout.