### PR TITLE
fix(usage): frame settings screen

### DIFF
--- a/.changeset/frame-usage-settings.md
+++ b/.changeset/frame-usage-settings.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Render the standard horizontal frame around the pi-usage Settings screen.

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -29,6 +29,8 @@ export async function showUsageSettings(
 		if (ctx.hasUI) ctx.ui.notify(`Edit settings manually: ${settingsRuntime.get().path}`, "info");
 		return false;
 	}
+	const { HorizontalRule } = await import("@narumitw/pi-tui-kit");
+	if (parentSignal.aborted || !isCurrent()) return false;
 	return (
 		(await ctx.ui.custom<boolean>((tui, theme, _keybindings, done) => {
 			const localController = new AbortController();
@@ -54,6 +56,9 @@ export async function showUsageSettings(
 				},
 			];
 			const container = new Container();
+			const createRule = () =>
+				new HorizontalRule({ ruleStyle: (text) => theme.fg("border", text) });
+			container.addChild(createRule());
 			container.addChild(new Text(theme.fg("accent", theme.bold("pi-usage Settings")), 1, 1));
 
 			let settingsList: SettingsList;
@@ -103,6 +108,7 @@ export async function showUsageSettings(
 				cancel,
 			);
 			container.addChild(settingsList);
+			container.addChild(createRule());
 
 			parentSignal.addEventListener("abort", cancel, { once: true });
 			return {

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -2583,6 +2583,12 @@ test("the TUI SettingsList describes and applies usage preferences immediately",
 	assert.deepEqual(applied, new Set(["codexFastMode", "codexStatusResetCountdown"]));
 	const renderedSettings = rendered.map((lines) => lines.join("\n"));
 	assert.ok(
+		rendered.some((frame) => {
+			const plain = frame.map(stripVTControlCharacters);
+			return plain[0] === "─".repeat(100) && plain.at(-1) === "─".repeat(100);
+		}),
+	);
+	assert.ok(
 		renderedSettings.some((frame) =>
 			/Show time remaining until each Codex usage limit resets/.test(frame),
 		),


### PR DESCRIPTION
## Summary

- add pi-tui-kit's width-safe `HorizontalRule` above and below the custom pi-usage Settings screen
- keep the Kit import lazy and revalidate interaction ownership after loading it
- verify framing alongside immediate settings persistence and remapped keybindings

## Verification

- `npx vitest run packages/pi-usage/test/usage.test.ts` (48 tests)
- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` (3,478 tests)
- `npm run package:pack -- usage`
- `pi --no-extensions --no-skills --offline -e ./packages/pi-usage --list-models`

## Semantic audit

- settings read/write ordering, rollback, unknown-field preservation, and invalid-file protection are unchanged
- cancellation and disposal still abort owned save work
- the new dynamic import is followed by owner-signal and generation revalidation