### PR TITLE
feat(session-skills): add session-scoped skill loading

### DIFF
--- a/.pi/extensions/pi-session-skills/README.md
+++ b/.pi/extensions/pi-session-skills/README.md
@@ -54,7 +54,7 @@ GitHub shorthand and HTTPS URLs first use normal Git credentials. Authentication
 
 ## 🔄 Session and cache behavior
 
-Activation is stored as a full snapshot in the current session branch. The desired snapshot is written before Pi reloads so the replacement runtime can discover it. If the broader Pi reload fails, that snapshot is applied by the next successful reload. A new session starts empty, while resume and fork follow the snapshot present on their active branch.
+Activation is stored as a full snapshot in the current session branch. The desired snapshot is written before Pi reloads so the replacement runtime can discover it. If the broader Pi reload fails, that snapshot is applied by the next successful reload. A saved activation skipped because it is missing, unsafe, or conflicting remains unloadable by name or with `unload --all`. A new session starts empty, while resume and fork follow the snapshot present on their active branch.
 
 Cache content is stored under:
 

--- a/.pi/extensions/pi-session-skills/README.md
+++ b/.pi/extensions/pi-session-skills/README.md
@@ -80,7 +80,7 @@ Temporary clone and copy directories are removed after success, failure, cancell
 
 Remote skills contain instructions and executable files that can run with the full permissions of the Pi process. Review the source before invoking the loaded skill.
 
-The extension rejects embedded URL credentials, unsafe repository subpaths, unsupported file types, and symbolic links inside skills. Git credentials remain owned by Git credential helpers or SSH and are not copied into the cache metadata.
+The extension rejects embedded URL credentials, unsafe repository subpaths, invalid skill names, unsupported file types, and symbolic links inside skills. Git credentials remain owned by Git credential helpers or SSH and are not copied into the cache metadata.
 
 Existing project or global skills win name collisions. The extension rejects activation when the selected name is already provided by another active skill path.
 

--- a/.pi/extensions/pi-session-skills/README.md
+++ b/.pi/extensions/pi-session-skills/README.md
@@ -45,15 +45,16 @@ The `load` route activates exactly one skill. A source containing multiple skill
 /session-skills load git@github.com:owner/repo.git --skill <name>
 /session-skills load ssh://git@example.com/team/repo.git --skill <name>
 /session-skills load ./local-skills --skill <name>
+/session-skills load .\\local-skills --skill <name>
 ```
 
-Use `--refresh` to resolve and replace an existing cache entry. Without it, the command reuses cached content, including for mutable branches and local paths. The `list` route shows active skills with their source and cache path. The `unload` route deactivates skills without deleting cached content.
+Use `--refresh` to resolve a fresh cache version. The prior version remains intact until validation and collision checks pass. Without refresh, the command reuses cached content, including for mutable branches and local paths. The `list` route shows active skills with their source and cache path. The `unload` route deactivates skills without deleting cached content.
 
-GitHub shorthand and HTTPS URLs first use normal Git credentials. Authentication failures retry the equivalent SSH URL when one can be derived. Explicit SSH sources use the user's SSH configuration and agent. Git runs non-interactively and times out after five minutes.
+GitHub shorthand and HTTPS URLs first use normal Git credentials. Authentication failures retry the equivalent SSH URL when one can be derived. Explicit SSH sources use the user's SSH configuration and agent. Git runs non-interactively, and each Git command times out after five minutes. Tree URLs with a 40-character commit hash fetch that commit directly and check it out detached.
 
 ## 🔄 Session and cache behavior
 
-Activation is stored as a full snapshot in the current session branch. A new session starts empty, while resume and fork follow the snapshot present on their active branch.
+Activation is stored as a full snapshot in the current session branch. The desired snapshot is written before Pi reloads so the replacement runtime can discover it. If the broader Pi reload fails, that snapshot is applied by the next successful reload. A new session starts empty, while resume and fork follow the snapshot present on their active branch.
 
 Cache content is stored under:
 
@@ -83,7 +84,7 @@ Existing project or global skills win name collisions. The extension rejects act
 - Discovery follows `SKILL.md` directories to a maximum depth of eight and rejects sources with more than 500 discovered skills.
 - GitHub and GitLab tree URLs treat the segment after `tree` as the ref; refs containing `/` are not currently supported.
 - Cache publication is serialized within one Pi process; independent Pi processes can still race while refreshing the same source.
-- Commands support TUI and RPC modes. Print and JSON modes reject them explicitly.
+- The command supports TUI and RPC modes. Print and JSON modes reject it explicitly.
 
 ## 🗂️ Layout
 

--- a/.pi/extensions/pi-session-skills/README.md
+++ b/.pi/extensions/pi-session-skills/README.md
@@ -1,0 +1,100 @@
+# 🧩 Pi Session Skills
+
+Load one Agent Skill from a Git repository or local path into the current Pi session without installing it into project or global skill directories.
+
+## ✨ Features
+
+- Resolves GitHub shorthand, GitHub and GitLab repository URLs, HTTPS or SSH Git URLs, and local paths.
+- Copies the selected skill into an extension-owned cache and activates only its cache path.
+- Uses Pi's native skill validation, system-prompt discovery, and `/skill:name` command.
+- Restores activation on `/reload`, `/resume`, `/fork`, and restart of the same saved session.
+- Keeps cache content separate from session activation and supports explicit refresh.
+- Has no runtime dependency on external skill manager CLIs or another extension.
+
+## 🚀 Quick start
+
+```text
+/session-skills load <source>
+/session-skills load <source> --skill <name>
+/session-skills list
+/session-skills unload <name>
+```
+
+Loading or unloading calls Pi's reload flow because Pi does not expose a dynamic `registerSkill()` API. The conversation remains in the same saved session, but all extensions and resources are reloaded.
+
+## 💬 Command
+
+### `/session-skills`
+
+With no arguments, show the current session skills and command usage. All actions use this single slash command:
+
+```text
+/session-skills load <source> [--skill <name>] [--refresh]
+/session-skills list
+/session-skills unload <name>
+/session-skills unload --all
+```
+
+The `load` route activates exactly one skill. A source containing multiple skills requires `--skill`.
+
+```text
+/session-skills load owner/repo
+/session-skills load owner/repo@<name>
+/session-skills load https://github.com/owner/repo/tree/main/path/to/skill
+/session-skills load https://gitlab.com/group/repo/-/tree/main/path/to/skill
+/session-skills load git@github.com:owner/repo.git --skill <name>
+/session-skills load ssh://git@example.com/team/repo.git --skill <name>
+/session-skills load ./local-skills --skill <name>
+```
+
+Use `--refresh` to resolve and replace an existing cache entry. Without it, the command reuses cached content, including for mutable branches and local paths. The `list` route shows active skills with their source and cache path. The `unload` route deactivates skills without deleting cached content.
+
+GitHub shorthand and HTTPS URLs first use normal Git credentials. Authentication failures retry the equivalent SSH URL when one can be derived. Explicit SSH sources use the user's SSH configuration and agent. Git runs non-interactively and times out after five minutes.
+
+## 🔄 Session and cache behavior
+
+Activation is stored as a full snapshot in the current session branch. A new session starts empty, while resume and fork follow the snapshot present on their active branch.
+
+Cache content is stored under:
+
+```text
+${XDG_CACHE_HOME}/pi/session-skills
+```
+
+When `XDG_CACHE_HOME` is unset or relative, the fallback is:
+
+```text
+~/.cache/pi/session-skills
+```
+
+Temporary clone and copy directories are removed after success, failure, cancellation, or shutdown. Cache entries are published only after Pi validates the copied skill.
+
+## 🔐 Security
+
+Remote skills contain instructions and executable files that can run with the full permissions of the Pi process. Review the source before invoking the loaded skill.
+
+The extension rejects embedded URL credentials, unsafe repository subpaths, unsupported file types, and symbolic links inside skills. Git credentials remain owned by Git credential helpers or SSH and are not copied into the cache metadata.
+
+Existing project or global skills win name collisions. The extension rejects activation when the selected name is already provided by another active skill path.
+
+## ⚠️ Limitations
+
+- Direct HTTP files, archives, well-known endpoints, and GitHub API downloads are not supported.
+- Discovery follows `SKILL.md` directories to a maximum depth of eight and rejects sources with more than 500 discovered skills.
+- GitHub and GitLab tree URLs treat the segment after `tree` as the ref; refs containing `/` are not currently supported.
+- Cache publication is serialized within one Pi process; independent Pi processes can still race while refreshing the same source.
+- Commands support TUI and RPC modes. Print and JSON modes reject them explicitly.
+
+## 🗂️ Layout
+
+```text
+pi-session-skills/
+├── index.ts
+├── extension.ts
+├── command-parser.ts
+├── source-parser.ts
+├── resolver.ts
+├── *.test.ts
+├── tsconfig.json
+└── vitest.config.ts
+```

--- a/.pi/extensions/pi-session-skills/README.md
+++ b/.pi/extensions/pi-session-skills/README.md
@@ -62,7 +62,13 @@ Cache content is stored under:
 ${XDG_CACHE_HOME}/pi/session-skills
 ```
 
-When `XDG_CACHE_HOME` is unset or relative, the fallback is:
+When `XDG_CACHE_HOME` is unset or relative, Windows uses `LOCALAPPDATA` when available:
+
+```text
+%LOCALAPPDATA%\pi\session-skills
+```
+
+Other platforms use:
 
 ```text
 ~/.cache/pi/session-skills

--- a/.pi/extensions/pi-session-skills/README.md
+++ b/.pi/extensions/pi-session-skills/README.md
@@ -87,7 +87,7 @@ Existing project or global skills win name collisions. The extension rejects act
 ## ⚠️ Limitations
 
 - Direct HTTP files, archives, well-known endpoints, and GitHub API downloads are not supported.
-- Discovery follows `SKILL.md` directories to a maximum depth of eight and rejects sources with more than 500 discovered skills.
+- Discovery follows Pi's hidden-directory and `.gitignore`, `.ignore`, and `.fdignore` rules, scans `SKILL.md` directories to a maximum depth of eight, and rejects sources with more than 500 discovered skills.
 - GitHub and GitLab tree URLs treat the segment after `tree` as the ref; refs containing `/` are not currently supported.
 - Cache publication is serialized within one Pi process; independent Pi processes can still race while refreshing the same source.
 - The command supports TUI and RPC modes. Print and JSON modes reject it explicitly.

--- a/.pi/extensions/pi-session-skills/command-parser.test.ts
+++ b/.pi/extensions/pi-session-skills/command-parser.test.ts
@@ -19,6 +19,9 @@ test("tokenizes quoted, escaped, and Windows-style command arguments", () => {
 		"load",
 		`C:\\Users\\name\\skill`,
 	]);
+	const uncPath = String.raw`\\server\share\skill`;
+	assert.deepEqual(tokenizeCommandArguments(`load ${uncPath}`), ["load", uncPath]);
+	assert.deepEqual(tokenizeCommandArguments(`load "${uncPath}"`), ["load", uncPath]);
 	assert.throws(() => tokenizeCommandArguments(`load "unfinished`), /Unterminated quote/);
 });
 

--- a/.pi/extensions/pi-session-skills/command-parser.test.ts
+++ b/.pi/extensions/pi-session-skills/command-parser.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	parseSessionSkillsCommandArguments,
+	SESSION_SKILLS_USAGE,
+	tokenizeCommandArguments,
+} from "./command-parser.js";
+
+test("tokenizes quoted, escaped, and Windows-style command arguments", () => {
+	assert.deepEqual(tokenizeCommandArguments(`load ./skill\\ repo --skill "web design" --refresh`), [
+		"load",
+		"./skill repo",
+		"--skill",
+		"web design",
+		"--refresh",
+	]);
+	assert.deepEqual(tokenizeCommandArguments(`load 'skill repo'`), ["load", "skill repo"]);
+	assert.deepEqual(tokenizeCommandArguments(`load C:\\Users\\name\\skill`), [
+		"load",
+		`C:\\Users\\name\\skill`,
+	]);
+	assert.throws(() => tokenizeCommandArguments(`load "unfinished`), /Unterminated quote/);
+});
+
+test("parses the status and list routes", () => {
+	assert.deepEqual(parseSessionSkillsCommandArguments(""), { action: "status" });
+	assert.deepEqual(parseSessionSkillsCommandArguments("list"), { action: "list" });
+	assert.throws(() => parseSessionSkillsCommandArguments("list extra"), {
+		message: SESSION_SKILLS_USAGE,
+	});
+});
+
+test("parses the load route and rejects unknown input", () => {
+	assert.deepEqual(
+		parseSessionSkillsCommandArguments("load owner/repo --skill example-skill --refresh"),
+		{
+			action: "load",
+			source: "owner/repo",
+			skill: "example-skill",
+			refresh: true,
+		},
+	);
+	assert.deepEqual(parseSessionSkillsCommandArguments("load --refresh ./local"), {
+		action: "load",
+		source: "./local",
+		refresh: true,
+	});
+	for (const input of ["load", "load owner/repo extra", "load owner/repo --unknown", "unknown"]) {
+		assert.throws(() => parseSessionSkillsCommandArguments(input), {
+			message: SESSION_SKILLS_USAGE,
+		});
+	}
+});
+
+test("parses the unload route", () => {
+	assert.deepEqual(parseSessionSkillsCommandArguments("unload example-skill"), {
+		action: "unload",
+		all: false,
+		name: "example-skill",
+	});
+	assert.deepEqual(parseSessionSkillsCommandArguments("unload --all"), {
+		action: "unload",
+		all: true,
+	});
+	assert.throws(() => parseSessionSkillsCommandArguments("unload"), {
+		message: SESSION_SKILLS_USAGE,
+	});
+});

--- a/.pi/extensions/pi-session-skills/command-parser.ts
+++ b/.pi/extensions/pi-session-skills/command-parser.ts
@@ -1,0 +1,121 @@
+export interface LoadCommandArguments {
+	action: "load";
+	source: string;
+	skill?: string;
+	refresh: boolean;
+}
+
+export interface UnloadCommandArguments {
+	action: "unload";
+	all: boolean;
+	name?: string;
+}
+
+export type SessionSkillsCommandArguments =
+	| { action: "status" }
+	| { action: "list" }
+	| LoadCommandArguments
+	| UnloadCommandArguments;
+
+export const SESSION_SKILLS_USAGE =
+	"Usage: /session-skills [load <source> [--skill <name>] [--refresh] | list | unload <name> | unload --all]";
+
+export function tokenizeCommandArguments(input: string): string[] {
+	const tokens: string[] = [];
+	const text = input.trim();
+	let current = "";
+	let quote: '"' | "'" | undefined;
+	let started = false;
+
+	for (let index = 0; index < text.length; index++) {
+		const character = text[index];
+		const next = text[index + 1];
+		if (
+			character === "\\" &&
+			quote !== "'" &&
+			next !== undefined &&
+			(/\s/u.test(next) || next === '"' || next === "'" || next === "\\")
+		) {
+			current += next;
+			index++;
+			started = true;
+			continue;
+		}
+		if (quote) {
+			if (character === quote) quote = undefined;
+			else current += character;
+			started = true;
+			continue;
+		}
+		if (character === '"' || character === "'") {
+			quote = character;
+			started = true;
+			continue;
+		}
+		if (/\s/u.test(character)) {
+			if (started) {
+				tokens.push(current);
+				current = "";
+				started = false;
+			}
+			continue;
+		}
+		current += character;
+		started = true;
+	}
+
+	if (quote) throw new Error("Unterminated quote in command arguments.");
+	if (started) tokens.push(current);
+	return tokens;
+}
+
+export function parseSessionSkillsCommandArguments(input: string): SessionSkillsCommandArguments {
+	const [route, ...tokens] = tokenizeCommandArguments(input);
+	if (route === undefined) return { action: "status" };
+	if (route === "list" && tokens.length === 0) return { action: "list" };
+	if (route === "load") return parseLoadTokens(tokens);
+	if (route === "unload") return parseUnloadTokens(tokens);
+	throw new Error(SESSION_SKILLS_USAGE);
+}
+
+function parseLoadTokens(tokens: string[]): LoadCommandArguments {
+	let source: string | undefined;
+	let skill: string | undefined;
+	let refresh = false;
+	let optionsEnded = false;
+
+	for (let index = 0; index < tokens.length; index++) {
+		const token = tokens[index];
+		if (token === "--" && !optionsEnded) {
+			optionsEnded = true;
+			continue;
+		}
+		if (!optionsEnded && token === "--refresh") {
+			if (refresh) throw new Error(SESSION_SKILLS_USAGE);
+			refresh = true;
+			continue;
+		}
+		if (!optionsEnded && (token === "--skill" || token === "-s")) {
+			const value = tokens[++index];
+			if (!value || value.startsWith("-") || skill !== undefined) {
+				throw new Error(SESSION_SKILLS_USAGE);
+			}
+			skill = value;
+			continue;
+		}
+		if (!optionsEnded && token.startsWith("-")) throw new Error(SESSION_SKILLS_USAGE);
+		if (source !== undefined) throw new Error(SESSION_SKILLS_USAGE);
+		source = token;
+	}
+
+	if (!source) throw new Error(SESSION_SKILLS_USAGE);
+	return { action: "load", source, refresh, ...(skill === undefined ? {} : { skill }) };
+}
+
+function parseUnloadTokens(tokens: string[]): UnloadCommandArguments {
+	if (tokens.length === 1 && tokens[0] === "--all") return { action: "unload", all: true };
+	if (tokens.length === 1 && !tokens[0].startsWith("-")) {
+		return { action: "unload", all: false, name: tokens[0] };
+	}
+	throw new Error(SESSION_SKILLS_USAGE);
+}

--- a/.pi/extensions/pi-session-skills/command-parser.ts
+++ b/.pi/extensions/pi-session-skills/command-parser.ts
@@ -30,6 +30,12 @@ export function tokenizeCommandArguments(input: string): string[] {
 	for (let index = 0; index < text.length; index++) {
 		const character = text[index];
 		const next = text[index + 1];
+		if (character === "\\" && next === "\\" && current === "") {
+			current = "\\\\";
+			index++;
+			started = true;
+			continue;
+		}
 		if (
 			character === "\\" &&
 			quote !== "'" &&

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -79,13 +79,16 @@ function createHarness(
 			entriesBySession.set(ctx.sessionManager, sessionEntries);
 			const sessionManager = ctx.sessionManager as ExtensionContext["sessionManager"] & {
 				appendCustomEntry(customType: string, data?: unknown): string;
+				appendTestCustomEntry(customType: string, data: unknown, id: string): void;
 			};
 			sessionManager.appendCustomEntry = (customType, data) => {
-				options.beforeAppendEntry?.();
+				const id = crypto.randomUUID();
+				sessionManager.appendTestCustomEntry(customType, data, id);
 				const entry = { customType, data };
 				entries.push(entry);
 				sessionEntries.push(entry);
-				return crypto.randomUUID();
+				options.beforeAppendEntry?.();
+				return id;
 			};
 			await command.handler(args, ctx);
 		},
@@ -103,8 +106,39 @@ function createContext(
 	let reloads = 0;
 	const notifications: Array<[string, string | undefined]> = [];
 	const statuses: Array<[string, string | undefined]> = [];
+	const entries = [...branch];
+	const byId = new Map(entries.map((entry) => [entry.id, entry]));
+	let leafId = entries.at(-1)?.id ?? null;
 	const sessionManager = {
-		getBranch: () => branch,
+		getBranch: () => {
+			const activeBranch: SessionEntry[] = [];
+			let entry = leafId ? byId.get(leafId) : undefined;
+			while (entry) {
+				activeBranch.push(entry);
+				entry = entry.parentId ? byId.get(entry.parentId) : undefined;
+			}
+			return activeBranch.reverse();
+		},
+		getLeafId: () => leafId,
+		branch: (entryId: string) => {
+			leafId = entryId;
+		},
+		resetLeaf: () => {
+			leafId = null;
+		},
+		appendTestCustomEntry: (customType: string, data: unknown, id: string) => {
+			const entry = {
+				type: "custom",
+				id,
+				parentId: leafId,
+				timestamp: new Date().toISOString(),
+				customType,
+				data,
+			} as SessionEntry;
+			entries.push(entry);
+			byId.set(id, entry);
+			leafId = id;
+		},
 	} as unknown as ExtensionContext["sessionManager"];
 	const ctx = {
 		cwd: "/work/project",
@@ -175,6 +209,9 @@ test("registers one session-skills command with status and route completions", a
 	assert.equal(complete?.("load owner/repo -s "), null);
 	assert.deepEqual(complete?.("load owner/repo --skill name --"), [
 		{ value: "load owner/repo --skill name --refresh", label: "--refresh" },
+	]);
+	assert.deepEqual(complete?.("load owner/repo -s name --"), [
+		{ value: "load owner/repo -s name --refresh", label: "--refresh" },
 	]);
 	const current = createContext();
 	await harness.emit("session_start", { reason: "startup" }, current.ctx);
@@ -307,6 +344,7 @@ test("rolls back a committed candidate when activation snapshot persistence fail
 		snapshotEntry([{ name: "old-name", path: oldPath, source: "owner/repo" }]),
 	]);
 	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	const previousLeafId = current.ctx.sessionManager.getLeafId();
 
 	await assert.rejects(
 		() => harness.command("session-skills", "load owner/repo --refresh", current.ctx),
@@ -317,6 +355,14 @@ test("rolls back a committed candidate when activation snapshot persistence fail
 	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {
 		skillPaths: [oldPath],
 	});
+	assert.equal(current.ctx.sessionManager.getLeafId(), previousLeafId);
+	const activeSnapshot = current.ctx.sessionManager.getBranch().at(-1);
+	assert.equal(activeSnapshot?.type, "custom");
+	if (activeSnapshot?.type === "custom") {
+		assert.deepEqual((activeSnapshot.data as { skills: Array<{ name: string }> }).skills, [
+			{ name: "old-name", path: oldPath, source: "owner/repo" },
+		]);
+	}
 	assert.equal(current.reloads, 0);
 });
 
@@ -541,6 +587,7 @@ test("restores activation state when snapshot persistence fails", async () => {
 		snapshotEntry([{ name: "demo-skill", path: skillPath, source: "owner/repo" }]),
 	]);
 	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	const previousLeafId = current.ctx.sessionManager.getLeafId();
 
 	await assert.rejects(
 		() => harness.command("session-skills", "unload demo-skill", current.ctx),
@@ -549,6 +596,14 @@ test("restores activation state when snapshot persistence fails", async () => {
 	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {
 		skillPaths: [skillPath],
 	});
+	assert.equal(current.ctx.sessionManager.getLeafId(), previousLeafId);
+	const activeSnapshot = current.ctx.sessionManager.getBranch().at(-1);
+	assert.equal(activeSnapshot?.type, "custom");
+	if (activeSnapshot?.type === "custom") {
+		assert.deepEqual((activeSnapshot.data as { skills: Array<{ name: string }> }).skills, [
+			{ name: "demo-skill", path: skillPath, source: "owner/repo" },
+		]);
+	}
 	assert.equal(current.reloads, 0);
 });
 

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -1,0 +1,334 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, test } from "vitest";
+import { ACTIVATION_ENTRY_TYPE, registerSessionSkills, STATUS_KEY } from "./extension.js";
+import type {
+	ResolvedSessionSkill,
+	ResolveSessionSkillOptions,
+	SkillResolverLike,
+} from "./resolver.js";
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+	);
+});
+
+type Handler = (event: never, ctx: ExtensionContext) => unknown;
+type CommandDefinition = {
+	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>;
+	getArgumentCompletions?: (prefix: string) => Array<{ value: string; label: string }> | null;
+};
+
+function createHarness(resolver: SkillResolverLike) {
+	const handlers = new Map<string, Handler[]>();
+	const commands = new Map<string, CommandDefinition>();
+	const entries: Array<{ customType: string; data: unknown }> = [];
+	const pi = {
+		on(event: string, handler: Handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerCommand(name: string, definition: CommandDefinition) {
+			commands.set(name, definition);
+		},
+		appendEntry(customType: string, data: unknown) {
+			entries.push({ customType, data });
+		},
+	} as unknown as ExtensionAPI;
+	registerSessionSkills(pi, { resolver });
+	return {
+		commands,
+		entries,
+		async emit(event: string, payload: Record<string, unknown>, ctx: ExtensionContext) {
+			let result: unknown;
+			for (const handler of handlers.get(event) ?? [])
+				result = await handler(payload as never, ctx);
+			return result;
+		},
+		async command(name: string, args: string, ctx: ExtensionCommandContext) {
+			const command = commands.get(name);
+			assert.ok(command, `missing command ${name}`);
+			await command.handler(args, ctx);
+		},
+	};
+}
+
+function createContext(
+	branch: SessionEntry[] = [],
+	mode: ExtensionContext["mode"] = "tui",
+	existingSkills: Array<{ name: string; baseDir: string; filePath: string }> = [],
+) {
+	let reloads = 0;
+	const notifications: Array<[string, string | undefined]> = [];
+	const statuses: Array<[string, string | undefined]> = [];
+	const sessionManager = {
+		getBranch: () => branch,
+	} as unknown as ExtensionContext["sessionManager"];
+	const ctx = {
+		cwd: "/work/project",
+		mode,
+		hasUI: mode === "tui" || mode === "rpc",
+		sessionManager,
+		ui: {
+			notify(message: string, level?: string) {
+				notifications.push([message, level]);
+			},
+			setStatus(key: string, value?: string) {
+				statuses.push([key, value]);
+			},
+		},
+		getSystemPromptOptions: () => ({ skills: existingSkills }),
+		reload: async () => {
+			reloads++;
+		},
+	} as unknown as ExtensionCommandContext;
+	return {
+		ctx,
+		notifications,
+		statuses,
+		sessionManager,
+		get reloads() {
+			return reloads;
+		},
+	};
+}
+
+async function createCachedSkill(cacheRoot: string, key: string, name: string): Promise<string> {
+	const skillPath = join(cacheRoot, "entries", key, "skill");
+	await mkdir(skillPath, { recursive: true });
+	await writeFile(
+		join(skillPath, "SKILL.md"),
+		`---\nname: ${name}\ndescription: Test skill.\n---\n`,
+	);
+	return skillPath;
+}
+
+function snapshotEntry(skills: unknown[]): SessionEntry {
+	return {
+		type: "custom",
+		id: crypto.randomUUID(),
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		customType: ACTIVATION_ENTRY_TYPE,
+		data: { version: 1, skills },
+	} as SessionEntry;
+}
+
+test("registers one session-skills command with status and route completions", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-extension-"));
+	temporaryPaths.push(cacheRoot);
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	assert.deepEqual([...harness.commands.keys()], ["session-skills"]);
+	assert.deepEqual(harness.commands.get("session-skills")?.getArgumentCompletions?.("l"), [
+		{ value: "load", label: "load" },
+		{ value: "list", label: "list" },
+	]);
+	const current = createContext();
+	await harness.emit("session_start", { reason: "startup" }, current.ctx);
+	await harness.command("session-skills", "", current.ctx);
+	assert.match(current.notifications.at(-1)?.[0] ?? "", /Session skills: none.*Usage:/s);
+});
+
+test("loads a remote skill, snapshots activation, and reloads exactly once", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-load-"));
+	temporaryPaths.push(cacheRoot);
+	const skillPath = await createCachedSkill(cacheRoot, "demo", "demo-skill");
+	let resolvedOptions: ResolveSessionSkillOptions | undefined;
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: async (options) => {
+			resolvedOptions = options;
+			return {
+				name: "demo-skill",
+				path: skillPath,
+				source: options.source.original,
+				selector: options.selector,
+				cacheHit: false,
+			};
+		},
+	};
+	const harness = createHarness(resolver);
+	const current = createContext();
+	await harness.emit("session_start", { reason: "startup" }, current.ctx);
+	await harness.command("session-skills", "load owner/repo --skill demo-skill", current.ctx);
+
+	assert.equal(resolvedOptions?.selector, "demo-skill");
+	assert.equal(current.reloads, 1);
+	assert.equal(harness.entries.length, 1);
+	assert.equal(harness.entries[0].customType, ACTIVATION_ENTRY_TYPE);
+	assert.deepEqual((harness.entries[0].data as { skills: unknown[] }).skills, [
+		{
+			name: "demo-skill",
+			path: skillPath,
+			source: "owner/repo",
+			selector: "demo-skill",
+		},
+	]);
+	assert.match(current.notifications[0][0], /full Pi permissions/);
+	assert.deepEqual(current.statuses.at(-1), [STATUS_KEY, undefined]);
+
+	await harness.command("session-skills", "load owner/repo --skill demo-skill", current.ctx);
+	assert.equal(current.reloads, 1);
+	assert.equal(harness.entries.length, 1);
+	assert.match(current.notifications.at(-1)?.[0] ?? "", /already active/);
+});
+
+test("restores the newest root-to-leaf snapshot and keeps discovery stable", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-restore-"));
+	temporaryPaths.push(cacheRoot);
+	const oldPath = await createCachedSkill(cacheRoot, "old", "old-skill");
+	const newPath = await createCachedSkill(cacheRoot, "new", "new-skill");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const current = createContext([
+		snapshotEntry([{ name: "old-skill", path: oldPath, source: "old/repo" }]),
+		snapshotEntry([{ name: "new-skill", path: newPath, source: "new/repo" }]),
+	]);
+
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	const first = await harness.emit("resources_discover", { reason: "startup" }, current.ctx);
+	const second = await harness.emit("resources_discover", { reason: "reload" }, current.ctx);
+	assert.deepEqual(first, { skillPaths: [newPath] });
+	assert.deepEqual(second, first);
+});
+
+test("unloads a selected skill, snapshots the empty state, and completes known values", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-unload-"));
+	temporaryPaths.push(cacheRoot);
+	const skillPath = await createCachedSkill(cacheRoot, "demo", "demo-skill");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const current = createContext([
+		snapshotEntry([{ name: "demo-skill", path: skillPath, source: "owner/repo" }]),
+	]);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	assert.deepEqual(
+		harness.commands.get("session-skills")?.getArgumentCompletions?.("unload demo"),
+		[{ value: "unload demo-skill", label: "demo-skill" }],
+	);
+
+	await harness.command("session-skills", "unload demo-skill", current.ctx);
+	assert.equal(current.reloads, 1);
+	const snapshot = harness.entries.at(-1);
+	assert.ok(snapshot);
+	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, []);
+});
+
+test("unloads all active skills through the documented --all route", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-unload-all-"));
+	temporaryPaths.push(cacheRoot);
+	const firstPath = await createCachedSkill(cacheRoot, "first", "first-skill");
+	const secondPath = await createCachedSkill(cacheRoot, "second", "second-skill");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const current = createContext([
+		snapshotEntry([
+			{ name: "first-skill", path: firstPath, source: "owner/first" },
+			{ name: "second-skill", path: secondPath, source: "owner/second" },
+		]),
+	]);
+	await harness.emit("session_start", { reason: "fork" }, current.ctx);
+	await harness.command("session-skills", "unload --all", current.ctx);
+	const snapshot = harness.entries.at(-1);
+	assert.ok(snapshot);
+	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, []);
+	assert.equal(current.reloads, 1);
+});
+
+test("rejects native skill collisions without changing activation", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-collision-"));
+	temporaryPaths.push(cacheRoot);
+	const skillPath = await createCachedSkill(cacheRoot, "demo", "demo-skill");
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: async (options): Promise<ResolvedSessionSkill> => ({
+			name: "demo-skill",
+			path: skillPath,
+			source: options.source.original,
+			cacheHit: false,
+		}),
+	};
+	const harness = createHarness(resolver);
+	const current = createContext([], "tui", [
+		{ name: "demo-skill", baseDir: "/global/demo", filePath: "/global/demo/SKILL.md" },
+	]);
+	await harness.emit("session_start", { reason: "startup" }, current.ctx);
+	await assert.rejects(
+		() => harness.command("session-skills", "load owner/repo", current.ctx),
+		/already provided/,
+	);
+	assert.equal(harness.entries.length, 0);
+	assert.equal(current.reloads, 0);
+});
+
+test("shutdown aborts an in-flight resolver and clears owned status", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-shutdown-"));
+	temporaryPaths.push(cacheRoot);
+	let started!: () => void;
+	let released = false;
+	const ready = new Promise<void>((resolve) => {
+		started = resolve;
+	});
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: (options) =>
+			new Promise((_resolve, reject) => {
+				started();
+				options.signal?.addEventListener(
+					"abort",
+					() => {
+						queueMicrotask(() => {
+							released = true;
+							reject(new Error("cancelled"));
+						});
+					},
+					{ once: true },
+				);
+			}),
+	};
+	const harness = createHarness(resolver);
+	const current = createContext();
+	await harness.emit("session_start", { reason: "startup" }, current.ctx);
+	const command = harness.command("session-skills", "load owner/repo", current.ctx);
+	await ready;
+	await harness.emit("session_shutdown", { reason: "quit" }, current.ctx);
+	assert.equal(released, true);
+	await assert.rejects(() => command, /cancelled/);
+	assert.deepEqual(current.statuses.at(-1), [STATUS_KEY, undefined]);
+	assert.equal(harness.entries.length, 0);
+});
+
+test("commands reject unsupported modes and trailing arguments", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-modes-"));
+	temporaryPaths.push(cacheRoot);
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const json = createContext([], "json");
+	await harness.emit("session_start", { reason: "startup" }, json.ctx);
+	await assert.rejects(
+		() => harness.command("session-skills", "", json.ctx),
+		/requires TUI or RPC/,
+	);
+
+	const tui = createContext();
+	await harness.emit("session_start", { reason: "new" }, tui.ctx);
+	await assert.rejects(
+		() => harness.command("session-skills", "list extra", tui.ctx),
+		/Usage: \/session-skills/,
+	);
+	await assert.rejects(
+		() => harness.command("session-skills", "unload", tui.ctx),
+		/Usage: \/session-skills/,
+	);
+});

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -443,17 +443,24 @@ test("omits unsafe restored names from completions while keeping them unloadable
 	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-unsafe-completion-"));
 	temporaryPaths.push(cacheRoot);
 	const missingPath = join(cacheRoot, "entries", "missing", "skill");
+	const unsafePath = join(cacheRoot, "entries", "unsafe", "skill");
+	await mkdir(unsafePath, { recursive: true });
+	await writeFile(
+		join(unsafePath, "SKILL.md"),
+		'---\nname: "ansi\\u001b[31m"\ndescription: Unsafe name.\n---\n',
+	);
 	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
 	const harness = createHarness(resolver);
 	const current = createContext([
 		snapshotEntry([
-			{ name: "ansi\u001b[31m", path: missingPath, source: "owner/ansi" },
+			{ name: "ansi\u001b[31m", path: unsafePath, source: "owner/ansi" },
 			{ name: "bidi\u202ename", path: missingPath, source: "owner/bidi" },
 			{ name: "line\nbreak", path: missingPath, source: "owner/line" },
 		]),
 	]);
 	await harness.emit("session_start", { reason: "resume" }, current.ctx);
 
+	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {});
 	assert.deepEqual(harness.commands.get("session-skills")?.getArgumentCompletions?.("unload "), [
 		{ value: "unload --all", label: "--all" },
 	]);

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -30,7 +30,17 @@ type CommandDefinition = {
 	getArgumentCompletions?: (prefix: string) => Array<{ value: string; label: string }> | null;
 };
 
