### PR TITLE
fix(lsp): drain session-owned client lifetimes

### DIFF
--- a/.changeset/tidy-lsp-lifetimes.md
+++ b/.changeset/tidy-lsp-lifetimes.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-lsp": patch
+---
+
+Cancel and drain session-owned LSP calls during shutdown and reload, including partially initialized servers. Keep resource cleanup independent of status UI failures, preserve original operation errors, and prevent cancelled continuations from writing fixes or starting another diagnostics route. Share client lifetime handling between diagnostics and fixes.

--- a/packages/pi-lsp/README.md
+++ b/packages/pi-lsp/README.md
@@ -127,6 +127,16 @@ Parameters:
   Defaults to false.
 - `server?`: optional configured server name.
 
+## 🛑 Cancellation and shutdown
+
+Cancellation stops the current server and prevents further diagnostics routes or fix writes once observed.
+Session shutdown, replacement, and reload cancel and await all LSP calls owned by that session before teardown completes, including partially initialized servers.
+Other sessions retain their own calls, even when they share a headless UI.
+A completed write is not rolled back if cancellation arrives during subsequent server shutdown.
+
+Status cleanup is best effort and cannot bypass process cleanup or replace an operation's result or error.
+A server-cleanup failure is reported when there is no earlier operation failure.
+
 ## 💬 Commands
 
 Run `/lsp` to show configured LSP commands and their availability on `PATH` in TUI or RPC mode.
@@ -147,6 +157,9 @@ A server process inherits Pi's environment and receives any `servers[].env` over
 - The tools provide diagnostics and source code actions, not symbol navigation, references, or semantic rename.
 - A clean LSP result does not replace the repository's formatter, linter, type checker, build, or tests.
 - This project has not demonstrated through benchmarks that LSP improves agent task success, latency, or tool use.
