### PR TITLE
fix(usage): respect settings row budget

### DIFF
--- a/.changeset/bound-usage-settings-frame.md
+++ b/.changeset/bound-usage-settings-frame.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Keep the Settings frame from hiding interactive rows in short terminals.

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -56,9 +56,7 @@ export async function showUsageSettings(
 				},
 			];
 			const container = new Container();
-			const createRule = () =>
-				new HorizontalRule({ ruleStyle: (text) => theme.fg("border", text) });
-			container.addChild(createRule());
+			const rule = new HorizontalRule({ ruleStyle: (text) => theme.fg("border", text) });
 			container.addChild(new Text(theme.fg("accent", theme.bold("pi-usage Settings")), 1, 1));
 
 			let settingsList: SettingsList;
@@ -108,11 +106,19 @@ export async function showUsageSettings(
 				cancel,
 			);
 			container.addChild(settingsList);
-			container.addChild(createRule());
 
 			parentSignal.addEventListener("abort", cancel, { once: true });
 			return {
-				render: (width: number) => container.render(width),
+				render(width: number) {
+					const content = container.render(width);
+					const terminalRows = Number.isFinite(tui.terminal?.rows)
+						? Math.floor(tui.terminal.rows)
+						: 24;
+					const availableRows = Math.max(1, terminalRows - 3);
+					if (content.length + 2 > availableRows) return content;
+					const [ruleLine = ""] = rule.render(width);
+					return [ruleLine, ...content, ruleLine];
+				},
 				invalidate: () => container.invalidate(),
 				handleInput(data: string) {
 					if (closing) return;

--- a/packages/pi-usage/src/usage-settings-ui.ts
+++ b/packages/pi-usage/src/usage-settings-ui.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import {
 	type ExtensionCommandContext,
 	getSettingsListTheme,
@@ -17,6 +18,26 @@ const OFF = "Off";
 const ON = "On";
 
 type UsageSettingId = "codexFastMode" | "codexStatusResetCountdown";
+
+function fitSettingsRows(lines: string[], maxRows: number): string[] {
+	if (lines.length <= maxRows) return lines;
+	const content = lines.filter((line) => stripVTControlCharacters(line).trim().length > 0);
+	if (content.length <= maxRows) return content;
+	const selectedIndex = content.findIndex((line) =>
+		/^[→›]\s/u.test(stripVTControlCharacters(line)),
+	);
+	if (selectedIndex < 0) return content.slice(0, maxRows);
+	return content
+		.map((line, index) => ({ index, line }))
+		.sort(
+			(left, right) =>
+				Math.abs(left.index - selectedIndex) - Math.abs(right.index - selectedIndex) ||
+				left.index - right.index,
+		)
+		.slice(0, maxRows)
+		.sort((left, right) => left.index - right.index)
+		.map(({ line }) => line);
+}
 
 export async function showUsageSettings(
 	ctx: ExtensionCommandContext,
@@ -115,7 +136,9 @@ export async function showUsageSettings(
 						? Math.floor(tui.terminal.rows)
 						: 24;
 					const availableRows = Math.max(1, terminalRows - 3);
-					if (content.length + 2 > availableRows) return content;
+					if (content.length + 2 > availableRows) {
+						return fitSettingsRows(content, availableRows);
+					}
 					const [ruleLine = ""] = rule.render(width);
 					return [ruleLine, ...content, ruleLine];
 				},

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -2603,6 +2603,7 @@ test("the Settings frame respects the live terminal row budget", async () => {
 	const terminal = { rows: 24 };
 	let full: string[] = [];
 	let constrained: string[] = [];
+	let tiny: string[] = [];
 	const { ctx } = createMockContext({
 		hasUI: true,
 		mode: "tui",
@@ -2635,7 +2636,10 @@ test("the Settings frame respects the live terminal row budget", async () => {
 				);
 				full = component.render(100);
 				terminal.rows = 12;
-				constrained = component.render(100);
+				constrained = component.render(20);
+				terminal.rows = 4;
+				component.handleInput("\u001b[B");
+				tiny = component.render(20);
 				component.handleInput("\u0003");
 			}),
 	});
@@ -2652,10 +2656,13 @@ test("the Settings frame respects the live terminal row budget", async () => {
 	assert.equal(fullPlain[0], "─".repeat(100));
 	assert.equal(fullPlain.at(-1), "─".repeat(100));
 	const constrainedPlain = constrained.map(stripVTControlCharacters);
-	assert.ok(constrainedPlain.length <= terminal.rows - 3);
-	assert.notEqual(constrainedPlain[0], "─".repeat(100));
-	assert.notEqual(constrainedPlain.at(-1), "─".repeat(100));
+	assert.ok(constrainedPlain.length <= 9);
+	assert.notEqual(constrainedPlain[0], "─".repeat(20));
+	assert.notEqual(constrainedPlain.at(-1), "─".repeat(20));
 	assert.match(constrainedPlain.join("\n"), /[→›]\s+Codex Fast mode/u);
+	const tinyPlain = tiny.map(stripVTControlCharacters);
+	assert.equal(tinyPlain.length, 1);
+	assert.match(tinyPlain[0] ?? "", /[→›]\s+Codex reset/u);
 });
 
 test("Ctrl+C hard-cancels Settings before conflicting configurable actions", async (t) => {

--- a/packages/pi-usage/test/usage.test.ts
+++ b/packages/pi-usage/test/usage.test.ts
@@ -2598,6 +2598,66 @@ test("the TUI SettingsList describes and applies usage preferences immediately",
 	assert.doesNotMatch(renderedSettings.join("\n"), /xAI|warning|undocumented|experimental/iu);
 });
 
+test("the Settings frame respects the live terminal row budget", async () => {
+	const settings = memorySettingsRuntime();
+	const terminal = { rows: 24 };
+	let full: string[] = [];
+	let constrained: string[] = [];
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		custom: async (factory: unknown) =>
+			new Promise<boolean>((resolve) => {
+				let component: {
+					dispose?(): void;
+					handleInput(data: string): void;
+					render(width: number): string[];
+				};
+				const done = (value: boolean) => {
+					component.dispose?.();
+					resolve(value);
+				};
+				component = (
+					factory as (
+						tui: { terminal: { rows: number }; requestRender(): void },
+						theme: {
+							bold(text: string): string;
+							fg(_color: string, text: string): string;
+						},
+						keybindings: object,
+						done: (value: boolean) => void,
+					) => typeof component
+				)(
+					{ terminal, requestRender() {} },
+					{ bold: (text) => text, fg: (_color, text) => text },
+					{ matches: () => false },
+					done,
+				);
+				full = component.render(100);
+				terminal.rows = 12;
+				constrained = component.render(100);
+				component.handleInput("\u0003");
+			}),
+	});
+
+	await showUsageSettings(
+		ctx,
+		settings.runtime,
+		new AbortController().signal,
+		() => true,
+		() => assert.fail("rendering must not change settings"),
+	);
+
+	const fullPlain = full.map(stripVTControlCharacters);
+	assert.equal(fullPlain[0], "─".repeat(100));
+	assert.equal(fullPlain.at(-1), "─".repeat(100));
+	const constrainedPlain = constrained.map(stripVTControlCharacters);
+	assert.ok(constrainedPlain.length <= terminal.rows - 3);
+	assert.notEqual(constrainedPlain[0], "─".repeat(100));
+	assert.notEqual(constrainedPlain.at(-1), "─".repeat(100));
+	assert.match(constrainedPlain.join("\n"), /[→›]\s+Codex Fast mode/u);
+});
+
 test("Ctrl+C hard-cancels Settings before conflicting configurable actions", async (t) => {
 	const settings = memorySettingsRuntime();
 	let applied = 0;


### PR DESCRIPTION
## Summary

- render the pi-usage Settings frame only when both rule rows fit the live terminal budget
- compact overflowing unframed content to that budget while always retaining the selected setting
- cover tall, narrow 12-row, and one-row component budgets
- follow up on the resolved row-budget feedback from #1188

## Verification

- `npx vitest run packages/pi-usage/test/usage.test.ts` (49 tests)
- `npm --workspace @narumitw/pi-usage run check`
- `npm run check`
- `npm test` (3,479 tests)
- `npm run package:pack -- usage`
- `pi --no-extensions --no-skills --offline -e ./packages/pi-usage --list-models`

## Semantic audit

- rendering uses the live `tui.terminal.rows - 3` component budget, omits rules when needed, and prioritizes the selected setting during compaction
- settings read/write ordering, rollback, unknown-field preservation, and invalid-file protection are unchanged
- cancellation, disposal, lazy-import ownership revalidation, and remapped keybindings remain covered