-function createHarness(resolver: SkillResolverLike) {
+function createHarness(
+	resolver: SkillResolverLike,
+	options: {
+		beforeAppendEntry?: () => void;
+		commands?: Array<{
+			name: string;
+			source: "skill";
+			sourceInfo: { path: string };
+		}>;
+	} = {},
+) {
 	const handlers = new Map<string, Handler[]>();
 	const commands = new Map<string, CommandDefinition>();
 	const entries: Array<{ customType: string; data: unknown }> = [];
@@ -42,7 +52,11 @@ function createHarness(resolver: SkillResolverLike) {
 			commands.set(name, definition);
 		},
 		appendEntry(customType: string, data: unknown) {
+			options.beforeAppendEntry?.();
 			entries.push({ customType, data });
+		},
+		getCommands() {
+			return options.commands ?? [];
 		},
 	} as unknown as ExtensionAPI;
 	registerSessionSkills(pi, { resolver });
@@ -134,6 +148,13 @@ test("registers one session-skills command with status and route completions", a
 		{ value: "load", label: "load" },
 		{ value: "list", label: "list" },
 	]);
+	assert.deepEqual(
+		harness.commands.get("session-skills")?.getArgumentCompletions?.("load owner/repo --"),
+		[
+			{ value: "load owner/repo --skill", label: "--skill" },
+			{ value: "load owner/repo --refresh", label: "--refresh" },
+		],
+	);
 	const current = createContext();
 	await harness.emit("session_start", { reason: "startup" }, current.ctx);
 	await harness.command("session-skills", "", current.ctx);
@@ -184,6 +205,98 @@ test("loads a remote skill, snapshots activation, and reloads exactly once", asy
 	assert.match(current.notifications.at(-1)?.[0] ?? "", /already active/);
 });
 
+test("replaces a renamed activation by source only after committing its cache transaction", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-rename-"));
+	temporaryPaths.push(cacheRoot);
+	const oldPath = await createCachedSkill(cacheRoot, "old", "old-name");
+	const newPath = await createCachedSkill(cacheRoot, "new", "new-name");
+	let committed = false;
+	let rolledBack = false;
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: async (options) => ({
+			name: "new-name",
+			path: newPath,
+			source: options.source.original,
+			cacheHit: false,
+			previousName: "old-name",
+			transaction: {
+				commit: async () => {
+					committed = true;
+				},
+				rollback: async () => {
+					rolledBack = true;
+				},
+			},
+		}),
+	};
+	const harness = createHarness(resolver);
+	const current = createContext(
+		[snapshotEntry([{ name: "old-name", path: oldPath, source: "owner/repo" }])],
+		"tui",
+		[{ name: "old-name", baseDir: oldPath, filePath: join(oldPath, "SKILL.md") }],
+	);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	await harness.command("session-skills", "load owner/repo --refresh", current.ctx);
+
+	assert.equal(committed, true);
+	assert.equal(rolledBack, false);
+	const snapshot = harness.entries.at(-1);
+	assert.ok(snapshot);
+	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, [
+		{ name: "new-name", path: newPath, source: "owner/repo" },
+	]);
+	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {
+		skillPaths: [newPath],
+	});
+});
+
+test("rolls back a committed candidate when activation snapshot persistence fails", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-load-snapshot-failure-"));
+	temporaryPaths.push(cacheRoot);
+	const oldPath = await createCachedSkill(cacheRoot, "old", "old-name");
+	const newPath = await createCachedSkill(cacheRoot, "new", "new-name");
+	let committed = false;
+	let rolledBack = false;
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: async (options) => ({
+			name: "new-name",
+			path: newPath,
+			source: options.source.original,
+			cacheHit: false,
+			transaction: {
+				commit: async () => {
+					committed = true;
+				},
+				rollback: async () => {
+					rolledBack = true;
+				},
+			},
+		}),
+	};
+	const harness = createHarness(resolver, {
+		beforeAppendEntry: () => {
+			throw new Error("snapshot failed");
+		},
+	});
+	const current = createContext([
+		snapshotEntry([{ name: "old-name", path: oldPath, source: "owner/repo" }]),
+	]);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+
+	await assert.rejects(
+		() => harness.command("session-skills", "load owner/repo --refresh", current.ctx),
+		/snapshot failed/,
+	);
+	assert.equal(committed, true);
+	assert.equal(rolledBack, true);
+	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {
+		skillPaths: [oldPath],
+	});
+	assert.equal(current.reloads, 0);
+});
+
 test("restores the newest root-to-leaf snapshot and keeps discovery stable", async () => {
 	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-restore-"));
 	temporaryPaths.push(cacheRoot);
@@ -203,6 +316,98 @@ test("restores the newest root-to-leaf snapshot and keeps discovery stable", asy
 	assert.deepEqual(second, first);
 });
 
+test("skips restored activations that now collide with native skills", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-restore-collision-"));
+	temporaryPaths.push(cacheRoot);
+	const skillPath = await createCachedSkill(cacheRoot, "cached", "same-name");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver, {
+		commands: [
+			{
+				name: "skill:same-name",
+				source: "skill",
+				sourceInfo: { path: "/global/same-name/SKILL.md" },
+			},
+		],
+	});
+	const current = createContext([
+		snapshotEntry([{ name: "same-name", path: skillPath, source: "owner/repo" }]),
+	]);
+
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {});
+	assert.match(current.notifications.at(-1)?.[0] ?? "", /conflicting.*same-name/);
+});
+
+test("keeps activation state isolated across concurrent session managers", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-concurrent-"));
+	temporaryPaths.push(cacheRoot);
+	const firstPath = await createCachedSkill(cacheRoot, "first", "first-skill");
+	const secondPath = await createCachedSkill(cacheRoot, "second", "second-skill");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const first = createContext([
+		snapshotEntry([{ name: "first-skill", path: firstPath, source: "owner/first" }]),
+	]);
+	const second = createContext([
+		snapshotEntry([{ name: "second-skill", path: secondPath, source: "owner/second" }]),
+	]);
+
+	await harness.emit("session_start", { reason: "startup" }, first.ctx);
+	await harness.emit("session_start", { reason: "startup" }, second.ctx);
+	assert.deepEqual(await harness.emit("resources_discover", {}, first.ctx), {
+		skillPaths: [firstPath],
+	});
+	assert.deepEqual(await harness.emit("resources_discover", {}, second.ctx), {
+		skillPaths: [secondPath],
+	});
+	await harness.emit("session_shutdown", { reason: "quit" }, second.ctx);
+	assert.deepEqual(await harness.emit("resources_discover", {}, first.ctx), {
+		skillPaths: [firstPath],
+	});
+});
+
+test("runs operations independently for concurrent session managers", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-concurrent-operations-"));
+	temporaryPaths.push(cacheRoot);
+	const fastPath = await createCachedSkill(cacheRoot, "fast", "fast-skill");
+	let slowStarted!: () => void;
+	const ready = new Promise<void>((resolve) => {
+		slowStarted = resolve;
+	});
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: (options) => {
+			if (options.source.original !== "owner/slow") {
+				return Promise.resolve({
+					name: "fast-skill",
+					path: fastPath,
+					source: options.source.original,
+					cacheHit: false,
+				});
+			}
+			return new Promise((_resolve, reject) => {
+				slowStarted();
+				options.signal?.addEventListener("abort", () => reject(new Error("cancelled")), {
+					once: true,
+				});
+			});
+		},
+	};
+	const harness = createHarness(resolver);
+	const slow = createContext();
+	const fast = createContext();
+	await harness.emit("session_start", { reason: "startup" }, slow.ctx);
+	await harness.emit("session_start", { reason: "startup" }, fast.ctx);
+
+	const slowCommand = harness.command("session-skills", "load owner/slow", slow.ctx);
+	await ready;
+	await harness.command("session-skills", "load owner/fast", fast.ctx);
+	assert.equal(fast.reloads, 1);
+	await harness.emit("session_shutdown", { reason: "quit" }, slow.ctx);
+	await assert.rejects(() => slowCommand, /cancelled/);
+});
+
 test("unloads a selected skill, snapshots the empty state, and completes known values", async () => {
 	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-unload-"));
 	temporaryPaths.push(cacheRoot);
@@ -213,16 +418,40 @@ test("unloads a selected skill, snapshots the empty state, and completes known v
 		snapshotEntry([{ name: "demo-skill", path: skillPath, source: "owner/repo" }]),
 	]);
 	await harness.emit("session_start", { reason: "resume" }, current.ctx);
-	assert.deepEqual(
-		harness.commands.get("session-skills")?.getArgumentCompletions?.("unload demo"),
-		[{ value: "unload demo-skill", label: "demo-skill" }],
-	);
+	assert.deepEqual(harness.commands.get("session-skills")?.getArgumentCompletions?.("unload --"), [
+		{ value: "unload --all", label: "--all" },
+	]);
 
 	await harness.command("session-skills", "unload demo-skill", current.ctx);
 	assert.equal(current.reloads, 1);
 	const snapshot = harness.entries.at(-1);
 	assert.ok(snapshot);
 	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, []);