+- Overlapping calls share one activity status; one completion can clear another call's indicator.
+- Fix writes do not participate in Pi's shared file-mutation queue. Avoid concurrent edits to the same file.
+- Diagnostics and fix previews are returned in full without an output-size bound. Keep requests targeted.
 
 This guidance is informed by [Eric Traut's comment on LSP integration for coding agents](https://github.com/openai/codex/issues/8745#issuecomment-3713058579).
 The comment notes that repository-native checks may already provide much of the useful verification.

--- a/packages/pi-lsp/src/pi-lsp.ts
+++ b/packages/pi-lsp/src/pi-lsp.ts
@@ -4,7 +4,8 @@ import { consumeLspConfigNotice, loadRuntime } from "./adapters.js";
 import { commandExists, commandPathValue } from "./command.js";
 import { resolveRoot } from "./files.js";
 import { selectDiagnosticRoutes, selectFixRoute } from "./routes.js";
-import { DEFAULT_FILE_LIMIT, runDiagnostics, runFix, textResult } from "./runner.js";
+import { clearStatus, DEFAULT_FILE_LIMIT, runDiagnostics, runFix, textResult } from "./runner.js";
+import { LspSessionScope } from "./session-lifecycle.js";
 
 const STATUS_KEY = "lsp";
 
@@ -69,6 +70,7 @@ const lspDiagnosticsTool = defineTool({
 		);
 		const results = [];
 		for (const route of routes) {
+			signal?.throwIfAborted();
 			const result = await runDiagnostics(
 				route.adapter,
 				{ root, paths: params.paths, limit: params.limit, files: route.files },
@@ -77,6 +79,7 @@ const lspDiagnosticsTool = defineTool({
 				ctx,
 				STATUS_KEY,
 			);
+			signal?.throwIfAborted();
 			results.push({ route, result });
 		}
 
@@ -143,8 +146,34 @@ const lspFixTool = defineTool({
 });
 
 export default function lsp(pi: ExtensionAPI) {
-	pi.registerTool(lspDiagnosticsTool);
-	pi.registerTool(lspFixTool);
+	const sessions = new WeakMap<object, { scope: LspSessionScope; generation: number }>();
+	const sessionFor = (key: object) => {
+		let session = sessions.get(key);
+		if (!session) {
+			session = { scope: new LspSessionScope(), generation: 0 };
+			sessions.set(key, session);
+		}
+		return session;
+	};
+
+	pi.registerTool({
+		...lspDiagnosticsTool,
+		execute(id, params, signal, onUpdate, ctx) {
+			const { scope } = sessionFor(ctx.sessionManager);
+			return scope.run(signal, (ownedSignal) =>
+				lspDiagnosticsTool.execute(id, params, ownedSignal, onUpdate, scope.context(ctx)),
+			);
+		},
+	});
+	pi.registerTool({
+		...lspFixTool,
+		execute(id, params, signal, onUpdate, ctx) {
+			const { scope } = sessionFor(ctx.sessionManager);
+			return scope.run(signal, (ownedSignal) =>
+				lspFixTool.execute(id, params, ownedSignal, onUpdate, scope.context(ctx)),
+			);
+		},
+	});
 
 	pi.registerCommand("lsp", {
 		description: "Show shared LSP extension configuration",
@@ -162,8 +191,13 @@ export default function lsp(pi: ExtensionAPI) {
 		},
 	});
 
-	pi.on("session_start", (_event, ctx) => {
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+	pi.on("session_start", async (_event, ctx) => {
+		const session = sessionFor(ctx.sessionManager);
+		const generation = ++session.generation;
+		await session.scope.close();
+		if (generation !== session.generation) return;
+		session.scope = new LspSessionScope();
+		clearStatus(ctx, STATUS_KEY);
 		try {
 			loadRuntime(ctx.cwd, { projectTrusted: ctx.isProjectTrusted() });
 			const notice = consumeLspConfigNotice();
@@ -173,8 +207,12 @@ export default function lsp(pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("session_shutdown", (_event, ctx) => {
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+	pi.on("session_shutdown", async (_event, ctx) => {
+		const session = sessionFor(ctx.sessionManager);
+		session.generation++;
+		const drained = session.scope.close();
+		clearStatus(ctx, STATUS_KEY);
+		await drained;
 	});
 }
 

--- a/packages/pi-lsp/src/runner.ts
+++ b/packages/pi-lsp/src/runner.ts
@@ -22,6 +22,7 @@ export async function runDiagnostics(
 	ctx: StatusContext,
 	statusKey: string,
 ) {
+	throwIfAborted(signal, adapter);
 	const root = resolveRoot(params.root);
 	const command = adapter.defaultCommand;
 	const files =
@@ -36,48 +37,44 @@ export async function runDiagnostics(
 		});
 	}
 
-	const client = new LspClient(adapter, command, root, timeoutMs);
-	const abort = () => client.close();
-	throwIfAborted(signal, adapter);
-	signal?.addEventListener("abort", abort, { once: true });
+	return withLspClient(
+		adapter,
+		root,
+		timeoutMs,
+		signal,
+		ctx,
+		statusKey,
+		"diagnostics",
+		async (client) => {
+			const openedFiles: Array<{ file: string; uri: string }> = [];
+			try {
+				for (const file of files) {
+					throwIfAborted(signal, adapter);
+					const uri = pathToFileURL(file).href;
+					const text = readFileSync(file, "utf8");
+					client.didOpen(uri, text, adapter.languageIdFor(file));
+					openedFiles.push({ file, uri });
+				}
 
-	try {
-		ctx.ui.setStatus(statusKey, `${adapter.name} diagnostics`);
-		throwIfAborted(signal, adapter);
-		await client.start();
-		await client.initialize(root);
-
-		const openedFiles: Array<{ file: string; uri: string }> = [];
-		try {
-			for (const file of files) {
+				const entries: DiagnosticEntry[] = await Promise.all(
+					openedFiles.map(async ({ file, uri }) => ({
+						path: path.relative(root, file) || file,
+						uri,
+						diagnostics: await client.diagnostics(uri),
+					})),
+				);
 				throwIfAborted(signal, adapter);
-				const uri = pathToFileURL(file).href;
-				const text = readFileSync(file, "utf8");
-				client.didOpen(uri, text, adapter.languageIdFor(file));
-				openedFiles.push({ file, uri });
+				return textResult(formatDiagnostics(adapter, entries), {
+					root,
+					command,
+					files: entries,
+					summary: summarize(entries),
+				});
+			} finally {
+				for (const { uri } of openedFiles) client.didClose(uri);
 			}
-
-			const entries: DiagnosticEntry[] = await Promise.all(
-				openedFiles.map(async ({ file, uri }) => ({
-					path: path.relative(root, file) || file,
-					uri,
-					diagnostics: await client.diagnostics(uri),
-				})),
-			);
-			return textResult(formatDiagnostics(adapter, entries), {
-				root,
-				command,
-				files: entries,
-				summary: summarize(entries),
-			});
-		} finally {
-			for (const { uri } of openedFiles) client.didClose(uri);
-		}
-	} finally {
-		ctx.ui.setStatus(statusKey, undefined);
-		signal?.removeEventListener("abort", abort);
-		await client.shutdown();
-	}
+		},
+	);
 }
 
 export async function runFix(
@@ -92,18 +89,7 @@ export async function runFix(
 	const file = resolveSupportedFile(adapter, root, params.path);
 	const actionKind = params.kind?.trim() || "source.fixAll";
 
-	const command = adapter.defaultCommand;
-	const client = new LspClient(adapter, command, root, timeoutMs);
-	const abort = () => client.close();
-	throwIfAborted(signal, adapter);
-	signal?.addEventListener("abort", abort, { once: true });
-
-	try {
-		ctx.ui.setStatus(statusKey, `${adapter.name} fix`);
-		throwIfAborted(signal, adapter);
-		await client.start();
-		await client.initialize(root);
-		throwIfAborted(signal, adapter);
+	return withLspClient(adapter, root, timeoutMs, signal, ctx, statusKey, "fix", async (client) => {
 		const uri = pathToFileURL(file).href;
 		const text = readFileSync(file, "utf8");
 		client.didOpen(uri, text, adapter.languageIdFor(file));
@@ -113,8 +99,11 @@ export async function runFix(
 		let newText: string;
 		try {
 			const diagnostics = await client.diagnostics(uri);
+			throwIfAborted(signal, adapter);
 			const actions = await client.codeActions(uri, text, diagnostics, actionKind);
+			throwIfAborted(signal, adapter);
 			resolvedActions = await client.resolveActions(actions);
+			throwIfAborted(signal, adapter);
 			selectedActions = selectCodeActions(resolvedActions, actionKind);
 			edits = selectedActions.flatMap((action) => collectWorkspaceEdits(action.edit, uri));
 			if (hasOverlappingTextEdits(text, edits)) {
@@ -130,6 +119,7 @@ export async function runFix(
 		}
 		const changed = newText !== text;
 
+		throwIfAborted(signal, adapter);
 		if (params.write && changed) writeFileSync(file, newText);
 
 		return textResult(
@@ -146,10 +136,54 @@ export async function runFix(
 				text: params.write ? undefined : newText,
 			},
 		);
+	});
+}
+
+async function withLspClient<T>(
+	adapter: LspServerAdapter,
+	root: string,
+	timeoutMs: number,
+	signal: AbortSignal | undefined,
+	ctx: StatusContext,
+	statusKey: string,
+	activity: "diagnostics" | "fix",
+	operation: (client: LspClient) => Promise<T>,
+): Promise<T> {
+	throwIfAborted(signal, adapter);
+	const client = new LspClient(adapter, adapter.defaultCommand, root, timeoutMs);
+	const abort = () => client.close();
+	signal?.addEventListener("abort", abort, { once: true });
+	let cleanupFailure: { error: unknown } | undefined;
+	let result: T;
+	try {
+		ctx.ui.setStatus(statusKey, `${adapter.name} ${activity}`);
+		throwIfAborted(signal, adapter);
+		await client.start();
+		throwIfAborted(signal, adapter);
+		await client.initialize(root);
+		throwIfAborted(signal, adapter);
+		result = await operation(client);
 	} finally {
+		clearStatus(ctx, statusKey);
+		try {
+			await client.shutdown();
+		} catch (error) {
+			cleanupFailure = { error };
+		} finally {
+			signal?.removeEventListener("abort", abort);
+		}
+	}
+	// An operation rejection already propagates through finally and remains primary.
+	if (cleanupFailure) throw cleanupFailure.error;
+	throwIfAborted(signal, adapter);
+	return result;
+}
+
+export function clearStatus(ctx: StatusContext, statusKey: string) {
+	try {
 		ctx.ui.setStatus(statusKey, undefined);
-		signal?.removeEventListener("abort", abort);
-		await client.shutdown();
+	} catch {
+		// UI may be unavailable during teardown; it must never bypass resource cleanup.
 	}
 }
 

--- a/packages/pi-lsp/src/session-lifecycle.ts
+++ b/packages/pi-lsp/src/session-lifecycle.ts
@@ -1,0 +1,59 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+/** One session's complete tool invocations, including all diagnostics routes. */
+export class LspSessionScope {
+	#operations = new Map<AbortController, Promise<void>>();
+	#closing?: Promise<void>;
+
+	assertOpen() {
+		if (this.#closing) throw new Error("LSP session is closing; request aborted.");
+	}
+
+	context(ctx: ExtensionContext): ExtensionContext {
+		// Keep Pi's lazy context getters. Never reach an old UI getter once shutdown starts.
+		return Object.create(ctx, {
+			ui: {
+				get: () => {
+					this.assertOpen();
+					return ctx.ui;
+				},
+			},
+		});
+	}
+
+	async run<T>(caller: AbortSignal | undefined, operation: (signal: AbortSignal) => Promise<T>) {
+		this.assertOpen();
+		const controller = new AbortController();
+		const abort = () => controller.abort(new Error("LSP request aborted."));
+		let settle!: () => void;
+		this.#operations.set(
+			controller,
+			new Promise<void>((resolve) => {
+				settle = resolve;
+			}),
+		);
+		caller?.addEventListener("abort", abort, { once: true });
+		if (caller?.aborted) abort();
+		try {
+			controller.signal.throwIfAborted();
+			const result = await operation(controller.signal);
+			controller.signal.throwIfAborted();
+			return result;
+		} finally {
+			caller?.removeEventListener("abort", abort);
+			this.#operations.delete(controller);
+			settle();
+		}
+	}
+
+	close(): Promise<void> {
+		if (!this.#closing) {
+			// Publish the closing state before abort callbacks can reenter this scope.
+			this.#closing = Promise.allSettled(this.#operations.values()).then(() => {});
+			for (const controller of this.#operations.keys()) {
+				controller.abort(new Error("LSP session is closing; request aborted."));
+			}
+		}
+		return this.#closing;
+	}
+}

--- a/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
+++ b/packages/pi-lsp/test/fixtures/diagnostics-server.mjs
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { appendFileSync, writeFileSync } from "node:fs";
 
 const scenario = process.argv[2];
 const expectedFiles = Number(process.argv[3] ?? "0");
@@ -6,6 +6,21 @@ let buffer = Buffer.alloc(0);
 const openedUris = [];
 
 if (scenario === "delayed-sigterm") process.on("SIGTERM", exitAfterDelay);
+
+const lifecycle = scenario.startsWith("lifecycle-");
+function record(event) {
+	if (process.env.PI_LSP_TEST_LOG) {
+		appendFileSync(
+			process.env.PI_LSP_TEST_LOG,
+			`${JSON.stringify({ pid: process.pid, ...event })}\n`,
+		);
+	}
+}
+if (lifecycle) {
+	process.on("SIGTERM", () => setTimeout(() => process.exit(0), 25));
+	process.on("exit", () => record({ method: "exited" }));
+	record({ method: "ready" });
+}
 
 function exitAfterDelay() {
 	setTimeout(() => {
@@ -58,6 +73,73 @@ function publish(uri, diagnostics) {
 }
 
 function handle(message) {
+	record(message);
+	if (lifecycle) {
+		if (scenario === `lifecycle-hang-${message.method}`) return;
+		if (scenario === `lifecycle-error-${message.method}`) {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				error: { code: -32603, message: "intentional operation failure" },
+			});
+			return;
+		}
+		if (message.method === "initialize") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				result: {
+					capabilities: { diagnosticProvider: {}, codeActionProvider: { resolveProvider: true } },
+				},
+			});
+			return;
+		}
+		if (message.method === "textDocument/diagnostic") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				result: { items: scenario === "lifecycle-large" ? [diagnostic("x".repeat(60_000))] : [] },
+			});
+			return;
+		}
+		if (message.method === "textDocument/codeAction") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				result:
+					scenario === "lifecycle-unchanged"
+						? []
+						: [
+								{
+									title: "fixture fix",
+									kind: "source.fixAll",
+									data: { uri: message.params.textDocument.uri },
+								},
+							],
+			});
+			return;
+		}
+		if (message.method === "codeAction/resolve") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				result: {
+					...message.params,
+					edit: {
+						changes: {
+							[message.params.data.uri]: [
+								{
+									range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+									newText: scenario === "lifecycle-large" ? "x".repeat(60_000) : "// fixed\n",
+								},
+							],
+						},
+					},
+				},
+			});
+			return;
+		}
+	}
 	if (message.method === "initialize") {
 		if (scenario === "require-environment" && process.env.PI_LSP_TEST_ENV !== "forwarded") {
 			send({

--- a/packages/pi-lsp/test/fixtures/package-smoke.mjs
+++ b/packages/pi-lsp/test/fixtures/package-smoke.mjs
@@ -1,0 +1,252 @@
+// Non-interactive package-directory smoke with a loopback-only scripted provider.
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-package-smoke-"));
+const agentDir = path.join(root, "agent");
+mkdirSync(agentDir);
+const file = path.join(root, "main.go");
+const log = path.join(root, "lsp.jsonl");
+const lifecycleLog = path.join(root, "lifecycle.jsonl");
+writeFileSync(file, "package main\n");
+let requestCount = 0;
+const server = createServer(async (request, response) => {
+	try {
+		let body = "";
+		for await (const chunk of request) body += chunk;
+		const input = JSON.parse(body);
+		assert.equal(request.url, "/v1/chat/completions");
+		assert.deepEqual(
+			input.tools.map((tool) => tool.function.name),
+			["lsp_diagnostics", "lsp_fix"],
+		);
+		requestCount++;
+		const last = input.messages.at(-1);
+		const toolResult = last.role === "tool";
+		const content = input.messages.findLast((message) => message.role === "user").content;
+		const prompt =
+			typeof content === "string" ? content : content.map((part) => part.text ?? "").join("\n");
+		const name = prompt.includes("diagnostics") ? "lsp_diagnostics" : "lsp_fix";
+		const args =
+			name === "lsp_diagnostics"
+				? { root, paths: ["main.go"] }
+				: { root, path: "main.go", write: prompt.includes("write") };
+		response.writeHead(200, { "content-type": "text/event-stream" });
+		response.write(
+			`data: ${JSON.stringify({ id: `fixture-${requestCount}`, object: "chat.completion.chunk", created: 0, model: "fixture", choices: [{ index: 0, delta: toolResult ? { role: "assistant", content: "done" } : { role: "assistant", tool_calls: [{ index: 0, id: `call-${requestCount}`, type: "function", function: { name, arguments: JSON.stringify(args) } }] }, finish_reason: toolResult ? "stop" : "tool_calls" }] })}\n\n`,
+		);
+		response.end("data: [DONE]\n\n");
+	} catch (error) {
+		response.writeHead(500);
+		response.end(String(error));
+	}
+});
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const address = server.address();
+writeFileSync(
+	path.join(agentDir, "models.json"),
+	JSON.stringify({
+		providers: {
+			"lifecycle-fixture": {
+				baseUrl: `http://127.0.0.1:${address.port}/v1`,
+				api: "openai-completions",
+				apiKey: "fixture",
+				models: [{ id: "fixture" }],
+			},
+		},
+	}),
+);
+writeFileSync(
+	path.join(agentDir, "settings.json"),
+	JSON.stringify({ enableInstallTelemetry: false, retry: { enabled: false } }),
+);
+writeFileSync(
+	path.join(agentDir, "pi-lsp.json"),
+	JSON.stringify({
+		timeout: 1_000,
+		servers: {
+			fixture: {
+				command: [
+					process.execPath,
+					path.resolve("packages/pi-lsp/test/fixtures/diagnostics-server.mjs"),
+					"lifecycle-normal",
+				],
+				extensions: [".go"],
+				env: { PI_LSP_TEST_LOG: log },
+			},
+		},
+	}),
+);
+const helper = path.join(root, "smoke.ts");
+writeFileSync(
+	helper,
+	`import { appendFileSync } from "node:fs";
+export default function(pi) {
+	pi.registerCommand("smoke-reload", { handler: async (_args, ctx) => { await ctx.reload(); return; } });
+	pi.registerCommand("smoke-quit", { handler: async (_args, ctx) => { ctx.shutdown(); } });
+	for (const event of ["session_start", "session_shutdown"]) pi.on(event, (data) => {
+		appendFileSync(${JSON.stringify(lifecycleLog)}, JSON.stringify(data) + "\\n");
+	});
+}`,
+);
+const args = [
+	"--mode",
+	"rpc",
+	"--offline",
+	"--no-approve",
+	"--no-session",
+	"--no-extensions",
+	"--no-skills",
+	"--no-prompt-templates",
+	"--no-themes",
+	"--no-context-files",
+	"--no-builtin-tools",
+	"--provider",
+	"lifecycle-fixture",
+	"--model",
+	"fixture",
+	"-e",
+	"./packages/pi-lsp",
+	"-e",
+	helper,
+];
+const child = spawn("pi", args, {
+	cwd: process.cwd(),
+	env: { ...process.env, PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: "1" },
+	stdio: "pipe",
+});
+const exited = once(child, "exit");
+let stderr = "";
+child.stderr.setEncoding("utf8");
+child.stderr.on("data", (chunk) => {
+	stderr += chunk;
+});
+let buffer = "";
+const events = [];
+const listeners = new Set();
+child.stdout.setEncoding("utf8");
+child.stdout.on("data", (chunk) => {
+	buffer += chunk;
+	while (buffer.includes("\n")) {
+		const newline = buffer.indexOf("\n");
+		const line = buffer.slice(0, newline);
+		buffer = buffer.slice(newline + 1);
+		if (!line.trim()) continue;
+		try {
+			events.push(JSON.parse(line));
+			for (const notify of listeners) notify();
+		} catch {
+			stderr += `Invalid RPC line: ${line}\n`;
+		}
+	}
+});
+const send = (command) => child.stdin.write(`${JSON.stringify(command)}\n`);
+let deadline;
+function waitFor(predicate, offset = 0) {
+	return new Promise((resolve, reject) => {
+		function check() {
+			const event = events.slice(offset).find(predicate);
+			if (event) {
+				cleanup();
+				resolve(event);
+			}
+		}
+		function failed() {
+			cleanup();
+			reject(new Error(`Pi exited before expected event: ${stderr}`));
+		}
+		function cleanup() {
+			listeners.delete(check);
+			child.off("exit", failed);
+		}
+		listeners.add(check);
+		child.once("exit", failed);
+		check();
+	});
+}
+async function command(id, message) {
+	const offset = events.length;
+	send({ id, type: "prompt", message });
+	const response = await waitFor((event) => event.type === "response" && event.id === id, offset);
+	assert.equal(response.success, true, JSON.stringify(response));
+	return offset;
+}
+async function run(id, message) {
+	const offset = await command(id, message);
+	await waitFor((event) => event.type === "agent_settled", offset);
+	const result = events.slice(offset).find((event) => event.type === "tool_execution_end");
+	assert.ok(result, JSON.stringify(events.slice(offset)));
+	assert.equal(result.isError, false, JSON.stringify(result));
+	return result.result;
+}
+try {
+	send({ id: "ready", type: "get_commands" });
+	const ready = await waitFor((event) => event.type === "response" && event.id === "ready");
+	assert.equal(ready.success, true);
+	assert.ok(ready.data.commands.some((command) => command.name === "lsp"));
+	// The subprocess deadline begins only after its RPC readiness handshake.
+	deadline = setTimeout(() => child.kill("SIGKILL"), 15_000);
+	const diagnostic = await run("diagnostics", "diagnostics");
+	assert.match(diagnostic.content[0].text, /0 diagnostic\(s\)/);
+	const preview = await run("preview", "preview");
+	assert.equal(preview.details.text, "// fixed\npackage main\n");
+	assert.equal(readFileSync(file, "utf8"), "package main\n");
+	const written = await run("write", "write");
+	assert.equal(written.details.write, true);
+	assert.equal(readFileSync(file, "utf8"), "// fixed\npackage main\n");
+	await command("reload", "/smoke-reload");
+	await run("after-reload", "diagnostics after reload");
+	await command("quit", "/smoke-quit");
+	const [code, signal] = await exited;
+	assert.equal(code, 0, `${signal}: ${stderr}`);
+	assert.ok(!events.some((event) => event.type === "extension_error"), JSON.stringify(events));
+	const records = readFileSync(log, "utf8")
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line));
+	const pids = [...new Set(records.map((event) => event.pid))];
+	assert.equal(pids.length, 4);
+	for (const pid of pids) {
+		assert.ok(records.some((event) => event.pid === pid && event.method === "exited"));
+		assert.throws(() => process.kill(pid, 0), /ESRCH/);
+	}
+	const lifecycle = readFileSync(lifecycleLog, "utf8")
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line));
+	assert.deepEqual(
+		lifecycle.map(({ type, reason }) => [type, reason]),
+		[
+			["session_start", "startup"],
+			["session_shutdown", "reload"],
+			["session_start", "reload"],
+			["session_shutdown", "quit"],
+		],
+	);
+	console.log(
+		JSON.stringify({
+			package: "pi-lsp",
+			mode: "rpc",
+			diagnostics: "passed",
+			preview: "passed",
+			write: "passed",
+			reload: "passed",
+			shutdown: "passed",
+			exitedServers: pids.length,
+			providerRequests: requestCount,
+			liveProvider: false,
+		}),
+	);
+} finally {
+	clearTimeout(deadline);
+	if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+	await exited;
+	server.closeAllConnections();
+	await new Promise((resolve) => server.close(resolve));
+	rmSync(root, { recursive: true, force: true });
+}

--- a/packages/pi-lsp/test/generated-lifecycle.test.ts
+++ b/packages/pi-lsp/test/generated-lifecycle.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+	DefaultResourceLoader,
+	ExtensionRunner,
+	type ModelRegistry,
+	SessionManager,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { test, vi } from "vitest";
+import { fixture } from "./lifecycle-support.js";
+
+for (const kind of ["diagnostics", "fix"] as const) {
+	test(`generated ${kind}: installed runner drains active work before stale-context invalidation`, async () => {
+		const f = fixture(
+			kind === "fix" ? "lifecycle-hang-textDocument/codeAction" : "lifecycle-hang-initialize",
+		);
+		const agentDir = path.join(f.root, "agent");
+		mkdirSync(agentDir);
+		vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+		writeFileSync(
+			path.join(agentDir, "pi-lsp.json"),
+			JSON.stringify({
+				timeout: 1_000,
+				servers: {
+					fixture: {
+						command: [f.adapter.defaultCommand.command, ...f.adapter.defaultCommand.args],
+						extensions: [".go"],
+						env: f.adapter.env,
+					},
+				},
+			}),
+		);
+		let runner: ExtensionRunner | undefined;
+		let invalidated = false;
+		try {
+			const loader = new DefaultResourceLoader({
+				cwd: f.root,
+				agentDir,
+				settingsManager: SettingsManager.inMemory({}),
+				additionalExtensionPaths: [path.resolve("packages/pi-lsp/dist/index.ts")],
+			});
+			await loader.reload();
+			const loaded = loader.getExtensions();
+			assert.deepEqual(loaded.errors, []);
+			runner = new ExtensionRunner(
+				loaded.extensions,
+				loaded.runtime,
+				f.root,
+				SessionManager.inMemory(f.root),
+				{} as ModelRegistry,
+			);
+			const errors: unknown[] = [];
+			runner.onError((error) => {
+				errors.push(error);
+			});
+			await runner.emit({ type: "session_start", reason: "startup" });
+			const ctx = runner.createContext();
+			const tool = runner.getToolDefinition(`lsp_${kind}`);
+			assert.ok(tool);
+			const task = f.track(
+				tool.execute(
+					"test",
+					{ root: f.root, path: "main.go", paths: ["main.go"], write: true },
+					f.controller.signal,
+					undefined,
+					ctx,
+				),
+			);
+			await f.ready(kind === "fix" ? "textDocument/codeAction" : "initialize");
+			await runner.emit({ type: "session_shutdown", reason: "reload" });
+			f.exited();
+			runner.invalidate();
+			invalidated = true;
+			assert.throws(() => ctx.ui, /stale/);
+			await assert.rejects(task, /aborted|cancelled/);
+			assert.deepEqual(errors, []);
+		} finally {
+			f.controller.abort();
+			if (runner && !invalidated) await runner.emit({ type: "session_shutdown", reason: "quit" });
+			await f.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+}

--- a/packages/pi-lsp/test/lifecycle-support.ts
+++ b/packages/pi-lsp/test/lifecycle-support.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { LspClient } from "../src/lsp-client.js";
+import { runDiagnostics, runFix } from "../src/runner.js";
+import type { LspServerAdapter, StatusContext } from "../src/types.js";
+
+export function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+export function fixture(scenario = "lifecycle-normal") {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-lifecycle-"));
+	const file = path.join(root, "main.go");
+	const log = path.join(root, "events.jsonl");
+	writeFileSync(file, "package main\n");
+	const adapter: LspServerAdapter = {
+		name: "fixture",
+		isDefault: false,
+		extensions: [".go"],
+		skipDirectories: new Set(),
+		defaultCommand: {
+			command: process.execPath,
+			args: [path.resolve("packages/pi-lsp/test/fixtures/diagnostics-server.mjs"), scenario],
+		},
+		env: { PI_LSP_TEST_LOG: log },
+		missingCommandHint: "install fixture",
+		isSupportedFile: (name) => name.endsWith(".go"),
+		languageIdFor: () => "go",
+	};
+	const controller = new AbortController();
+	const statuses: Array<string | undefined> = [];
+	const ctx: StatusContext = {
+		ui: {
+			setStatus: (_key, value) => {
+				statuses.push(value);
+			},
+		},
+	};
+	const clients = new Set<LspClient>();
+	const tasks: Promise<unknown>[] = [];
+	const originalStart = LspClient.prototype.start;
+	// Each test owns its spies; remember real clients for cleanup even against the broken baseline.
+	function start(this: LspClient) {
+		clients.add(this);
+		return originalStart.call(this);
+	}
+	function track<T>(task: Promise<T>) {
+		tasks.push(task);
+		void task.catch(() => {});
+		return task;
+	}
+	function run(
+		kind: "diagnostics" | "fix",
+		options: {
+			write?: boolean;
+			files?: string[];
+			context?: StatusContext;
+			timeoutMs?: number;
+		} = {},
+	) {
+		return track(
+			kind === "diagnostics"
+				? runDiagnostics(
+						adapter,
+						{ root, files: options.files ?? [file] },
+						options.timeoutMs ?? 1_000,
+						controller.signal,
+						options.context ?? ctx,
+						"lsp",
+					)
+				: runFix(
+						adapter,
+						{ root, path: "main.go", write: options.write },
+						options.timeoutMs ?? 1_000,
+						controller.signal,
+						options.context ?? ctx,
+						"lsp",
+					),
+		);
+	}
+	function events(): Array<{
+		method: string;
+		pid: number;
+		params?: { textDocument?: { uri: string } };
+	}> {
+		return existsSync(log)
+			? readFileSync(log, "utf8")
+					.trim()
+					.split("\n")
+					.filter(Boolean)
+					.map((line) => JSON.parse(line))
+			: [];
+	}
+	async function ready(method: string) {
+		// No timing assertion or subprocess deadline before the server-observable handshake.
+		while (!events().some((event) => event.method === method)) await setTimeout(5);
+	}
+	function exited() {
+		const records = events();
+		for (const pid of new Set(records.map((event) => event.pid))) {
+			assert.ok(records.some((event) => event.pid === pid && event.method === "exited"));
+			assert.throws(() => process.kill(pid, 0), /ESRCH/);
+		}
+	}
+	async function dispose() {
+		controller.abort();
+		for (const client of clients) client.close();
+		await Promise.allSettled(tasks);
+		await Promise.all([...clients].map((client) => client.shutdown()));
+		rmSync(root, { recursive: true, force: true });
+	}
+	return {
+		root,
+		file,
+		log,
+		adapter,
+		controller,
+		statuses,
+		ctx,
+		start,
+		track,
+		run,
+		events,
+		ready,
+		exited,
+		dispose,
+	};
+}

--- a/packages/pi-lsp/test/runner-lifecycle.test.ts
+++ b/packages/pi-lsp/test/runner-lifecycle.test.ts
@@ -1,0 +1,418 @@
+import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { test, vi } from "vitest";
+import { LspClient } from "../src/lsp-client.js";
+import { deferred, fixture } from "./lifecycle-support.js";
+
+for (const kind of ["diagnostics", "fix"] as const) {
+	test(`${kind}: normal document scope, result, listeners and process exit`, async () => {
+		const f = fixture();
+		vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+		try {
+			const result = await f.run(kind);
+			assert.match(
+				result.content[0].text,
+				kind === "fix" ? /computed changes/ : /0 diagnostic\(s\)/,
+			);
+			assert.equal(readFileSync(f.file, "utf8"), "package main\n");
+			assert.deepEqual(
+				f.events().map((event) => event.method),
+				[
+					"ready",
+					"initialize",
+					"initialized",
+					"textDocument/didOpen",
+					"textDocument/diagnostic",
+					...(kind === "fix" ? ["textDocument/codeAction", "codeAction/resolve"] : []),
+					"textDocument/didClose",
+					"shutdown",
+					"exit",
+					"exited",
+				],
+			);
+			assert.deepEqual(f.statuses, [`fixture ${kind}`, undefined]);
+			assert.equal(getEventListeners(f.controller.signal, "abort").length, 0);
+			f.exited();
+		} finally {
+			await f.dispose();
+			vi.restoreAllMocks();
+		}
+	});
+
+	for (const method of [
+		"initialize",
+		"textDocument/diagnostic",
+		...(kind === "fix" ? ["textDocument/codeAction", "codeAction/resolve"] : []),
+	]) {
+		test(`${kind}: ${method} rejection preserves error and releases process`, async () => {
+			const f = fixture(`lifecycle-error-${method}`);
+			vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+			try {
+				await assert.rejects(f.run(kind), /intentional operation failure/);
+				assert.equal(f.statuses.at(-1), undefined);
+				assert.equal(getEventListeners(f.controller.signal, "abort").length, 0);
+				if (method === "initialize")
+					assert.ok(!f.events().some((event) => event.method === "textDocument/didOpen"));
+				else assert.ok(f.events().some((event) => event.method === "textDocument/didClose"));
+				f.exited();
+			} finally {
+				await f.dispose();
+				vi.restoreAllMocks();
+			}
+		});
+		test(`${kind}: caller cancellation during ${method} drains the real child`, async () => {
+			const f = fixture(`lifecycle-hang-${method}`);
+			vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+			try {
+				const task = f.run(kind, { write: true });
+				await f.ready(method);
+				f.controller.abort();
+				await assert.rejects(task, /cancelled|aborted/);
+				assert.equal(readFileSync(f.file, "utf8"), "package main\n");
+				assert.equal(getEventListeners(f.controller.signal, "abort").length, 0);
+				f.exited();
+			} finally {
+				await f.dispose();
+				vi.restoreAllMocks();
+			}
+		});
+	}
+
+	for (const failure of ["missing", "spawn", "timeout", "initial-status"] as const) {
+		test(`${kind}: ${failure} startup failure releases owned resources`, async () => {
+			const f = fixture(failure === "timeout" ? "lifecycle-hang-initialize" : undefined);
+			vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+			const shutdown = vi.spyOn(LspClient.prototype, "shutdown");
+			if (failure === "missing") f.adapter.defaultCommand.command = path.join(f.root, "missing");
+			if (failure === "spawn") {
+				const command = path.join(f.root, "broken");
+				writeFileSync(command, "#!/nonexistent-interpreter\n", { mode: 0o755 });
+				f.adapter.defaultCommand.command = command;
+			}
+			try {
+				await assert.rejects(
+					f.run(kind, {
+						timeoutMs: failure === "timeout" ? 300 : 1_000,
+						context:
+							failure === "initial-status"
+								? {
+										ui: {
+											setStatus() {
+												throw new Error("initial status failed");
+											},
+										},
+									}
+								: undefined,
+					}),
+					/not found|failed to start|timed out|initial status failed/,
+				);
+				assert.equal(shutdown.mock.calls.length, 1);
+				assert.equal(getEventListeners(f.controller.signal, "abort").length, 0);
+				if (failure === "timeout") f.exited();
+				assert.ok(!f.events().some((event) => event.method === "textDocument/didOpen"));
+			} finally {
+				await f.dispose();
+				vi.restoreAllMocks();
+			}
+		});
+	}
+
+	for (const uiFailure of ["getter", "setter"] as const) {
+		for (const operationFails of [false, true]) {
+			test(`${kind}: cleanup ${uiFailure} failure cannot replace ${operationFails ? "operation error" : "result"}`, async () => {
+				const f = fixture();
+				vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+				const shutdown = vi.spyOn(LspClient.prototype, "shutdown");
+				let stale = false;
+				const original = LspClient.prototype.diagnostics;
+				vi.spyOn(LspClient.prototype, "diagnostics").mockImplementation(async function (
+					this: LspClient,
+					uri,
+				) {
+					const result = await original.call(this, uri);
+					stale = true;
+					if (operationFails) throw new Error("original operation error");
+					return result;
+				});
+				const context = {
+					get ui() {
+						if (stale && uiFailure === "getter") throw new Error("stale context");
+						return {
+							setStatus(_key: string, value: string | undefined) {
+								if (value === undefined) throw new Error("status cleanup failed");
+							},
+						};
+					},
+				};
+				try {
+					const task = f.run(kind, { context });
+					if (operationFails) await assert.rejects(task, /original operation error/);
+					else await task;
+					assert.equal(shutdown.mock.calls.length, 1);
+					assert.equal(getEventListeners(f.controller.signal, "abort").length, 0);
+					f.exited();
+				} finally {
+					await f.dispose();
+					vi.restoreAllMocks();
+				}
+			});
+		}
+	}
+
+	test(`${kind}: cancellation interrupts a pending shutdown and removes its subscription`, async () => {
+		const f = fixture("lifecycle-hang-shutdown");
+		vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+		try {
+			const task = f.run(kind);
+			await f.ready("shutdown");
+			assert.equal(getEventListeners(f.controller.signal, "abort").length, 1);
+			f.controller.abort();
+			await assert.rejects(task, /aborted|cancelled/);
+			assert.equal(getEventListeners(f.controller.signal, "abort").length, 0);
+			f.exited();
+		} finally {
+			await f.dispose();
+			vi.restoreAllMocks();
+		}
+	});
+
+	for (const operationFails of [false, true]) {
+		test(`${kind}: resource cleanup error is ${operationFails ? "secondary" : "observable"}`, async () => {
+			const f = fixture(operationFails ? "lifecycle-error-initialize" : undefined);
+			vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+			const shutdown = LspClient.prototype.shutdown;
+			const spy = vi.spyOn(LspClient.prototype, "shutdown").mockImplementation(async function (
+				this: LspClient,
+			) {
+				await shutdown.call(this);
+				throw new Error("shutdown failure");
+			});
+			try {
+				await assert.rejects(
+					f.run(kind),
+					operationFails ? /intentional operation failure/ : /shutdown failure/,
+				);
+				f.exited();
+			} finally {
+				spy.mockRestore();
+				await f.dispose();
+				vi.restoreAllMocks();
+			}
+		});
+	}
+
+	for (const method of [
+		"start",
+		"initialize",
+		"diagnostics",
+		...(kind === "fix" ? (["codeActions", "resolveActions"] as const) : []),
+	] as const) {
+		test(`${kind}: cancellation after ${method} response prevents next work`, async () => {
+			const f = fixture();
+			vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+			const original = method === "start" ? f.start : LspClient.prototype[method];
+			vi.spyOn(LspClient.prototype, method).mockImplementation(async function (
+				this: LspClient,
+				...args: unknown[]
+			) {
+				const result = await (original as (...args: unknown[]) => Promise<unknown>).apply(
+					this,
+					args,
+				);
+				f.controller.abort();
+				return result;
+			} as never);
+			try {
+				await assert.rejects(f.run(kind, { write: true }), /aborted|cancelled/);
+				assert.equal(readFileSync(f.file, "utf8"), "package main\n");
+				const next = {
+					start: "initialize",
+					initialize: "textDocument/didOpen",
+					diagnostics: "textDocument/codeAction",
+					codeActions: "codeAction/resolve",
+					resolveActions: "never",
+				}[method];
+				assert.ok(!f.events().some((event) => event.method === next));
+				if (method !== "start") f.exited();
+			} finally {
+				await f.dispose();
+				vi.restoreAllMocks();
+			}
+		});
+	}
+}
+
+test("empty diagnostics selection does not allocate, spawn or publish status", async () => {
+	const f = fixture();
+	const start = vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+	try {
+		const result = await f.run("diagnostics", { files: [] });
+		assert.match(result.content[0].text, /no supported files/);
+		assert.equal(start.mock.calls.length, 0);
+		assert.deepEqual(f.statuses, []);
+	} finally {
+		await f.dispose();
+		vi.restoreAllMocks();
+	}
+});
+
+for (const write of [false, true]) {
+	for (const unchanged of [false, true]) {
+		test(`fix: write=${write}, unchanged=${unchanged} preserves exact result and disk semantics`, async () => {
+			const f = fixture(unchanged ? "lifecycle-unchanged" : undefined);
+			vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+			try {
+				const result = await f.run("fix", { write });
+				const text = `${unchanged ? "" : "// fixed\n"}package main\n`;
+				const details = result.details as {
+					changed: boolean;
+					text?: string;
+					write: boolean;
+					kind: string;
+					actions: unknown[];
+					appliedActions: unknown[];
+				};
+				assert.equal(details.changed, !unchanged);
+				assert.equal(details.write, write);
+				assert.equal(details.kind, "source.fixAll");
+				assert.equal(details.text, write ? undefined : text);
+				assert.deepEqual(
+					details.actions,
+					unchanged ? [] : [{ title: "fixture fix", kind: "source.fixAll" }],
+				);
+				assert.deepEqual(details.appliedActions, details.actions);
+				assert.equal(readFileSync(f.file, "utf8"), write ? text : "package main\n");
+				f.exited();
+			} finally {
+				await f.dispose();
+				vi.restoreAllMocks();
+			}
+		});
+	}
+}
+
+test("diagnostics: partial file open closes all previously opened documents", async () => {
+	const f = fixture();
+	vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+	try {
+		await assert.rejects(
+			f.run("diagnostics", { files: [f.file, path.join(f.root, "missing.go")] }),
+			/ENOENT/,
+		);
+		assert.deepEqual(
+			f
+				.events()
+				.filter((event) => /didOpen|didClose/.test(event.method))
+				.map((event) => event.method),
+			["textDocument/didOpen", "textDocument/didClose"],
+		);
+		f.exited();
+	} finally {
+		await f.dispose();
+		vi.restoreAllMocks();
+	}
+});
+
+test("fix: write failure still closes document and drains process", async () => {
+	const f = fixture();
+	vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+	const resolve = LspClient.prototype.resolveActions;
+	vi.spyOn(LspClient.prototype, "resolveActions").mockImplementation(async function (
+		this: LspClient,
+		actions,
+	) {
+		const result = await resolve.call(this, actions);
+		unlinkSync(f.file);
+		mkdirSync(f.file);
+		return result;
+	});
+	try {
+		await assert.rejects(f.run("fix", { write: true }), /EISDIR/);
+		assert.ok(f.events().some((event) => event.method === "textDocument/didClose"));
+		f.exited();
+	} finally {
+		await f.dispose();
+		vi.restoreAllMocks();
+	}
+});
+
+for (const kind of ["diagnostics", "fix"] as const) {
+	test(`${kind}: B3 deferred, oversized output remains complete`, async () => {
+		const f = fixture("lifecycle-large");
+		vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+		try {
+			assert.ok((await f.run(kind)).content[0].text.includes("x".repeat(60_000)));
+		} finally {
+			await f.dispose();
+			vi.restoreAllMocks();
+		}
+	});
+}
+
+test("B1 deferred: one completion still clears a pending sibling's status", async () => {
+	const f = fixture();
+	vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+	const gates = [deferred(), deferred()];
+	const ready = [deferred(), deferred()];
+	let index = 0;
+	const original = LspClient.prototype.diagnostics;
+	vi.spyOn(LspClient.prototype, "diagnostics").mockImplementation(async function (
+		this: LspClient,
+		uri,
+	) {
+		const id = index++;
+		const result = await original.call(this, uri);
+		ready[id].resolve();
+		await gates[id].promise;
+		return result;
+	});
+	try {
+		const first = f.run("diagnostics");
+		await ready[0].promise;
+		const second = f.run("diagnostics");
+		await ready[1].promise;
+		gates[0].resolve();
+		await first;
+		assert.deepEqual(f.statuses, ["fixture diagnostics", "fixture diagnostics", undefined]);
+		gates[1].resolve();
+		await second;
+		f.exited();
+	} finally {
+		for (const gate of gates) gate.resolve();
+		await f.dispose();
+		vi.restoreAllMocks();
+	}
+});
+
+test("B2 deferred: concurrent fixes retain the unqueued read/await/write window", async () => {
+	const f = fixture();
+	vi.spyOn(LspClient.prototype, "start").mockImplementation(f.start);
+	const gate = deferred();
+	const ready = deferred();
+	let count = 0;
+	const original = LspClient.prototype.resolveActions;
+	vi.spyOn(LspClient.prototype, "resolveActions").mockImplementation(async function (
+		this: LspClient,
+		actions,
+	) {
+		const result = await original.call(this, actions);
+		if (++count === 2) ready.resolve();
+		await gate.promise;
+		return result;
+	});
+	try {
+		const tasks = [f.run("fix", { write: true }), f.run("fix", { write: true })];
+		await ready.promise;
+		writeFileSync(f.file, "concurrent external edit\n");
+		gate.resolve();
+		await Promise.all(tasks);
+		assert.equal(readFileSync(f.file, "utf8"), "// fixed\npackage main\n");
+		f.exited();
+	} finally {
+		gate.resolve();
+		await f.dispose();
+		vi.restoreAllMocks();
+	}
+});

--- a/packages/pi-lsp/test/session-lifecycle.test.ts
+++ b/packages/pi-lsp/test/session-lifecycle.test.ts
@@ -1,0 +1,315 @@
+import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { test, vi } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import type { LspClient } from "../src/lsp-client.js";
+import { deferred, fixture } from "./lifecycle-support.js";
+
+async function harness(scenario = "lifecycle-normal") {
+	const f = fixture(scenario);
+	const agentDir = path.join(f.root, "agent");
+	mkdirSync(agentDir);
+	vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+	vi.resetModules();
+	const { default: lsp } = await import("../src/pi-lsp.js");
+	// Fresh extension import also owns a fresh client module.
+	const { LspClient: Client } = await import("../src/lsp-client.js");
+	const mock = createMockPi();
+	lsp(mock.pi);
+	writeFileSync(
+		path.join(agentDir, "pi-lsp.json"),
+		JSON.stringify({
+			timeout: 1_000,
+			servers: {
+				fixture: {
+					command: [f.adapter.defaultCommand.command, ...f.adapter.defaultCommand.args],
+					extensions: [".go"],
+					env: f.adapter.env,
+				},
+			},
+		}),
+	);
+	const context = createMockContext({ cwd: f.root }) as Omit<
+		ReturnType<typeof createMockContext>,
+		"ctx"
+	> & { ctx: ExtensionContext };
+	let stale = false;
+	let staleAccesses = 0;
+	const ctx = Object.create(context.ctx, {
+		ui: {
+			get() {
+				if (stale) {
+					staleAccesses++;
+					throw new Error("stale context");
+				}
+				return context.ctx.ui;
+			},
+		},
+	});
+	async function emit(name: string, reason = "quit", target = ctx) {
+		for (const handler of mock.events.get(name) ?? [])
+			await handler({ type: name, reason }, target);
+	}
+	function execute(kind: "diagnostics" | "fix", target = ctx, params = {}) {
+		const tool = mock.tools.find((tool) => tool.name === `lsp_${kind}`);
+		assert.ok(tool);
+		return f.track(
+			(tool.execute as (...args: unknown[]) => Promise<unknown>)(
+				"test",
+				{ root: f.root, path: "main.go", paths: ["main.go"], write: true, ...params },
+				f.controller.signal,
+				undefined,
+				target,
+			),
+		);
+	}
+	return {
+		...f,
+		Client,
+		mock,
+		context,
+		ctx,
+		emit,
+		execute,
+		invalidate() {
+			stale = true;
+		},
+		staleAccesses: () => staleAccesses,
+		async dispose() {
+			await f.dispose();
+			vi.restoreAllMocks();
+			vi.unstubAllEnvs();
+		},
+	};
+}
+
+for (const kind of ["diagnostics", "fix"] as const) {
+	for (const method of [
+		"initialize",
+		"textDocument/diagnostic",
+		...(kind === "fix" ? ["textDocument/codeAction", "codeAction/resolve"] : []),
+	]) {
+		for (const reason of ["quit", "reload"] as const) {
+			test(`${kind}: active ${reason} drains pending ${method} before invalidation`, async () => {
+				const h = await harness(`lifecycle-hang-${method}`);
+				try {
+					await h.emit("session_start", "startup");
+					const task = h.execute(kind);
+					await h.ready(method);
+					const shutdown = h.emit("session_shutdown", reason);
+					const repeated = h.emit("session_shutdown", reason);
+					await assert.rejects(h.execute(kind, h.ctx, { server: "missing" }), /closing|aborted/);
+					await Promise.all([shutdown, repeated]);
+					h.exited();
+					h.invalidate();
+					await assert.rejects(task, /cancelled|aborted/);
+					assert.equal(h.staleAccesses(), 0);
+					assert.equal(getEventListeners(h.controller.signal, "abort").length, 0);
+					assert.equal(readFileSync(h.file, "utf8"), "package main\n");
+				} finally {
+					await h.dispose();
+				}
+			});
+		}
+	}
+}
+
+test("shutdown waits for every sibling, even after one operation fails; restart waits for drain", async () => {
+	const h = await harness();
+	const ready = [deferred(), deferred()];
+	const gates = [deferred(), deferred()];
+	let index = 0;
+	const diagnostics = h.Client.prototype.diagnostics;
+	vi.spyOn(h.Client.prototype, "diagnostics").mockImplementation(async function (
+		this: LspClient,
+		uri,
+	) {
+		const id = index++;
+		const result = await diagnostics.call(this, uri);
+		if (id < 2) {
+			ready[id].resolve();
+			await gates[id].promise;
+		}
+		if (id === 0) throw new Error("original operation failure");
+		return result;
+	});
+	try {
+		const first = h.execute("diagnostics");
+		await ready[0].promise;
+		const second = h.execute("diagnostics");
+		await ready[1].promise;
+		let settled = false;
+		const closing = h.emit("session_shutdown").then(() => {
+			settled = true;
+		});
+		const restarting = h.emit("session_start", "reload");
+		gates[0].resolve();
+		await assert.rejects(first, /original operation failure/);
+		assert.equal(settled, false);
+		await assert.rejects(h.execute("diagnostics", h.ctx, { server: "missing" }), /closing|aborted/);
+		gates[1].resolve();
+		await assert.rejects(second, /aborted|cancelled/);
+		await Promise.all([closing, restarting]);
+		await h.execute("diagnostics");
+		h.exited();
+	} finally {
+		for (const gate of gates) gate.resolve();
+		await h.dispose();
+	}
+});
+
+test("session managers sharing one headless UI have independent cancellation scopes", async () => {
+	const h = await harness();
+	const gate = deferred();
+	const ready = deferred();
+	const diagnostics = h.Client.prototype.diagnostics;
+	let count = 0;
+	vi.spyOn(h.Client.prototype, "diagnostics").mockImplementation(async function (
+		this: LspClient,
+		uri,
+	) {
+		const result = await diagnostics.call(this, uri);
+		if (++count === 2) ready.resolve();
+		await gate.promise;
+		return result;
+	});
+	const other = createMockContext({ cwd: h.root, ui: h.context.ctx.ui });
+	// The mock helper owns its UI; explicitly reuse exactly the same object.
+	const otherCtx = Object.create(other.ctx, { ui: { value: h.context.ctx.ui } });
+	try {
+		const first = h.execute("diagnostics");
+		const second = h.execute("diagnostics", otherCtx);
+		await ready.promise;
+		const shutdown = h.emit("session_shutdown");
+		gate.resolve();
+		await assert.rejects(first, /aborted|cancelled/);
+		await second;
+		await shutdown;
+		h.exited();
+	} finally {
+		gate.resolve();
+		await h.dispose();
+	}
+});
+
+test("shutdown after first route response prevents a later diagnostics route from starting", async () => {
+	const h = await harness();
+	const agentDir = path.join(h.root, "agent");
+	const config = JSON.parse(readFileSync(path.join(agentDir, "pi-lsp.json"), "utf8"));
+	config.servers.second = { ...config.servers.fixture };
+	writeFileSync(path.join(agentDir, "pi-lsp.json"), JSON.stringify(config));
+	const ready = deferred();
+	const gate = deferred();
+	const shutdown = h.Client.prototype.shutdown;
+	vi.spyOn(h.Client.prototype, "shutdown").mockImplementation(async function (this: LspClient) {
+		await shutdown.call(this);
+		ready.resolve();
+		await gate.promise;
+	});
+	try {
+		const task = h.execute("diagnostics");
+		await ready.promise;
+		const closing = h.emit("session_shutdown");
+		gate.resolve();
+		await assert.rejects(task, /aborted|cancelled/);
+		await closing;
+		assert.equal(h.events().filter((event) => event.method === "ready").length, 1);
+		h.exited();
+	} finally {
+		gate.resolve();
+		await h.dispose();
+	}
+});
+
+test("scope closure after a fix response prevents a late disk write", async () => {
+	const h = await harness();
+	let closing: Promise<void> | undefined;
+	const resolve = h.Client.prototype.resolveActions;
+	vi.spyOn(h.Client.prototype, "resolveActions").mockImplementation(async function (
+		this: LspClient,
+		actions,
+	) {
+		const result = await resolve.call(this, actions);
+		closing = h.emit("session_shutdown");
+		return result;
+	});
+	try {
+		await assert.rejects(h.execute("fix"), /aborted|cancelled/);
+		await closing;
+		assert.equal(readFileSync(h.file, "utf8"), "package main\n");
+		h.exited();
+	} finally {
+		await h.dispose();
+	}
+});
+
+test("shutdown supersedes an awaiting session start without reopening its scope", async () => {
+	const h = await harness();
+	const ready = deferred();
+	const gate = deferred();
+	const diagnostics = h.Client.prototype.diagnostics;
+	vi.spyOn(h.Client.prototype, "diagnostics").mockImplementation(async function (
+		this: LspClient,
+		uri,
+	) {
+		const result = await diagnostics.call(this, uri);
+		ready.resolve();
+		await gate.promise;
+		return result;
+	});
+	try {
+		const task = h.execute("diagnostics");
+		await ready.promise;
+		const starting = h.emit("session_start", "reload");
+		const closing = h.emit("session_shutdown");
+		gate.resolve();
+		await assert.rejects(task, /aborted|cancelled/);
+		await Promise.all([starting, closing]);
+		await assert.rejects(h.execute("diagnostics", h.ctx, { server: "missing" }), /closing/);
+		h.exited();
+	} finally {
+		gate.resolve();
+		await h.dispose();
+	}
+});
+
+test("throwing shutdown UI cannot prevent cancellation or settlement", async () => {
+	const h = await harness("lifecycle-hang-initialize");
+	try {
+		const task = h.execute("fix");
+		await h.ready("initialize");
+		const context = Object.create(h.ctx, {
+			ui: {
+				get() {
+					throw new Error("UI unavailable");
+				},
+			},
+		});
+		await h.emit("session_shutdown", "quit", context);
+		await assert.rejects(task, /aborted|cancelled/);
+		h.exited();
+	} finally {
+		await h.dispose();
+	}
+});
+
+test("abort-and-idle replacement and repeated idle lifecycle events leave no old work", async () => {
+	const h = await harness("lifecycle-hang-textDocument/diagnostic");
+	try {
+		await h.emit("session_start", "startup");
+		const task = h.execute("diagnostics");
+		await h.ready("textDocument/diagnostic");
+		h.controller.abort();
+		await assert.rejects(task, /cancelled|aborted/);
+		await h.emit("session_shutdown", "resume");
+		h.exited();
+		await h.emit("session_shutdown", "resume");
+		await h.emit("session_start", "resume");
+		await h.emit("session_shutdown");
+	} finally {
+		await h.dispose();
+	}
+});


### PR DESCRIPTION
## Summary

- Cancel and drain complete LSP tool invocations by session manager during shutdown/reload, including partially initialized servers and multi-route diagnostics.
- Release clients despite status UI failures, preserve primary operation errors, and prevent cancelled continuations from writing fixes or starting more routes.
- Share client lifetime handling while retaining separate document scopes and spawn-per-call behavior. Add a patch Changeset and cancellation/limitations documentation.

Production lines: original **2,115** → corrected baseline **2,253** → final **2,246**. The extraction reduced code by 6 lines; the final cleanup adjustment reduced one more. Full safety-change delta: +131 lines.

## Verification

- `npm run check` — build, Biome, package boundaries, workspace typechecks passed.
- `npm test` — **355 files / 3,579 tests passed**, including 76 new lifecycle/characterization cases.
- `npm --workspace @narumitw/pi-lsp run build --if-present` passed.
- `node packages/pi-lsp/test/fixtures/package-smoke.mjs` — offline RPC `pi -e ./packages/pi-lsp` with isolated settings and loopback fixtures: diagnostics, preview/write, reload, post-reload diagnostics, shutdown, and four confirmed server exits passed; no live provider.
- Generated runtime exercised through Pi's Jiti loader and installed `ExtensionRunner` during active teardown.
- `npm run package:pack -- lsp` — inspected 17-file dry-run contents; `npm run changeset:status` confirms the intended patch only.
- README heading audit and `git diff --check` passed. Commit is SSH-signed and verified against the configured signing key.

Audited lifecycle ownership, cancellation, every changed await/write boundary, status failure isolation, error precedence, settings/trust preservation, and compatibility against `docs/extension-conventions.md`, `docs/extension-settings.md`, `docs/readme-conventions.md`, and package instructions. Tool schemas/prompt metadata, settings, routing, dependencies, and JSON-RPC transport remain unchanged.

## Accepted limitations

The approved plan explicitly defers **B1** sibling activity-status loss, **B2** unqueued same-path writes, and **B3** unbounded output. Tests characterize these limitations without claiming they are fixed; README guidance now names them. Cancellation does not roll back a write already completed before shutdown.

Live-provider, interactive TUI, and live Windows-server smokes were not run; this change's required smoke is non-interactive and fixture-backed. No package publication, version tag, or release workflow was performed.

Completed and deleted the supplied untracked `2026-09-05_pi-lsp-client-lifecycle-plan.md`. The unrelated transport plan remains untouched.
