### PR TITLE
fix(usage): add standard menu frame

### DIFF
--- a/.changeset/fresh-usage-menu-frame.md
+++ b/.changeset/fresh-usage-menu-frame.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Render the usage menu with the standard horizontal frame used by other Pi extension menus.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7166,7 +7166,7 @@
 			"version": "0.60.2",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.59.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.11",
@@ -7184,22 +7184,32 @@
 			}
 		},
 		"packages/pi-usage/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.59.0.tgz",
+			"integrity": "sha512-KBbOcciJD+HVbeduUwBUiSy2AehMGYeOwiRPXvac5tcjuh3SDoQ+7qsNPt2s/ku6exJKZp0GYtAVsiu5ySddmA==",
 			"license": "MIT",
 			"dependencies": {
-				"highlight.js": "11.11.1"
+				"grok-mermaid": "0.2.3",
+				"highlight.js": "11.12.0"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"packages/pi-usage/node_modules/grok-mermaid": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.3.tgz",
+			"integrity": "sha512-/4KopAbsjvuRP9MdPtlDjOHUmUVEohOX73JNcsWpzAtFxh+bq5+Dhb6gzvRieLDwIPQIR3/vy8V1NNTuz4Zsmg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"packages/pi-usage/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+			"integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=12.0.0"

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -70,6 +70,6 @@
 		"directory": "packages/pi-usage"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.59.0"
 	}
 }

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import {
 	getKeybindings,
@@ -787,6 +788,7 @@ test("TUI usage queries complete through the loader before opening the menu", as
 	const command = mock.commands.get("usage");
 	assert.ok(command);
 	let customCalls = 0;
+	let menuLines: string[] = [];
 	const { ctx } = createMockContext({
 		hasUI: true,
 		mode: "tui",
@@ -806,13 +808,26 @@ test("TUI usage queries complete through the loader before opening the menu", as
 				};
 				component = (
 					factory as (
-						tui: { requestRender(): void },
-						theme: { fg(_color: string, text: string): string },
-						keybindings: object,
+						tui: { requestRender(): void; terminal: { rows: number } },
+						theme: {
+							bold(text: string): string;
+							fg(_color: string, text: string): string;
+						},
+						keybindings: ReturnType<typeof getKeybindings>,
 						done: (value: unknown) => void,
 					) => typeof component
-				)({ requestRender() {} }, { fg: (_color, text) => text }, {}, done);
-				if (customCalls === 2) setImmediate(() => component.handleInput("\u0003"));
+				)(
+					{ requestRender() {}, terminal: { rows: 24 } },
+					{ bold: (text) => text, fg: (_color, text) => text },
+					getKeybindings(),
+					done,
+				);
+				if (customCalls === 2) {
+					setImmediate(() => {
+						menuLines = component.render(40).map(stripVTControlCharacters);
+						component.handleInput("\u0003");
+					});
+				}
 			}),
 		modelRegistry: {
 			getProviderAuth: async () => ({ auth: { apiKey: "openrouter-key" } }),
@@ -826,6 +841,8 @@ test("TUI usage queries complete through the loader before opening the menu", as
 	await command.handler("", ctx);
 
 	assert.equal(customCalls, 2);
+	assert.equal(menuLines[0], "─".repeat(40));
+	assert.equal(menuLines.at(-1), "─".repeat(40));
 });
 
 test("a loader UI failure propagates once without an extra task notification", async () => {


### PR DESCRIPTION
## Summary

- raise pi-usage's pi-tui-kit floor to the version that provides standard framed menus
- verify the usage TUI renders width-safe horizontal rules above and below the menu
- add a patch changeset for the published behavior change

## Verification

- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` (3,478 tests)
- `npm run package:pack -- usage`
- `pi --no-extensions --no-skills --offline -e ./packages/pi-usage --list-models`
- `npm ls @narumitw/pi-tui-kit --workspace @narumitw/pi-usage`