### PR TITLE
docs: clarify settings documentation ownership

### DIFF
--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -327,8 +327,10 @@ restore the latest remaining activity rather than letting one completion clear i
 [`docs/readme-conventions.md`](readme-conventions.md) owns the shared structure, labels, applicability rules, and verification checklist for active package READMEs.
 
 Package READMEs **SHOULD** remain practical and scannable: capabilities, installation, usage,
-commands/tools/settings, operational behavior, package layout, keywords, and license. Apply these
-shared presentation conventions:
+commands/tools/settings, operational behavior, package layout, keywords, and license. Keep complex
+configuration details in package-owned documentation or a bundled package-owned skill when that is
+more practical, while the README retains the entry point, minimal example, essential behavior, and
+access instructions. Apply these shared presentation conventions:
 
 - Write user-facing prose in English and retain the package's emoji title plus npm, Pi extension, and
   license badges.
@@ -343,8 +345,9 @@ shared presentation conventions:
   compatibility is actually guaranteed.
 
 Document the applicable persistent npm install, temporary npm execution, and local checkout commands.
-Include security, privacy, precedence, persistence, failure, or lifecycle details when users need them
-to use the extension safely.
+Keep security, privacy, and other information users need before installation or enablement in the
+README. Put additional precedence, persistence, failure, or lifecycle details in the README or its
+linked package-owned guidance when users need them to use the extension safely.
 
 - **MUST:** Add or update deterministic tests for changed behavior when practical; when a behavior
   requires a real Pi runtime or external service, record and run the smallest representative smoke

--- a/docs/extension-settings.md
+++ b/docs/extension-settings.md
@@ -197,7 +197,11 @@ defaults -> user settings -> trusted project overrides -> explicit runtime overr
 - Return or retain storage errors for the command, lifecycle, or UI layer to report through a
   mode-appropriate channel; do not print from the persistence helper.
 - Reload settings on `session_start`, including starts caused by `/reload` and session replacement.
-- Document defaults, precedence, paths, reload behavior, and accepted values in the package README.
+- Document defaults, precedence, paths, reload behavior, and accepted values in package-owned
+  guidance. The detailed guidance may live in the package README, package-owned documentation, or a
+  bundled package-owned skill. Keep the README's Settings section aligned with
+  [`docs/readme-conventions.md`](readme-conventions.md), including access instructions when the
+  detailed guidance lives elsewhere.
 
 For a filename migration, prefer the canonical file when both names exist. Validate legacy content,
 copy its original JSON bytes to the canonical path, install it without overwriting a concurrently
@@ -222,8 +226,9 @@ created canonical file, and remove the legacy file only after confirming it did 
 `ctx.ui.custom()` is TUI-only. In print, JSON, and RPC modes, the Settings action and any justified
 direct settings route must not attempt to open the interactive screen. RPC mode may use
 `ctx.ui.notify()` to provide the active settings path. Do not write ad hoc output that would corrupt
-JSON protocol output. Keep settings paths and manual instructions available through the package
-README and any supported Status or Help route.
+JSON protocol output. Keep the settings entry point and access instructions available through the
+package README and any supported Status or Help route. Detailed manual instructions may live in the
+linked package-owned guidance.
 
 ## Verification
 

--- a/docs/readme-conventions.md
+++ b/docs/readme-conventions.md
@@ -29,7 +29,7 @@ Use these exact labels when the subject applies:
 - `## 🚀 Quick start` for the shortest successful first use.
 - `## 💬 Commands` for user-facing slash commands.
 - `## 🛠️ Tools` for tools registered for the model.
-- `## ⚙️ Settings` for configuration sources, defaults, precedence, persistence, and interactive settings.
+- `## ⚙️ Settings` for configuration entry points, minimal examples, essential defaults or safety behavior, and links to detailed guidance.
 - `## 🔒 Security and privacy` for permissions, credentials, external data, or other material trust boundaries.
 - `## 🚧 Limitations` for known unsupported behavior and important constraints.
 - `## 🗂️ Package layout` for the package's maintained source and publication structure.
@@ -63,9 +63,14 @@ Treat model IDs, paths, session text, and pasted text shown in examples as untru
 Use stable absolute GitHub and npm links when referring to another package in this monorepo.
 Describe borrowed syntax as inspired by another project unless compatibility is guaranteed.
 
+Keep Settings sections focused on the configuration entry points, a minimal example, and essential default or safety behavior.
+Detailed configuration guidance may live in package-owned documentation or a package-owned skill bundled with the package.
+When it does, the README must identify that source and explain how to access it instead of duplicating the complete configuration reference.
+
 Installation instructions must state that extensions run with Pi's permissions when that warning is material to the package's install flow.
 Build-backed packages must explain that an unbuilt local checkout needs its build before package-directory loading.
-Document security, privacy, precedence, persistence, failure, cancellation, recovery, or lifecycle behavior when users need it for safe operation.
+Keep security, privacy, and other information that users must understand before installing or enabling the package in the README.
+Document additional precedence, persistence, failure, cancellation, recovery, or lifecycle behavior in the README or its linked package-owned guidance when users need it for safe operation.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- focus README Settings sections on entry points, minimal examples, and essential behavior
- allow detailed configuration guidance to live in package-owned documentation or a bundled package-owned skill
- align the README, extension, and settings conventions while keeping pre-installation security and privacy information in the README

## Verification

- fenced-code-aware heading audit for all 29 active package READMEs
- `npm run check`
- `npm test` (349 files, 3,483 tests)

Package pack and Pi runtime smokes were not applicable because this changes documentation conventions only.
