### PR TITLE
fix(pi-goal): session-chrome tools must not reset no-progress

### DIFF
--- a/packages/pi-goal/CHANGELOG.md
+++ b/packages/pi-goal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @narumitw/pi-goal
 
+## Unreleased
+
+### Patch Changes
+
+- Treat session-chrome tool calls (no `path`, no `command`) as no-progress even when assistant text paraphrases. Workspace tools still reset the guard. Optional `progressTools` / `chromeTools` lists are exceptions only.
+
 ## 0.54.4
 
 ### Patch Changes

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -113,11 +113,14 @@ Reload, replacement, and shutdown clear that in-memory ownership.
   Pi may invoke a provider adapter once more with an already-aborted signal to produce its synthetic terminal event; that event is not counted and cannot resume Goal work.
   Set this field explicitly to `null` to opt into Unlimited mode; existing explicit `null` values remain compatible.
 - `noProgressTurns` is a positive safe integer and defaults to `3`.
-  At the end of an automatic run, pi-goal compares visible assistant text after Unicode normalization, lowercase conversion, control-character removal, and whitespace collapse.
+  At the end of an automatic run, pi-goal classifies the turn's tools before looking at text.
+  Workspace work (`read` / `write` / `edit` / `bash` / `grep` / `find` / `ls` / `subagent`, or any call with a `path` or `command` argument) resets the repeat count.
+  Session-chrome calls (no `path`, no `command`) increment it even when the visible pep talk changes, so a checkbox/overlay loop cannot reset the guard.
+  Tool-free runs still compare visible assistant text after Unicode normalization, lowercase conversion, control-character removal, and whitespace collapse.
   Thinking and tool blocks are excluded; empty and punctuation-only output are equivalent.
-  Consecutive empty or identical tool-free outputs increment the repeat count.
-  Different non-empty output starts a new run at one, and any attempted tool call resets it.
-  Set this field to `null` to disable only this heuristic.
+  Consecutive empty or identical tool-free outputs increment the repeat count; different non-empty tool-free output starts a new run at one.
+  Optional `continuationLimits.progressTools` / `chromeTools` string lists are exceptions only.
+  Set `noProgressTurns` to `null` to disable only this heuristic.
 
 Settings are reread at Pi startup, session replacement, and `/reload`.
 Direct file edits are not watched, while Goal-menu changes apply immediately.

--- a/packages/pi-goal/src/lifecycle.ts
+++ b/packages/pi-goal/src/lifecycle.ts
@@ -25,7 +25,7 @@ import {
 	transitionGoal,
 	truncateNotification,
 } from "./runtime.js";
-import { hasAssistantToolCall } from "./safety.js";
+import { hasWorkspaceToolCall, isWorkspaceToolCall } from "./safety.js";
 import { DEFAULT_GOAL_SETTINGS, readGoalSettings } from "./settings.js";
 
 const REMOVED_QUEUE_SETTING_WARNING =
