### PR TITLE
fix: frame remaining standard menus

### DIFF
--- a/.changeset/complete-menu-frames.md
+++ b/.changeset/complete-menu-frames.md
@@ -1,0 +1,7 @@
+---
+"@narumitw/pi-analytics": patch
+"@narumitw/pi-caffeinate": patch
+"@narumitw/pi-firecrawl": patch
+---
+
+Render standard horizontal frames around the remaining extension menus.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6000,7 +6000,7 @@
 			"version": "0.49.8",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.51.0"
+				"@narumitw/pi-tui-kit": "^0.59.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.11",
@@ -6014,22 +6014,32 @@
 			}
 		},
 		"packages/pi-analytics/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.51.0",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.51.0.tgz",
-			"integrity": "sha512-NH5G2GTegZwU7H5anGnTox7q+2PIhTOz6W+4YRgyYb9xuqLfOBBtY58xwoDxYqrgnmfycc0d9O6PvF37gWtzug==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.59.0.tgz",
+			"integrity": "sha512-KBbOcciJD+HVbeduUwBUiSy2AehMGYeOwiRPXvac5tcjuh3SDoQ+7qsNPt2s/ku6exJKZp0GYtAVsiu5ySddmA==",
 			"license": "MIT",
 			"dependencies": {
-				"highlight.js": "11.11.1"
+				"grok-mermaid": "0.2.3",
+				"highlight.js": "11.12.0"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"packages/pi-analytics/node_modules/grok-mermaid": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.3.tgz",
+			"integrity": "sha512-/4KopAbsjvuRP9MdPtlDjOHUmUVEohOX73JNcsWpzAtFxh+bq5+Dhb6gzvRieLDwIPQIR3/vy8V1NNTuz4Zsmg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"packages/pi-analytics/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+			"integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=12.0.0"
@@ -6093,7 +6103,7 @@
 			"version": "0.49.6",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1",
+				"@narumitw/pi-tui-kit": "^0.59.0",
 				"dbus-native": "^0.15.2"
 			},
 			"devDependencies": {
@@ -6108,22 +6118,32 @@
 			}
 		},
 		"packages/pi-caffeinate/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.59.0.tgz",
+			"integrity": "sha512-KBbOcciJD+HVbeduUwBUiSy2AehMGYeOwiRPXvac5tcjuh3SDoQ+7qsNPt2s/ku6exJKZp0GYtAVsiu5ySddmA==",
 			"license": "MIT",
 			"dependencies": {
-				"highlight.js": "11.11.1"
+				"grok-mermaid": "0.2.3",
+				"highlight.js": "11.12.0"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"packages/pi-caffeinate/node_modules/grok-mermaid": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.3.tgz",
+			"integrity": "sha512-/4KopAbsjvuRP9MdPtlDjOHUmUVEohOX73JNcsWpzAtFxh+bq5+Dhb6gzvRieLDwIPQIR3/vy8V1NNTuz4Zsmg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"packages/pi-caffeinate/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+			"integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=12.0.0"
@@ -6345,7 +6365,7 @@
 			"version": "0.50.2",
 			"license": "MIT",
 			"dependencies": {
-				"@narumitw/pi-tui-kit": "^0.49.1"
+				"@narumitw/pi-tui-kit": "^0.59.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.11",
@@ -6360,22 +6380,32 @@
 			}
 		},
 		"packages/pi-firecrawl/node_modules/@narumitw/pi-tui-kit": {
-			"version": "0.49.3",
-			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.49.3.tgz",
-			"integrity": "sha512-ha4MybnoJgAiNpW83Ap7EftfOuO8oNf3mIY3baPO0RFrBPyAUuxSlz7hcs9qh+9daDUMxg3sRPsvzYqFsEQKHg==",
+			"version": "0.59.0",
+			"resolved": "https://registry.npmjs.org/@narumitw/pi-tui-kit/-/pi-tui-kit-0.59.0.tgz",
+			"integrity": "sha512-KBbOcciJD+HVbeduUwBUiSy2AehMGYeOwiRPXvac5tcjuh3SDoQ+7qsNPt2s/ku6exJKZp0GYtAVsiu5ySddmA==",
 			"license": "MIT",
 			"dependencies": {
-				"highlight.js": "11.11.1"
+				"grok-mermaid": "0.2.3",
+				"highlight.js": "11.12.0"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
 				"@earendil-works/pi-tui": "*"
 			}
 		},
+		"packages/pi-firecrawl/node_modules/grok-mermaid": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.3.tgz",
+			"integrity": "sha512-/4KopAbsjvuRP9MdPtlDjOHUmUVEohOX73JNcsWpzAtFxh+bq5+Dhb6gzvRieLDwIPQIR3/vy8V1NNTuz4Zsmg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"packages/pi-firecrawl/node_modules/highlight.js": {
-			"version": "11.11.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+			"integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=12.0.0"

