### PR TITLE
test(sync): cover setup reviews and credential preservation

### DIFF
--- a/packages/pi-sync/test/git-ui.test.ts
+++ b/packages/pi-sync/test/git-ui.test.ts
@@ -15,7 +15,39 @@ import {
 	showEditGitTarget,
 	showGitSetup,
 } from "../src/git-ui.js";
+import { showStorageConnections } from "../src/storage-connections-ui.js";
 import { v3S3Settings, withTempHome } from "./helpers.js";
+
+for (const remote of [
+	"git@github.com:owner-a/pi-sync.git",
+	"git@github.com:owner-b/another-repo.git",
+	"ssh://git@github.com/owner-a/pi-sync.git",
+	"https://github.com/owner-a/pi-sync.git",
+]) {
+	test(`storage connection review preserves the exact Git repository ${remote}`, async () => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			const settings = v3S3Settings();
+			Object.assign(settings.storageConnections, { git: { type: "git", remote } });
+			const before = JSON.stringify(settings);
+			writeFileSync(localConfigPath(), before, { mode: 0o600 });
+			const choices = ["git", "Back"];
+			const reviews: string[] = [];
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "rpc",
+				select: async (title: string) => {
+					reviews.push(title);
+					return choices.shift();
+				},
+			});
+			await showStorageConnections(ctx);
+			assert.ok(reviews.some((review) => review.includes(`Endpoint: ${remote}`)));
+			assert.deepEqual(notifications, []);
+			assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+		});
+	});
+}
 
 test("first Git setup writes the exact version 3 connection and setup shapes", async () => {
 	await withTempHome(async (agentDir) => {

--- a/packages/pi-sync/test/s3-credentials-ui.test.ts
+++ b/packages/pi-sync/test/s3-credentials-ui.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { localConfigPath, readLocalConfigObject } from "../src/config.js";
+import { v3S3Settings, withTempHome } from "./helpers.js";
+
+const credentials = {
+	accessKeyId: "temporary-access-id",
+	secretAccessKey: "temporary-secret-key",
+	sessionToken: "temporary-session-token",
+};
+
+test("keeping S3 credentials preserves the session token and unknown fields", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		const { showStorageConnections } = await import("../src/storage-connections-ui.js");
+		const settings = v3S3Settings();
+		Object.assign(settings.storageConnections.r2.credentials, credentials, { future: "preserved" });
+		writeFileSync(localConfigPath(), JSON.stringify(settings), { mode: 0o600 });
+		const choices = [
+			"r2",
+			"Edit storage connection…",
+			"Keep current credentials",
+			"Save storage connection",
+			"Back",
+		];
+		let secretPrompts = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async (title: string) => (title === "Endpoint" ? "https://new.example.com" : "auto"),
+			select: async () => choices.shift(),
+			custom: async () => {
+				secretPrompts += 1;
+				return undefined;
+			},
+		});
+		await showStorageConnections(ctx);
+		assert.equal(secretPrompts, 0);
+		const saved = await readLocalConfigObject();
+		assert.deepEqual(saved?.storageConnections.r2.credentials, {
+			...credentials,
+			future: "preserved",
+		});
+		assert.equal(saved?.storageConnections.r2.endpoint, "https://new.example.com");
+		assert.ok(notifications.some(({ message }) => message.includes("Saved storage connection")));
+		assert.ok(notifications.every(({ level }) => level !== "error"));
+	});
+});