+});
+
+test("restores activation state when snapshot persistence fails", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-snapshot-failure-"));
+	temporaryPaths.push(cacheRoot);
+	const skillPath = await createCachedSkill(cacheRoot, "demo", "demo-skill");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver, {
+		beforeAppendEntry: () => {
+			throw new Error("snapshot failed");
+		},
+	});
+	const current = createContext([
+		snapshotEntry([{ name: "demo-skill", path: skillPath, source: "owner/repo" }]),
+	]);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+
+	await assert.rejects(
+		() => harness.command("session-skills", "unload demo-skill", current.ctx),
+		/snapshot failed/,
+	);
+	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {
+		skillPaths: [skillPath],
+	});
+	assert.equal(current.reloads, 0);
 });
 
 test("unloads all active skills through the documented --all route", async () => {
@@ -246,10 +475,12 @@ test("unloads all active skills through the documented --all route", async () =>
 	assert.equal(current.reloads, 1);
 });
 
-test("rejects native skill collisions without changing activation", async () => {
+test("rejects native skill collisions and rolls back candidate cache entries", async () => {
 	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-collision-"));
 	temporaryPaths.push(cacheRoot);
 	const skillPath = await createCachedSkill(cacheRoot, "demo", "demo-skill");
+	let committed = false;
+	let rolledBack = false;
 	const resolver: SkillResolverLike = {
 		getCacheRoot: () => cacheRoot,
 		resolve: async (options): Promise<ResolvedSessionSkill> => ({
@@ -257,6 +488,14 @@ test("rejects native skill collisions without changing activation", async () => 
 			path: skillPath,
 			source: options.source.original,
 			cacheHit: false,
+			transaction: {
+				commit: async () => {
+					committed = true;
+				},
+				rollback: async () => {
+					rolledBack = true;
+				},
+			},
 		}),
 	};
 	const harness = createHarness(resolver);
@@ -270,6 +509,8 @@ test("rejects native skill collisions without changing activation", async () => 
 	);
 	assert.equal(harness.entries.length, 0);
 	assert.equal(current.reloads, 0);
+	assert.equal(committed, false);
+	assert.equal(rolledBack, true);
 });
 
 test("shutdown aborts an in-flight resolver and clears owned status", async () => {
@@ -307,6 +548,23 @@ test("shutdown aborts an in-flight resolver and clears owned status", async () =
 	await assert.rejects(() => command, /cancelled/);
 	assert.deepEqual(current.statuses.at(-1), [STATUS_KEY, undefined]);
 	assert.equal(harness.entries.length, 0);
+});
+
+test("renders identifier and path fields as single-line terminal-safe text", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-display-safety-"));
+	temporaryPaths.push(cacheRoot);
+	const skillPath = await createCachedSkill(cacheRoot, "safe", "safe-name");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const current = createContext([
+		snapshotEntry([{ name: "safe-name", path: skillPath, source: "owner/\nrepo\tname" }]),
+	]);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	await harness.command("session-skills", "list", current.ctx);
+
+	const lines = current.notifications.at(-1)?.[0].split("\n") ?? [];
+	assert.equal(lines.length, 4);
+	assert.equal(lines[2], "    source: owner/ repo name");
 });
 
 test("commands reject unsupported modes and trailing arguments", async () => {

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -44,6 +44,10 @@ function createHarness(
 	const handlers = new Map<string, Handler[]>();
 	const commands = new Map<string, CommandDefinition>();
 	const entries: Array<{ customType: string; data: unknown }> = [];
+	const entriesBySession = new Map<
+		ExtensionContext["sessionManager"],
+		Array<{ customType: string; data: unknown }>
+	>();
 	const pi = {
 		on(event: string, handler: Handler) {
 			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
@@ -51,9 +55,8 @@ function createHarness(
 		registerCommand(name: string, definition: CommandDefinition) {
 			commands.set(name, definition);
 		},
-		appendEntry(customType: string, data: unknown) {
-			options.beforeAppendEntry?.();
-			entries.push({ customType, data });
+		appendEntry() {
+			throw new Error("factory-bound persistence is not allowed");
 		},
 		getCommands() {
 			return options.commands ?? [];
@@ -72,7 +75,22 @@ function createHarness(
 		async command(name: string, args: string, ctx: ExtensionCommandContext) {
 			const command = commands.get(name);
 			assert.ok(command, `missing command ${name}`);
+			const sessionEntries = entriesBySession.get(ctx.sessionManager) ?? [];
+			entriesBySession.set(ctx.sessionManager, sessionEntries);
+			const sessionManager = ctx.sessionManager as ExtensionContext["sessionManager"] & {
+				appendCustomEntry(customType: string, data?: unknown): string;
+			};
+			sessionManager.appendCustomEntry = (customType, data) => {
+				options.beforeAppendEntry?.();
+				const entry = { customType, data };
+				entries.push(entry);
+				sessionEntries.push(entry);
+				return crypto.randomUUID();
+			};
 			await command.handler(args, ctx);
+		},
+		entriesFor(ctx: ExtensionContext) {
+			return entriesBySession.get(ctx.sessionManager) ?? [];
 		},
 	};
 }
@@ -399,6 +417,48 @@ test("keeps activation state isolated across concurrent session managers", async
 	assert.deepEqual(await harness.emit("resources_discover", {}, first.ctx), {
 		skillPaths: [firstPath],
 	});
+});
+
+test("persists each command snapshot through its owning session manager", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-session-writers-"));
+	temporaryPaths.push(cacheRoot);
+	const firstPath = await createCachedSkill(cacheRoot, "first", "first-skill");
+	const secondPath = await createCachedSkill(cacheRoot, "second", "second-skill");
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: async (options) => ({
+			name: options.source.original === "owner/first" ? "first-skill" : "second-skill",
+			path: options.source.original === "owner/first" ? firstPath : secondPath,
+			source: options.source.original,
+			cacheHit: false,
+		}),
+	};
+	const harness = createHarness(resolver);
+	const first = createContext();
+	const second = createContext();
+	await harness.emit("session_start", { reason: "startup" }, first.ctx);
+	await harness.emit("session_start", { reason: "startup" }, second.ctx);
+
+	await harness.command("session-skills", "load owner/first", first.ctx);
+	await harness.command("session-skills", "load owner/second", second.ctx);
+	assert.deepEqual(
+		(harness.entriesFor(first.ctx)[0].data as { skills: Array<{ source: string }> }).skills.map(
+			(skill) => skill.source,
+		),
+		["owner/first"],
+	);
+	assert.deepEqual(
+		(harness.entriesFor(second.ctx)[0].data as { skills: Array<{ source: string }> }).skills.map(
+			(skill) => skill.source,
+		),
+		["owner/second"],
+	);
+
+	await harness.command("session-skills", "unload first-skill", first.ctx);
+	const firstFinalEntry = harness.entriesFor(first.ctx).at(-1);
+	assert.ok(firstFinalEntry);
+	assert.deepEqual((firstFinalEntry.data as { skills: unknown[] }).skills, []);
+	assert.equal(harness.entriesFor(second.ctx).length, 1);
 });
 
 test("runs operations independently for concurrent session managers", async () => {

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -205,6 +205,8 @@ test("registers one session-skills command with status and route completions", a
 		{ value: "load owner/repo --skill", label: "--skill" },
 		{ value: "load owner/repo --refresh", label: "--refresh" },
 	]);
+	assert.equal(complete?.("load owner/repo -- "), null);
+	assert.equal(complete?.("load owner/repo -- --"), null);
 	assert.equal(complete?.("load owner/repo --skill "), null);
 	assert.equal(complete?.("load owner/repo -s "), null);
 	assert.deepEqual(complete?.("load owner/repo --skill name --"), [
@@ -435,6 +437,30 @@ test("unload --all clears skipped activations whose cache entries are missing", 
 	assert.ok(snapshot);
 	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, []);
 	assert.equal(current.reloads, 1);
+});
+
+test("omits unsafe restored names from completions while keeping them unloadable", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-unsafe-completion-"));
+	temporaryPaths.push(cacheRoot);
+	const missingPath = join(cacheRoot, "entries", "missing", "skill");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const current = createContext([
+		snapshotEntry([
+			{ name: "ansi\u001b[31m", path: missingPath, source: "owner/ansi" },
+			{ name: "bidi\u202ename", path: missingPath, source: "owner/bidi" },
+			{ name: "line\nbreak", path: missingPath, source: "owner/line" },
+		]),
+	]);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+
+	assert.deepEqual(harness.commands.get("session-skills")?.getArgumentCompletions?.("unload "), [
+		{ value: "unload --all", label: "--all" },
+	]);
+	await harness.command("session-skills", "unload --all", current.ctx);
+	const snapshot = harness.entries.at(-1);
+	assert.ok(snapshot);
+	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, []);
 });
 
 test("keeps activation state isolated across concurrent session managers", async () => {

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -148,13 +148,16 @@ test("registers one session-skills command with status and route completions", a
 		{ value: "load", label: "load" },
 		{ value: "list", label: "list" },
 	]);
-	assert.deepEqual(
-		harness.commands.get("session-skills")?.getArgumentCompletions?.("load owner/repo --"),
-		[
-			{ value: "load owner/repo --skill", label: "--skill" },
-			{ value: "load owner/repo --refresh", label: "--refresh" },
-		],
-	);
+	const complete = harness.commands.get("session-skills")?.getArgumentCompletions;
+	assert.deepEqual(complete?.("load owner/repo --"), [
+		{ value: "load owner/repo --skill", label: "--skill" },
+		{ value: "load owner/repo --refresh", label: "--refresh" },
+	]);
+	assert.equal(complete?.("load owner/repo --skill "), null);
+	assert.equal(complete?.("load owner/repo -s "), null);
+	assert.deepEqual(complete?.("load owner/repo --skill name --"), [
+		{ value: "load owner/repo --skill name --refresh", label: "--refresh" },
+	]);
 	const current = createContext();
 	await harness.emit("session_start", { reason: "startup" }, current.ctx);
 	await harness.command("session-skills", "", current.ctx);
@@ -547,6 +550,46 @@ test("rejects native skill collisions and rolls back candidate cache entries", a
 	assert.equal(current.reloads, 0);
 	assert.equal(committed, false);
 	assert.equal(rolledBack, true);
+});
+
+test("rejects a same-name skill from a different session source", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-source-collision-"));
+	temporaryPaths.push(cacheRoot);
+	const existingPath = await createCachedSkill(cacheRoot, "existing", "same-name");
+	const candidatePath = await createCachedSkill(cacheRoot, "candidate", "same-name");
+	let rolledBack = false;
+	const resolver: SkillResolverLike = {
+		getCacheRoot: () => cacheRoot,
+		resolve: async (options) => ({
+			name: "same-name",
+			path: candidatePath,
+			source: options.source.original,
+			cacheHit: false,
+			transaction: {
+				commit: async (apply) => apply?.(),
+				rollback: async () => {
+					rolledBack = true;
+				},
+			},
+		}),
+	};
+	const harness = createHarness(resolver);
+	const current = createContext(
+		[snapshotEntry([{ name: "same-name", path: existingPath, source: "owner/first" }])],
+		"tui",
+		[{ name: "same-name", baseDir: existingPath, filePath: join(existingPath, "SKILL.md") }],
+	);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+
+	await assert.rejects(
+		() => harness.command("session-skills", "load owner/second", current.ctx),
+		/already belongs to session source owner\/first/,
+	);
+	assert.equal(rolledBack, true);
+	assert.equal(harness.entries.length, 0);
+	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {
+		skillPaths: [existingPath],
+	});
 });
 
 test("shutdown aborts an in-flight resolver and clears owned status", async () => {

--- a/.pi/extensions/pi-session-skills/extension.test.ts
+++ b/.pi/extensions/pi-session-skills/extension.test.ts
@@ -221,8 +221,9 @@ test("replaces a renamed activation by source only after committing its cache tr
 			cacheHit: false,
 			previousName: "old-name",
 			transaction: {
-				commit: async () => {
+				commit: async (apply) => {
 					committed = true;
+					apply?.();
 				},
 				rollback: async () => {
 					rolledBack = true;
@@ -266,8 +267,9 @@ test("rolls back a committed candidate when activation snapshot persistence fail
 			source: options.source.original,
 			cacheHit: false,
 			transaction: {
-				commit: async () => {
+				commit: async (apply) => {
 					committed = true;
+					apply?.();
 				},
 				rollback: async () => {
 					rolledBack = true;
@@ -337,6 +339,35 @@ test("skips restored activations that now collide with native skills", async () 
 	await harness.emit("session_start", { reason: "resume" }, current.ctx);
 	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {});
 	assert.match(current.notifications.at(-1)?.[0] ?? "", /conflicting.*same-name/);
+	assert.deepEqual(
+		harness.commands.get("session-skills")?.getArgumentCompletions?.("unload same"),
+		[{ value: "unload same-name", label: "same-name" }],
+	);
+
+	await harness.command("session-skills", "unload same-name", current.ctx);
+	const snapshot = harness.entries.at(-1);
+	assert.ok(snapshot);
+	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, []);
+	assert.equal(current.reloads, 1);
+});
+
+test("unload --all clears skipped activations whose cache entries are missing", async () => {
+	const cacheRoot = await mkdtemp(join(tmpdir(), "pi-session-skills-missing-unload-"));
+	temporaryPaths.push(cacheRoot);
+	const missingPath = join(cacheRoot, "entries", "missing", "skill");
+	const resolver = { getCacheRoot: () => cacheRoot, resolve: async () => assert.fail("unused") };
+	const harness = createHarness(resolver);
+	const current = createContext([
+		snapshotEntry([{ name: "missing-skill", path: missingPath, source: "owner/repo" }]),
+	]);
+	await harness.emit("session_start", { reason: "resume" }, current.ctx);
+	assert.deepEqual(await harness.emit("resources_discover", {}, current.ctx), {});
+
+	await harness.command("session-skills", "unload --all", current.ctx);
+	const snapshot = harness.entries.at(-1);
+	assert.ok(snapshot);
+	assert.deepEqual((snapshot.data as { skills: unknown[] }).skills, []);
+	assert.equal(current.reloads, 1);
 });
 
 test("keeps activation state isolated across concurrent session managers", async () => {
@@ -421,6 +452,10 @@ test("unloads a selected skill, snapshots the empty state, and completes known v
 	assert.deepEqual(harness.commands.get("session-skills")?.getArgumentCompletions?.("unload --"), [
 		{ value: "unload --all", label: "--all" },
 	]);
+	assert.deepEqual(
+		harness.commands.get("session-skills")?.getArgumentCompletions?.("unload demo"),
+		[{ value: "unload demo-skill", label: "demo-skill" }],
+	);
 
 	await harness.command("session-skills", "unload demo-skill", current.ctx);
 	assert.equal(current.reloads, 1);
@@ -489,8 +524,9 @@ test("rejects native skill collisions and rolls back candidate cache entries", a
 			source: options.source.original,
 			cacheHit: false,
 			transaction: {
-				commit: async () => {
+				commit: async (apply) => {
 					committed = true;
+					apply?.();
 				},
 				rollback: async () => {
 					rolledBack = true;

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -64,6 +64,10 @@ interface SessionStateSnapshot {
 	desiredActivations: Map<string, SessionSkillActivation>;
 }
 
+interface SessionEntryWriter {
+	appendCustomEntry(customType: string, data?: unknown): string;
+}
+
 export function registerSessionSkills(
 	pi: ExtensionAPI,
 	options: SessionSkillsExtensionOptions = {},
@@ -78,12 +82,14 @@ export function registerSessionSkills(
 		return state;
 	};
 
-	const saveSnapshot = (state: SessionState): void => {
+	const saveSnapshot = (ctx: ExtensionCommandContext, state: SessionState): void => {
 		const snapshot: ActivationSnapshot = {
 			version: 1,
 			skills: [...state.desiredActivations.values()],
 		};
-		pi.appendEntry(ACTIVATION_ENTRY_TYPE, snapshot);
+		const sessionManager = ctx.sessionManager as ExtensionContext["sessionManager"] &
+			SessionEntryWriter;
+		sessionManager.appendCustomEntry(ACTIVATION_ENTRY_TYPE, snapshot);
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -262,7 +268,7 @@ export function registerSessionSkills(
 				state.activations.set(resolvedResult.name, activation);
 				state.desiredActivations.set(resolvedResult.name, activation);
 				try {
-					saveSnapshot(state);
+					saveSnapshot(ctx, state);
 				} catch (error) {
 					restoreSessionState(state, previousState);
 					throw error;
@@ -333,7 +339,7 @@ export function registerSessionSkills(
 			return;
 		}
 		try {
-			saveSnapshot(state);
+			saveSnapshot(ctx, state);
 		} catch (error) {
 			restoreSessionState(state, previousState);
 			throw error;

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -403,7 +403,12 @@ function commandCompletions(
 		if (valuePrefix && !valuePrefix.startsWith("-")) return null;
 		const base = input.slice(0, lastSpace + 1);
 		const completedTokens = base.trim().split(/\s+/u);
-		if (["--skill", "-s"].includes(completedTokens.at(-1) ?? "")) return null;
+		if (
+			completedTokens.includes("--") ||
+			["--skill", "-s"].includes(completedTokens.at(-1) ?? "")
+		) {
+			return null;
+		}
 		const used = new Set(completedTokens);
 		if (used.has("-s")) used.add("--skill");
 		const values = ["--skill", "--refresh"]
@@ -414,11 +419,20 @@ function commandCompletions(
 	const unload = input.match(/^unload\s+([^\s]*)$/u);
 	if (!unload) return null;
 	const valuePrefix = unload[1];
-	const values = ["--all", ...desiredNames]
+	const values = ["--all", ...[...desiredNames].filter(isSafeCompletionValue)]
 		.filter((value) => value.startsWith(valuePrefix))
 		.sort()
 		.map((value) => ({ value: `unload ${value}`, label: value }));
 	return values.length > 0 ? values : null;
+}
+
+function isSafeCompletionValue(value: string): boolean {
+	return (
+		value.length > 0 &&
+		!value.startsWith("-") &&
+		!/\s/u.test(value) &&
+		sanitizeDisplayLine(value) === value
+	);
 }
 
 function collectDesiredActivationNames(

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -66,6 +66,8 @@ interface SessionStateSnapshot {
 
 interface SessionEntryWriter {
 	appendCustomEntry(customType: string, data?: unknown): string;
+	branch(entryId: string): void;
+	resetLeaf(): void;
 }
 
 export function registerSessionSkills(
@@ -89,7 +91,14 @@ export function registerSessionSkills(
 		};
 		const sessionManager = ctx.sessionManager as ExtensionContext["sessionManager"] &
 			SessionEntryWriter;
-		sessionManager.appendCustomEntry(ACTIVATION_ENTRY_TYPE, snapshot);
+		const previousLeafId = sessionManager.getLeafId();
+		try {
+			sessionManager.appendCustomEntry(ACTIVATION_ENTRY_TYPE, snapshot);
+		} catch (error) {
+			if (previousLeafId === null) sessionManager.resetLeaf();
+			else sessionManager.branch(previousLeafId);
+			throw error;
+		}
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -396,6 +405,7 @@ function commandCompletions(
 		const completedTokens = base.trim().split(/\s+/u);
 		if (["--skill", "-s"].includes(completedTokens.at(-1) ?? "")) return null;
 		const used = new Set(completedTokens);
+		if (used.has("-s")) used.add("--skill");
 		const values = ["--skill", "--refresh"]
 			.filter((value) => !used.has(value) && value.startsWith(valuePrefix))
 			.map((value) => ({ value: `${base}${value}`, label: value }));

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -1,0 +1,360 @@
+import { existsSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import {
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+	loadSkills,
+	type SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
+import {
+	type LoadCommandArguments,
+	parseSessionSkillsCommandArguments,
+	SESSION_SKILLS_USAGE,
+	type UnloadCommandArguments,
+} from "./command-parser.js";
+import {
+	GitCommandError,
+	isPathInside,
+	type ResolvedSessionSkill,
+	SessionSkillResolver,
+	type SkillResolverLike,
+} from "./resolver.js";
+import { parseSkillSource, resolveSkillSelector } from "./source-parser.js";
+
+export const ACTIVATION_ENTRY_TYPE = "pi-session-skills:activation-v1";
+export const STATUS_KEY = "session-skills";
+
+interface SessionSkillActivation {
+	name: string;
+	path: string;
+	source: string;
+	selector?: string;
+}
+
+interface ActivationSnapshot {
+	version: 1;
+	skills: SessionSkillActivation[];
+}
+
+interface RestoredActivationSnapshot {
+	version: 1;
+	skills: Array<Partial<SessionSkillActivation> | undefined>;
+}
+
+export interface SessionSkillsExtensionOptions {
+	resolver?: SkillResolverLike;
+}
+
+interface RunningOperation {
+	controller: AbortController;
+	settled: Promise<void>;
+}
+
+export function registerSessionSkills(
+	pi: ExtensionAPI,
+	options: SessionSkillsExtensionOptions = {},
+): void {
+	const resolver = options.resolver ?? new SessionSkillResolver();
+	const activations = new Map<string, SessionSkillActivation>();
+	let activeSession: ExtensionContext["sessionManager"] | undefined;
+	let generation = 0;
+	let currentOperation: RunningOperation | undefined;
+
+	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
+
+	const requireCommandContext = (ctx: ExtensionCommandContext): void => {
+		if (!ctx.hasUI) throw new Error("/session-skills requires TUI or RPC mode.");
+		if (!ownsSession(ctx)) throw new Error("/session-skills is unavailable for a stale session.");
+	};
+
+	const saveSnapshot = (): void => {
+		const snapshot: ActivationSnapshot = {
+			version: 1,
+			skills: [...activations.values()],
+		};
+		pi.appendEntry(ACTIVATION_ENTRY_TYPE, snapshot);
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (activeSession && activeSession !== ctx.sessionManager && ctx.hasUI) {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+		}
+		const startGeneration = ++generation;
+		const previousOperation = currentOperation;
+		previousOperation?.controller.abort();
+		if (previousOperation) await previousOperation.settled;
+		if (generation !== startGeneration) return;
+		currentOperation = undefined;
+		activeSession = ctx.sessionManager;
+		activations.clear();
+
+		const snapshot = latestSnapshot(ctx.sessionManager.getBranch());
+		const missing: string[] = [];
+		for (const activation of snapshot?.skills ?? []) {
+			if (isUsableActivation(activation, resolver.getCacheRoot())) {
+				activations.set(activation.name, activation);
+			} else if (typeof activation?.name === "string") {
+				missing.push(sanitizeDisplay(activation.name));
+			}
+		}
+		if (missing.length > 0 && ctx.hasUI) {
+			ctx.ui.notify(`Skipped missing or unsafe session skills: ${missing.join(", ")}`, "warning");
+		}
+	});
+
+	pi.on("resources_discover", (_event, ctx) => {
+		if (!ownsSession(ctx) || activations.size === 0) return {};
+		return { skillPaths: [...activations.values()].map((activation) => activation.path) };
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		if (!ownsSession(ctx)) return;
+		generation++;
+		const operation = currentOperation;
+		operation?.controller.abort();
+		if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+		if (operation) await operation.settled;
+		if (!ownsSession(ctx)) return;
+		currentOperation = undefined;
+		activeSession = undefined;
+		activations.clear();
+	});
+
+	const loadSkill = async (
+		command: LoadCommandArguments,
+		ctx: ExtensionCommandContext,
+	): Promise<void> => {
+		if (currentOperation) throw new Error("Another session skill operation is already running.");
+		const source = parseSkillSource(command.source, ctx.cwd);
+		const selector = resolveSkillSelector(source, command.skill);
+		const commandGeneration = generation;
+		const commandSession = ctx.sessionManager;
+		const controller = new AbortController();
+
+		if (source.kind === "git") {
+			ctx.ui.notify(
+				"Remote skills contain instructions and code that run with your full Pi permissions. Review them before use.",
+				"warning",
+			);
+		}
+		ctx.ui.setStatus(STATUS_KEY, "Resolving session skill…");
+
+		let result: ResolvedSessionSkill;
+		const resolution = Promise.resolve().then(() =>
+			resolver.resolve({
+				source,
+				selector,
+				refresh: command.refresh,
+				signal: controller.signal,
+			}),
+		);
+		const operation: RunningOperation = {
+			controller,
+			settled: resolution.then(
+				() => {},
+				() => {},
+			),
+		};
+		currentOperation = operation;
+		try {
+			result = await resolution;
+			if (
+				generation !== commandGeneration ||
+				activeSession !== commandSession ||
+				controller.signal.aborted
+			) {
+				throw new Error("Session changed while the skill was resolving.");
+			}
+		} catch (error) {
+			throw new Error(formatResolverError(error));
+		} finally {
+			if (currentOperation === operation) currentOperation = undefined;
+			if (ownsSession(ctx) && ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+		}
+
+		const existing = activations.get(result.name);
+		if (
+			!command.refresh &&
+			existing?.path === result.path &&
+			existing.source === result.source &&
+			existing.selector === result.selector
+		) {
+			ctx.ui.notify(`Skill already active: ${sanitizeDisplay(result.name)}`, "info");
+			return;
+		}
+
+		const ownPaths = new Set([...activations.values()].map((activation) => activation.path));
+		const conflict = ctx
+			.getSystemPromptOptions()
+			.skills?.find((skill) => skill.name === result.name && !ownPaths.has(skill.baseDir));
+		if (conflict) {
+			throw new Error(
+				`Skill "${sanitizeDisplay(result.name)}" is already provided by ${sanitizeDisplay(conflict.filePath)}.`,
+			);
+		}
+
+		activations.set(result.name, {
+			name: result.name,
+			path: result.path,
+			source: result.source,
+			selector: result.selector,
+		});
+		saveSnapshot();
+		ctx.ui.notify(
+			`${result.cacheHit ? "Activated cached" : "Loaded"} skill: ${sanitizeDisplay(result.name)}`,
+			"info",
+		);
+		await ctx.reload();
+	};
+
+	const showSkills = (ctx: ExtensionCommandContext, includeUsage: boolean): void => {
+		const lines = activations.size === 0 ? ["Session skills: none"] : ["Session skills:"];
+		for (const activation of activations.values()) {
+			lines.push(`  ${sanitizeDisplay(activation.name)}`);
+			lines.push(`    source: ${sanitizeDisplay(activation.source)}`);
+			lines.push(`    cache: ${sanitizeDisplay(activation.path)}`);
+		}
+		if (includeUsage) lines.push("", SESSION_SKILLS_USAGE);
+		ctx.ui.notify(lines.join("\n"), "info");
+	};
+
+	const unloadSkill = async (
+		command: UnloadCommandArguments,
+		ctx: ExtensionCommandContext,
+	): Promise<void> => {
+		if (currentOperation) throw new Error("Another session skill operation is already running.");
+		let changed = false;
+		let message: string;
+		if (command.all) {
+			const count = activations.size;
+			activations.clear();
+			changed = count > 0;
+			message = changed
+				? `Unloaded ${count} session skill${count === 1 ? "" : "s"}.`
+				: "No session skills loaded.";
+		} else {
+			const name = command.name ?? "";
+			changed = activations.delete(name);
+			message = changed
+				? `Unloaded skill: ${sanitizeDisplay(name)}`
+				: `Session skill not loaded: ${sanitizeDisplay(name)}`;
+		}
+		ctx.ui.notify(message, changed ? "info" : "warning");
+		if (!changed) return;
+		saveSnapshot();
+		await ctx.reload();
+	};
+
+	pi.registerCommand("session-skills", {
+		description: "Manage skills loaded into the current session",
+		getArgumentCompletions: (prefix) => commandCompletions(prefix, activations.keys()),
+		handler: async (rawArguments, ctx) => {
+			requireCommandContext(ctx);
+			const command = parseSessionSkillsCommandArguments(rawArguments);
+			switch (command.action) {
+				case "status":
+					showSkills(ctx, true);
+					return;
+				case "list":
+					showSkills(ctx, false);
+					return;
+				case "load":
+					await loadSkill(command, ctx);
+					return;
+				case "unload":
+					await unloadSkill(command, ctx);
+					return;
+			}
+		},
+	});
+}
+
+export default function sessionSkills(pi: ExtensionAPI): void {
+	registerSessionSkills(pi);
+}
+
+function commandCompletions(
+	prefix: string,
+	activeNames: Iterable<string>,
+): Array<{ value: string; label: string }> | null {
+	const input = prefix.trimStart();
+	if (!/\s/u.test(input)) {
+		const routes = ["load", "list", "unload"]
+			.filter((route) => route.startsWith(input))
+			.map((route) => ({ value: route, label: route }));
+		return routes.length > 0 ? routes : null;
+	}
+	const unload = input.match(/^unload\s+([^\s]*)$/u);
+	if (!unload) return null;
+	const valuePrefix = unload[1];
+	const values = ["--all", ...activeNames]
+		.filter((value) => value.startsWith(valuePrefix))
+		.map((value) => ({ value: `unload ${value}`, label: value }));
+	return values.length > 0 ? values : null;
+}
+
+function latestSnapshot(entries: SessionEntry[]): RestoredActivationSnapshot | undefined {
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry.type !== "custom" || entry.customType !== ACTIVATION_ENTRY_TYPE) continue;
+		const data = entry.data as Partial<RestoredActivationSnapshot> | undefined;
+		if (data?.version !== 1 || !Array.isArray(data.skills)) return { version: 1, skills: [] };
+		return { version: 1, skills: data.skills };
+	}
+	return undefined;
+}
+
+function isUsableActivation(
+	activation: Partial<SessionSkillActivation> | undefined,
+	cacheRoot: string,
+): activation is SessionSkillActivation {
+	if (
+		typeof activation?.name !== "string" ||
+		typeof activation.path !== "string" ||
+		typeof activation.source !== "string" ||
+		(activation.selector !== undefined && typeof activation.selector !== "string") ||
+		!isPathInside(join(cacheRoot, "entries"), activation.path) ||
+		!existsSync(join(activation.path, "SKILL.md"))
+	) {
+		return false;
+	}
+	try {
+		if (!isPathInside(realpathSync(join(cacheRoot, "entries")), realpathSync(activation.path))) {
+			return false;
+		}
+		const loaded = loadSkills({
+			cwd: cacheRoot,
+			agentDir: cacheRoot,
+			skillPaths: [activation.path],
+			includeDefaults: false,
+		});
+		return loaded.skills.length === 1 && loaded.skills[0].name === activation.name;
+	} catch {
+		return false;
+	}
+}
+
+function formatResolverError(error: unknown): string {
+	if (error instanceof GitCommandError) {
+		const detail = sanitizeDisplay(error.output).trim().slice(-2_000);
+		return detail ? `${error.message}\n${detail}` : error.message;
+	}
+	return sanitizeDisplay(error instanceof Error ? error.message : String(error));
+}
+
+function sanitizeDisplay(value: string): string {
+	return [...stripTerminalSequences(value)]
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			const unsafe =
+				(codePoint <= 0x1f && character !== "\n" && character !== "\t") ||
+				(codePoint >= 0x7f && codePoint <= 0x9f) ||
+				(codePoint >= 0x202a && codePoint <= 0x202e) ||
+				(codePoint >= 0x2066 && codePoint <= 0x2069);
+			return unsafe ? " " : character;
+		})
+		.join("")
+		.trim();
+}

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -52,85 +52,104 @@ interface RunningOperation {
 	settled: Promise<void>;
 }
 
+interface SessionState {
+	activations: Map<string, SessionSkillActivation>;
+	generation: number;
+	operation?: RunningOperation;
+}
+
 export function registerSessionSkills(
 	pi: ExtensionAPI,
 	options: SessionSkillsExtensionOptions = {},
 ): void {
 	const resolver = options.resolver ?? new SessionSkillResolver();
-	const activations = new Map<string, SessionSkillActivation>();
-	let activeSession: ExtensionContext["sessionManager"] | undefined;
-	let generation = 0;
-	let currentOperation: RunningOperation | undefined;
+	const sessionStates = new Map<ExtensionContext["sessionManager"], SessionState>();
 
-	const ownsSession = (ctx: ExtensionContext): boolean => ctx.sessionManager === activeSession;
-
-	const requireCommandContext = (ctx: ExtensionCommandContext): void => {
+	const requireCommandContext = (ctx: ExtensionCommandContext): SessionState => {
 		if (!ctx.hasUI) throw new Error("/session-skills requires TUI or RPC mode.");
-		if (!ownsSession(ctx)) throw new Error("/session-skills is unavailable for a stale session.");
+		const state = sessionStates.get(ctx.sessionManager);
+		if (!state) throw new Error("/session-skills is unavailable for a stale session.");
+		return state;
 	};
 
-	const saveSnapshot = (): void => {
+	const saveSnapshot = (state: SessionState): void => {
 		const snapshot: ActivationSnapshot = {
 			version: 1,
-			skills: [...activations.values()],
+			skills: [...state.activations.values()],
 		};
 		pi.appendEntry(ACTIVATION_ENTRY_TYPE, snapshot);
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
-		if (activeSession && activeSession !== ctx.sessionManager && ctx.hasUI) {
-			ctx.ui.setStatus(STATUS_KEY, undefined);
+		let state = sessionStates.get(ctx.sessionManager);
+		if (!state) {
+			state = { activations: new Map(), generation: 0 };
+			sessionStates.set(ctx.sessionManager, state);
 		}
-		const startGeneration = ++generation;
-		const previousOperation = currentOperation;
+		const startGeneration = ++state.generation;
+		const previousOperation = state.operation;
 		previousOperation?.controller.abort();
 		if (previousOperation) await previousOperation.settled;
-		if (generation !== startGeneration) return;
-		currentOperation = undefined;
-		activeSession = ctx.sessionManager;
-		activations.clear();
+		if (sessionStates.get(ctx.sessionManager) !== state || state.generation !== startGeneration) {
+			return;
+		}
+		state.operation = undefined;
+		state.activations.clear();
 
 		const snapshot = latestSnapshot(ctx.sessionManager.getBranch());
-		const missing: string[] = [];
+		const nativeSkillNames = getNonSessionSkillNames(pi, resolver.getCacheRoot());
+		const skipped: string[] = [];
 		for (const activation of snapshot?.skills ?? []) {
-			if (isUsableActivation(activation, resolver.getCacheRoot())) {
-				activations.set(activation.name, activation);
+			if (
+				isUsableActivation(activation, resolver.getCacheRoot()) &&
+				!nativeSkillNames.has(activation.name)
+			) {
+				state.activations.set(activation.name, activation);
 			} else if (typeof activation?.name === "string") {
-				missing.push(sanitizeDisplay(activation.name));
+				skipped.push(sanitizeDisplayLine(activation.name));
 			}
 		}
-		if (missing.length > 0 && ctx.hasUI) {
-			ctx.ui.notify(`Skipped missing or unsafe session skills: ${missing.join(", ")}`, "warning");
+		if (skipped.length > 0 && ctx.hasUI) {
+			ctx.ui.notify(
+				`Skipped missing, unsafe, or conflicting session skills: ${skipped.join(", ")}`,
+				"warning",
+			);
 		}
 	});
 
 	pi.on("resources_discover", (_event, ctx) => {
-		if (!ownsSession(ctx) || activations.size === 0) return {};
-		return { skillPaths: [...activations.values()].map((activation) => activation.path) };
+		const state = sessionStates.get(ctx.sessionManager);
+		if (!state || state.activations.size === 0) return {};
+		return { skillPaths: [...state.activations.values()].map((activation) => activation.path) };
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
-		if (!ownsSession(ctx)) return;
-		generation++;
-		const operation = currentOperation;
+		const state = sessionStates.get(ctx.sessionManager);
+		if (!state) return;
+		const shutdownGeneration = ++state.generation;
+		const operation = state.operation;
 		operation?.controller.abort();
 		if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
 		if (operation) await operation.settled;
-		if (!ownsSession(ctx)) return;
-		currentOperation = undefined;
-		activeSession = undefined;
-		activations.clear();
+		if (
+			sessionStates.get(ctx.sessionManager) !== state ||
+			state.generation !== shutdownGeneration
+		) {
+			return;
+		}
+		sessionStates.delete(ctx.sessionManager);
+		state.activations.clear();
 	});
 
 	const loadSkill = async (
 		command: LoadCommandArguments,
 		ctx: ExtensionCommandContext,
+		state: SessionState,
 	): Promise<void> => {
-		if (currentOperation) throw new Error("Another session skill operation is already running.");
+		if (state.operation) throw new Error("Another session skill operation is already running.");
 		const source = parseSkillSource(command.source, ctx.cwd);
 		const selector = resolveSkillSelector(source, command.skill);
-		const commandGeneration = generation;
-		const commandSession = ctx.sessionManager;
+		const commandGeneration = state.generation;
 		const controller = new AbortController();
 
 		if (source.kind === "git") {
@@ -141,7 +160,8 @@ export function registerSessionSkills(
 		}
 		ctx.ui.setStatus(STATUS_KEY, "Resolving session skill…");
 
-		let result: ResolvedSessionSkill;
+		let result: ResolvedSessionSkill | undefined;
+		let prepared = false;
 		const resolution = Promise.resolve().then(() =>
 			resolver.resolve({
 				source,
@@ -150,71 +170,99 @@ export function registerSessionSkills(
 				signal: controller.signal,
 			}),
 		);
+		let settleOperation!: () => void;
 		const operation: RunningOperation = {
 			controller,
-			settled: resolution.then(
-				() => {},
-				() => {},
-			),
+			settled: new Promise<void>((resolve) => {
+				settleOperation = resolve;
+			}),
 		};
-		currentOperation = operation;
+		state.operation = operation;
 		try {
 			result = await resolution;
+			assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
+
+			const existing = state.activations.get(result.name);
 			if (
-				generation !== commandGeneration ||
-				activeSession !== commandSession ||
-				controller.signal.aborted
+				!command.refresh &&
+				existing?.path === result.path &&
+				existing.source === result.source &&
+				existing.selector === result.selector
 			) {
-				throw new Error("Session changed while the skill was resolving.");
+				await result.transaction?.rollback();
+				assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
+				ctx.ui.notify(`Skill already active: ${sanitizeDisplayLine(result.name)}`, "info");
+				return;
 			}
-		} catch (error) {
-			throw new Error(formatResolverError(error));
-		} finally {
-			if (currentOperation === operation) currentOperation = undefined;
-			if (ownsSession(ctx) && ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
-		}
 
-		const existing = activations.get(result.name);
-		if (
-			!command.refresh &&
-			existing?.path === result.path &&
-			existing.source === result.source &&
-			existing.selector === result.selector
-		) {
-			ctx.ui.notify(`Skill already active: ${sanitizeDisplay(result.name)}`, "info");
-			return;
-		}
-
-		const ownPaths = new Set([...activations.values()].map((activation) => activation.path));
-		const conflict = ctx
-			.getSystemPromptOptions()
-			.skills?.find((skill) => skill.name === result.name && !ownPaths.has(skill.baseDir));
-		if (conflict) {
-			throw new Error(
-				`Skill "${sanitizeDisplay(result.name)}" is already provided by ${sanitizeDisplay(conflict.filePath)}.`,
+			const ownPaths = new Set(
+				[...state.activations.values()].map((activation) => activation.path),
 			);
+			const resultName = result.name;
+			const conflict = ctx
+				.getSystemPromptOptions()
+				.skills?.find((skill) => skill.name === resultName && !ownPaths.has(skill.baseDir));
+			if (conflict) {
+				throw new Error(
+					`Skill "${sanitizeDisplayLine(result.name)}" is already provided by ${sanitizeDisplayLine(conflict.filePath)}.`,
+				);
+			}
+
+			const previousActivations = new Map(state.activations);
+			await result.transaction?.commit();
+			assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
+			for (const [name, activation] of state.activations) {
+				if (activation.source === result.source && activation.selector === result.selector) {
+					state.activations.delete(name);
+				}
+			}
+			state.activations.set(result.name, {
+				name: result.name,
+				path: result.path,
+				source: result.source,
+				...(result.selector === undefined ? {} : { selector: result.selector }),
+			});
+			try {
+				saveSnapshot(state);
+			} catch (error) {
+				restoreActivations(state, previousActivations);
+				throw error;
+			}
+			prepared = true;
+		} catch (error) {
+			let failure = error;
+			if (!prepared && result?.transaction) {
+				try {
+					await result.transaction.rollback();
+				} catch (rollbackError) {
+					failure = new Error(
+						`${formatResolverError(error)} Cache rollback failed: ${formatResolverError(rollbackError)}`,
+					);
+				}
+			}
+			throw new Error(formatResolverError(failure));
+		} finally {
+			settleOperation();
+			if (state.operation === operation) state.operation = undefined;
+			if (sessionStates.get(ctx.sessionManager) === state && ctx.hasUI) {
+				ctx.ui.setStatus(STATUS_KEY, undefined);
+			}
 		}
 
-		activations.set(result.name, {
-			name: result.name,
-			path: result.path,
-			source: result.source,
-			selector: result.selector,
-		});
-		saveSnapshot();
-		ctx.ui.notify(
-			`${result.cacheHit ? "Activated cached" : "Loaded"} skill: ${sanitizeDisplay(result.name)}`,
-			"info",
-		);
+		ctx.ui.notify(`Reloading to activate skill: ${sanitizeDisplayLine(result.name)}`, "info");
 		await ctx.reload();
 	};
 
-	const showSkills = (ctx: ExtensionCommandContext, includeUsage: boolean): void => {
-		const lines = activations.size === 0 ? ["Session skills: none"] : ["Session skills:"];
-		for (const activation of activations.values()) {
-			lines.push(`  ${sanitizeDisplay(activation.name)}`);
-			lines.push(`    source: ${sanitizeDisplay(activation.source)}`);
-			lines.push(`    cache: ${sanitizeDisplay(activation.path)}`);
+	const showSkills = (
+		ctx: ExtensionCommandContext,
+		state: SessionState,
+		includeUsage: boolean,
+	): void => {
+		const lines = state.activations.size === 0 ? ["Session skills: none"] : ["Session skills:"];
+		for (const activation of state.activations.values()) {
+			lines.push(`  ${sanitizeDisplayLine(activation.name)}`);
+			lines.push(`    source: ${sanitizeDisplayLine(activation.source)}`);
+			lines.push(`    cache: ${sanitizeDisplayLine(activation.path)}`);
 		}
 		if (includeUsage) lines.push("", SESSION_SKILLS_USAGE);
 		ctx.ui.notify(lines.join("\n"), "info");
@@ -223,48 +271,49 @@ export function registerSessionSkills(
 	const unloadSkill = async (
 		command: UnloadCommandArguments,
 		ctx: ExtensionCommandContext,
+		state: SessionState,
 	): Promise<void> => {
-		if (currentOperation) throw new Error("Another session skill operation is already running.");
+		if (state.operation) throw new Error("Another session skill operation is already running.");
+		const previousActivations = new Map(state.activations);
 		let changed = false;
-		let message: string;
 		if (command.all) {
-			const count = activations.size;
-			activations.clear();
-			changed = count > 0;
-			message = changed
-				? `Unloaded ${count} session skill${count === 1 ? "" : "s"}.`
-				: "No session skills loaded.";
+			changed = state.activations.size > 0;
+			state.activations.clear();
 		} else {
-			const name = command.name ?? "";
-			changed = activations.delete(name);
-			message = changed
-				? `Unloaded skill: ${sanitizeDisplay(name)}`
-				: `Session skill not loaded: ${sanitizeDisplay(name)}`;
+			changed = state.activations.delete(command.name ?? "");
 		}
-		ctx.ui.notify(message, changed ? "info" : "warning");
-		if (!changed) return;
-		saveSnapshot();
+		if (!changed) {
+			ctx.ui.notify("No matching session skills are loaded.", "warning");
+			return;
+		}
+		try {
+			saveSnapshot(state);
+		} catch (error) {
+			restoreActivations(state, previousActivations);
+			throw error;
+		}
+		ctx.ui.notify("Reloading to apply session skill changes.", "info");
 		await ctx.reload();
 	};
 
 	pi.registerCommand("session-skills", {
 		description: "Manage skills loaded into the current session",
-		getArgumentCompletions: (prefix) => commandCompletions(prefix, activations.keys()),
+		getArgumentCompletions: commandCompletions,
 		handler: async (rawArguments, ctx) => {
-			requireCommandContext(ctx);
+			const state = requireCommandContext(ctx);
 			const command = parseSessionSkillsCommandArguments(rawArguments);
 			switch (command.action) {
 				case "status":
-					showSkills(ctx, true);
+					showSkills(ctx, state, true);
 					return;
 				case "list":
-					showSkills(ctx, false);
+					showSkills(ctx, state, false);
 					return;
 				case "load":
-					await loadSkill(command, ctx);
+					await loadSkill(command, ctx, state);
 					return;
 				case "unload":
-					await unloadSkill(command, ctx);
+					await unloadSkill(command, ctx, state);
 					return;
 			}
 		},
@@ -275,10 +324,7 @@ export default function sessionSkills(pi: ExtensionAPI): void {
 	registerSessionSkills(pi);
 }
 
-function commandCompletions(
-	prefix: string,
-	activeNames: Iterable<string>,
-): Array<{ value: string; label: string }> | null {
+function commandCompletions(prefix: string): Array<{ value: string; label: string }> | null {
 	const input = prefix.trimStart();
 	if (!/\s/u.test(input)) {
 		const routes = ["load", "list", "unload"]
@@ -286,13 +332,55 @@ function commandCompletions(
 			.map((route) => ({ value: route, label: route }));
 		return routes.length > 0 ? routes : null;
 	}
-	const unload = input.match(/^unload\s+([^\s]*)$/u);
-	if (!unload) return null;
-	const valuePrefix = unload[1];
-	const values = ["--all", ...activeNames]
-		.filter((value) => value.startsWith(valuePrefix))
-		.map((value) => ({ value: `unload ${value}`, label: value }));
-	return values.length > 0 ? values : null;
+	if (input.startsWith("load ")) {
+		const lastSpace = input.lastIndexOf(" ");
+		const valuePrefix = input.slice(lastSpace + 1);
+		if (valuePrefix && !valuePrefix.startsWith("-")) return null;
+		const base = input.slice(0, lastSpace + 1);
+		const used = new Set(base.trim().split(/\s+/u));
+		const values = ["--skill", "--refresh"]
+			.filter((value) => !used.has(value) && value.startsWith(valuePrefix))
+			.map((value) => ({ value: `${base}${value}`, label: value }));
+		return values.length > 0 ? values : null;
+	}
+	const unload = input.match(/^unload\s+(--[^\s]*)$/u);
+	if (!unload || !"--all".startsWith(unload[1])) return null;
+	return [{ value: "unload --all", label: "--all" }];
+}
+
+function assertCurrentSessionState(
+	states: Map<ExtensionContext["sessionManager"], SessionState>,
+	ctx: ExtensionContext,
+	state: SessionState,
+	generation: number,
+	signal: AbortSignal,
+): void {
+	if (
+		states.get(ctx.sessionManager) !== state ||
+		state.generation !== generation ||
+		signal.aborted
+	) {
+		throw new Error("Session changed while the skill was resolving.");
+	}
+}
+
+function restoreActivations(
+	state: SessionState,
+	previous: Map<string, SessionSkillActivation>,
+): void {
+	state.activations.clear();
+	for (const [name, activation] of previous) state.activations.set(name, activation);
+}
+
+function getNonSessionSkillNames(pi: ExtensionAPI, cacheRoot: string): Set<string> {
+	const names = new Set<string>();
+	for (const command of pi.getCommands()) {
+		if (command.source !== "skill" || isPathInside(cacheRoot, command.sourceInfo.path)) continue;
+		names.add(
+			command.name.startsWith("skill:") ? command.name.slice("skill:".length) : command.name,
+		);
+	}
+	return names;
 }
 
 function latestSnapshot(entries: SessionEntry[]): RestoredActivationSnapshot | undefined {
@@ -338,18 +426,27 @@ function isUsableActivation(
 
 function formatResolverError(error: unknown): string {
 	if (error instanceof GitCommandError) {
-		const detail = sanitizeDisplay(error.output).trim().slice(-2_000);
-		return detail ? `${error.message}\n${detail}` : error.message;
+		const detail = sanitizeDiagnostic(error.output).trim().slice(-2_000);
+		const message = sanitizeDisplayLine(error.message);
+		return detail ? `${message}\n${detail}` : message;
 	}
-	return sanitizeDisplay(error instanceof Error ? error.message : String(error));
+	return sanitizeDisplayLine(error instanceof Error ? error.message : String(error));
 }
 
-function sanitizeDisplay(value: string): string {
+function sanitizeDisplayLine(value: string): string {
+	return sanitizeCharacters(value, false);
+}
+
+function sanitizeDiagnostic(value: string): string {
+	return sanitizeCharacters(value, true);
+}
+
+function sanitizeCharacters(value: string, preserveNewlines: boolean): string {
 	return [...stripTerminalSequences(value)]
 		.map((character) => {
 			const codePoint = character.codePointAt(0) ?? 0;
 			const unsafe =
-				(codePoint <= 0x1f && character !== "\n" && character !== "\t") ||
+				(codePoint <= 0x1f && !(preserveNewlines && character === "\n")) ||
 				(codePoint >= 0x7f && codePoint <= 0x9f) ||
 				(codePoint >= 0x202a && codePoint <= 0x202e) ||
 				(codePoint >= 0x2066 && codePoint <= 0x2069);

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -17,6 +17,7 @@ import {
 import {
 	GitCommandError,
 	isPathInside,
+	isValidSkillName,
 	type ResolvedSessionSkill,
 	SessionSkillResolver,
 	type SkillResolverLike,
@@ -516,6 +517,7 @@ function isUsableActivation(
 ): activation is SessionSkillActivation {
 	if (
 		!isActivationRecord(activation) ||
+		!isValidSkillName(activation.name) ||
 		!isPathInside(join(cacheRoot, "entries"), activation.path) ||
 		!existsSync(join(activation.path, "SKILL.md"))
 	) {

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -194,34 +194,50 @@ export function registerSessionSkills(
 		try {
 			result = await resolution;
 			assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
+			const resolvedResult = result;
 
-			const existing = state.activations.get(result.name);
+			const existing = state.activations.get(resolvedResult.name);
 			if (
 				!command.refresh &&
-				existing?.path === result.path &&
-				existing.source === result.source &&
-				existing.selector === result.selector
+				existing?.path === resolvedResult.path &&
+				existing.source === resolvedResult.source &&
+				existing.selector === resolvedResult.selector
 			) {
-				await result.transaction?.rollback();
+				await resolvedResult.transaction?.rollback();
 				assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
-				ctx.ui.notify(`Skill already active: ${sanitizeDisplayLine(result.name)}`, "info");
+				ctx.ui.notify(`Skill already active: ${sanitizeDisplayLine(resolvedResult.name)}`, "info");
 				return;
 			}
 
-			const ownPaths = new Set(
-				[...state.activations.values()].map((activation) => activation.path),
+			const sameNameActivation = state.desiredActivations.get(resolvedResult.name);
+			if (
+				sameNameActivation &&
+				(sameNameActivation.source !== resolvedResult.source ||
+					sameNameActivation.selector !== resolvedResult.selector)
+			) {
+				throw new Error(
+					`Skill "${sanitizeDisplayLine(resolvedResult.name)}" already belongs to session source ${sanitizeDisplayLine(sameNameActivation.source)}.`,
+				);
+			}
+			const refreshedPaths = new Set(
+				[...state.activations.values()]
+					.filter(
+						(activation) =>
+							activation.source === resolvedResult.source &&
+							activation.selector === resolvedResult.selector,
+					)
+					.map((activation) => activation.path),
 			);
-			const resultName = result.name;
+			const resultName = resolvedResult.name;
 			const conflict = ctx
 				.getSystemPromptOptions()
-				.skills?.find((skill) => skill.name === resultName && !ownPaths.has(skill.baseDir));
+				.skills?.find((skill) => skill.name === resultName && !refreshedPaths.has(skill.baseDir));
 			if (conflict) {
 				throw new Error(
-					`Skill "${sanitizeDisplayLine(result.name)}" is already provided by ${sanitizeDisplayLine(conflict.filePath)}.`,
+					`Skill "${sanitizeDisplayLine(resolvedResult.name)}" is already provided by ${sanitizeDisplayLine(conflict.filePath)}.`,
 				);
 			}
 
-			const resolvedResult = result;
 			const previousState = snapshotSessionState(state);
 			let applied = false;
 			const applyActivation = () => {
@@ -371,7 +387,9 @@ function commandCompletions(
 		const valuePrefix = input.slice(lastSpace + 1);
 		if (valuePrefix && !valuePrefix.startsWith("-")) return null;
 		const base = input.slice(0, lastSpace + 1);
-		const used = new Set(base.trim().split(/\s+/u));
+		const completedTokens = base.trim().split(/\s+/u);
+		if (["--skill", "-s"].includes(completedTokens.at(-1) ?? "")) return null;
+		const used = new Set(completedTokens);
 		const values = ["--skill", "--refresh"]
 			.filter((value) => !used.has(value) && value.startsWith(valuePrefix))
 			.map((value) => ({ value: `${base}${value}`, label: value }));

--- a/.pi/extensions/pi-session-skills/extension.ts
+++ b/.pi/extensions/pi-session-skills/extension.ts
@@ -54,8 +54,14 @@ interface RunningOperation {
 
 interface SessionState {
 	activations: Map<string, SessionSkillActivation>;
+	desiredActivations: Map<string, SessionSkillActivation>;
 	generation: number;
 	operation?: RunningOperation;
+}
+
+interface SessionStateSnapshot {
+	activations: Map<string, SessionSkillActivation>;
+	desiredActivations: Map<string, SessionSkillActivation>;
 }
 
 export function registerSessionSkills(
@@ -75,7 +81,7 @@ export function registerSessionSkills(
 	const saveSnapshot = (state: SessionState): void => {
 		const snapshot: ActivationSnapshot = {
 			version: 1,
-			skills: [...state.activations.values()],
+			skills: [...state.desiredActivations.values()],
 		};
 		pi.appendEntry(ACTIVATION_ENTRY_TYPE, snapshot);
 	};
@@ -83,7 +89,7 @@ export function registerSessionSkills(
 	pi.on("session_start", async (_event, ctx) => {
 		let state = sessionStates.get(ctx.sessionManager);
 		if (!state) {
-			state = { activations: new Map(), generation: 0 };
+			state = { activations: new Map(), desiredActivations: new Map(), generation: 0 };
 			sessionStates.set(ctx.sessionManager, state);
 		}
 		const startGeneration = ++state.generation;
@@ -95,17 +101,23 @@ export function registerSessionSkills(
 		}
 		state.operation = undefined;
 		state.activations.clear();
+		state.desiredActivations.clear();
 
 		const snapshot = latestSnapshot(ctx.sessionManager.getBranch());
 		const nativeSkillNames = getNonSessionSkillNames(pi, resolver.getCacheRoot());
 		const skipped: string[] = [];
 		for (const activation of snapshot?.skills ?? []) {
-			if (
-				isUsableActivation(activation, resolver.getCacheRoot()) &&
-				!nativeSkillNames.has(activation.name)
-			) {
-				state.activations.set(activation.name, activation);
-			} else if (typeof activation?.name === "string") {
+			if (isActivationRecord(activation)) {
+				state.desiredActivations.set(activation.name, activation);
+				if (
+					isUsableActivation(activation, resolver.getCacheRoot()) &&
+					!nativeSkillNames.has(activation.name)
+				) {
+					state.activations.set(activation.name, activation);
+					continue;
+				}
+			}
+			if (typeof activation?.name === "string") {
 				skipped.push(sanitizeDisplayLine(activation.name));
 			}
 		}
@@ -139,6 +151,7 @@ export function registerSessionSkills(
 		}
 		sessionStates.delete(ctx.sessionManager);
 		state.activations.clear();
+		state.desiredActivations.clear();
 	});
 
 	const loadSkill = async (
@@ -208,27 +221,41 @@ export function registerSessionSkills(
 				);
 			}
 
-			const previousActivations = new Map(state.activations);
-			await result.transaction?.commit();
-			assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
-			for (const [name, activation] of state.activations) {
-				if (activation.source === result.source && activation.selector === result.selector) {
-					state.activations.delete(name);
+			const resolvedResult = result;
+			const previousState = snapshotSessionState(state);
+			let applied = false;
+			const applyActivation = () => {
+				applied = true;
+				assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
+				for (const activations of [state.activations, state.desiredActivations]) {
+					for (const [name, activation] of activations) {
+						if (
+							activation.source === resolvedResult.source &&
+							activation.selector === resolvedResult.selector
+						) {
+							activations.delete(name);
+						}
+					}
 				}
-			}
-			state.activations.set(result.name, {
-				name: result.name,
-				path: result.path,
-				source: result.source,
-				...(result.selector === undefined ? {} : { selector: result.selector }),
-			});
-			try {
-				saveSnapshot(state);
-			} catch (error) {
-				restoreActivations(state, previousActivations);
-				throw error;
-			}
-			prepared = true;
+				const activation: SessionSkillActivation = {
+					name: resolvedResult.name,
+					path: resolvedResult.path,
+					source: resolvedResult.source,
+					...(resolvedResult.selector === undefined ? {} : { selector: resolvedResult.selector }),
+				};
+				state.activations.set(resolvedResult.name, activation);
+				state.desiredActivations.set(resolvedResult.name, activation);
+				try {
+					saveSnapshot(state);
+				} catch (error) {
+					restoreSessionState(state, previousState);
+					throw error;
+				}
+				prepared = true;
+			};
+			await resolvedResult.transaction?.commit(applyActivation);
+			if (!applied) applyActivation();
+			assertCurrentSessionState(sessionStates, ctx, state, commandGeneration, controller.signal);
 		} catch (error) {
 			let failure = error;
 			if (!prepared && result?.transaction) {
@@ -274,13 +301,16 @@ export function registerSessionSkills(
 		state: SessionState,
 	): Promise<void> => {
 		if (state.operation) throw new Error("Another session skill operation is already running.");
-		const previousActivations = new Map(state.activations);
+		const previousState = snapshotSessionState(state);
 		let changed = false;
 		if (command.all) {
-			changed = state.activations.size > 0;
+			changed = state.desiredActivations.size > 0;
 			state.activations.clear();
+			state.desiredActivations.clear();
 		} else {
-			changed = state.activations.delete(command.name ?? "");
+			const name = command.name ?? "";
+			changed = state.desiredActivations.delete(name);
+			state.activations.delete(name);
 		}
 		if (!changed) {
 			ctx.ui.notify("No matching session skills are loaded.", "warning");
@@ -289,7 +319,7 @@ export function registerSessionSkills(
 		try {
 			saveSnapshot(state);
 		} catch (error) {
-			restoreActivations(state, previousActivations);
+			restoreSessionState(state, previousState);
 			throw error;
 		}
 		ctx.ui.notify("Reloading to apply session skill changes.", "info");
@@ -298,7 +328,8 @@ export function registerSessionSkills(
 
 	pi.registerCommand("session-skills", {
 		description: "Manage skills loaded into the current session",
-		getArgumentCompletions: commandCompletions,
+		getArgumentCompletions: (prefix) =>
+			commandCompletions(prefix, collectDesiredActivationNames(sessionStates)),
 		handler: async (rawArguments, ctx) => {
 			const state = requireCommandContext(ctx);
 			const command = parseSessionSkillsCommandArguments(rawArguments);
@@ -324,7 +355,10 @@ export default function sessionSkills(pi: ExtensionAPI): void {
 	registerSessionSkills(pi);
 }
 
-function commandCompletions(prefix: string): Array<{ value: string; label: string }> | null {
+function commandCompletions(
+	prefix: string,
+	desiredNames: Iterable<string>,
+): Array<{ value: string; label: string }> | null {
 	const input = prefix.trimStart();
 	if (!/\s/u.test(input)) {
 		const routes = ["load", "list", "unload"]
@@ -343,9 +377,24 @@ function commandCompletions(prefix: string): Array<{ value: string; label: strin
 			.map((value) => ({ value: `${base}${value}`, label: value }));
 		return values.length > 0 ? values : null;
 	}
-	const unload = input.match(/^unload\s+(--[^\s]*)$/u);
-	if (!unload || !"--all".startsWith(unload[1])) return null;
-	return [{ value: "unload --all", label: "--all" }];
+	const unload = input.match(/^unload\s+([^\s]*)$/u);
+	if (!unload) return null;
+	const valuePrefix = unload[1];
+	const values = ["--all", ...desiredNames]
+		.filter((value) => value.startsWith(valuePrefix))
+		.sort()
+		.map((value) => ({ value: `unload ${value}`, label: value }));
+	return values.length > 0 ? values : null;
+}
+
+function collectDesiredActivationNames(
+	states: Map<ExtensionContext["sessionManager"], SessionState>,
+): string[] {
+	const names = new Set<string>();
+	for (const state of states.values()) {
+		for (const name of state.desiredActivations.keys()) names.add(name);
+	}
+	return [...names];
 }
 
 function assertCurrentSessionState(
@@ -364,12 +413,20 @@ function assertCurrentSessionState(
 	}
 }
 
-function restoreActivations(
-	state: SessionState,
-	previous: Map<string, SessionSkillActivation>,
-): void {
+function snapshotSessionState(state: SessionState): SessionStateSnapshot {
+	return {
+		activations: new Map(state.activations),
+		desiredActivations: new Map(state.desiredActivations),
+	};
+}
+
+function restoreSessionState(state: SessionState, previous: SessionStateSnapshot): void {
 	state.activations.clear();
-	for (const [name, activation] of previous) state.activations.set(name, activation);
+	state.desiredActivations.clear();
+	for (const [name, activation] of previous.activations) state.activations.set(name, activation);
+	for (const [name, activation] of previous.desiredActivations) {
+		state.desiredActivations.set(name, activation);
+	}
 }
 
 function getNonSessionSkillNames(pi: ExtensionAPI, cacheRoot: string): Set<string> {
@@ -394,15 +451,23 @@ function latestSnapshot(entries: SessionEntry[]): RestoredActivationSnapshot | u
 	return undefined;
 }
 
+function isActivationRecord(
+	activation: Partial<SessionSkillActivation> | undefined,
+): activation is SessionSkillActivation {
+	return (
+		typeof activation?.name === "string" &&
+		typeof activation.path === "string" &&
+		typeof activation.source === "string" &&
+		(activation.selector === undefined || typeof activation.selector === "string")
+	);
+}
+
 function isUsableActivation(
 	activation: Partial<SessionSkillActivation> | undefined,
 	cacheRoot: string,
 ): activation is SessionSkillActivation {
 	if (
-		typeof activation?.name !== "string" ||
-		typeof activation.path !== "string" ||
-		typeof activation.source !== "string" ||
-		(activation.selector !== undefined && typeof activation.selector !== "string") ||
+		!isActivationRecord(activation) ||
 		!isPathInside(join(cacheRoot, "entries"), activation.path) ||
 		!existsSync(join(activation.path, "SKILL.md"))
 	) {

--- a/.pi/extensions/pi-session-skills/index.ts
+++ b/.pi/extensions/pi-session-skills/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extension.js";

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -106,6 +106,40 @@ test("ignores frontmatter in Markdown files that are not named SKILL.md", async 
 	assert.equal(result.name, "real-skill");
 });
 
+test("honors Pi ignore files and hidden directories during discovery", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-ignore-");
+	const sourceRoot = join(workspace, "skills");
+	await writeSkill(sourceRoot, "visible", "visible-skill");
+	await writeSkill(sourceRoot, "ignored-git", "ignored-git-skill");
+	await writeSkill(sourceRoot, "ignored-general", "ignored-general-skill");
+	await writeSkill(sourceRoot, "ignored-fd", "ignored-fd-skill");
+	await writeSkill(sourceRoot, "group/keep", "reincluded-skill");
+	await writeSkill(sourceRoot, ".hidden", "hidden-skill");
+	await writeFile(
+		join(sourceRoot, ".gitignore"),
+		"ignored-git/\ngroup/*\n!group/keep/\n!group/keep/**\n",
+	);
+	await writeFile(join(sourceRoot, ".ignore"), "ignored-general/\n");
+	await writeFile(join(sourceRoot, ".fdignore"), "ignored-fd/\n");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+
+	const source = parseSkillSource(sourceRoot, workspace);
+	const visible = await resolver.resolve({ source, selector: "visible-skill" });
+	assert.equal(visible.name, "visible-skill");
+	await visible.transaction?.rollback();
+	const reincluded = await resolver.resolve({ source, selector: "reincluded-skill" });
+	assert.equal(reincluded.name, "reincluded-skill");
+	await reincluded.transaction?.rollback();
+	for (const ignored of [
+		"ignored-git-skill",
+		"ignored-general-skill",
+		"ignored-fd-skill",
+		"hidden-skill",
+	]) {
+		await assert.rejects(() => resolver.resolve({ source, selector: ignored }), /No skill named/);
+	}
+});
+
 test("selects one skill from a multi-skill source", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-select-");
 	await writeSkill(workspace, "skills/alpha", "alpha");

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import {
+	chmod,
 	cp,
 	mkdir,
 	mkdtemp,
@@ -19,8 +20,11 @@ import {
 	type CloneRepository,
 	defaultCacheRoot,
 	GitCommandError,
+	type ResolveSessionSkillOptions,
 	runGitClone,
 	SessionSkillResolver,
+	type SkillResolverLike,
+	windowsProcessTreeKillArguments,
 } from "./resolver.js";
 
 const execFileAsync = promisify(execFile);
@@ -39,6 +43,12 @@ async function temporaryDirectory(prefix: string): Promise<string> {
 	const path = await mkdtemp(join(tmpdir(), prefix));
 	temporaryPaths.push(path);
 	return path;
+}
+
+async function resolveAndCommit(resolver: SkillResolverLike, options: ResolveSessionSkillOptions) {
+	const result = await resolver.resolve(options);
+	await result.transaction?.commit();
+	return result;
 }
 
 async function writeSkill(
@@ -67,7 +77,7 @@ test("copies and caches one local skill without linking it", async () => {
 	const resolver = new SessionSkillResolver({ cacheRoot });
 	const source = parseSkillSource(skillRoot, workspace);
 
-	const first = await resolver.resolve({ source });
+	const first = await resolveAndCommit(resolver, { source });
 	assert.equal(first.name, "demo-skill");
 	assert.equal(first.cacheHit, false);
 	assert.notEqual(first.path, skillRoot);
@@ -124,7 +134,7 @@ test("refresh replaces a cache entry only after the new skill validates", async 
 	const skillRoot = await writeSkill(workspace, "source", "refreshable");
 	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
 	const source = parseSkillSource(skillRoot, workspace);
-	const first = await resolver.resolve({ source });
+	const first = await resolveAndCommit(resolver, { source });
 
 	await writeFile(join(skillRoot, "SKILL.md"), "---\nname: refreshable\n---\n\n# Invalid\n");
 	await assert.rejects(() => resolver.resolve({ source, refresh: true }), /No valid skills/);
@@ -137,8 +147,67 @@ test("refresh replaces a cache entry only after the new skill validates", async 
 	const cached = await resolver.resolve({ source });
 	assert.doesNotMatch(await readFile(join(cached.path, "SKILL.md"), "utf8"), /Updated/);
 	const refreshed = await resolver.resolve({ source, refresh: true });
-	assert.equal(refreshed.path, first.path);
+	assert.notEqual(refreshed.path, first.path);
 	assert.match(await readFile(join(refreshed.path, "SKILL.md"), "utf8"), /Updated/);
+	await refreshed.transaction?.commit();
+	assert.doesNotMatch(await readFile(join(first.path, "SKILL.md"), "utf8"), /Updated/);
+});
+
+test("keeps the previous cache current until a refresh transaction commits", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-transaction-");
+	const skillRoot = await writeSkill(workspace, "source", "old-name");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+	const original = await resolveAndCommit(resolver, { source });
+
+	await writeFile(
+		join(skillRoot, "SKILL.md"),
+		"---\nname: new-name\ndescription: Renamed skill.\n---\n",
+	);
+	const refreshed = await resolver.resolve({ source, refresh: true });
+	assert.equal(refreshed.previousName, "old-name");
+	assert.notEqual(refreshed.path, original.path);
+	assert.equal((await resolver.resolve({ source })).name, "old-name");
+
+	await refreshed.transaction?.rollback();
+	assert.equal((await resolver.resolve({ source })).path, original.path);
+});
+
+test("excludes a nested cache root from broad local discovery", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-cache-subtree-");
+	await writeSkill(workspace, "skills/source", "source-skill");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, ".cache") });
+	const source = parseSkillSource(workspace, workspace);
+	await resolveAndCommit(resolver, { source });
+
+	const refreshed = await resolver.resolve({ source, refresh: true });
+	assert.equal(refreshed.name, "source-skill");
+	await refreshed.transaction?.rollback();
+});
+
+test("does not copy a cache nested inside a local skill root", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-root-cache-");
+	const skillRoot = await writeSkill(workspace, ".", "root-skill");
+	const cacheRoot = join(workspace, ".cache");
+	const resolver = new SessionSkillResolver({ cacheRoot });
+	const result = await resolver.resolve({ source: parseSkillSource(skillRoot, workspace) });
+	await assert.rejects(() => stat(join(result.path, ".cache")), { code: "ENOENT" });
+	await result.transaction?.rollback();
+});
+
+test("populates read-only directories before restoring their modes", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-read-only-");
+	const skillRoot = await writeSkill(workspace, "source", "read-only-skill", true);
+	const scriptsPath = join(skillRoot, "scripts");
+	await chmod(scriptsPath, 0o555);
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const result = await resolver.resolve({ source: parseSkillSource(skillRoot, workspace) });
+	const copiedScripts = join(result.path, "scripts");
+	assert.equal((await stat(copiedScripts)).mode & 0o777, 0o555);
+	assert.match(await readFile(join(copiedScripts, "run.sh"), "utf8"), /echo ok/);
+	await chmod(scriptsPath, 0o755);
+	await chmod(copiedScripts, 0o755);
+	await result.transaction?.rollback();
 });
 
 test("rejects symbolic links in a skill and removes staging files", async () => {
@@ -207,6 +276,36 @@ test("clones through the system Git executable", async () => {
 	await execFileAsync("git", ["init", "--bare", source]);
 	await runGitClone(`file://${source}`, target, undefined, undefined);
 	assert.ok((await stat(join(target, ".git"))).isDirectory());
+});
+
+test("fetches and checks out a commit hash without treating it as a branch", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-commit-");
+	const source = join(workspace, "source");
+	const target = join(workspace, "clone");
+	await execFileAsync("git", ["init", source]);
+	await writeSkill(source, "skill", "commit-skill");
+	await execFileAsync("git", ["-C", source, "add", "."]);
+	await execFileAsync("git", [
+		"-C",
+		source,
+		"-c",
+		"user.name=Test",
+		"-c",
+		"user.email=test@example.com",
+		"commit",
+		"-m",
+		"fixture",
+	]);
+	const { stdout } = await execFileAsync("git", ["-C", source, "rev-parse", "HEAD"]);
+	const commit = stdout.trim();
+	assert.match(commit, /^[0-9a-f]{40}$/u);
+
+	await runGitClone(`file://${source}`, target, commit, undefined);
+	assert.match(await readFile(join(target, "skill", "SKILL.md"), "utf8"), /commit-skill/);
+});
+
+test("builds a forced Windows process-tree termination command", () => {
+	assert.deepEqual(windowsProcessTreeKillArguments(42), ["/PID", "42", "/T", "/F"]);
 });
 
 test("honors cancellation before resolution starts", async () => {

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -8,13 +8,14 @@ import {
 	mkdtemp,
 	readdir,
 	readFile,
+	rename,
 	rm,
 	stat,
 	symlink,
 	writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, test } from "vitest";
 import {
@@ -96,6 +97,47 @@ test("copies and caches one local skill without linking it", async () => {
 	assert.equal(second.path, first.path);
 });
 
+test("reuses legacy flat cache entries without skill-directory metadata", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-legacy-cache-");
+	const skillRoot = await writeSkill(workspace, "source", "legacy-skill");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+	const original = await resolveAndCommit(resolver, { source });
+	const versionPath = dirname(dirname(original.path));
+	const metadataPath = join(versionPath, "metadata.json");
+	const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as {
+		skillDirectory?: string;
+	};
+	delete metadata.skillDirectory;
+	await writeFile(metadataPath, JSON.stringify(metadata));
+	const flatSkillPath = dirname(original.path);
+	const temporarySkillPath = join(versionPath, "legacy-skill");
+	await rename(original.path, temporarySkillPath);
+	await rm(flatSkillPath, { recursive: true });
+	await rename(temporarySkillPath, flatSkillPath);
+
+	const cached = await resolver.resolve({ source });
+	assert.equal(cached.cacheHit, true);
+	assert.equal(cached.path, flatSkillPath);
+});
+
+test("preserves inferred skill names in the cache layout", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-inferred-name-");
+	const skillRoot = join(workspace, "inferred-skill");
+	await mkdir(skillRoot);
+	await writeFile(join(skillRoot, "SKILL.md"), "---\ndescription: Inferred name.\n---\n");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+
+	const first = await resolveAndCommit(resolver, { source });
+	assert.equal(first.name, "inferred-skill");
+	assert.equal(basename(dirname(first.path)), "skill");
+	assert.equal(basename(first.path), "inferred-skill");
+	const second = await resolver.resolve({ source });
+	assert.equal(second.cacheHit, true);
+	assert.equal(second.path, first.path);
+});
+
 test("rejects invalid skill names before caching", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-invalid-name-");
 	const skillRoot = join(workspace, "source");
@@ -120,7 +162,7 @@ test("does not reuse cached skills with invalid names", async () => {
 	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
 	const source = parseSkillSource(skillRoot, workspace);
 	const original = await resolveAndCommit(resolver, { source });
-	const metadataPath = join(dirname(original.path), "metadata.json");
+	const metadataPath = join(dirname(dirname(original.path)), "metadata.json");
 	const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as { name: string };
 	metadata.name = "evil\u001b[31m";
 	await writeFile(metadataPath, JSON.stringify(metadata));
@@ -182,6 +224,24 @@ test("honors Pi ignore files and hidden directories during discovery", async () 
 	}
 });
 
+test("continues into nested skills when the root skill is ignored", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-ignored-root-");
+	const sourceRoot = await writeSkill(workspace, "source", "root-skill");
+	await writeSkill(sourceRoot, "nested", "nested-skill");
+	await writeFile(join(sourceRoot, ".gitignore"), "SKILL.md\n!nested/SKILL.md\n");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+
+	const source = parseSkillSource(sourceRoot, workspace);
+	const result = await resolver.resolve({ source });
+	assert.equal(result.name, "nested-skill");
+	await result.transaction?.rollback();
+
+	await rm(join(sourceRoot, ".gitignore"));
+	const visibleRoot = await resolver.resolve({ source });
+	assert.equal(visibleRoot.name, "root-skill");
+	await visibleRoot.transaction?.rollback();
+});
+
 test("selects one skill from a multi-skill source", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-select-");
 	await writeSkill(workspace, "skills/alpha", "alpha");
@@ -204,6 +264,21 @@ test("rejects duplicate skill names instead of choosing a discovery winner", asy
 			resolver.resolve({ source: parseSkillSource("./skills", workspace), selector: "duplicate" }),
 		/duplicate names: duplicate/,
 	);
+});
+
+test("allows a unique selection despite unrelated duplicate names", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-unrelated-duplicate-");
+	await writeSkill(workspace, "skills/alpha", "alpha");
+	await writeSkill(workspace, "skills/beta-one", "beta");
+	await writeSkill(workspace, "skills/beta-two", "beta");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+
+	const result = await resolver.resolve({
+		source: parseSkillSource("./skills", workspace),
+		selector: "alpha",
+	});
+	assert.equal(result.name, "alpha");
+	await result.transaction?.rollback();
 });
 
 test("refresh replaces a cache entry only after the new skill validates", async () => {

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -20,6 +20,7 @@ import {
 	type CloneRepository,
 	defaultCacheRoot,
 	GitCommandError,
+	isRelativePathInside,
 	type ResolveSessionSkillOptions,
 	runGitClone,
 	SessionSkillResolver,
@@ -173,6 +174,30 @@ test("keeps the previous cache current until a refresh transaction commits", asy
 	assert.equal((await resolver.resolve({ source })).path, original.path);
 });
 
+test("rollback restores the index observed when a concurrent transaction commits", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-concurrent-cache-");
+	const skillRoot = await writeSkill(workspace, "source", "concurrent-skill");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+	await resolveAndCommit(resolver, { source });
+
+	await writeFile(
+		join(skillRoot, "SKILL.md"),
+		"---\nname: concurrent-skill\ndescription: Candidate A.\n---\n",
+	);
+	const candidateA = await resolver.resolve({ source, refresh: true });
+	await writeFile(
+		join(skillRoot, "SKILL.md"),
+		"---\nname: concurrent-skill\ndescription: Candidate B.\n---\n",
+	);
+	const candidateB = await resolver.resolve({ source, refresh: true });
+
+	await candidateA.transaction?.commit();
+	await candidateB.transaction?.commit();
+	await candidateB.transaction?.rollback();
+	assert.equal((await resolver.resolve({ source })).path, candidateA.path);
+});
+
 test("excludes a nested cache root from broad local discovery", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-cache-subtree-");
 	await writeSkill(workspace, "skills/source", "source-skill");
@@ -322,6 +347,13 @@ test("honors cancellation before resolution starts", async () => {
 			}),
 		/aborted/i,
 	);
+});
+
+test("rejects absolute cross-drive relative results as outside a root", () => {
+	assert.equal(isRelativePathInside("child/skill"), true);
+	assert.equal(isRelativePathInside("../skill"), false);
+	assert.equal(isRelativePathInside("D:\\repo\\skill"), false);
+	assert.equal(isRelativePathInside("\\\\server\\share\\skill"), false);
 });
 
 test("chooses a private cache root and ignores relative XDG_CACHE_HOME", () => {

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -294,6 +294,31 @@ test("retries a GitHub authentication failure over SSH", async () => {
 	]);
 });
 
+test("retries GitLab HTTPS authentication failures over SSH", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-gitlab-fallback-");
+	const fixture = join(workspace, "fixture");
+	await writeSkill(fixture, "demo", "private-skill");
+	const repositories: string[] = [];
+	const cloneRepository: CloneRepository = async (repository, target) => {
+		repositories.push(repository);
+		if (repositories.length === 1) {
+			throw new GitCommandError("Git clone failed.", "Authentication failed");
+		}
+		await cp(fixture, target, { recursive: true });
+	};
+	const resolver = new SessionSkillResolver({
+		cacheRoot: join(workspace, "cache"),
+		cloneRepository,
+	});
+	const source = parseSkillSource("https://gitlab.com/group/subgroup/private", workspace);
+	const result = await resolver.resolve({ source });
+	assert.equal(result.name, "private-skill");
+	assert.deepEqual(repositories, [
+		"https://gitlab.com/group/subgroup/private.git",
+		"git@gitlab.com:group/subgroup/private.git",
+	]);
+});
+
 test("clones through the system Git executable", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-real-git-");
 	const source = join(workspace, "source.git");

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import {
+	cp,
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	rm,
+	stat,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, test } from "vitest";
+import {
+	type CloneRepository,
+	defaultCacheRoot,
+	GitCommandError,
+	runGitClone,
+	SessionSkillResolver,
+} from "./resolver.js";
+
+const execFileAsync = promisify(execFile);
+
+import { parseSkillSource } from "./source-parser.js";
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+	);
+});
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+	const path = await mkdtemp(join(tmpdir(), prefix));
+	temporaryPaths.push(path);
+	return path;
+}
+
+async function writeSkill(
+	parent: string,
+	directory: string,
+	name: string,
+	extra = false,
+): Promise<string> {
+	const root = join(parent, directory);
+	await mkdir(root, { recursive: true });
+	await writeFile(
+		join(root, "SKILL.md"),
+		`---\nname: ${name}\ndescription: Use ${name} in tests.\n---\n\n# ${name}\n`,
+	);
+	if (extra) {
+		await mkdir(join(root, "scripts"));
+		await writeFile(join(root, "scripts", "run.sh"), "#!/bin/sh\necho ok\n", { mode: 0o755 });
+	}
+	return root;
+}
+
+test("copies and caches one local skill without linking it", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-local-");
+	const cacheRoot = join(workspace, "cache");
+	const skillRoot = await writeSkill(workspace, "source", "demo-skill", true);
+	const resolver = new SessionSkillResolver({ cacheRoot });
+	const source = parseSkillSource(skillRoot, workspace);
+
+	const first = await resolver.resolve({ source });
+	assert.equal(first.name, "demo-skill");
+	assert.equal(first.cacheHit, false);
+	assert.notEqual(first.path, skillRoot);
+	assert.equal(
+		await readFile(join(first.path, "scripts", "run.sh"), "utf8"),
+		"#!/bin/sh\necho ok\n",
+	);
+	assert.notEqual((await stat(join(first.path, "scripts", "run.sh"))).mode & 0o111, 0);
+	assert.equal((await stat(join(cacheRoot, "entries"))).mode & 0o077, 0);
+
+	const second = await resolver.resolve({ source });
+	assert.equal(second.cacheHit, true);
+	assert.equal(second.path, first.path);
+});
+
+test("ignores frontmatter in Markdown files that are not named SKILL.md", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-decoy-");
+	await writeSkill(workspace, "catalog/demo", "real-skill");
+	await writeFile(
+		join(workspace, "DESIGN.md"),
+		"---\nname: decoy\ndescription: This is design metadata, not a skill.\n---\n",
+	);
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const result = await resolver.resolve({ source: parseSkillSource(workspace, workspace) });
+	assert.equal(result.name, "real-skill");
+});
+
+test("selects one skill from a multi-skill source", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-select-");
+	await writeSkill(workspace, "skills/alpha", "alpha");
+	await writeSkill(workspace, "skills/beta", "beta");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource("./skills", workspace);
+
+	await assert.rejects(() => resolver.resolve({ source }), /multiple skills.*alpha, beta/i);
+	const selected = await resolver.resolve({ source, selector: "beta" });
+	assert.equal(selected.name, "beta");
+});
+
+test("rejects duplicate skill names instead of choosing a discovery winner", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-duplicate-");
+	await writeSkill(workspace, "skills/first", "duplicate");
+	await writeSkill(workspace, "skills/second", "duplicate");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	await assert.rejects(
+		() =>
+			resolver.resolve({ source: parseSkillSource("./skills", workspace), selector: "duplicate" }),
+		/duplicate names: duplicate/,
+	);
+});
+
+test("refresh replaces a cache entry only after the new skill validates", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-refresh-");
+	const skillRoot = await writeSkill(workspace, "source", "refreshable");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+	const first = await resolver.resolve({ source });
+
+	await writeFile(join(skillRoot, "SKILL.md"), "---\nname: refreshable\n---\n\n# Invalid\n");
+	await assert.rejects(() => resolver.resolve({ source, refresh: true }), /No valid skills/);
+	assert.doesNotMatch(await readFile(join(first.path, "SKILL.md"), "utf8"), /Invalid/);
+
+	await writeFile(
+		join(skillRoot, "SKILL.md"),
+		"---\nname: refreshable\ndescription: Updated description.\n---\n\n# Updated\n",
+	);
+	const cached = await resolver.resolve({ source });
+	assert.doesNotMatch(await readFile(join(cached.path, "SKILL.md"), "utf8"), /Updated/);
+	const refreshed = await resolver.resolve({ source, refresh: true });
+	assert.equal(refreshed.path, first.path);
+	assert.match(await readFile(join(refreshed.path, "SKILL.md"), "utf8"), /Updated/);
+});
+
+test("rejects symbolic links in a skill and removes staging files", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-symlink-");
+	const skillRoot = await writeSkill(workspace, "source", "unsafe-skill");
+	await writeFile(join(workspace, "secret.txt"), "secret");
+	await symlink(join(workspace, "secret.txt"), join(skillRoot, "secret-link"));
+	const cacheRoot = join(workspace, "cache");
+	const resolver = new SessionSkillResolver({ cacheRoot });
+
+	await assert.rejects(
+		() => resolver.resolve({ source: parseSkillSource(skillRoot, workspace) }),
+		/symbolic link/,
+	);
+	assert.deepEqual(await readdir(join(cacheRoot, "staging")), []);
+});
+
+test("uses a clone adapter for Git sources and forwards the ref", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-git-");
+	const fixture = join(workspace, "fixture");
+	await writeSkill(fixture, "skills/demo", "git-skill");
+	const calls: Array<{ repository: string; ref?: string }> = [];
+	const cloneRepository: CloneRepository = async (repository, target, ref) => {
+		calls.push({ repository, ref });
+		await cp(fixture, target, { recursive: true });
+	};
+	const resolver = new SessionSkillResolver({
+		cacheRoot: join(workspace, "cache"),
+		cloneRepository,
+	});
+	const source = parseSkillSource("https://github.com/owner/repo/tree/main/skills/demo", workspace);
+	const result = await resolver.resolve({ source });
+
+	assert.equal(result.name, "git-skill");
+	assert.deepEqual(calls, [{ repository: "https://github.com/owner/repo.git", ref: "main" }]);
+});
+
+test("retries a GitHub authentication failure over SSH", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-ssh-fallback-");
+	const fixture = join(workspace, "fixture");
+	await writeSkill(fixture, "demo", "private-skill");
+	const repositories: string[] = [];
+	const cloneRepository: CloneRepository = async (repository, target) => {
+		repositories.push(repository);
+		if (repositories.length === 1) {
+			throw new GitCommandError("Git clone failed.", "Repository not found");
+		}
+		await cp(fixture, target, { recursive: true });
+	};
+	const resolver = new SessionSkillResolver({
+		cacheRoot: join(workspace, "cache"),
+		cloneRepository,
+	});
+	const result = await resolver.resolve({ source: parseSkillSource("owner/private", workspace) });
+	assert.equal(result.name, "private-skill");
+	assert.deepEqual(repositories, [
+		"https://github.com/owner/private.git",
+		"git@github.com:owner/private.git",
+	]);
+});
+
+test("clones through the system Git executable", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-real-git-");
+	const source = join(workspace, "source.git");
+	const target = join(workspace, "clone");
+	await execFileAsync("git", ["init", "--bare", source]);
+	await runGitClone(`file://${source}`, target, undefined, undefined);
+	assert.ok((await stat(join(target, ".git"))).isDirectory());
+});
+
+test("honors cancellation before resolution starts", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-cancel-");
+	const skillRoot = await writeSkill(workspace, "source", "cancelled-skill");
+	const controller = new AbortController();
+	controller.abort();
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	await assert.rejects(
+		() =>
+			resolver.resolve({
+				source: parseSkillSource(skillRoot, workspace),
+				signal: controller.signal,
+			}),
+		/aborted/i,
+	);
+});
+
+test("chooses a private cache root and ignores relative XDG_CACHE_HOME", () => {
+	assert.equal(
+		defaultCacheRoot({ XDG_CACHE_HOME: "/var/cache/user" }, "/home/test"),
+		"/var/cache/user/pi/session-skills",
+	);
+	assert.equal(
+		defaultCacheRoot({ XDG_CACHE_HOME: "relative" }, "/home/test"),
+		"/home/test/.cache/pi/session-skills",
+	);
+});

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -210,6 +210,28 @@ test("excludes a nested cache root from broad local discovery", async () => {
 	await refreshed.transaction?.rollback();
 });
 
+test("allows exactly 500 discovered skills and rejects the 501st", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-discovery-limit-");
+	const sourceRoot = join(workspace, "skills");
+	await Promise.all(
+		Array.from({ length: 500 }, (_, index) => {
+			const suffix = String(index).padStart(3, "0");
+			return writeSkill(sourceRoot, suffix, `skill-${suffix}`);
+		}),
+	);
+	await mkdir(join(sourceRoot, "zzz-empty"));
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(sourceRoot, workspace);
+	const accepted = await resolver.resolve({ source, selector: "skill-000" });
+	await accepted.transaction?.rollback();
+
+	await writeSkill(sourceRoot, "zzz-skill", "skill-500");
+	await assert.rejects(
+		() => resolver.resolve({ source, selector: "skill-000", refresh: true }),
+		/exceeds the 500-skill discovery limit/,
+	);
+});
+
 test("does not copy a cache nested inside a local skill root", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-root-cache-");
 	const skillRoot = await writeSkill(workspace, ".", "root-skill");
@@ -317,6 +339,52 @@ test("retries GitLab HTTPS authentication failures over SSH", async () => {
 		"https://gitlab.com/group/subgroup/private.git",
 		"git@gitlab.com:group/subgroup/private.git",
 	]);
+});
+
+test("cancels a same-source resolution without waiting for another materialization", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-queued-cancel-");
+	const fixture = join(workspace, "fixture");
+	await writeSkill(fixture, "demo", "concurrent-skill");
+	let callCount = 0;
+	let startFirst!: () => void;
+	let startSecond!: () => void;
+	let releaseFirst!: () => void;
+	const firstStarted = new Promise<void>((resolve) => {
+		startFirst = resolve;
+	});
+	const secondStarted = new Promise<void>((resolve) => {
+		startSecond = resolve;
+	});
+	const firstRelease = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
+	const cloneRepository: CloneRepository = async (_repository, target, _ref, signal) => {
+		callCount++;
+		if (callCount === 1) {
+			startFirst();
+			await firstRelease;
+			await cp(fixture, target, { recursive: true });
+			return;
+		}
+		startSecond();
+		await new Promise<void>((_resolve, reject) => {
+			signal?.addEventListener("abort", () => reject(new Error("cancelled")), { once: true });
+		});
+	};
+	const cacheRoot = join(workspace, "cache");
+	const resolver = new SessionSkillResolver({ cacheRoot, cloneRepository });
+	const source = parseSkillSource("https://example.com/repo.git", workspace);
+	const first = resolver.resolve({ source });
+	await firstStarted;
+	const controller = new AbortController();
+	const second = resolver.resolve({ source, signal: controller.signal });
+	await secondStarted;
+	controller.abort();
+	await assert.rejects(() => second, /cancelled/);
+	releaseFirst();
+	const firstResult = await first;
+	await firstResult.transaction?.rollback();
+	assert.deepEqual(await readdir(join(cacheRoot, "staging")), []);
 });
 
 test("clones through the system Git executable", async () => {

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -198,6 +198,37 @@ test("rollback restores the index observed when a concurrent transaction commits
 	assert.equal((await resolver.resolve({ source })).path, candidateA.path);
 });
 
+test("keeps failed cache publication invisible to concurrent readers", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-publication-read-");
+	const skillRoot = await writeSkill(workspace, "source", "original-skill");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+	const original = await resolveAndCommit(resolver, { source });
+
+	await writeFile(
+		join(skillRoot, "SKILL.md"),
+		"---\nname: candidate-skill\ndescription: Candidate skill.\n---\n",
+	);
+	const candidate = await resolver.resolve({ source, refresh: true });
+	const transaction = candidate.transaction;
+	assert.ok(transaction);
+	let concurrentRead: ReturnType<SessionSkillResolver["resolve"]> | undefined;
+	await assert.rejects(
+		() =>
+			transaction.commit(() => {
+				concurrentRead = resolver.resolve({ source });
+				throw new Error("activation snapshot failed");
+			}),
+		/activation snapshot failed/,
+	);
+
+	assert.ok(concurrentRead);
+	const observed = await concurrentRead;
+	assert.equal(observed.path, original.path);
+	assert.equal(observed.name, original.name);
+	await assert.rejects(() => stat(candidate.path), { code: "ENOENT" });
+});
+
 test("excludes a nested cache root from broad local discovery", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-cache-subtree-");
 	await writeSkill(workspace, "skills/source", "source-skill");

--- a/.pi/extensions/pi-session-skills/resolver.test.ts
+++ b/.pi/extensions/pi-session-skills/resolver.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { renameSync, rmSync, writeFileSync } from "node:fs";
 import {
 	chmod,
 	cp,
@@ -13,7 +14,7 @@ import {
 	writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, test } from "vitest";
 import {
@@ -21,6 +22,7 @@ import {
 	defaultCacheRoot,
 	GitCommandError,
 	isRelativePathInside,
+	isValidSkillName,
 	type ResolveSessionSkillOptions,
 	runGitClone,
 	SessionSkillResolver,
@@ -92,6 +94,46 @@ test("copies and caches one local skill without linking it", async () => {
 	const second = await resolver.resolve({ source });
 	assert.equal(second.cacheHit, true);
 	assert.equal(second.path, first.path);
+});
+
+test("rejects invalid skill names before caching", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-invalid-name-");
+	const skillRoot = join(workspace, "source");
+	await mkdir(skillRoot);
+	await writeFile(
+		join(skillRoot, "SKILL.md"),
+		'---\nname: "evil\\u001b[31m"\ndescription: Unsafe name.\n---\n',
+	);
+	const cacheRoot = join(workspace, "cache");
+	const resolver = new SessionSkillResolver({ cacheRoot });
+
+	await assert.rejects(
+		() => resolver.resolve({ source: parseSkillSource(skillRoot, workspace) }),
+		/invalid name/,
+	);
+	assert.deepEqual(await readdir(join(cacheRoot, "staging")), []);
+});
+
+test("does not reuse cached skills with invalid names", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-invalid-cache-name-");
+	const skillRoot = await writeSkill(workspace, "source", "valid-skill");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+	const original = await resolveAndCommit(resolver, { source });
+	const metadataPath = join(dirname(original.path), "metadata.json");
+	const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as { name: string };
+	metadata.name = "evil\u001b[31m";
+	await writeFile(metadataPath, JSON.stringify(metadata));
+	await writeFile(
+		join(original.path, "SKILL.md"),
+		'---\nname: "evil\\u001b[31m"\ndescription: Unsafe name.\n---\n',
+	);
+
+	const replacement = await resolver.resolve({ source });
+	assert.equal(replacement.cacheHit, false);
+	assert.equal(replacement.name, "valid-skill");
+	assert.notEqual(replacement.path, original.path);
+	await replacement.transaction?.rollback();
 });
 
 test("ignores frontmatter in Markdown files that are not named SKILL.md", async () => {
@@ -232,6 +274,40 @@ test("rollback restores the index observed when a concurrent transaction commits
 	assert.equal((await resolver.resolve({ source })).path, candidateA.path);
 });
 
+test("restores a published index when rollback follows failed recovery", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-pending-rollback-");
+	const skillRoot = await writeSkill(workspace, "source", "original-skill");
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+	const source = parseSkillSource(skillRoot, workspace);
+	const original = await resolveAndCommit(resolver, { source });
+
+	await writeFile(
+		join(skillRoot, "SKILL.md"),
+		"---\nname: candidate-skill\ndescription: Candidate skill.\n---\n",
+	);
+	const candidate = await resolver.resolve({ source, refresh: true });
+	const transaction = candidate.transaction;
+	assert.ok(transaction);
+	const entryRoot = dirname(dirname(dirname(candidate.path)));
+	const displacedRoot = `${entryRoot}-displaced`;
+	try {
+		await assert.rejects(() =>
+			transaction.commit(() => {
+				renameSync(entryRoot, displacedRoot);
+				writeFileSync(entryRoot, "block cache index recovery");
+				throw new Error("activation snapshot failed");
+			}),
+		);
+	} finally {
+		rmSync(entryRoot, { force: true });
+		renameSync(displacedRoot, entryRoot);
+	}
+
+	await transaction.rollback();
+	assert.equal((await resolver.resolve({ source })).path, original.path);
+	await assert.rejects(() => stat(candidate.path), { code: "ENOENT" });
+});
+
 test("keeps failed cache publication invisible to concurrent readers", async () => {
 	const workspace = await temporaryDirectory("pi-session-skills-publication-read-");
 	const skillRoot = await writeSkill(workspace, "source", "original-skill");
@@ -335,6 +411,20 @@ test("rejects symbolic links in a skill and removes staging files", async () => 
 		/symbolic link/,
 	);
 	assert.deepEqual(await readdir(join(cacheRoot, "staging")), []);
+});
+
+test("skips symlinks outside the selected skill", async () => {
+	const workspace = await temporaryDirectory("pi-session-skills-unrelated-symlink-");
+	const sourceRoot = join(workspace, "source");
+	await writeSkill(sourceRoot, "selected", "selected-skill");
+	const linkedRoot = join(workspace, "linked");
+	await writeSkill(linkedRoot, "other", "other-skill");
+	await symlink(linkedRoot, join(sourceRoot, "unrelated-link"));
+	const resolver = new SessionSkillResolver({ cacheRoot: join(workspace, "cache") });
+
+	const result = await resolver.resolve({ source: parseSkillSource(sourceRoot, workspace) });
+	assert.equal(result.name, "selected-skill");
+	await result.transaction?.rollback();
 });
 
 test("uses a clone adapter for Git sources and forwards the ref", async () => {
@@ -505,6 +595,24 @@ test("honors cancellation before resolution starts", async () => {
 			}),
 		/aborted/i,
 	);
+});
+
+test("validates skill names against the activation-safe grammar", () => {
+	for (const name of ["a", "valid-skill", "skill-123"]) {
+		assert.equal(isValidSkillName(name), true);
+	}
+	for (const name of [
+		"",
+		"Uppercase",
+		"two words",
+		"-leading",
+		"trailing-",
+		"double--hyphen",
+		"evil\u001b[31m",
+		"a".repeat(65),
+	]) {
+		assert.equal(isValidSkillName(name), false);
+	}
 });
 
 test("rejects absolute cross-drive relative results as outside a root", () => {

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -245,6 +245,7 @@ export class SessionSkillResolver implements SkillResolverLike {
 			if (
 				metadata.version !== CACHE_VERSION ||
 				typeof metadata.name !== "string" ||
+				!isValidSkillName(metadata.name) ||
 				metadata.source !== options.source.original ||
 				metadata.selector !== options.selector
 			) {
@@ -446,6 +447,17 @@ export function isRelativePathInside(pathFromRoot: string): boolean {
 	);
 }
 
+export function isValidSkillName(name: string): boolean {
+	return (
+		name.length > 0 &&
+		name.length <= 64 &&
+		/^[a-z0-9-]+$/u.test(name) &&
+		!name.startsWith("-") &&
+		!name.endsWith("-") &&
+		!name.includes("--")
+	);
+}
+
 async function selectSkill(
 	sourcePath: string,
 	selector: string | undefined,
@@ -478,6 +490,11 @@ async function selectSkill(
 		? loaded.skills.filter((skill) => skill.name.toLowerCase() === selector.toLowerCase())
 		: loaded.skills;
 	if (skills.length === 1) {
+		if (!isValidSkillName(skills[0].name)) {
+			throw new Error(
+				"Selected skill has an invalid name. Use 1-64 lowercase letters, numbers, or single hyphens.",
+			);
+		}
 		const sourceStat = await stat(sourcePath);
 		signal?.throwIfAborted();
 		const sourceRoot = await realpath(sourceStat.isDirectory() ? sourcePath : dirname(sourcePath));
@@ -526,9 +543,7 @@ async function discoverSkillPaths(
 		if (canonicalExcludedRoot && isPathInside(canonicalExcludedRoot, current)) return;
 		const currentStat = await lstat(current);
 		signal?.throwIfAborted();
-		if (currentStat.isSymbolicLink()) {
-			throw new Error(`Skill source contains a symbolic link: ${current}`);
-		}
+		if (currentStat.isSymbolicLink()) return;
 		if (currentStat.isFile()) {
 			if (basename(current) === "SKILL.md") {
 				await copyDiscoveryFile(current, mirror);
@@ -544,9 +559,7 @@ async function discoverSkillPaths(
 			try {
 				const ignoreStat = await lstat(ignoreFile);
 				signal?.throwIfAborted();
-				if (ignoreStat.isSymbolicLink()) {
-					throw new Error(`Skill source contains a symbolic link: ${ignoreFile}`);
-				}
+				if (ignoreStat.isSymbolicLink()) continue;
 				if (ignoreStat.isFile()) {
 					await copyDiscoveryFile(ignoreFile, join(mirror, ignoreFileName));
 				}
@@ -562,9 +575,7 @@ async function discoverSkillPaths(
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 		}
 		signal?.throwIfAborted();
-		if (rootSkillStat?.isSymbolicLink()) {
-			throw new Error(`Skill source contains a symbolic link: ${rootSkill}`);
-		}
+		if (rootSkillStat?.isSymbolicLink()) rootSkillStat = undefined;
 		if (rootSkillStat?.isFile()) {
 			const discoverySkill = join(mirror, "SKILL.md");
 			await copyDiscoveryFile(rootSkill, discoverySkill);
@@ -577,10 +588,7 @@ async function discoverSkillPaths(
 		for (const entry of entries) {
 			if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
 			const entryPath = join(current, entry.name);
-			if (entry.isSymbolicLink()) {
-				throw new Error(`Skill source contains a symbolic link: ${entryPath}`);
-			}
-			if (!entry.isDirectory()) continue;
+			if (entry.isSymbolicLink() || !entry.isDirectory()) continue;
 			await walk(entryPath, join(mirror, entry.name), depth + 1);
 		}
 	};
@@ -699,9 +707,7 @@ function createCacheTransaction(entryRoot: string, entry: string): ResolvedSkill
 			if (state === "rolled-back") return;
 			await withFileMutationQueue(entryRoot, async () => {
 				const current = await readCacheIndex(entryRoot);
-				if (state === "committed" && current?.entry === entry) {
-					await writeCacheIndex(entryRoot, predecessor);
-				}
+				if (current?.entry === entry) await writeCacheIndex(entryRoot, predecessor);
 				await rm(versionPath, { recursive: true, force: true });
 			});
 			state = "rolled-back";

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -34,7 +34,7 @@ const SKIPPED_DISCOVERY_DIRECTORIES = new Set([
 ]);
 
 export interface ResolvedSkillTransaction {
-	commit(): Promise<void>;
+	commit(apply?: () => void): Promise<void>;
 	rollback(): Promise<void>;
 }
 
@@ -81,7 +81,6 @@ interface CacheIndex {
 }
 
 interface CurrentCacheEntry {
-	index: CacheIndex;
 	result: ResolvedSessionSkill;
 }
 
@@ -162,7 +161,7 @@ export class SessionSkillResolver implements SkillResolverLike {
 			const entry = randomUUID();
 			const versionPath = join(entryRoot, "versions", entry);
 			await rename(candidateEntry, versionPath);
-			const transaction = createCacheTransaction(entryRoot, entry, current?.index);
+			const transaction = createCacheTransaction(entryRoot, entry);
 			if (options.signal?.aborted) {
 				await rm(versionPath, { recursive: true, force: true });
 				options.signal.throwIfAborted();
@@ -257,7 +256,6 @@ export class SessionSkillResolver implements SkillResolverLike {
 			validateMaterializedSkill(skillPath, metadata.name, this.#cacheRoot);
 			options.signal?.throwIfAborted();
 			return {
-				index,
 				result: {
 					name: metadata.name,
 					path: skillPath,
@@ -330,6 +328,7 @@ async function runGitCommand(args: string[], signal: AbortSignal | undefined): P
 		let timedOut = false;
 		let settled = false;
 		let terminationRequested = false;
+		let timeout: NodeJS.Timeout | undefined;
 		let killTimer: NodeJS.Timeout | undefined;
 
 		const appendOutput = (chunk: Buffer) => {
@@ -374,23 +373,26 @@ async function runGitCommand(args: string[], signal: AbortSignal | undefined): P
 			killTimer.unref();
 		};
 		const onAbort = () => terminate();
-		const timeout = setTimeout(() => {
-			timedOut = true;
-			terminate();
-		}, GIT_TIMEOUT_MS);
-		timeout.unref();
 		signal?.addEventListener("abort", onAbort, { once: true });
 		if (signal?.aborted) terminate();
 
 		const finish = (callback: () => void) => {
 			if (settled) return;
 			settled = true;
-			clearTimeout(timeout);
+			if (timeout) clearTimeout(timeout);
 			if (killTimer) clearTimeout(killTimer);
 			signal?.removeEventListener("abort", onAbort);
 			callback();
 		};
 
+		child.once("spawn", () => {
+			if (settled) return;
+			timeout = setTimeout(() => {
+				timedOut = true;
+				terminate();
+			}, GIT_TIMEOUT_MS);
+			timeout.unref();
+		});
 		child.on("error", (error) => {
 			finish(() => {
 				if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -431,8 +433,19 @@ export function defaultCacheRoot(
 }
 
 export function isPathInside(root: string, candidate: string): boolean {
-	const pathFromRoot = relative(resolve(root), resolve(candidate));
-	return pathFromRoot === "" || (!pathFromRoot.startsWith(`..${sep}`) && pathFromRoot !== "..");
+	return isRelativePathInside(relative(resolve(root), resolve(candidate)));
+}
+
+export function isRelativePathInside(pathFromRoot: string): boolean {
+	const absoluteOnAnotherPlatform =
+		/^[A-Za-z]:[/\\]/u.test(pathFromRoot) || pathFromRoot.startsWith("\\\\");
+	return (
+		pathFromRoot === "" ||
+		(!isAbsolute(pathFromRoot) &&
+			!absoluteOnAnotherPlatform &&
+			!pathFromRoot.startsWith(`..${sep}`) &&
+			pathFromRoot !== "..")
+	);
 }
 
 async function selectSkill(
@@ -594,21 +607,27 @@ function assertPathInside(root: string, candidate: string): void {
 		throw new Error("Skill source path escapes its repository root.");
 }
 
-function createCacheTransaction(
-	entryRoot: string,
-	entry: string,
-	previousIndex: CacheIndex | undefined,
-): ResolvedSkillTransaction {
+function createCacheTransaction(entryRoot: string, entry: string): ResolvedSkillTransaction {
 	let state: "pending" | "committed" | "rolled-back" = "pending";
+	let predecessor: CacheIndex | undefined;
 	const versionPath = join(entryRoot, "versions", entry);
 	return {
-		async commit() {
+		async commit(apply) {
 			if (state === "committed") return;
 			if (state === "rolled-back")
 				throw new Error("Cannot commit a rolled-back skill cache entry.");
-			await withFileMutationQueue(entryRoot, () =>
-				writeCacheIndex(entryRoot, { version: CACHE_VERSION, entry }),
-			);
+			await withFileMutationQueue(entryRoot, async () => {
+				predecessor = await readCacheIndex(entryRoot);
+				await writeCacheIndex(entryRoot, { version: CACHE_VERSION, entry });
+				try {
+					apply?.();
+				} catch (error) {
+					await writeCacheIndex(entryRoot, predecessor);
+					await rm(versionPath, { recursive: true, force: true });
+					state = "rolled-back";
+					throw error;
+				}
+			});
 			state = "committed";
 		},
 		async rollback() {
@@ -616,7 +635,7 @@ function createCacheTransaction(
 			await withFileMutationQueue(entryRoot, async () => {
 				const current = await readCacheIndex(entryRoot);
 				if (state === "committed" && current?.entry === entry) {
-					await writeCacheIndex(entryRoot, previousIndex);
+					await writeCacheIndex(entryRoot, predecessor);
 				}
 				await rm(versionPath, { recursive: true, force: true });
 			});

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -65,6 +65,7 @@ export type CloneRepository = (
 interface CacheMetadata {
 	version: number;
 	name: string;
+	skillDirectory?: string;
 	source: string;
 	selector?: string;
 	createdAt: string;
@@ -131,11 +132,12 @@ export class SessionSkillResolver implements SkillResolverLike {
 			options.signal?.throwIfAborted();
 
 			const candidateEntry = join(stagingPath, "entry");
-			const candidateSkill = join(candidateEntry, "skill");
+			const skillDirectory = selected.name;
+			const candidateSkill = join(candidateEntry, "skill", skillDirectory);
 			const excludedCopyRoot =
 				options.source.kind === "local" ? await realpath(this.#cacheRoot) : undefined;
 			options.signal?.throwIfAborted();
-			await mkdir(candidateEntry, { recursive: true, mode: 0o700 });
+			await mkdir(dirname(candidateSkill), { recursive: true, mode: 0o700 });
 			options.signal?.throwIfAborted();
 			await copySkillTree(selected.baseDir, candidateSkill, excludedCopyRoot, options.signal);
 			options.signal?.throwIfAborted();
@@ -144,6 +146,7 @@ export class SessionSkillResolver implements SkillResolverLike {
 			const metadata: CacheMetadata = {
 				version: CACHE_VERSION,
 				name: selected.name,
+				skillDirectory,
 				source: options.source.original,
 				selector: options.selector,
 				createdAt: new Date().toISOString(),
@@ -166,7 +169,7 @@ export class SessionSkillResolver implements SkillResolverLike {
 			}
 			return {
 				name: selected.name,
-				path: join(versionPath, "skill"),
+				path: join(versionPath, "skill", skillDirectory),
 				source: options.source.original,
 				selector: options.selector,
 				cacheHit: false,
@@ -246,12 +249,16 @@ export class SessionSkillResolver implements SkillResolverLike {
 				metadata.version !== CACHE_VERSION ||
 				typeof metadata.name !== "string" ||
 				!isValidSkillName(metadata.name) ||
+				(metadata.skillDirectory !== undefined && metadata.skillDirectory !== metadata.name) ||
 				metadata.source !== options.source.original ||
 				metadata.selector !== options.selector
 			) {
 				return undefined;
 			}
-			const skillPath = join(versionPath, "skill");
+			const skillPath =
+				metadata.skillDirectory === undefined
+					? join(versionPath, "skill")
+					: join(versionPath, "skill", metadata.skillDirectory);
 			validateMaterializedSkill(skillPath, metadata.name, this.#cacheRoot);
 			options.signal?.throwIfAborted();
 			return {
@@ -480,9 +487,11 @@ async function selectSkill(
 		skillPaths: skillPaths,
 		includeDefaults: false,
 	});
-	const collisionNames = loaded.diagnostics.flatMap((diagnostic) =>
-		diagnostic.type === "collision" && diagnostic.collision ? [diagnostic.collision.name] : [],
-	);
+	const collisionNames = loaded.diagnostics.flatMap((diagnostic) => {
+		if (diagnostic.type !== "collision" || !diagnostic.collision) return [];
+		const name = diagnostic.collision.name;
+		return !selector || name.toLowerCase() === selector.toLowerCase() ? [name] : [];
+	});
 	if (collisionNames.length > 0) {
 		throw new Error(`Skill source contains duplicate names: ${collisionNames.join(", ")}`);
 	}
@@ -580,7 +589,6 @@ async function discoverSkillPaths(
 			const discoverySkill = join(mirror, "SKILL.md");
 			await copyDiscoveryFile(rootSkill, discoverySkill);
 			discovered.push({ sourcePath: rootSkill, discoveryPath: discoverySkill });
-			return;
 		}
 		const entries = await readdir(current, { withFileTypes: true });
 		signal?.throwIfAborted();
@@ -592,7 +600,9 @@ async function discoverSkillPaths(
 			await walk(entryPath, join(mirror, entry.name), depth + 1);
 		}
 	};
-	const discoveryPath = sourceIsFile ? join(discoveryRoot, basename(sourcePath)) : discoveryRoot;
+	const discoveryPath = sourceIsFile
+		? join(discoveryRoot, basename(dirname(sourcePath)), basename(sourcePath))
+		: join(discoveryRoot, basename(sourcePath));
 	await walk(sourcePath, discoveryPath, 0);
 	signal?.throwIfAborted();
 	const includedPaths = piDiscoveredPaths(discoveryPath, cacheRoot);

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, createWriteStream } from "node:fs";
 import {
 	chmod,
+	copyFile,
 	lstat,
 	mkdir,
 	mkdtemp,
@@ -25,13 +26,7 @@ const GIT_TIMEOUT_MS = 300_000;
 const MAX_GIT_OUTPUT_CHARS = 32_000;
 const MAX_DISCOVERY_DEPTH = 8;
 const MAX_DISCOVERED_SKILLS = 500;
-const SKIPPED_DISCOVERY_DIRECTORIES = new Set([
-	".git",
-	"node_modules",
-	"dist",
-	"build",
-	"__pycache__",
-]);
+const IGNORE_FILE_NAMES = [".gitignore", ".ignore", ".fdignore"];
 
 export interface ResolvedSkillTransaction {
 	commit(apply?: () => void): Promise<void>;
@@ -130,6 +125,7 @@ export class SessionSkillResolver implements SkillResolverLike {
 				options.selector,
 				this.#cacheRoot,
 				options.source.kind === "local" ? this.#cacheRoot : undefined,
+				join(stagingPath, "discovery"),
 				options.signal,
 			);
 			options.signal?.throwIfAborted();
@@ -455,9 +451,16 @@ async function selectSkill(
 	selector: string | undefined,
 	cacheRoot: string,
 	excludedRoot: string | undefined,
+	discoveryRoot: string,
 	signal: AbortSignal | undefined,
 ): Promise<Skill> {
-	const skillPaths = await discoverSkillPaths(sourcePath, excludedRoot, signal);
+	const skillPaths = await discoverSkillPaths(
+		sourcePath,
+		excludedRoot,
+		discoveryRoot,
+		cacheRoot,
+		signal,
+	);
 	signal?.throwIfAborted();
 	const loaded = loadSkills({
 		cwd: dirname(sourcePath),
@@ -502,29 +505,55 @@ async function selectSkill(
 async function discoverSkillPaths(
 	sourcePath: string,
 	excludedRoot: string | undefined,
+	discoveryRoot: string,
+	cacheRoot: string,
 	signal: AbortSignal | undefined,
 ): Promise<string[]> {
-	const discovered: string[] = [];
-	const addSkill = (skillPath: string) => {
-		if (discovered.length >= MAX_DISCOVERED_SKILLS) {
-			throw new Error(`Skill source exceeds the ${MAX_DISCOVERED_SKILLS}-skill discovery limit.`);
-		}
-		discovered.push(skillPath);
-	};
+	const discovered: Array<{ sourcePath: string; discoveryPath: string }> = [];
 	const canonicalExcludedRoot = excludedRoot ? await realpath(excludedRoot) : undefined;
 	signal?.throwIfAborted();
-	const walk = async (current: string, depth: number): Promise<void> => {
+	const sourceStat = await lstat(sourcePath);
+	signal?.throwIfAborted();
+	const sourceIsFile = sourceStat.isFile();
+	const copyDiscoveryFile = async (source: string, destination: string): Promise<void> => {
+		await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
+		signal?.throwIfAborted();
+		await copyFile(source, destination);
+		signal?.throwIfAborted();
+	};
+	const walk = async (current: string, mirror: string, depth: number): Promise<void> => {
 		signal?.throwIfAborted();
 		if (canonicalExcludedRoot && isPathInside(canonicalExcludedRoot, current)) return;
 		const currentStat = await lstat(current);
 		signal?.throwIfAborted();
-		if (currentStat.isSymbolicLink())
+		if (currentStat.isSymbolicLink()) {
 			throw new Error(`Skill source contains a symbolic link: ${current}`);
+		}
 		if (currentStat.isFile()) {
-			if (basename(current) === "SKILL.md") addSkill(current);
+			if (basename(current) === "SKILL.md") {
+				await copyDiscoveryFile(current, mirror);
+				discovered.push({ sourcePath: current, discoveryPath: mirror });
+			}
 			return;
 		}
 		if (!currentStat.isDirectory() || depth > MAX_DISCOVERY_DEPTH) return;
+		await mkdir(mirror, { recursive: true, mode: 0o700 });
+		signal?.throwIfAborted();
+		for (const ignoreFileName of IGNORE_FILE_NAMES) {
+			const ignoreFile = join(current, ignoreFileName);
+			try {
+				const ignoreStat = await lstat(ignoreFile);
+				signal?.throwIfAborted();
+				if (ignoreStat.isSymbolicLink()) {
+					throw new Error(`Skill source contains a symbolic link: ${ignoreFile}`);
+				}
+				if (ignoreStat.isFile()) {
+					await copyDiscoveryFile(ignoreFile, join(mirror, ignoreFileName));
+				}
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			}
+		}
 		const rootSkill = join(current, "SKILL.md");
 		let rootSkillStat: Awaited<ReturnType<typeof lstat>> | undefined;
 		try {
@@ -537,20 +566,51 @@ async function discoverSkillPaths(
 			throw new Error(`Skill source contains a symbolic link: ${rootSkill}`);
 		}
 		if (rootSkillStat?.isFile()) {
-			addSkill(rootSkill);
+			const discoverySkill = join(mirror, "SKILL.md");
+			await copyDiscoveryFile(rootSkill, discoverySkill);
+			discovered.push({ sourcePath: rootSkill, discoveryPath: discoverySkill });
 			return;
 		}
 		const entries = await readdir(current, { withFileTypes: true });
 		signal?.throwIfAborted();
 		entries.sort((left, right) => left.name.localeCompare(right.name));
 		for (const entry of entries) {
-			if (!entry.isDirectory() || SKIPPED_DISCOVERY_DIRECTORIES.has(entry.name)) continue;
-			await walk(join(current, entry.name), depth + 1);
+			if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+			const entryPath = join(current, entry.name);
+			if (entry.isSymbolicLink()) {
+				throw new Error(`Skill source contains a symbolic link: ${entryPath}`);
+			}
+			if (!entry.isDirectory()) continue;
+			await walk(entryPath, join(mirror, entry.name), depth + 1);
 		}
 	};
-	await walk(sourcePath, 0);
+	const discoveryPath = sourceIsFile ? join(discoveryRoot, basename(sourcePath)) : discoveryRoot;
+	await walk(sourcePath, discoveryPath, 0);
 	signal?.throwIfAborted();
-	return discovered;
+	const includedPaths = piDiscoveredPaths(discoveryPath, cacheRoot);
+	signal?.throwIfAborted();
+	const included = discovered
+		.filter((skill) => includedPaths.has(resolve(skill.discoveryPath)))
+		.map((skill) => skill.sourcePath);
+	if (included.length > MAX_DISCOVERED_SKILLS) {
+		throw new Error(`Skill source exceeds the ${MAX_DISCOVERED_SKILLS}-skill discovery limit.`);
+	}
+	return included;
+}
+
+function piDiscoveredPaths(discoveryPath: string, cacheRoot: string): Set<string> {
+	const discovery = loadSkills({
+		cwd: dirname(discoveryPath),
+		agentDir: cacheRoot,
+		skillPaths: [discoveryPath],
+		includeDefaults: false,
+	});
+	return new Set([
+		...discovery.skills.map((skill) => resolve(skill.filePath)),
+		...discovery.diagnostics.flatMap((diagnostic) =>
+			diagnostic.path ? [resolve(diagnostic.path)] : [],
+		),
+	]);
 }
 
 function validateMaterializedSkill(path: string, expectedName: string, cacheRoot: string): void {

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -101,7 +101,7 @@ export class SessionSkillResolver implements SkillResolverLike {
 		options.signal?.throwIfAborted();
 		const key = cacheKey(options.source, options.selector);
 		const entryPath = join(this.#cacheRoot, "entries", key);
-		return withFileMutationQueue(entryPath, () => this.#resolveEntry(options, key, entryPath));
+		return this.#resolveEntry(options, key, entryPath);
 	}
 
 	async #resolveEntry(
@@ -119,8 +119,8 @@ export class SessionSkillResolver implements SkillResolverLike {
 		await mkdir(join(entryRoot, "versions"), { recursive: true, mode: 0o700 });
 		options.signal?.throwIfAborted();
 		const stagingPath = await mkdtemp(join(this.#cacheRoot, "staging", `${key}-`));
-		options.signal?.throwIfAborted();
 		try {
+			options.signal?.throwIfAborted();
 			const sourcePath = await this.#materializeSource(options.source, stagingPath, options.signal);
 			options.signal?.throwIfAborted();
 			const selected = await selectSkill(
@@ -503,6 +503,12 @@ async function discoverSkillPaths(
 	signal: AbortSignal | undefined,
 ): Promise<string[]> {
 	const discovered: string[] = [];
+	const addSkill = (skillPath: string) => {
+		if (discovered.length >= MAX_DISCOVERED_SKILLS) {
+			throw new Error(`Skill source exceeds the ${MAX_DISCOVERED_SKILLS}-skill discovery limit.`);
+		}
+		discovered.push(skillPath);
+	};
 	const canonicalExcludedRoot = excludedRoot ? await realpath(excludedRoot) : undefined;
 	signal?.throwIfAborted();
 	const walk = async (current: string, depth: number): Promise<void> => {
@@ -513,7 +519,7 @@ async function discoverSkillPaths(
 		if (currentStat.isSymbolicLink())
 			throw new Error(`Skill source contains a symbolic link: ${current}`);
 		if (currentStat.isFile()) {
-			if (basename(current) === "SKILL.md") discovered.push(current);
+			if (basename(current) === "SKILL.md") addSkill(current);
 			return;
 		}
 		if (!currentStat.isDirectory() || depth > MAX_DISCOVERY_DEPTH) return;
@@ -529,7 +535,7 @@ async function discoverSkillPaths(
 			throw new Error(`Skill source contains a symbolic link: ${rootSkill}`);
 		}
 		if (rootSkillStat?.isFile()) {
-			discovered.push(rootSkill);
+			addSkill(rootSkill);
 			return;
 		}
 		const entries = await readdir(current, { withFileTypes: true });
@@ -537,9 +543,6 @@ async function discoverSkillPaths(
 		entries.sort((left, right) => left.name.localeCompare(right.name));
 		for (const entry of entries) {
 			if (!entry.isDirectory() || SKIPPED_DISCOVERY_DIRECTORIES.has(entry.name)) continue;
-			if (discovered.length >= MAX_DISCOVERED_SKILLS) {
-				throw new Error(`Skill source exceeds the ${MAX_DISCOVERED_SKILLS}-skill discovery limit.`);
-			}
 			await walk(join(current, entry.name), depth + 1);
 		}
 	};

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -1,0 +1,545 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import {
+	access,
+	chmod,
+	lstat,
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	realpath,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { loadSkills, type Skill, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import type { ParsedSkillSource } from "./source-parser.js";
+
+const CACHE_VERSION = 1;
+const GIT_TIMEOUT_MS = 300_000;
+const MAX_GIT_OUTPUT_CHARS = 32_000;
+const MAX_DISCOVERY_DEPTH = 8;
+const MAX_DISCOVERED_SKILLS = 500;
+const SKIPPED_DISCOVERY_DIRECTORIES = new Set([
+	".git",
+	"node_modules",
+	"dist",
+	"build",
+	"__pycache__",
+]);
+
+export interface ResolvedSessionSkill {
+	name: string;
+	path: string;
+	source: string;
+	selector?: string;
+	cacheHit: boolean;
+}
+
+export interface ResolveSessionSkillOptions {
+	source: ParsedSkillSource;
+	selector?: string;
+	refresh?: boolean;
+	signal?: AbortSignal;
+}
+
+export interface SkillResolverLike {
+	resolve(options: ResolveSessionSkillOptions): Promise<ResolvedSessionSkill>;
+	getCacheRoot(): string;
+}
+
+export type CloneRepository = (
+	repository: string,
+	target: string,
+	ref: string | undefined,
+	signal: AbortSignal | undefined,
+) => Promise<void>;
+
+interface CacheMetadata {
+	version: number;
+	name: string;
+	source: string;
+	selector?: string;
+	createdAt: string;
+}
+
+export class SessionSkillResolver implements SkillResolverLike {
+	readonly #cacheRoot: string;
+	readonly #cloneRepository: CloneRepository;
+
+	constructor(options: { cacheRoot?: string; cloneRepository?: CloneRepository } = {}) {
+		this.#cacheRoot = resolve(options.cacheRoot ?? defaultCacheRoot());
+		this.#cloneRepository = options.cloneRepository ?? runGitClone;
+	}
+
+	getCacheRoot(): string {
+		return this.#cacheRoot;
+	}
+
+	async resolve(options: ResolveSessionSkillOptions): Promise<ResolvedSessionSkill> {
+		options.signal?.throwIfAborted();
+		const key = cacheKey(options.source, options.selector);
+		const entryPath = join(this.#cacheRoot, "entries", key);
+		return withFileMutationQueue(entryPath, () => this.#resolveEntry(options, key, entryPath));
+	}
+
+	async #resolveEntry(
+		options: ResolveSessionSkillOptions,
+		key: string,
+		entryPath: string,
+	): Promise<ResolvedSessionSkill> {
+		options.signal?.throwIfAborted();
+		if (!options.refresh) {
+			const cached = await this.#readCachedEntry(entryPath, options);
+			options.signal?.throwIfAborted();
+			if (cached) return cached;
+		}
+
+		await mkdir(join(this.#cacheRoot, "staging"), { recursive: true, mode: 0o700 });
+		options.signal?.throwIfAborted();
+		await mkdir(join(this.#cacheRoot, "entries"), { recursive: true, mode: 0o700 });
+		options.signal?.throwIfAborted();
+		const stagingPath = await mkdtemp(join(this.#cacheRoot, "staging", `${key}-`));
+		options.signal?.throwIfAborted();
+		try {
+			const sourcePath = await this.#materializeSource(options.source, stagingPath, options.signal);
+			options.signal?.throwIfAborted();
+			const selected = await selectSkill(
+				sourcePath,
+				options.selector,
+				this.#cacheRoot,
+				options.signal,
+			);
+			options.signal?.throwIfAborted();
+
+			const candidateEntry = join(stagingPath, "entry");
+			const candidateSkill = join(candidateEntry, "skill");
+			await mkdir(candidateEntry, { recursive: true, mode: 0o700 });
+			options.signal?.throwIfAborted();
+			await copySkillTree(selected.baseDir, candidateSkill, options.signal);
+			options.signal?.throwIfAborted();
+			await chmod(candidateEntry, 0o700);
+			options.signal?.throwIfAborted();
+			const metadata: CacheMetadata = {
+				version: CACHE_VERSION,
+				name: selected.name,
+				source: options.source.original,
+				selector: options.selector,
+				createdAt: new Date().toISOString(),
+			};
+			await writeFile(join(candidateEntry, "metadata.json"), JSON.stringify(metadata, null, 2), {
+				encoding: "utf8",
+				mode: 0o600,
+			});
+			options.signal?.throwIfAborted();
+			validateMaterializedSkill(candidateSkill, selected.name, this.#cacheRoot);
+			options.signal?.throwIfAborted();
+			await publishEntry(candidateEntry, entryPath, options.signal);
+			options.signal?.throwIfAborted();
+
+			return {
+				name: selected.name,
+				path: join(entryPath, "skill"),
+				source: options.source.original,
+				selector: options.selector,
+				cacheHit: false,
+			};
+		} finally {
+			await rm(stagingPath, { recursive: true, force: true });
+		}
+	}
+
+	async #materializeSource(
+		source: ParsedSkillSource,
+		stagingPath: string,
+		signal: AbortSignal | undefined,
+	): Promise<string> {
+		if (source.kind === "local") {
+			let localPath: string;
+			try {
+				localPath = await realpath(source.localPath);
+			} catch {
+				throw new Error(`Local skill source does not exist: ${source.localPath}`);
+			}
+			signal?.throwIfAborted();
+			const sourceStat = await stat(localPath);
+			signal?.throwIfAborted();
+			if (!sourceStat.isDirectory() && !sourceStat.isFile()) {
+				throw new Error(`Local skill source is not a file or directory: ${source.localPath}`);
+			}
+			return localPath;
+		}
+
+		const repositoryPath = join(stagingPath, "repository");
+		try {
+			await this.#cloneRepository(source.repository, repositoryPath, source.ref, signal);
+		} catch (error) {
+			if (!source.sshFallback || !(error instanceof GitCommandError) || !error.isAuthFailure) {
+				throw error;
+			}
+			await rm(repositoryPath, { recursive: true, force: true });
+			signal?.throwIfAborted();
+			await this.#cloneRepository(source.sshFallback, repositoryPath, source.ref, signal);
+		}
+		signal?.throwIfAborted();
+		const requestedPath = source.subpath ? join(repositoryPath, source.subpath) : repositoryPath;
+		assertPathInside(repositoryPath, requestedPath);
+		let resolvedPath: string;
+		try {
+			resolvedPath = await realpath(requestedPath);
+		} catch {
+			throw new Error(`Repository subpath does not exist: ${source.subpath}`);
+		}
+		signal?.throwIfAborted();
+		const repositoryRoot = await realpath(repositoryPath);
+		signal?.throwIfAborted();
+		assertPathInside(repositoryRoot, resolvedPath);
+		return resolvedPath;
+	}
+
+	async #readCachedEntry(
+		entryPath: string,
+		options: ResolveSessionSkillOptions,
+	): Promise<ResolvedSessionSkill | undefined> {
+		try {
+			const metadata = JSON.parse(
+				await readFile(join(entryPath, "metadata.json"), "utf8"),
+			) as CacheMetadata;
+			options.signal?.throwIfAborted();
+			if (
+				metadata.version !== CACHE_VERSION ||
+				typeof metadata.name !== "string" ||
+				metadata.source !== options.source.original ||
+				metadata.selector !== options.selector
+			) {
+				return undefined;
+			}
+			const skillPath = join(entryPath, "skill");
+			validateMaterializedSkill(skillPath, metadata.name, this.#cacheRoot);
+			options.signal?.throwIfAborted();
+			return {
+				name: metadata.name,
+				path: skillPath,
+				source: metadata.source,
+				selector: metadata.selector,
+				cacheHit: true,
+			};
+		} catch {
+			options.signal?.throwIfAborted();
+			return undefined;
+		}
+	}
+}
+
+export class GitCommandError extends Error {
+	readonly output: string;
+	readonly isAuthFailure: boolean;
+
+	constructor(message: string, output: string) {
+		super(message);
+		this.name = "GitCommandError";
+		this.output = output;
+		this.isAuthFailure =
+			/authentication failed|could not read username|permission denied|repository not found|403|saml sso/iu.test(
+				output,
+			);
+	}
+}
+
+export async function runGitClone(
+	repository: string,
+	target: string,
+	ref: string | undefined,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	if (signal?.aborted) throw new Error("Skill resolution cancelled.");
+	const args = ["clone", "--depth", "1"];
+	if (ref) args.push("--branch", ref);
+	args.push("--", repository, target);
+
+	await new Promise<void>((resolvePromise, rejectPromise) => {
+		const detached = process.platform !== "win32";
+		const child = spawn("git", args, {
+			detached,
+			env: {
+				...process.env,
+				GIT_TERMINAL_PROMPT: "0",
+				GIT_LFS_SKIP_SMUDGE: "1",
+				GCM_INTERACTIVE: "Never",
+				GIT_SSH_COMMAND: `${process.env.GIT_SSH_COMMAND ?? "ssh"} -o BatchMode=yes`,
+			},
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let output = "";
+		let timedOut = false;
+		let settled = false;
+		let killTimer: NodeJS.Timeout | undefined;
+
+		const appendOutput = (chunk: Buffer) => {
+			output = `${output}${chunk.toString("utf8")}`.slice(-MAX_GIT_OUTPUT_CHARS);
+		};
+		child.stdout?.on("data", appendOutput);
+		child.stderr?.on("data", appendOutput);
+
+		const terminate = () => {
+			if (child.exitCode !== null || child.signalCode !== null) return;
+			try {
+				if (detached && child.pid) process.kill(-child.pid, "SIGTERM");
+				else child.kill("SIGTERM");
+			} catch {
+				child.kill("SIGTERM");
+			}
+			killTimer = setTimeout(() => {
+				try {
+					if (detached && child.pid) process.kill(-child.pid, "SIGKILL");
+					else child.kill("SIGKILL");
+				} catch {
+					// The process already exited.
+				}
+			}, 1_000);
+			killTimer.unref();
+		};
+		const onAbort = () => terminate();
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			terminate();
+		}, GIT_TIMEOUT_MS);
+		timeout.unref();
+		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal?.aborted) terminate();
+
+		const finish = (callback: () => void) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			if (killTimer) clearTimeout(killTimer);
+			signal?.removeEventListener("abort", onAbort);
+			callback();
+		};
+
+		child.on("error", (error) => {
+			finish(() => {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+					rejectPromise(new Error("Git is required to load remote session skills."));
+				} else rejectPromise(error);
+			});
+		});
+		child.on("close", (code) => {
+			finish(() => {
+				if (signal?.aborted) rejectPromise(new Error("Skill resolution cancelled."));
+				else if (timedOut) rejectPromise(new Error("Git clone timed out after 300 seconds."));
+				else if (code === 0) resolvePromise();
+				else rejectPromise(new GitCommandError(`Git clone failed with exit code ${code}.`, output));
+			});
+		});
+	});
+}
+
+export function defaultCacheRoot(
+	environment: NodeJS.ProcessEnv = process.env,
+	userHome: string = homedir(),
+): string {
+	const xdg = environment.XDG_CACHE_HOME;
+	if (xdg && isAbsolute(xdg)) return join(xdg, "pi", "session-skills");
+	if (process.platform === "win32" && environment.LOCALAPPDATA) {
+		return join(environment.LOCALAPPDATA, "pi", "session-skills");
+	}
+	return join(userHome, ".cache", "pi", "session-skills");
+}
+
+export function isPathInside(root: string, candidate: string): boolean {
+	const pathFromRoot = relative(resolve(root), resolve(candidate));
+	return pathFromRoot === "" || (!pathFromRoot.startsWith(`..${sep}`) && pathFromRoot !== "..");
+}
+
+async function selectSkill(
+	sourcePath: string,
+	selector: string | undefined,
+	cacheRoot: string,
+	signal: AbortSignal | undefined,
+): Promise<Skill> {
+	const skillPaths = await discoverSkillPaths(sourcePath, signal);
+	signal?.throwIfAborted();
+	const loaded = loadSkills({
+		cwd: dirname(sourcePath),
+		agentDir: cacheRoot,
+		skillPaths: skillPaths,
+		includeDefaults: false,
+	});
+	const collisionNames = loaded.diagnostics.flatMap((diagnostic) =>
+		diagnostic.type === "collision" && diagnostic.collision ? [diagnostic.collision.name] : [],
+	);
+	if (collisionNames.length > 0) {
+		throw new Error(`Skill source contains duplicate names: ${collisionNames.join(", ")}`);
+	}
+	const skills = selector
+		? loaded.skills.filter((skill) => skill.name.toLowerCase() === selector.toLowerCase())
+		: loaded.skills;
+	if (skills.length === 1) {
+		const sourceStat = await stat(sourcePath);
+		signal?.throwIfAborted();
+		const sourceRoot = await realpath(sourceStat.isDirectory() ? sourcePath : dirname(sourcePath));
+		signal?.throwIfAborted();
+		const skillRoot = await realpath(skills[0].baseDir);
+		signal?.throwIfAborted();
+		assertPathInside(sourceRoot, skillRoot);
+		return { ...skills[0], baseDir: skillRoot };
+	}
+	const names = loaded.skills.map((skill) => skill.name).sort();
+	if (skills.length === 0 && selector) {
+		throw new Error(
+			`No skill named "${selector}" was found.${names.length ? ` Available: ${names.join(", ")}` : ""}`,
+		);
+	}
+	if (loaded.skills.length === 0) {
+		const diagnostics = loaded.diagnostics.map((diagnostic) => diagnostic.message).join("; ");
+		throw new Error(`No valid skills were found.${diagnostics ? ` ${diagnostics}` : ""}`);
+	}
+	throw new Error(
+		`This source contains multiple skills. Use --skill with one of: ${names.join(", ")}`,
+	);
+}
+
+async function discoverSkillPaths(
+	sourcePath: string,
+	signal: AbortSignal | undefined,
+): Promise<string[]> {
+	const discovered: string[] = [];
+	const walk = async (current: string, depth: number): Promise<void> => {
+		signal?.throwIfAborted();
+		const currentStat = await lstat(current);
+		signal?.throwIfAborted();
+		if (currentStat.isSymbolicLink())
+			throw new Error(`Skill source contains a symbolic link: ${current}`);
+		if (currentStat.isFile()) {
+			if (basename(current) === "SKILL.md") discovered.push(current);
+			return;
+		}
+		if (!currentStat.isDirectory() || depth > MAX_DISCOVERY_DEPTH) return;
+		const rootSkill = join(current, "SKILL.md");
+		let rootSkillStat: Awaited<ReturnType<typeof lstat>> | undefined;
+		try {
+			rootSkillStat = await lstat(rootSkill);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+		signal?.throwIfAborted();
+		if (rootSkillStat?.isSymbolicLink()) {
+			throw new Error(`Skill source contains a symbolic link: ${rootSkill}`);
+		}
+		if (rootSkillStat?.isFile()) {
+			discovered.push(rootSkill);
+			return;
+		}
+		const entries = await readdir(current, { withFileTypes: true });
+		signal?.throwIfAborted();
+		entries.sort((left, right) => left.name.localeCompare(right.name));
+		for (const entry of entries) {
+			if (!entry.isDirectory() || SKIPPED_DISCOVERY_DIRECTORIES.has(entry.name)) continue;
+			if (discovered.length >= MAX_DISCOVERED_SKILLS) {
+				throw new Error(`Skill source exceeds the ${MAX_DISCOVERED_SKILLS}-skill discovery limit.`);
+			}
+			await walk(join(current, entry.name), depth + 1);
+		}
+	};
+	await walk(sourcePath, 0);
+	signal?.throwIfAborted();
+	return discovered;
+}
+
+function validateMaterializedSkill(path: string, expectedName: string, cacheRoot: string): void {
+	const loaded = loadSkills({
+		cwd: dirname(path),
+		agentDir: cacheRoot,
+		skillPaths: [path],
+		includeDefaults: false,
+	});
+	if (loaded.skills.length !== 1 || loaded.skills[0].name !== expectedName) {
+		throw new Error(`Cached skill validation failed for ${expectedName}.`);
+	}
+}
+
+async function copySkillTree(
+	source: string,
+	destination: string,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	signal?.throwIfAborted();
+	const sourceStat = await lstat(source);
+	signal?.throwIfAborted();
+	if (sourceStat.isSymbolicLink()) throw new Error(`Skill contains a symbolic link: ${source}`);
+	if (sourceStat.isDirectory()) {
+		await mkdir(destination, { mode: sourceStat.mode & 0o777 });
+		signal?.throwIfAborted();
+		const entries = await readdir(source, { withFileTypes: true });
+		signal?.throwIfAborted();
+		for (const entry of entries) {
+			if (entry.name === ".git") continue;
+			await copySkillTree(join(source, entry.name), join(destination, entry.name), signal);
+		}
+		return;
+	}
+	if (!sourceStat.isFile()) throw new Error(`Skill contains an unsupported file type: ${source}`);
+	await pipeline(
+		createReadStream(source),
+		createWriteStream(destination, { mode: sourceStat.mode }),
+		{
+			signal,
+		},
+	);
+	await chmod(destination, sourceStat.mode & 0o777);
+	signal?.throwIfAborted();
+}
+
+function assertPathInside(root: string, candidate: string): void {
+	if (!isPathInside(root, candidate))
+		throw new Error("Skill source path escapes its repository root.");
+}
+
+async function publishEntry(
+	candidate: string,
+	destination: string,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	try {
+		await access(destination);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		signal?.throwIfAborted();
+		await rename(candidate, destination);
+		return;
+	}
+
+	signal?.throwIfAborted();
+	// Once replacement starts, finish the atomic recovery sequence even if the session is cancelled.
+	const backup = join(dirname(candidate), "previous");
+	await rename(destination, backup);
+	try {
+		await rename(candidate, destination);
+	} catch (error) {
+		await rename(backup, destination).catch(() => {});
+		throw error;
+	}
+	// The caller removes the staging parent, including the previous cache entry.
+}
+
+function cacheKey(source: ParsedSkillSource, selector: string | undefined): string {
+	const identity =
+		source.kind === "local"
+			? { kind: source.kind, original: source.original, path: source.localPath, selector }
+			: {
+					kind: source.kind,
+					original: source.original,
+					repository: source.repository,
+					ref: source.ref,
+					subpath: source.subpath,
+					selector,
+				};
+	return createHash("sha256").update(JSON.stringify(identity)).digest("hex");
+}

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -1,8 +1,7 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, createWriteStream } from "node:fs";
 import {
-	access,
 	chmod,
 	lstat,
 	mkdir,
@@ -34,12 +33,19 @@ const SKIPPED_DISCOVERY_DIRECTORIES = new Set([
 	"__pycache__",
 ]);
 
+export interface ResolvedSkillTransaction {
+	commit(): Promise<void>;
+	rollback(): Promise<void>;
+}
+
 export interface ResolvedSessionSkill {
 	name: string;
 	path: string;
 	source: string;
 	selector?: string;
 	cacheHit: boolean;
+	previousName?: string;
+	transaction?: ResolvedSkillTransaction;
 }
 
 export interface ResolveSessionSkillOptions {
@@ -69,6 +75,16 @@ interface CacheMetadata {
 	createdAt: string;
 }
 
+interface CacheIndex {
+	version: number;
+	entry: string;
+}
+
+interface CurrentCacheEntry {
+	index: CacheIndex;
+	result: ResolvedSessionSkill;
+}
+
 export class SessionSkillResolver implements SkillResolverLike {
 	readonly #cacheRoot: string;
 	readonly #cloneRepository: CloneRepository;
@@ -92,18 +108,16 @@ export class SessionSkillResolver implements SkillResolverLike {
 	async #resolveEntry(
 		options: ResolveSessionSkillOptions,
 		key: string,
-		entryPath: string,
+		entryRoot: string,
 	): Promise<ResolvedSessionSkill> {
 		options.signal?.throwIfAborted();
-		if (!options.refresh) {
-			const cached = await this.#readCachedEntry(entryPath, options);
-			options.signal?.throwIfAborted();
-			if (cached) return cached;
-		}
+		const current = await this.#readCachedEntry(entryRoot, options);
+		options.signal?.throwIfAborted();
+		if (!options.refresh && current) return current.result;
 
 		await mkdir(join(this.#cacheRoot, "staging"), { recursive: true, mode: 0o700 });
 		options.signal?.throwIfAborted();
-		await mkdir(join(this.#cacheRoot, "entries"), { recursive: true, mode: 0o700 });
+		await mkdir(join(entryRoot, "versions"), { recursive: true, mode: 0o700 });
 		options.signal?.throwIfAborted();
 		const stagingPath = await mkdtemp(join(this.#cacheRoot, "staging", `${key}-`));
 		options.signal?.throwIfAborted();
@@ -114,15 +128,19 @@ export class SessionSkillResolver implements SkillResolverLike {
 				sourcePath,
 				options.selector,
 				this.#cacheRoot,
+				options.source.kind === "local" ? this.#cacheRoot : undefined,
 				options.signal,
 			);
 			options.signal?.throwIfAborted();
 
 			const candidateEntry = join(stagingPath, "entry");
 			const candidateSkill = join(candidateEntry, "skill");
+			const excludedCopyRoot =
+				options.source.kind === "local" ? await realpath(this.#cacheRoot) : undefined;
+			options.signal?.throwIfAborted();
 			await mkdir(candidateEntry, { recursive: true, mode: 0o700 });
 			options.signal?.throwIfAborted();
-			await copySkillTree(selected.baseDir, candidateSkill, options.signal);
+			await copySkillTree(selected.baseDir, candidateSkill, excludedCopyRoot, options.signal);
 			options.signal?.throwIfAborted();
 			await chmod(candidateEntry, 0o700);
 			options.signal?.throwIfAborted();
@@ -140,15 +158,23 @@ export class SessionSkillResolver implements SkillResolverLike {
 			options.signal?.throwIfAborted();
 			validateMaterializedSkill(candidateSkill, selected.name, this.#cacheRoot);
 			options.signal?.throwIfAborted();
-			await publishEntry(candidateEntry, entryPath, options.signal);
-			options.signal?.throwIfAborted();
 
+			const entry = randomUUID();
+			const versionPath = join(entryRoot, "versions", entry);
+			await rename(candidateEntry, versionPath);
+			const transaction = createCacheTransaction(entryRoot, entry, current?.index);
+			if (options.signal?.aborted) {
+				await rm(versionPath, { recursive: true, force: true });
+				options.signal.throwIfAborted();
+			}
 			return {
 				name: selected.name,
-				path: join(entryPath, "skill"),
+				path: join(versionPath, "skill"),
 				source: options.source.original,
 				selector: options.selector,
 				cacheHit: false,
+				previousName: current?.result.name,
+				transaction,
 			};
 		} finally {
 			await rm(stagingPath, { recursive: true, force: true });
@@ -204,12 +230,19 @@ export class SessionSkillResolver implements SkillResolverLike {
 	}
 
 	async #readCachedEntry(
-		entryPath: string,
+		entryRoot: string,
 		options: ResolveSessionSkillOptions,
-	): Promise<ResolvedSessionSkill | undefined> {
+	): Promise<CurrentCacheEntry | undefined> {
 		try {
+			const index = JSON.parse(
+				await readFile(join(entryRoot, "current.json"), "utf8"),
+			) as CacheIndex;
+			options.signal?.throwIfAborted();
+			if (index.version !== CACHE_VERSION || !isCacheEntryName(index.entry)) return undefined;
+			const versionPath = join(entryRoot, "versions", index.entry);
+			assertPathInside(join(entryRoot, "versions"), versionPath);
 			const metadata = JSON.parse(
-				await readFile(join(entryPath, "metadata.json"), "utf8"),
+				await readFile(join(versionPath, "metadata.json"), "utf8"),
 			) as CacheMetadata;
 			options.signal?.throwIfAborted();
 			if (
@@ -220,15 +253,18 @@ export class SessionSkillResolver implements SkillResolverLike {
 			) {
 				return undefined;
 			}
-			const skillPath = join(entryPath, "skill");
+			const skillPath = join(versionPath, "skill");
 			validateMaterializedSkill(skillPath, metadata.name, this.#cacheRoot);
 			options.signal?.throwIfAborted();
 			return {
-				name: metadata.name,
-				path: skillPath,
-				source: metadata.source,
-				selector: metadata.selector,
-				cacheHit: true,
+				index,
+				result: {
+					name: metadata.name,
+					path: skillPath,
+					source: metadata.source,
+					selector: metadata.selector,
+					cacheHit: true,
+				},
 			};
 		} catch {
 			options.signal?.throwIfAborted();
@@ -258,11 +294,25 @@ export async function runGitClone(
 	ref: string | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<void> {
-	if (signal?.aborted) throw new Error("Skill resolution cancelled.");
+	if (ref && isCommitHash(ref)) {
+		await runGitCommand(["init", target], signal);
+		signal?.throwIfAborted();
+		await runGitCommand(["-C", target, "remote", "add", "origin", repository], signal);
+		signal?.throwIfAborted();
+		await runGitCommand(["-C", target, "fetch", "--depth", "1", "origin", ref], signal);
+		signal?.throwIfAborted();
+		await runGitCommand(["-C", target, "checkout", "--detach", "FETCH_HEAD"], signal);
+		return;
+	}
+
 	const args = ["clone", "--depth", "1"];
 	if (ref) args.push("--branch", ref);
 	args.push("--", repository, target);
+	await runGitCommand(args, signal);
+}
 
+async function runGitCommand(args: string[], signal: AbortSignal | undefined): Promise<void> {
+	if (signal?.aborted) throw new Error("Skill resolution cancelled.");
 	await new Promise<void>((resolvePromise, rejectPromise) => {
 		const detached = process.platform !== "win32";
 		const child = spawn("git", args, {
@@ -279,6 +329,7 @@ export async function runGitClone(
 		let output = "";
 		let timedOut = false;
 		let settled = false;
+		let terminationRequested = false;
 		let killTimer: NodeJS.Timeout | undefined;
 
 		const appendOutput = (chunk: Buffer) => {
@@ -287,17 +338,34 @@ export async function runGitClone(
 		child.stdout?.on("data", appendOutput);
 		child.stderr?.on("data", appendOutput);
 
+		const killWindowsTree = () => {
+			if (!child.pid) {
+				child.kill("SIGTERM");
+				return;
+			}
+			const killer = spawn("taskkill", windowsProcessTreeKillArguments(child.pid), {
+				stdio: "ignore",
+				windowsHide: true,
+			});
+			killer.once("error", () => child.kill("SIGTERM"));
+			killer.once("close", (code) => {
+				if (code !== 0 && child.exitCode === null) child.kill("SIGTERM");
+			});
+		};
 		const terminate = () => {
-			if (child.exitCode !== null || child.signalCode !== null) return;
+			if (terminationRequested || child.exitCode !== null || child.signalCode !== null) return;
+			terminationRequested = true;
 			try {
-				if (detached && child.pid) process.kill(-child.pid, "SIGTERM");
+				if (process.platform === "win32") killWindowsTree();
+				else if (detached && child.pid) process.kill(-child.pid, "SIGTERM");
 				else child.kill("SIGTERM");
 			} catch {
 				child.kill("SIGTERM");
 			}
 			killTimer = setTimeout(() => {
 				try {
-					if (detached && child.pid) process.kill(-child.pid, "SIGKILL");
+					if (process.platform === "win32") killWindowsTree();
+					else if (detached && child.pid) process.kill(-child.pid, "SIGKILL");
 					else child.kill("SIGKILL");
 				} catch {
 					// The process already exited.
@@ -333,12 +401,21 @@ export async function runGitClone(
 		child.on("close", (code) => {
 			finish(() => {
 				if (signal?.aborted) rejectPromise(new Error("Skill resolution cancelled."));
-				else if (timedOut) rejectPromise(new Error("Git clone timed out after 300 seconds."));
+				else if (timedOut) rejectPromise(new Error("Git command timed out after 300 seconds."));
 				else if (code === 0) resolvePromise();
-				else rejectPromise(new GitCommandError(`Git clone failed with exit code ${code}.`, output));
+				else
+					rejectPromise(new GitCommandError(`Git command failed with exit code ${code}.`, output));
 			});
 		});
 	});
+}
+
+export function windowsProcessTreeKillArguments(pid: number): string[] {
+	return ["/PID", String(pid), "/T", "/F"];
+}
+
+function isCommitHash(ref: string): boolean {
+	return /^[0-9a-f]{40}$/iu.test(ref);
 }
 
 export function defaultCacheRoot(
@@ -362,9 +439,10 @@ async function selectSkill(
 	sourcePath: string,
 	selector: string | undefined,
 	cacheRoot: string,
+	excludedRoot: string | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<Skill> {
-	const skillPaths = await discoverSkillPaths(sourcePath, signal);
+	const skillPaths = await discoverSkillPaths(sourcePath, excludedRoot, signal);
 	signal?.throwIfAborted();
 	const loaded = loadSkills({
 		cwd: dirname(sourcePath),
@@ -408,11 +486,15 @@ async function selectSkill(
 
 async function discoverSkillPaths(
 	sourcePath: string,
+	excludedRoot: string | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<string[]> {
 	const discovered: string[] = [];
+	const canonicalExcludedRoot = excludedRoot ? await realpath(excludedRoot) : undefined;
+	signal?.throwIfAborted();
 	const walk = async (current: string, depth: number): Promise<void> => {
 		signal?.throwIfAborted();
+		if (canonicalExcludedRoot && isPathInside(canonicalExcludedRoot, current)) return;
 		const currentStat = await lstat(current);
 		signal?.throwIfAborted();
 		if (currentStat.isSymbolicLink())
@@ -468,21 +550,31 @@ function validateMaterializedSkill(path: string, expectedName: string, cacheRoot
 async function copySkillTree(
 	source: string,
 	destination: string,
+	excludedRoot: string | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<void> {
 	signal?.throwIfAborted();
+	if (excludedRoot && isPathInside(excludedRoot, source)) return;
 	const sourceStat = await lstat(source);
 	signal?.throwIfAborted();
 	if (sourceStat.isSymbolicLink()) throw new Error(`Skill contains a symbolic link: ${source}`);
 	if (sourceStat.isDirectory()) {
-		await mkdir(destination, { mode: sourceStat.mode & 0o777 });
+		const sourceMode = sourceStat.mode & 0o777;
+		await mkdir(destination, { mode: sourceMode | 0o700 });
 		signal?.throwIfAborted();
 		const entries = await readdir(source, { withFileTypes: true });
 		signal?.throwIfAborted();
 		for (const entry of entries) {
 			if (entry.name === ".git") continue;
-			await copySkillTree(join(source, entry.name), join(destination, entry.name), signal);
+			await copySkillTree(
+				join(source, entry.name),
+				join(destination, entry.name),
+				excludedRoot,
+				signal,
+			);
 		}
+		await chmod(destination, sourceMode);
+		signal?.throwIfAborted();
 		return;
 	}
 	if (!sourceStat.isFile()) throw new Error(`Skill contains an unsupported file type: ${source}`);
@@ -502,31 +594,66 @@ function assertPathInside(root: string, candidate: string): void {
 		throw new Error("Skill source path escapes its repository root.");
 }
 
-async function publishEntry(
-	candidate: string,
-	destination: string,
-	signal: AbortSignal | undefined,
-): Promise<void> {
+function createCacheTransaction(
+	entryRoot: string,
+	entry: string,
+	previousIndex: CacheIndex | undefined,
+): ResolvedSkillTransaction {
+	let state: "pending" | "committed" | "rolled-back" = "pending";
+	const versionPath = join(entryRoot, "versions", entry);
+	return {
+		async commit() {
+			if (state === "committed") return;
+			if (state === "rolled-back")
+				throw new Error("Cannot commit a rolled-back skill cache entry.");
+			await withFileMutationQueue(entryRoot, () =>
+				writeCacheIndex(entryRoot, { version: CACHE_VERSION, entry }),
+			);
+			state = "committed";
+		},
+		async rollback() {
+			if (state === "rolled-back") return;
+			await withFileMutationQueue(entryRoot, async () => {
+				const current = await readCacheIndex(entryRoot);
+				if (state === "committed" && current?.entry === entry) {
+					await writeCacheIndex(entryRoot, previousIndex);
+				}
+				await rm(versionPath, { recursive: true, force: true });
+			});
+			state = "rolled-back";
+		},
+	};
+}
+
+async function readCacheIndex(entryRoot: string): Promise<CacheIndex | undefined> {
 	try {
-		await access(destination);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-		signal?.throwIfAborted();
-		await rename(candidate, destination);
+		const index = JSON.parse(await readFile(join(entryRoot, "current.json"), "utf8")) as CacheIndex;
+		return index.version === CACHE_VERSION && isCacheEntryName(index.entry) ? index : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function writeCacheIndex(entryRoot: string, index: CacheIndex | undefined): Promise<void> {
+	const indexPath = join(entryRoot, "current.json");
+	if (!index) {
+		await rm(indexPath, { force: true });
 		return;
 	}
-
-	signal?.throwIfAborted();
-	// Once replacement starts, finish the atomic recovery sequence even if the session is cancelled.
-	const backup = join(dirname(candidate), "previous");
-	await rename(destination, backup);
+	const temporaryPath = join(entryRoot, `.current-${randomUUID()}.json`);
 	try {
-		await rename(candidate, destination);
-	} catch (error) {
-		await rename(backup, destination).catch(() => {});
-		throw error;
+		await writeFile(temporaryPath, JSON.stringify(index, null, 2), {
+			encoding: "utf8",
+			mode: 0o600,
+		});
+		await rename(temporaryPath, indexPath);
+	} finally {
+		await rm(temporaryPath, { force: true });
 	}
-	// The caller removes the staging parent, including the previous cache entry.
+}
+
+function isCacheEntryName(value: unknown): value is string {
+	return typeof value === "string" && /^[0-9a-f-]{36}$/iu.test(value);
 }
 
 function cacheKey(source: ParsedSkillSource, selector: string | undefined): string {

--- a/.pi/extensions/pi-session-skills/resolver.ts
+++ b/.pi/extensions/pi-session-skills/resolver.ts
@@ -110,7 +110,9 @@ export class SessionSkillResolver implements SkillResolverLike {
 		entryRoot: string,
 	): Promise<ResolvedSessionSkill> {
 		options.signal?.throwIfAborted();
-		const current = await this.#readCachedEntry(entryRoot, options);
+		const current = await withFileMutationQueue(entryRoot, () =>
+			this.#readCachedEntry(entryRoot, options),
+		);
 		options.signal?.throwIfAborted();
 		if (!options.refresh && current) return current.result;
 

--- a/.pi/extensions/pi-session-skills/source-parser.test.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.test.ts
@@ -57,6 +57,16 @@ test("parses explicit SSH, HTTPS, and local sources", () => {
 		original: "ssh://git@example.com/team/repo.git",
 		repository: "ssh://git@example.com/team/repo.git",
 	});
+	for (const source of [
+		"ssh://custom@github.com:2222/owner/repo.git",
+		"ssh://custom@gitlab.com:2222/group/repo.git",
+	]) {
+		assert.deepEqual(parseSkillSource(source, "/work"), {
+			kind: "git",
+			original: source,
+			repository: source,
+		});
+	}
 	assert.deepEqual(parseSkillSource("https://example.com/team/repo.git", "/work"), {
 		kind: "git",
 		original: "https://example.com/team/repo.git",
@@ -69,6 +79,7 @@ test("parses explicit SSH, HTTPS, and local sources", () => {
 	});
 	assert.equal(parseSkillSource(".\\skills\\foo", "/work/project").kind, "local");
 	assert.equal(parseSkillSource("..\\skills\\foo", "/work/project").kind, "local");
+	assert.equal(parseSkillSource("\\\\server\\share\\skill", "/work/project").kind, "local");
 });
 
 test("rejects unsupported protocols, embedded credentials, and unsafe paths", () => {

--- a/.pi/extensions/pi-session-skills/source-parser.test.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.test.ts
@@ -27,6 +27,13 @@ test("parses GitHub and GitLab tree URLs", () => {
 			sshFallback: "git@github.com:owner/repo.git",
 		},
 	);
+	const commit = "0123456789abcdef0123456789abcdef01234567";
+	const commitSource = parseSkillSource(
+		`https://github.com/owner/repo/tree/${commit}/skills/foo`,
+		"/work",
+	);
+	assert.equal(commitSource.kind, "git");
+	if (commitSource.kind === "git") assert.equal(commitSource.ref, commit);
 	assert.deepEqual(
 		parseSkillSource("https://gitlab.com/group/subgroup/repo/-/tree/v1/skills/foo", "/work"),
 		{
@@ -60,6 +67,8 @@ test("parses explicit SSH, HTTPS, and local sources", () => {
 		original: "./skills/foo",
 		localPath: "/work/project/skills/foo",
 	});
+	assert.equal(parseSkillSource(".\\skills\\foo", "/work/project").kind, "local");
+	assert.equal(parseSkillSource("..\\skills\\foo", "/work/project").kind, "local");
 });
 
 test("rejects unsupported protocols, embedded credentials, and unsafe paths", () => {

--- a/.pi/extensions/pi-session-skills/source-parser.test.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.test.ts
@@ -42,6 +42,7 @@ test("parses GitHub and GitLab tree URLs", () => {
 			repository: "https://gitlab.com/group/subgroup/repo.git",
 			ref: "v1",
 			subpath: "skills/foo",
+			sshFallback: "git@gitlab.com:group/subgroup/repo.git",
 		},
 	);
 });

--- a/.pi/extensions/pi-session-skills/source-parser.test.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { normalizeSubpath, parseSkillSource, resolveSkillSelector } from "./source-parser.js";
+
+test("parses GitHub shorthand and optional skill selector", () => {
+	assert.deepEqual(parseSkillSource("owner/repo", "/work"), {
+		kind: "git",
+		original: "owner/repo",
+		repository: "https://github.com/owner/repo.git",
+		sshFallback: "git@github.com:owner/repo.git",
+	});
+	const selected = parseSkillSource("owner/repo@diagram", "/work");
+	assert.equal(selected.selector, "diagram");
+	assert.equal(resolveSkillSelector(selected), "diagram");
+	assert.throws(() => resolveSkillSelector(selected, "other"), /Conflicting skill selectors/);
+});
+
+test("parses GitHub and GitLab tree URLs", () => {
+	assert.deepEqual(
+		parseSkillSource("https://github.com/owner/repo/tree/main/skills/foo", "/work"),
+		{
+			kind: "git",
+			original: "https://github.com/owner/repo/tree/main/skills/foo",
+			repository: "https://github.com/owner/repo.git",
+			ref: "main",
+			subpath: "skills/foo",
+			sshFallback: "git@github.com:owner/repo.git",
+		},
+	);
+	assert.deepEqual(
+		parseSkillSource("https://gitlab.com/group/subgroup/repo/-/tree/v1/skills/foo", "/work"),
+		{
+			kind: "git",
+			original: "https://gitlab.com/group/subgroup/repo/-/tree/v1/skills/foo",
+			repository: "https://gitlab.com/group/subgroup/repo.git",
+			ref: "v1",
+			subpath: "skills/foo",
+		},
+	);
+});
+
+test("parses explicit SSH, HTTPS, and local sources", () => {
+	assert.deepEqual(parseSkillSource("git@github.com:owner/repo.git", "/work"), {
+		kind: "git",
+		original: "git@github.com:owner/repo.git",
+		repository: "git@github.com:owner/repo.git",
+	});
+	assert.deepEqual(parseSkillSource("ssh://git@example.com/team/repo.git", "/work"), {
+		kind: "git",
+		original: "ssh://git@example.com/team/repo.git",
+		repository: "ssh://git@example.com/team/repo.git",
+	});
+	assert.deepEqual(parseSkillSource("https://example.com/team/repo.git", "/work"), {
+		kind: "git",
+		original: "https://example.com/team/repo.git",
+		repository: "https://example.com/team/repo.git",
+	});
+	assert.deepEqual(parseSkillSource("./skills/foo", "/work/project"), {
+		kind: "local",
+		original: "./skills/foo",
+		localPath: "/work/project/skills/foo",
+	});
+});
+
+test("rejects unsupported protocols, embedded credentials, and unsafe paths", () => {
+	assert.throws(
+		() => parseSkillSource("http://example.com/repo.git", "/work"),
+		/Unsupported Git protocol/,
+	);
+	assert.throws(
+		() => parseSkillSource("https://user:secret@example.com/repo.git", "/work"),
+		/Credentials must not be embedded/,
+	);
+	assert.throws(
+		() => parseSkillSource("https://github.com/owner/repo/tree/../secret", "/work"),
+		/Unsafe repository path/,
+	);
+	assert.throws(() => normalizeSubpath("skills/../secret"), /Unsafe repository subpath/);
+	assert.throws(() => parseSkillSource("owner/repo\u001b[31m", "/work"), /Invalid skill source/);
+});

--- a/.pi/extensions/pi-session-skills/source-parser.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.ts
@@ -136,6 +136,7 @@ function parseGitLabUrl(original: string, url: URL): GitSkillSource {
 		kind: "git",
 		original,
 		repository: `https://${url.host}/${repositoryParts.join("/")}.git`,
+		sshFallback: `git@${url.hostname}:${repositoryParts.join("/")}.git`,
 	};
 	if (markerIndex < 0) return result;
 	const rawRef = segments[markerIndex + 2];

--- a/.pi/extensions/pi-session-skills/source-parser.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.ts
@@ -195,6 +195,8 @@ function isLocalSource(input: string): boolean {
 		input === "~" ||
 		input.startsWith("./") ||
 		input.startsWith("../") ||
+		input.startsWith(".\\") ||
+		input.startsWith("..\\") ||
 		input.startsWith("~/") ||
 		input.startsWith("~\\") ||
 		/^[A-Za-z]:[/\\]/u.test(input)

--- a/.pi/extensions/pi-session-skills/source-parser.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.ts
@@ -66,6 +66,7 @@ export function parseSkillSource(input: string, cwd: string): ParsedSkillSource 
 	if (url.protocol !== "https:" && url.protocol !== "ssh:") {
 		throw new Error(`Unsupported Git protocol: ${url.protocol}`);
 	}
+	if (url.protocol === "ssh:") return { kind: "git", original, repository: original };
 
 	if (url.hostname.toLowerCase() === "github.com") return parseGitHubUrl(original, url);
 	if (url.hostname.toLowerCase() === "gitlab.com") return parseGitLabUrl(original, url);
@@ -199,6 +200,7 @@ function isLocalSource(input: string): boolean {
 		input.startsWith("..\\") ||
 		input.startsWith("~/") ||
 		input.startsWith("~\\") ||
+		input.startsWith("\\\\") ||
 		/^[A-Za-z]:[/\\]/u.test(input)
 	);
 }

--- a/.pi/extensions/pi-session-skills/source-parser.ts
+++ b/.pi/extensions/pi-session-skills/source-parser.ts
@@ -1,0 +1,224 @@
+import { homedir } from "node:os";
+import { isAbsolute, resolve } from "node:path";
+
+export interface LocalSkillSource {
+	kind: "local";
+	original: string;
+	localPath: string;
+	selector?: string;
+}
+
+export interface GitSkillSource {
+	kind: "git";
+	original: string;
+	repository: string;
+	ref?: string;
+	subpath?: string;
+	selector?: string;
+	sshFallback?: string;
+}
+
+export type ParsedSkillSource = LocalSkillSource | GitSkillSource;
+
+export function parseSkillSource(input: string, cwd: string): ParsedSkillSource {
+	const original = input.trim();
+	if (!original || containsUnsafeText(original)) throw new Error("Invalid skill source.");
+
+	if (isLocalSource(original)) {
+		return {
+			kind: "local",
+			original,
+			localPath: resolve(cwd, expandTilde(original)),
+		};
+	}
+
+	const shorthand = original.match(/^([^/@:\s]+)\/([^/@\s]+?)(?:@([^\s]+))?$/u);
+	if (shorthand) {
+		const [, owner, repository, selector] = shorthand;
+		validateSelector(selector);
+		return {
+			kind: "git",
+			original,
+			repository: `https://github.com/${owner}/${stripGitSuffix(repository)}.git`,
+			...(selector === undefined ? {} : { selector }),
+			sshFallback: `git@github.com:${owner}/${stripGitSuffix(repository)}.git`,
+		};
+	}
+
+	if (/^[^@\s]+@[^:\s]+:[^\s]+$/u.test(original)) {
+		return { kind: "git", original, repository: original };
+	}
+
+	if (/(?:^|\/)(?:\.\.|%2e%2e)(?:\/|$)/iu.test(original)) {
+		throw new Error("Unsafe repository path in skill source URL.");
+	}
+	let url: URL;
+	try {
+		url = new URL(original);
+	} catch {
+		throw new Error(`Unsupported skill source: ${original}`);
+	}
+	if (url.password || (url.protocol === "https:" && url.username)) {
+		throw new Error("Credentials must not be embedded in a skill source URL.");
+	}
+	if (url.search || url.hash)
+		throw new Error("Skill source URLs cannot contain query strings or fragments.");
+	if (url.protocol !== "https:" && url.protocol !== "ssh:") {
+		throw new Error(`Unsupported Git protocol: ${url.protocol}`);
+	}
+
+	if (url.hostname.toLowerCase() === "github.com") return parseGitHubUrl(original, url);
+	if (url.hostname.toLowerCase() === "gitlab.com") return parseGitLabUrl(original, url);
+	return { kind: "git", original, repository: original };
+}
+
+export function resolveSkillSelector(
+	source: ParsedSkillSource,
+	optionSelector?: string,
+): string | undefined {
+	validateSelector(optionSelector);
+	if (
+		source.selector &&
+		optionSelector &&
+		source.selector.toLowerCase() !== optionSelector.toLowerCase()
+	) {
+		throw new Error(
+			`Conflicting skill selectors: source selects "${source.selector}" but --skill selects "${optionSelector}".`,
+		);
+	}
+	return optionSelector ?? source.selector;
+}
+
+export function normalizeSubpath(value: string): string {
+	const normalized = value.replaceAll("\\", "/").replace(/^\/+|\/+$/g, "");
+	if (!normalized) return "";
+	const segments = normalized.split("/");
+	if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+		throw new Error(`Unsafe repository subpath: ${value}`);
+	}
+	if (segments.some((segment) => containsUnsafeText(segment))) {
+		throw new Error("Repository subpath contains terminal control characters.");
+	}
+	return segments.join("/");
+}
+
+function parseGitHubUrl(original: string, url: URL): GitSkillSource {
+	const segments = decodePathSegments(url);
+	if (segments.length < 2) throw new Error(`Invalid GitHub repository URL: ${original}`);
+	const [owner, rawRepository, marker, rawRef, ...subpathParts] = segments;
+	const repositoryName = stripGitSuffix(rawRepository);
+	const base = `https://${url.host}/${owner}/${repositoryName}.git`;
+	const result: GitSkillSource = {
+		kind: "git",
+		original,
+		repository: base,
+		sshFallback: `git@${url.host}:${owner}/${repositoryName}.git`,
+	};
+	if (segments.length === 2) return result;
+	if (marker !== "tree" || !rawRef)
+		throw new Error(`Unsupported GitHub repository URL: ${original}`);
+	result.ref = validateRef(rawRef);
+	const subpath = normalizeSubpath(subpathParts.join("/"));
+	if (subpath) result.subpath = subpath;
+	return result;
+}
+
+function parseGitLabUrl(original: string, url: URL): GitSkillSource {
+	const segments = decodePathSegments(url);
+	const markerIndex = segments.findIndex(
+		(segment, index) => segment === "-" && segments[index + 1] === "tree",
+	);
+	const repositoryParts = markerIndex >= 0 ? segments.slice(0, markerIndex) : segments;
+	if (repositoryParts.length < 2) throw new Error(`Invalid GitLab repository URL: ${original}`);
+	repositoryParts[repositoryParts.length - 1] = stripGitSuffix(repositoryParts.at(-1) ?? "");
+	const result: GitSkillSource = {
+		kind: "git",
+		original,
+		repository: `https://${url.host}/${repositoryParts.join("/")}.git`,
+	};
+	if (markerIndex < 0) return result;
+	const rawRef = segments[markerIndex + 2];
+	if (!rawRef) throw new Error(`Invalid GitLab tree URL: ${original}`);
+	result.ref = validateRef(rawRef);
+	const subpath = normalizeSubpath(segments.slice(markerIndex + 3).join("/"));
+	if (subpath) result.subpath = subpath;
+	return result;
+}
+
+function decodePathSegments(url: URL): string[] {
+	return url.pathname
+		.split("/")
+		.filter(Boolean)
+		.map((segment) => {
+			let decoded: string;
+			try {
+				decoded = decodeURIComponent(segment);
+			} catch {
+				throw new Error(`Invalid URL path encoding: ${url.pathname}`);
+			}
+			if (decoded.includes("/") || decoded.includes("\\") || containsUnsafeText(decoded)) {
+				throw new Error(`Unsafe URL path segment: ${segment}`);
+			}
+			return decoded;
+		});
+}
+
+function validateRef(ref: string): string {
+	if (
+		!ref ||
+		ref.startsWith("-") ||
+		ref.endsWith("/") ||
+		ref.includes("..") ||
+		ref.includes("//") ||
+		ref.includes("@{") ||
+		/\s/u.test(ref) ||
+		["~", "^", ":", "?", "*", "[", "\\"].some((character) => ref.includes(character)) ||
+		containsUnsafeText(ref)
+	) {
+		throw new Error(`Unsafe Git ref: ${ref}`);
+	}
+	return ref;
+}
+
+function validateSelector(selector: string | undefined): void {
+	if (selector === undefined) return;
+	if (!selector || containsUnsafeText(selector) || selector.startsWith("-")) {
+		throw new Error(`Invalid skill selector: ${selector}`);
+	}
+}
+
+function isLocalSource(input: string): boolean {
+	return (
+		isAbsolute(input) ||
+		input === "." ||
+		input === ".." ||
+		input === "~" ||
+		input.startsWith("./") ||
+		input.startsWith("../") ||
+		input.startsWith("~/") ||
+		input.startsWith("~\\") ||
+		/^[A-Za-z]:[/\\]/u.test(input)
+	);
+}
+
+function expandTilde(input: string): string {
+	if (input === "~") return homedir();
+	if (input.startsWith("~/") || input.startsWith("~\\")) return `${homedir()}${input.slice(1)}`;
+	return input;
+}
+
+function stripGitSuffix(value: string): string {
+	return value.replace(/\.git$/iu, "");
+}
+
+function containsUnsafeText(value: string): boolean {
+	return [...value].some((character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		return (
+			codePoint <= 0x1f ||
+			(codePoint >= 0x7f && codePoint <= 0x9f) ||
+			(codePoint >= 0x202a && codePoint <= 0x202e) ||
+			(codePoint >= 0x2066 && codePoint <= 0x2069)
+		);
+	});
+}

--- a/.pi/extensions/pi-session-skills/tsconfig.json
+++ b/.pi/extensions/pi-session-skills/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["*.ts"]
+}

--- a/.pi/extensions/pi-session-skills/vitest.config.ts
+++ b/.pi/extensions/pi-session-skills/vitest.config.ts
@@ -1,0 +1,12 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: dirname(fileURLToPath(import.meta.url)),
+	test: {
+		environment: "node",
+		include: ["*.test.ts"],
+		testTimeout: 5_000,
+	},
+});


### PR DESCRIPTION
## Summary

- add the project-local `pi-session-skills` extension for activating one Git or local Agent Skill in the current Pi session
- expose one `/session-skills` slash command with status, load, list, and unload routes
- support GitHub shorthand, GitHub and GitLab tree URLs, explicit HTTPS/SSH Git sources, local paths, selection, and cache refresh
- isolate active and desired state by session manager and persist snapshots through the issuing session's concrete manager
- restore the prior active branch when snapshot persistence mutates memory before failing
- retain unloadable skipped snapshots and unload-name completions while rejecting same-name ownership conflicts
- materialize outside cache publication locks so queued same-source operations remain cancellable
- publish refreshes through short queued versioned cache transactions with commit-time predecessor capture
- support detached commit checkout, GitHub/GitLab SSH fallback, cache-subtree exclusion, read-only directories, Windows-relative and UNC paths, and cross-drive containment
- start Git deadlines after process readiness, clean staging on every cancellation boundary, and cancel Unix or Windows process trees
- enforce the documented discovery limit when adding the 501st skill
- provide argument-aware completion with equivalent handling for long and short selector options
- sanitize displayed identifiers and paths separately from bounded multiline Git diagnostics
- avoid runtime dependencies on external skill manager CLIs or another extension

## Verification

- `./node_modules/.bin/tsc -p .pi/extensions/pi-session-skills/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run --config .pi/extensions/pi-session-skills/vitest.config.ts` — 48 tests passed
- `npm run check`
- `npm test` — 349 files, 3478 tests passed
- isolated RPC load/list/unload/reload smokes
- session-owned persistence RPC smokes
- transactional rename-refresh RPC smokes
- trusted-project auto-discovery smoke
- public GitHub shorthand smoke

## Notes

- No Changeset is included because this is a repository-only project-local extension.
- Direct HTTP downloads, archives, and well-known endpoints remain out of scope.
- Private-repository, GitLab, and live Windows process-tree paths were not exercised against external services or a Windows host; deterministic coverage verifies their parsing and command construction.