--- a/packages/pi-analytics/package.json
+++ b/packages/pi-analytics/package.json
@@ -32,7 +32,7 @@
 		"prepack": "npm run build"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.51.0"
+		"@narumitw/pi-tui-kit": "^0.59.0"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*"

--- a/packages/pi-analytics/test/menu.test.ts
+++ b/packages/pi-analytics/test/menu.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 import { initTheme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { resolveMenuScreen, runConfirmation, runMenu } from "@narumitw/pi-tui-kit";
@@ -522,7 +523,10 @@ test("dashboard rendering is width-safe and owner cancellation settles the menu"
 	await tui.waitForOpen();
 	for (const width of [40, 80, 120]) {
 		tui.resize({ width, rows: 20 });
-		for (const line of tui.render()) assert.ok(visibleWidth(line) <= width);
+		const frame = tui.render();
+		for (const line of frame) assert.ok(visibleWidth(line) <= width);
+		assert.equal(stripVTControlCharacters(frame[0] ?? ""), "─".repeat(width));
+		assert.equal(stripVTControlCharacters(frame.at(-1) ?? ""), "─".repeat(width));
 	}
 	owner.abort();
 	assert.equal((await running).kind, "stale");

--- a/packages/pi-caffeinate/package.json
+++ b/packages/pi-caffeinate/package.json
@@ -47,7 +47,7 @@
 		"directory": "packages/pi-caffeinate"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1",
+		"@narumitw/pi-tui-kit": "^0.59.0",
 		"dbus-native": "^0.15.2"
 	}
 }

--- a/packages/pi-caffeinate/test/caffeinate.test.ts
+++ b/packages/pi-caffeinate/test/caffeinate.test.ts
@@ -12,8 +12,9 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { test, vi } from "vitest";
-import { createMockContext, createMockPi } from "../../../test/support.js";
+import { createMockContext, createMockPi, driveCustomSelector } from "../../../test/support.js";
 import caffeinate, {
 	commandCompletions,
 	formatMode,
@@ -49,6 +50,30 @@ test("parseCommand accepts documented commands and aliases", () => {
 	assert.equal(parseCommand("screen"), "display");
 	assert.equal(parseCommand("off"), "stop");
 	assert.equal(parseCommand("wat"), "unknown");
+});
+
+test("caffeinate menu uses the standard horizontal frame", async () => {
+	await withTempAgentDir(async () => {
+		const caffeinateModule = await importFreshCaffeinate();
+		const mock = createMockPi();
+		let frame: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			custom: async (factory: unknown) => {
+				const driven = driveCustomSelector(factory, ["\u0003"], 40);
+				frame = driven.renders[0] ?? [];
+				return driven.result;
+			},
+		});
+		caffeinateModule.default(mock.pi);
+
+		await mock.commands.get("caffeinate")?.handler("", ctx);
+
+		const plain = frame.map(stripVTControlCharacters);
+		assert.equal(plain[0], "─".repeat(40));
+		assert.equal(plain.at(-1), "─".repeat(40));
+	});
 });
 
 test("commandCompletions filters single-token prefixes", () => {

--- a/packages/pi-firecrawl/package.json
+++ b/packages/pi-firecrawl/package.json
@@ -43,7 +43,7 @@
 		"typescript": "7.0.2"
 	},
 	"dependencies": {
-		"@narumitw/pi-tui-kit": "^0.49.1"
+		"@narumitw/pi-tui-kit": "^0.59.0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/pi-firecrawl/test/firecrawl.test.ts
+++ b/packages/pi-firecrawl/test/firecrawl.test.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path, { dirname } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test, vi } from "vitest";
@@ -587,6 +588,9 @@ test("Firecrawl main menu dispatches declarative actions at narrow widths", asyn
 	});
 	await mock.commands.get("firecrawl")?.handler("", ctx);
 	assert.ok(renderedLines.every((line) => visibleWidth(line) <= 20));
+	const plain = renderedLines.map(stripVTControlCharacters);
+	assert.equal(plain[0], "─".repeat(20));
+	assert.equal(plain.at(-1), "─".repeat(20));
 	const rendered = renderedLines.join("\n");
 	assert.match(rendered, /Tool catalog: 0\/5/);
 	assert.match(rendered, /Loaded this session:\s+0\/5/);


### PR DESCRIPTION
## Summary

- raise the pi-tui-kit floor for pi-analytics, pi-caffeinate, and pi-firecrawl
- enable the standard top and bottom horizontal frame on their existing declarative menus
- add package-specific render coverage and patch changesets

## Verification

- `npm run check`
- `npm test` (3,479 tests)
- `npm run package:pack -- analytics`
- `npm run package:pack -- caffeinate`
- `npm run package:pack -- firecrawl`
- offline package-load smokes for all three extensions
- `npm ls @narumitw/pi-tui-kit` confirms `0.59.0` for all three packages