--- a/packages/pi-sync/test/setup-review.test.ts
+++ b/packages/pi-sync/test/setup-review.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { loadConfig, localConfigPath } from "../src/config.js";
+import { saveOnSwitch, useSyncSetup } from "../src/setup-switch.js";
+import { showSyncSetups } from "../src/sync-setups-ui.js";
+import { v3S3Settings, withTempHome } from "./helpers.js";
+
+for (const url of [
+	"https://cloud.example.com/dav/owner-a/",
+	"https://cloud.example.com/dav/owner-b/",
+]) {
+	test(`saved WebDAV setup detail exposes the exact collection ${url} without writes`, async () => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			const settings = v3S3Settings();
+			Object.assign(settings.storageConnections, {
+				dav: {
+					type: "webdav",
+					url,
+					credentials: { username: "user", password: "private-password" },
+				},
+			});
+			Object.assign(settings.syncSetups, {
+				work: {
+					storage: { connection: "dav", path: "pi-sync/work" },
+					sync: { include: ["settings.json"], automatic: false },
+				},
+			});
+			const before = JSON.stringify(settings);
+			writeFileSync(localConfigPath(), before, { mode: 0o600 });
+			const { showSyncManager } = await import("../src/manager-ui.js");
+			const choices = ["More…", "Sync setups…", "work"];
+			const frames: string[] = [];
+			const routes: string[] = [];
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "rpc",
+				select: async (title: string) => {
+					frames.push(title);
+					return choices.shift();
+				},
+			});
+			await showSyncManager(ctx, async (route) => {
+				routes.push(route);
+			});
+			assert.ok(frames.some((frame) => frame.includes(`Endpoint: ${url}`)));
+			assert.ok(frames.some((frame) => frame.includes("Storage location: WebDAV · pi-sync/work")));
+			assert.doesNotMatch(frames.join("\n"), /private-password/u);
+			assert.deepEqual(routes, []);
+			assert.deepEqual(notifications, []);
+			assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+		});
+	});
+}
+
+for (const originalPolicy of ["switch-only", "ask-before-pull", "pull-after-switch"]) {
+	test(`switch-only selection replaces ${originalPolicy} without pulling`, async () => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			const settings = v3S3Settings();
+			settings.onSwitch = originalPolicy;
+			Object.assign(settings.syncSetups, {
+				work: {
+					storage: { connection: "r2", bucket: "work-bucket", path: "pi-sync/work" },
+					sync: { include: ["settings.json"], automatic: false },
+				},
+			});
+			writeFileSync(localConfigPath(), JSON.stringify(settings), { mode: 0o600 });
+			assert.equal((await loadConfig()).setupName, "home");
+			assert.equal((await loadConfig("work")).setupName, "work");
+			const { ctx, notifications } = createMockContext({ hasUI: true, mode: "rpc" });
+			await saveOnSwitch("switch-only");
+			let pulls = 0;
+			await useSyncSetup(ctx, "work", async () => {
+				pulls += 1;
+				return "applied";
+			});
+			assert.equal(pulls, 0);
+			assert.equal((await loadConfig()).setupName, "work");
+			const { default: sync } = await import("../src/sync.js");
+			const mock = createMockPi();
+			sync(mock.pi);
+			await mock.commands.get("sync")?.handler("config", ctx);
+			assert.ok(notifications.some(({ message }) => message.includes("sync setup: work")));
+			const selections: string[][] = [];
+			const menuContext = createMockContext({
+				hasUI: true,
+				mode: "rpc",
+				select: async (_title: string, options: string[]) => {
+					selections.push(options);
+					return undefined;
+				},
+			});
+			await showSyncSetups(menuContext.ctx, {
+				add: async () => undefined,
+				edit: async () => undefined,
+				makeCurrent: async () => undefined,
+				remove: async () => undefined,
+			});
+			assert.ok(selections[0]?.includes("work (current)"));
+		});
+	});
+}

--- a/packages/pi-sync/test/sync-resolution-ui.test.ts
+++ b/packages/pi-sync/test/sync-resolution-ui.test.ts
@@ -20,6 +20,32 @@ import { v3S3Settings, withTempHome } from "./helpers.js";
 
 initTheme("dark", false);
 
+for (const direction of ["push", "pull"] as const) {
+	test(`manager preserves an explicit ${direction} direction through conflict resolution`, async () => {
+		await withConfiguredDecision(async (decision) => {
+			const choices = [
+				"More…",
+				direction === "push" ? "Push to remote…" : "Pull from remote…",
+				direction === "push"
+					? "Keep local content and replace remote…"
+					: "Use remote content and replace local…",
+			];
+			const routes: string[] = [];
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "rpc",
+				select: async () => choices.shift(),
+			});
+			await showSyncManager(ctx, async (route) => {
+				routes.push(route);
+				if (route === direction) return { kind: "decision-required", decision };
+				return { kind: "completed", outcome: "applied" };
+			});
+			assert.deepEqual(routes, [direction, `${direction} --force`]);
+		});
+	});
+}
+
 test("resolution reviews exact differences and invokes local-wins push through the captured setup", async () => {
 	await withConfiguredDecision(async (decision) => {
 		const tui = createTuiHarness({ width: 60, rows: 18 });


### PR DESCRIPTION
## Summary

Extract 12 independently useful regression tests from #1196 onto `main`, without its skill or runtime changes. The original commits mixed tests with implementation, so this PR transplants selected test changes rather than cherry-picking those commits wholesale.

Coverage includes exact Git repository and saved WebDAV collection reviews, explicit push/pull direction through manager conflict resolution, switching the current setup without pulling, and preserving existing S3 session tokens and unknown credential fields while editing an endpoint. Assertions verify unchanged settings for read-only flows and successful saves for credential preservation.

Only four files under `packages/pi-sync/test/` change. No package metadata, dependencies, skills, runtime behavior, or automatic-sync defaults change. Tests depending on the new temporary-token entry flow, changed automatic-sync defaults, or removed setup skill remain out of scope. The original branch and its uncommitted skill deletion are untouched.

## Verification

- Focused Vitest run: 4 files / 32 tests passed, including all 12 extracted tests.
- `npm run check`: passed (build, Biome, boundaries, workspace typechecks).
- `npm test`: passed, 352 files / 3,503 tests.
- `git diff --check` and staged precommit checks: passed.
- Reviewed against `docs/extension-conventions.md` and `docs/extension-settings.md`: tests exercise existing APIs, keep temporary settings isolated, capture UI evidence before assertions, and do not contact live backends.

No Changeset, pack, or live Pi smoke is needed for this test-only extraction; no published behavior or runtime-loading boundary changes. Existing lifecycle, cancellation, persistence, and loader tests pass in the full suite.