@@ -344,7 +344,14 @@ export function registerGoalLifecycle(
 	});
 
 	pi.on("tool_call", (event, ctx) => {
-		runtime.markAgentToolAttempted();
+		if (
+			isWorkspaceToolCall(event.toolName, event.input, {
+				progressTools: runtime.settings.continuationLimits.progressTools,
+				chromeTools: runtime.settings.continuationLimits.chromeTools,
+			})
+		) {
+			runtime.markAgentToolAttempted();
+		}
 		if (
 			runtime.activeGoal?.status === "budget_limited" &&
 			runtime.budgetWrapUp?.goalId === runtime.activeGoal.id &&
@@ -565,7 +572,11 @@ export function registerGoalLifecycle(
 				ctx,
 				goalId,
 				event.messages,
-				run.toolAttempted || hasAssistantToolCall(event.messages),
+				run.toolAttempted ||
+					hasWorkspaceToolCall(event.messages, {
+						progressTools: runtime.settings.continuationLimits.progressTools,
+						chromeTools: runtime.settings.continuationLimits.chromeTools,
+					}),
 			)
 		) {
 			return;

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -812,7 +812,10 @@ export class GoalRuntime {
 	) {
 		const goal = this.activeGoal;
 		if (goal?.id !== goalId || goal.status !== "active") return false;
-		const next = nextToolFreeRepeatState(goal, messages, toolAttempted);
+		const next = nextToolFreeRepeatState(goal, messages, toolAttempted, {
+			progressTools: this.settings.continuationLimits.progressTools,
+			chromeTools: this.settings.continuationLimits.chromeTools,
+		});
 		goal.toolFreeRepeatCount = next.toolFreeRepeatCount;
 		goal.lastToolFreeOutputFingerprint = next.lastToolFreeOutputFingerprint;
 		this.persistGoal(goal);

--- a/packages/pi-goal/src/safety.ts
+++ b/packages/pi-goal/src/safety.ts
@@ -21,13 +21,84 @@ export function resetGoalSafetyEpoch(goal: ActiveGoal): ActiveGoal {
 	};
 }
 
+/** Built-in tools that inspect or change the workspace. Not a product denylist. */
+export const WORKSPACE_TOOL_NAMES = new Set([
+	"read",
+	"write",
+	"edit",
+	"bash",
+	"grep",
+	"find",
+	"ls",
+	"subagent",
+]);
+
+export interface ToolProgressOptions {
+	progressTools?: readonly string[];
+	chromeTools?: readonly string[];
+}
+
+export type AssistantToolClass = "none" | "chrome" | "progress";
+
+function stringArg(input: unknown, key: string): string {
+	if (!isRecord(input)) return "";
+	const value = input[key];
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function nameSet(names: readonly string[] | undefined): Set<string> {
+	return new Set((names ?? []).map((name) => name.trim()).filter(Boolean));
+}
+
+/** True when this call is workspace (or user-listed progress) work, not session chrome. */
+export function isWorkspaceToolCall(
+	name: string,
+	input: unknown,
+	opts: ToolProgressOptions = {},
+): boolean {
+	const toolName = (name ?? "").trim();
+	if (!toolName) return false;
+	if (nameSet(opts.chromeTools).has(toolName)) return false;
+	if (nameSet(opts.progressTools).has(toolName)) return true;
+	if (WORKSPACE_TOOL_NAMES.has(toolName)) return true;
+	return Boolean(stringArg(input, "path") || stringArg(input, "command"));
+}
+
+export function classifyAssistantTools(
+	messages: readonly unknown[],
+	opts: ToolProgressOptions = {},
+): AssistantToolClass {
+	let sawTool = false;
+	for (const message of messages) {
+		if (!isRecord(message) || message.role !== "assistant" || !Array.isArray(message.content)) {
+			continue;
+		}
+		for (const block of message.content) {
+			if (!isRecord(block) || block.type !== "toolCall") continue;
+			sawTool = true;
+			const name = typeof block.name === "string" ? block.name : "";
+			const input = block.arguments ?? block.input;
+			if (isWorkspaceToolCall(name, input, opts)) return "progress";
+		}
+	}
+	return sawTool ? "chrome" : "none";
+}
+
 export function nextToolFreeRepeatState(
 	current: ToolFreeRepeatState,
 	messages: readonly unknown[],
 	toolAttempted: boolean,
+	opts: ToolProgressOptions = {},
 ): ToolFreeRepeatState {
-	if (toolAttempted) return { toolFreeRepeatCount: 0 };
+	const kind = classifyAssistantTools(messages, opts);
+	if (toolAttempted || kind === "progress") return { toolFreeRepeatCount: 0 };
 	const fingerprint = fingerprintVisibleAssistantOutput(messages);
+	if (kind === "chrome") {
+		return {
+			toolFreeRepeatCount: Math.min(Number.MAX_SAFE_INTEGER, current.toolFreeRepeatCount + 1),
+			lastToolFreeOutputFingerprint: fingerprint,
+		};
+	}
 	return {
 		toolFreeRepeatCount:
 			fingerprint === current.lastToolFreeOutputFingerprint
@@ -38,13 +109,11 @@ export function nextToolFreeRepeatState(
 }
 
 export function hasAssistantToolCall(messages: readonly unknown[]) {
-	for (const message of messages) {
-		if (!isRecord(message) || message.role !== "assistant" || !Array.isArray(message.content)) {
-			continue;
-		}
-		if (message.content.some((block) => isRecord(block) && block.type === "toolCall")) return true;
-	}
-	return false;
+	return classifyAssistantTools(messages) !== "none";
+}
+
+export function hasWorkspaceToolCall(messages: readonly unknown[], opts: ToolProgressOptions = {}) {
+	return classifyAssistantTools(messages, opts) === "progress";
 }
 
 export function fingerprintVisibleAssistantOutput(messages: readonly unknown[]) {

--- a/packages/pi-goal/src/settings.ts
+++ b/packages/pi-goal/src/settings.ts
@@ -14,6 +14,8 @@ export interface GoalSettings {
 	continuationLimits: {
 		automaticTurns: ContinuationLimit;
 		noProgressTurns: ContinuationLimit;
+		progressTools?: string[];
+		chromeTools?: string[];
 	};
 }
 
@@ -76,11 +78,30 @@ export function normalizeGoalSettings(value: unknown): GoalSettings | undefined 
 			)
 		: DEFAULT_GOAL_SETTINGS.continuationLimits.noProgressTurns;
 	if (automaticTurns === undefined || noProgressTurns === undefined) return undefined;
+	const progressTools = continuationLimitsValue
+		? normalizeToolNameList(Reflect.get(continuationLimitsValue, "progressTools"))
+		: undefined;
+	const chromeTools = continuationLimitsValue
+		? normalizeToolNameList(Reflect.get(continuationLimitsValue, "chromeTools"))
+		: undefined;
+	if (progressTools === false || chromeTools === false) return undefined;
 
 	return {
 		rpc: { enabled: rpcEnabled },
-		continuationLimits: { automaticTurns, noProgressTurns },
+		continuationLimits: {
+			automaticTurns,
+			noProgressTurns,
+			...(progressTools ? { progressTools } : {}),
+			...(chromeTools ? { chromeTools } : {}),
+		},
 	};
+}
+
+function normalizeToolNameList(value: unknown): string[] | undefined | false {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) return false;
+	const names = value.map((entry) => entry.trim()).filter(Boolean);
+	return names;
 }
 
 function normalizeContinuationLimit(
@@ -124,6 +145,12 @@ export function saveGoalSettings(
 				...continuationLimits,
 				automaticTurns: normalized.continuationLimits.automaticTurns,
 				noProgressTurns: normalized.continuationLimits.noProgressTurns,
+				...(normalized.continuationLimits.progressTools
+					? { progressTools: normalized.continuationLimits.progressTools }
+					: {}),
+				...(normalized.continuationLimits.chromeTools
+					? { chromeTools: normalized.continuationLimits.chromeTools }
+					: {}),
 			},
 		},
 		null,

--- a/packages/pi-goal/test/goal-safety.test.ts
+++ b/packages/pi-goal/test/goal-safety.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+	classifyAssistantTools,
 	fingerprintVisibleAssistantOutput,
 	hasAssistantToolCall,
+	isWorkspaceToolCall,
 	nextToolFreeRepeatState,
 	normalizeVisibleAssistantOutput,
 } from "../src/safety.js";
@@ -12,6 +14,7 @@ import {
 	ONE_TURN_LIMIT_SETTINGS_PATH,
 	requireLastGoal,
 	startGoalForTest,
+	UNLIMITED_SETTINGS_PATH,
 } from "./support/goal-fixture.js";
 
 test("no-progress classifier normalizes visible output conservatively", () => {
@@ -68,6 +71,67 @@ test("no-progress classifier normalizes visible output conservatively", () => {
 	assert.equal(state.toolFreeRepeatCount, 1);
 	state = nextToolFreeRepeatState(state, blank, true);
 	assert.deepEqual(state, { toolFreeRepeatCount: 0 });
+
+	assert.equal(isWorkspaceToolCall("read", { path: "src/a.ts" }), true);
+	assert.equal(isWorkspaceToolCall("bash", { command: "npm test" }), true);
+	assert.equal(isWorkspaceToolCall("scratch_board", { action: "update" }), false);
+	assert.equal(isWorkspaceToolCall("overlay_tick", {}), false);
+	assert.equal(
+		isWorkspaceToolCall("custom_ui", { path: "x" }, { chromeTools: ["custom_ui"] }),
+		false,
+	);
+	assert.equal(isWorkspaceToolCall("my_deploy", {}, { progressTools: ["my_deploy"] }), true);
+	assert.equal(
+		classifyAssistantTools([
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", name: "scratch_board", arguments: { id: 1 } }],
+			},
+		]),
+		"chrome",
+	);
+	assert.equal(
+		classifyAssistantTools([
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", name: "read", arguments: { path: "a.ts" } }],
+			},
+		]),
+		"progress",
+	);
+	let chromeState = { toolFreeRepeatCount: 0 };
+	chromeState = nextToolFreeRepeatState(
+		chromeState,
+		[
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "step 1 is the gate" },
+					{ type: "toolCall", name: "scratch_board", arguments: { action: "update" } },
+				],
+			},
+		],
+		false,
+	);
+	assert.equal(chromeState.toolFreeRepeatCount, 1);
+	chromeState = nextToolFreeRepeatState(
+		chromeState,
+		[
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "step 1 still owns this" },
+					{ type: "toolCall", name: "overlay_tick", arguments: {} },
+				],
+			},
+		],
+		false,
+	);
+	assert.equal(
+		chromeState.toolFreeRepeatCount,
+		2,
+		"chrome-only paraphrases must increment even when visible text changes",
+	);
 });
 
 test("assistant toolCall blocks reset no-progress even when tool_call hook never fires", async () => {
@@ -99,7 +163,7 @@ test("assistant toolCall blocks reset no-progress even when tool_call hook never
 				{
 					role: "assistant",
 					stopReason: "toolUse",
-					content: [{ type: "toolCall", name: "unknown", arguments: {} }],
+					content: [{ type: "toolCall", name: "read", arguments: { path: "src/a.ts" } }],
 				},
 			],
 		},
@@ -880,6 +944,90 @@ test("queued non-goal follow-up does not inherit automatic recovery ownership", 
 	);
 	await active.mock.events.get("agent_settled")?.[0]?.({}, active.ctx);
 	assert.equal(active.mock.sentUserMessages.length, 3);
+});
+
+/** Session-chrome: no path, no command. Names must not matter (not `todo`). */
+function chromeOnlyAssistant(text: string, toolName: string, args: Record<string, unknown>) {
+	return {
+		role: "assistant" as const,
+		stopReason: "toolUse" as const,
+		content: [
+			{ type: "text", text },
+			{ type: "toolCall", name: toolName, arguments: args },
+		],
+	};
+}
+
+test("session-chrome automatic runs with paraphrased text still trip no-progress", async () => {
+	const stalled = await startGoalForTest({}, "close remaining Xid holes", UNLIMITED_SETTINGS_PATH);
+	await stalled.mock.events.get("agent_end")?.[0]?.(
+		{
+			messages: [
+				{
+					role: "assistant",
+					stopReason: "stop",
+					content: [{ type: "text", text: "starting" }],
+				},
+			],
+		},
+		stalled.ctx,
+	);
+	await stalled.mock.events.get("agent_settled")?.[0]?.({}, stalled.ctx);
+
+	const chromeTurns = [
+		{
+			text: "Step 1 is still the gate: hashing and block-submit must never overlap.",
+			toolName: "scratch_board",
+			input: { action: "update", id: 1, status: "in_progress" },
+		},
+		{
+			text: "Step 1 still owns this: I'll close remaining SIGTERM holes.",
+			toolName: "session_flags",
+			input: { flag: "working" },
+		},
+		{
+			text: "Continuing the goal. Step 1 remains incomplete.",
+			toolName: "overlay_tick",
+			input: {},
+		},
+	];
+	for (const [i, turn] of chromeTurns.entries()) {
+		const prompt = stalled.mock.sentUserMessages.at(-1)?.text ?? "";
+		stalled.mock.events.get("before_agent_start")?.[0]?.(
+			{ prompt, systemPrompt: "base" },
+			stalled.ctx,
+		);
+		stalled.mock.events.get("tool_call")?.[0]?.(
+			{
+				toolName: turn.toolName,
+				toolCallId: `chrome-${i + 1}`,
+				input: turn.input,
+			},
+			stalled.ctx,
+		);
+		await stalled.mock.events.get("agent_end")?.[0]?.(
+			{ messages: [chromeOnlyAssistant(turn.text, turn.toolName, turn.input)] },
+			stalled.ctx,
+		);
+		await stalled.mock.events.get("agent_settled")?.[0]?.({}, stalled.ctx);
+	}
+
+	const stopped = requireLastGoal(stalled.mock);
+	assert.equal(
+		stopped.status,
+		"paused",
+		"chrome-only continuations (no path, no command) must not reset no-progress, regardless of tool name",
+	);
+	assert.equal(stopped.safetyPauseCause, "no_progress");
+	assert.ok(
+		(stopped.toolFreeRepeatCount ?? 0) >= 3,
+		`expected no-progress count >= 3, got ${stopped.toolFreeRepeatCount}`,
+	);
+	assert.equal(
+		stalled.mock.sentUserMessages.length,
+		4,
+		"must not keep injecting Continue the active /goal after three chrome-only runs",
+	);
 });
 
 test("three blank automatic runs pause for no progress without a fourth continuation", async () => {


### PR DESCRIPTION
Fixes https://github.com/narumiruna/pi-extensions/issues/1199

## Problem

`noProgressTurns` resets on **any** tool call (`if (toolAttempted) return 0`) and tool-free runs restart when visible text changes. A paraphrased checkbox/overlay loop therefore never pauses (inverse of #338).

## Change

Classify calls by **shape**, not product name:

- Workspace: built-in read/write/edit/bash/grep/find/ls/subagent, or args with `path`/`command` → reset
- Chrome: any other call (no path, no command) → increment even if the pep talk changes
- No tools: existing identical-text logic from #338

Optional settings exceptions only: `continuationLimits.progressTools` / `chromeTools`.

## Test

Vanilla `packages/pi-goal` only:

```bash
npx vitest run packages/pi-goal/test/goal-safety.test.ts -t "session-chrome automatic"
```

Red on 0.54.4 (`active`); green with this patch (`paused` / `no_progress`). Three chrome tool names, none of them `todo`.
