### PR TITLE
test(lsp): retain transport after JSON-RPC evaluation

### DIFF
--- a/docs/research/2026-09-05_pi-lsp-jsonrpc-transport.md
+++ b/docs/research/2026-09-05_pi-lsp-jsonrpc-transport.md
@@ -1,0 +1,149 @@
+# Pi LSP JSON-RPC transport evaluation
+
+## Decision
+
+Reject the `vscode-jsonrpc@9.0.2` candidate and retain the handwritten transport. The candidate
+removed 90 production lines but introduced an unhandled `write EPIPE` rejection when the server
+closed stdin. Catching the returned request promise did not prevent that rejection. The same
+subprocess regression passes on the existing client.
+
+No dependency, production-code change, new wrapper, or Changeset is retained. Installation and
+startup costs were measured, not accepted. This decision applies to the inspected release and
+prototype, not every possible library release or integration.
+
+## Baseline and method
+
+Baseline commit: `0a669038` (after lifecycle PR #1212). The lifecycle refactor's deletions are not
+credited here. Experiments ran in a detached worktree outside the repository. Baseline root
+`npm test` passed 355 files / 3,579 tests before transport changes.
+
+Production lines count all physical lines in `packages/pi-lsp/src/*.ts`, including comments and
+blank lines. Generated output and tests are excluded. Both implementations used the existing build
+and package manifest file list. The candidate imported `vscode-jsonrpc/node` externally, deleted
+framing/IDs/response dispatch and `JsonRpcMessage`, and kept process ownership, deadlines,
+diagnostics, initialization, and server-request policy in `LspClient`.
+
+Package load used ten separate Node v26.5.0 processes on Linux. Each imported the same installed Pi
+host before timing `DefaultResourceLoader.reload()` of the built `dist/index.ts`, with a fresh agent
+directory and cwd. No LSP server starts during this measurement. The retained harness is
+`packages/pi-lsp/test/fixtures/measure-package-load.mjs`; pass a built repository root as its first
+argument. The harness does not clear Jiti's filesystem cache or enforce performance thresholds.
+
+Production installation used temporary scopes with `npm install --omit=dev --ignore-scripts`, the
+packed extension, and explicit Pi 0.85.0 / typebox 1.3.25 peers. Installed bytes sum regular-file
+lengths beneath `node_modules`, excluding symlinks and directory allocation. Identical peers were
+retained when swapping tarballs. Unique dependency counts use package-name/version pairs from
+`npm ls --omit=dev --all --json`, including the extension and peers.
+
+## Measurements
+
+| Metric | Baseline | Candidate | Delta |
+| --- | ---: | ---: | ---: |
+| Owned production lines | 2,246 | 2,156 | -90 |
+| Client source lines | 554 | 473 | -81 |
+| Compressed tarball bytes | 63,505 | 61,734 | -1,771 |
+| Unpacked extension bytes | 264,742 | 257,217 | -7,525 |
+| Direct runtime dependencies | 0 | 1 | +1 |
+| Unique packages including peers | 130 | 131 | +1 |
+| Dependency-inclusive installed file bytes | 127,011,203 | 127,229,227 | +218,024 |
+| Median package-load milliseconds | 9.845 | 19.219 | +9.374 |
+
+The sole added dependency was `vscode-jsonrpc@9.0.2`: 225,125 installed file bytes and no runtime
+transitive dependencies. The installed-total delta also includes npm's hidden lockfile changes.
+Both extension tarballs contained 17 files. The dependency is MIT licensed and retains Microsoft's
+`License.txt`; package-owned output did not embed its implementation.
+
+All load samples, in milliseconds, in execution order:
+
+```text
+Baseline:  138.080 11.938 12.190  8.403  7.870  7.699 12.412  7.960 11.287  7.685
+Candidate:  19.671 18.969 19.148 14.805 19.290 15.182 18.237 19.451 19.831 19.776
+```
+
+The first baseline sample is a cold outlier and is not discarded. Filesystem/Jiti cache state and
+host scheduling differ between samples; these results do not establish a universal startup penalty
+or measure end-to-end tool latency. Rejection does not depend on the timing difference.
+
+## Implementation findings
+
+Registry metadata declares Node >=14 and a Node export resolving to CommonJS `lib/node/main.js`.
+Runtime behavior was inspected in the installed `lib/common/{connection,messageReader,messageWriter,
+messageBuffer}.js` and `lib/node/{main,ril}.js`, not inferred from types.
+
+The reader buffers byte fragments, handles multiple frames, normalizes header keys, and serializes
+JSON decoding. Missing or nonnumeric lengths and invalid JSON emit errors. Connection dispatch
+correlates response IDs, returns `ResponseError` for request failures, ignores unknown notifications,
+and responds to unknown requests with -32601. Known LSP request handlers remain extension-owned.
+
+Cancellation sends `$/cancelRequest` but does not settle the response promise. Stream close emits a
+close event without rejecting pending requests. Connection disposal rejects pending responses, but
+reader disposal does not detach its underlying stream listeners or clear its recurring
+partial-message timer. The prototype therefore disabled that timer, kept local deadlines, disposed
+the connection on failure/close, detached stdout data dispatch, and retained process termination.
+No new source module or reusable transport wrapper was added.
+
+The decisive failure is in `connection.js`'s `sendRequest`: an async Promise executor catches writer
+failure, rejects the returned request promise, then throws again from the executor. Closing fd 0 in
+the fake server triggers both the caught request error and an unhandled rejection. Merely calling
+`process.stdin.destroy()` did not reliably close the fd, so the regression uses `closeSync(0)`.
+The hardened candidate run passed all 3,595 assertions but failed the root test gate with one Vitest
+unhandled `write EPIPE` error. This is not reported as a passing candidate.
+
+## Compatibility and lifecycle evidence
+
+`packages/pi-lsp/test/transport.test.ts` retains 19 real-subprocess cases. Each client request
+sequence starts after a server-observable readiness record. Tests remain under the repository's
+5,000 ms hard timeout and dispose clients repeatedly before asserting that child PIDs are gone.
+
+| Contract | Evidence |
+| --- | --- |
+| Split headers/bodies and multibyte UTF-8 | Fragmented writes split a code point; exact action titles round-trip |
+| Multiple frames and response correlation | Coalesced messages, unknown notification/response, reversed replies, timeout followed by late/current replies |
+| Server requests | String and zero IDs, ty/Ruff configuration objects, workspace folders, register/unregister, unknown-method -32601 |
+| Faults and cancellation | Malformed header/JSON, incomplete frame, closed stdout, real stdin EPIPE, child exit/stderr, request timeout, concurrent request/push-waiter rejection, repeated disposal |
+| Diagnostics policy | Existing client suite: supported/error pull, empty pull with earlier/later push, grace fallback, push-only silence, repeated publications, equivalent URI encoding, all files opened first |
+| Actions and edits | Existing client/runner/helper suites: capability-gated resolve, resolve errors, target-file edits, overlap rejection, preview/write, abort before write |
+| Session ownership | Existing runner/session/generated lifecycle suites: startup failures, abort at await boundaries, replacement, reload, shutdown, child exit and status/context cleanup |
+| Settings and launch | Existing settings/launch suite: missing/invalid files, canonical/legacy precedence, trust, effective env/PATH, Windows shim resolution |
+
+The generated-entry test now loads the package directory through Pi's `DefaultResourceLoader`,
+checks the declared `dist/index.ts` path and command/hooks, and exercises shutdown before startup,
+startup, and repeated shutdown through `ExtensionRunner`. Existing builder Jiti and generated
+active-work lifecycle tests remain in place. The current generated runtime has no lazy chunks.
+
+Semantic review used `docs/extension-conventions.md`, `docs/extension-settings.md`, and
+`packages/pi-lsp/AGENTS.md`, plus installed Pi extension/package/RPC documentation, the hello example,
+and the actual Jiti loader. Factory/process ownership, cancellation, post-await guards, diagnostic
+waiter timers, shutdown escalation, settings reads/writes, output bounds, edit policy, and same-path
+mutation behavior were audited. No Pi action-at-load, prompt/tool-prefix, settings, status, or file
+mutation policy change is retained.
+
+Existing baseline dispositions remain unchanged: runner tests explicitly defer B1 (one completion
+clears a sibling's status), B2 (same-path mutations are not queued), and B3 (output is unbounded).
+This evaluation neither fixes nor newly approves those deviations. They are not hidden by passing
+regression tests and must be addressed separately from transport adoption.
+
+## Final verification
+
+`npm run check` passes build, Biome, boundaries, and workspace typechecks. An initial Biome import
+ordering error in the new benchmark harness was corrected before rerunning the gate. Final
+`npm test` passes 356 files / 3,598 tests with no unhandled errors.
+
+`npm run package:pack -- lsp` and the workspace `npm pack --dry-run --json` pass. The final tarball
+contains the expected source, generated runtime/map, settings documentation, README, manifest, and
+license; it excludes tests. Its SHA-1 is `8c03b4fb46054f23e3a8886814335667a7d54b20`, identical to
+the measured baseline tarball. Production sources, manifest, and lockfile were restored through
+path-scoped Git recovery in the experimental worktree, followed by root `npm install` and rebuild.
+
+`packages/pi-lsp/test/fixtures/package-smoke.mjs` passes with the built local package directory and
+with the production-only packed baseline install. It invokes non-interactive Pi RPC with `-e`, an
+isolated agent directory, a loopback-only scripted provider, and real fake LSP subprocesses. Both
+smokes verify diagnostics, preview without mutation, write, cancellation, reload, shutdown, and the
+exit of all five server processes (nine loopback provider requests). A missing Pi executable was
+also injected: the smoke fails with exit 1 and cleans up instead of hanging on a missing exit event.
+The retained benchmark harness completes its ten-process baseline load smoke. The candidate packed install
+also passed this normal/cancellation smoke; that does not override its failing EPIPE regression.
+
+No live provider, real language server, or Windows host smoke was run; Windows launch behavior is
+covered deterministically and unchanged. No package was published, version tagged, visibility
+changed, or release workflow dispatched.

--- a/packages/pi-lsp/test/fixtures/measure-package-load.mjs
+++ b/packages/pi-lsp/test/fixtures/measure-package-load.mjs
@@ -1,0 +1,59 @@
+// One-off evaluation harness: pass a built repository root; each sample gets a new process.
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = resolve(process.argv[2] ?? ".");
+if (process.argv[3] === "load") {
+	const agentDir = mkdtempSync(join(tmpdir(), "pi-lsp-load-"));
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		const { DefaultResourceLoader, SettingsManager } = await import(
+			pathToFileURL(join(root, "node_modules/@earendil-works/pi-coding-agent/dist/index.js")).href
+		);
+		const start = performance.now();
+		const loader = new DefaultResourceLoader({
+			cwd: agentDir,
+			agentDir,
+			settingsManager: SettingsManager.inMemory({}),
+			additionalExtensionPaths: [join(root, "packages/pi-lsp/dist/index.ts")],
+		});
+		await loader.reload();
+		const result = loader.getExtensions();
+		if (result.errors.length || result.extensions.length !== 1) {
+			throw new Error(JSON.stringify(result.errors));
+		}
+		console.log((performance.now() - start).toFixed(3));
+		result.runtime.invalidate();
+	} finally {
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+} else {
+	const files = readdirSync(join(root, "packages/pi-lsp/src")).filter((f) => f.endsWith(".ts"));
+	const productionLines = files.reduce(
+		(n, f) => n + readFileSync(join(root, "packages/pi-lsp/src", f), "utf8").split("\n").length - 1,
+		0,
+	);
+	const samples = Array.from({ length: 10 }, () => {
+		const child = spawnSync(process.execPath, [import.meta.filename, root, "load"], {
+			encoding: "utf8",
+		});
+		if (child.status !== 0) throw new Error(child.stderr);
+		return Number(child.stdout.trim());
+	});
+	const sorted = [...samples].sort((a, b) => a - b);
+	console.log(
+		JSON.stringify(
+			{
+				node: process.version,
+				productionLines,
+				samples,
+				median: (sorted[4] + sorted[5]) / 2,
+			},
+			null,
+			2,
+		),
+	);
+}

--- a/packages/pi-lsp/test/fixtures/package-smoke.mjs
+++ b/packages/pi-lsp/test/fixtures/package-smoke.mjs
@@ -1,11 +1,11 @@
 // Non-interactive package-directory smoke with a loopback-only scripted provider.
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { once } from "node:events";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-package-smoke-"));
 const agentDir = path.join(root, "agent");
@@ -111,17 +111,26 @@ const args = [
 	"--model",
 	"fixture",
 	"-e",
-	"./packages/pi-lsp",
+	process.argv[2] ?? "./packages/pi-lsp",
 	"-e",
 	helper,
 ];
-const child = spawn("pi", args, {
+const child = spawn(process.argv[3] ?? "pi", args, {
 	cwd: process.cwd(),
 	env: { ...process.env, PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: "1" },
 	stdio: "pipe",
 });
-const exited = once(child, "exit");
+let childClosed = false;
+const exited = new Promise((resolve) =>
+	child.once("close", (code, signal) => {
+		childClosed = true;
+		resolve([code, signal]);
+	}),
+);
 let stderr = "";
+child.on("error", (error) => {
+	stderr += `${error.message}\n`;
+});
 child.stderr.setEncoding("utf8");
 child.stderr.on("data", (chunk) => {
 	stderr += chunk;
@@ -162,11 +171,12 @@ function waitFor(predicate, offset = 0) {
 		}
 		function cleanup() {
 			listeners.delete(check);
-			child.off("exit", failed);
+			child.off("close", failed);
 		}
 		listeners.add(check);
-		child.once("exit", failed);
+		child.once("close", failed);
 		check();
+		if (childClosed && listeners.has(check)) failed();
 	});
 }
 async function command(id, message) {
@@ -175,6 +185,13 @@ async function command(id, message) {
 	const response = await waitFor((event) => event.type === "response" && event.id === id, offset);
 	assert.equal(response.success, true, JSON.stringify(response));
 	return offset;
+}
+function readRecords() {
+	return readFileSync(log, "utf8")
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
 }
 async function run(id, message) {
 	const offset = await command(id, message);
@@ -201,16 +218,40 @@ try {
 	assert.equal(readFileSync(file, "utf8"), "// fixed\npackage main\n");
 	await command("reload", "/smoke-reload");
 	await run("after-reload", "diagnostics after reload");
+	const settingsPath = path.join(agentDir, "pi-lsp.json");
+	const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+	settings.servers.fixture.command[2] = "lifecycle-hang-textDocument/diagnostic";
+	writeFileSync(settingsPath, JSON.stringify(settings));
+	await command("reload-for-abort", "/smoke-reload");
+	const previousPids = new Set(readRecords().map((event) => event.pid));
+	const abortOffset = await command("cancelled-diagnostics", "diagnostics to cancel");
+	// Wait for a server-observable request rather than racing startup with a fixed sleep.
+	while (
+		!readRecords().some(
+			(event) => !previousPids.has(event.pid) && event.method === "textDocument/diagnostic",
+		)
+	) {
+		if (child.exitCode !== null || child.signalCode !== null)
+			throw new Error(`Pi exited: ${stderr}`);
+		await delay(5);
+	}
+	send({ id: "abort", type: "abort" });
+	const aborted = await waitFor(
+		(event) => event.type === "response" && event.id === "abort",
+		abortOffset,
+	);
+	assert.equal(aborted.success, true);
+	await waitFor((event) => event.type === "agent_settled", abortOffset);
+	const cancelled = events.slice(abortOffset).find((event) => event.type === "tool_execution_end");
+	assert.equal(cancelled?.isError, true, JSON.stringify(cancelled));
+	assert.match(JSON.stringify(cancelled.result), /abort|cancel/i);
 	await command("quit", "/smoke-quit");
 	const [code, signal] = await exited;
 	assert.equal(code, 0, `${signal}: ${stderr}`);
 	assert.ok(!events.some((event) => event.type === "extension_error"), JSON.stringify(events));
-	const records = readFileSync(log, "utf8")
-		.trim()
-		.split("\n")
-		.map((line) => JSON.parse(line));
+	const records = readRecords();
 	const pids = [...new Set(records.map((event) => event.pid))];
-	assert.equal(pids.length, 4);
+	assert.equal(pids.length, 5);
 	for (const pid of pids) {
 		assert.ok(records.some((event) => event.pid === pid && event.method === "exited"));
 		assert.throws(() => process.kill(pid, 0), /ESRCH/);
@@ -225,6 +266,8 @@ try {
 			["session_start", "startup"],
 			["session_shutdown", "reload"],
 			["session_start", "reload"],
+			["session_shutdown", "reload"],
+			["session_start", "reload"],
 			["session_shutdown", "quit"],
 		],
 	);
@@ -235,6 +278,7 @@ try {
 			diagnostics: "passed",
 			preview: "passed",
 			write: "passed",
+			cancellation: "passed",
 			reload: "passed",
 			shutdown: "passed",
 			exitedServers: pids.length,
@@ -244,7 +288,7 @@ try {
 	);
 } finally {
 	clearTimeout(deadline);
-	if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+	if (!childClosed) child.kill("SIGKILL");
 	await exited;
 	server.closeAllConnections();
 	await new Promise((resolve) => server.close(resolve));

--- a/packages/pi-lsp/test/fixtures/transport-server.mjs
+++ b/packages/pi-lsp/test/fixtures/transport-server.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { appendFileSync, closeSync } from "node:fs";
+
+const [scenario, log] = process.argv.slice(2);
+let buffer = Buffer.alloc(0);
+const requests = [];
+const replies = new Map();
+function record(method) {
+	appendFileSync(log, `${JSON.stringify({ method, pid: process.pid })}\n`);
+}
+function frame(message) {
+	const body = Buffer.from(JSON.stringify({ jsonrpc: "2.0", ...message }));
+	return Buffer.concat([Buffer.from(`Content-Length: ${body.length}\r\n\r\n`), body]);
+}
+function send(message) {
+	process.stdout.write(frame(message));
+}
+async function handle(message) {
+	record(message.method ?? `response:${message.id}`);
+	if (!message.method) {
+		replies.set(message.id, message);
+		if (replies.size === 5) {
+			assert.deepEqual(replies.get("config").result, [{}, {}, {}]);
+			assert.equal(replies.get(0).result.length, 1);
+			assert.equal(replies.get("register").result, null);
+			assert.equal(replies.get("unregister").result, null);
+			assert.equal(replies.get("unknown").error.code, -32601);
+			send({ id: requests[0].id, result: { capabilities: {} } });
+		}
+		return;
+	}
+	if (message.method === "initialize") {
+		if (scenario === "server-requests") {
+			requests.push(message);
+			for (const [id, method, params] of [
+				[
+					"config",
+					"workspace/configuration",
+					{ items: [{}, { section: "ty" }, { section: "ruff" }] },
+				],
+				[0, "workspace/workspaceFolders", {}],
+				["register", "client/registerCapability", {}],
+				["unregister", "client/unregisterCapability", {}],
+				["unknown", "fixture/unknown", {}],
+			])
+				send({ id, method, params });
+		} else send({ id: message.id, result: { capabilities: {} } });
+		return;
+	}
+	if (message.method === "textDocument/codeAction") {
+		const result = [{ title: message.params.context.only[0] }];
+		if (scenario === "split") {
+			const data = frame({ id: message.id, result });
+			// Force separate writes across the header separator and inside a UTF-8 code point.
+			const split = data.indexOf(Buffer.from("語")) + 1;
+			for (const part of [
+				data.subarray(0, 12),
+				data.subarray(12, 21),
+				data.subarray(21, split),
+				data.subarray(split),
+			]) {
+				await new Promise((resolve) => process.stdout.write(part, resolve));
+				await new Promise((resolve) => setTimeout(resolve, 5));
+			}
+		} else if (scenario === "multiple") {
+			process.stdout.write(
+				Buffer.concat([
+					frame({ method: "fixture/ignored", params: { text: "語🙂" } }),
+					frame({ id: 999999, result: null }),
+					frame({ id: message.id, result }),
+				]),
+			);
+		} else if (scenario === "out-of-order") {
+			requests.push({ id: message.id, result });
+			if (requests.length === 2) process.stdout.write(Buffer.concat(requests.reverse().map(frame)));
+		} else if (scenario === "late") {
+			requests.push({ id: message.id, result });
+			if (requests.length === 2) process.stdout.write(Buffer.concat(requests.map(frame)));
+		} else if (scenario === "bad-header") process.stdout.write("Invalid: header\r\n\r\n");
+		else if (scenario === "bad-json") process.stdout.write("Content-Length: 1\r\n\r\n{");
+		else if (scenario === "partial") process.stdout.write("Content-Length: 100\r\n\r\n{");
+		else if (scenario === "exit") {
+			process.stderr.write("intentional transport exit\n", () => process.exit(7));
+		} else if (scenario === "stdout-close") process.stdout.end();
+		else if (scenario !== "hang") send({ id: message.id, result });
+		return;
+	}
+	if (message.method === "shutdown") send({ id: message.id, result: null });
+	if (message.method === "exit") process.exit(0);
+}
+process.on("SIGTERM", () => process.exit(0));
+process.on("exit", () => record("exited"));
+process.stdin.on("data", (chunk) => {
+	buffer = Buffer.concat([buffer, chunk]);
+	while (true) {
+		const separator = buffer.indexOf("\r\n\r\n");
+		if (separator < 0) return;
+		const length = Number(
+			/Content-Length:\s*(\d+)/i.exec(buffer.subarray(0, separator).toString())?.[1],
+		);
+		const end = separator + 4 + length;
+		if (buffer.length < end) return;
+		const message = JSON.parse(buffer.subarray(separator + 4, end).toString());
+		buffer = buffer.subarray(end);
+		void handle(message);
+	}
+});
+if (scenario === "stdin-close") {
+	// Keep the process alive after its input pipe closes, then acknowledge the closed fd.
+	process.stdin.destroy();
+	closeSync(0);
+	setInterval(() => {}, 1000);
+}
+record("ready");

--- a/packages/pi-lsp/test/generated-entry.test.ts
+++ b/packages/pi-lsp/test/generated-entry.test.ts
@@ -1,32 +1,53 @@
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import type { ExtensionRunner, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
-import { createMockContext, createMockPi } from "../../../test/support.js";
-
-async function emit(
-	events: ReadonlyMap<string, Array<(...args: unknown[]) => unknown>>,
-	name: string,
-	...args: unknown[]
-) {
-	for (const handler of events.get(name) ?? []) await handler(...args);
-}
 
 test("declared generated entry preserves registration and partial lifecycle cleanup", async () => {
 	const root = mkdtempSync(join(tmpdir(), "pi-lsp-generated-entry-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-	process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+	const agentDir = join(root, "agent");
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	let runner: ExtensionRunner | undefined;
 	try {
-		const { default: extension } = await import("../dist/index.js");
-		const mock = createMockPi();
-		await extension(mock.pi);
-		assert.ok(mock.commands.has("lsp"));
-		assert.ok(mock.events.has("session_start"));
-		assert.ok(mock.events.has("session_shutdown"));
-		const context = createMockContext({ mode: "tui", cwd: root });
-		await emit(mock.events, "session_shutdown", { reason: "quit" }, context.ctx);
+		const { DefaultResourceLoader, ExtensionRunner, SessionManager, SettingsManager } =
+			await import("@earendil-works/pi-coding-agent");
+		const loader = new DefaultResourceLoader({
+			cwd: root,
+			agentDir,
+			settingsManager: SettingsManager.inMemory({}),
+			additionalExtensionPaths: [resolve("packages/pi-lsp")],
+		});
+		await loader.reload();
+		const loaded = loader.getExtensions();
+		assert.deepEqual(loaded.errors, []);
+		assert.equal(loaded.extensions.length, 1);
+		const extension = loaded.extensions[0];
+		assert.equal(extension.resolvedPath, resolve("packages/pi-lsp/dist/index.ts"));
+		assert.ok(extension.commands.has("lsp"));
+		assert.ok(extension.handlers.has("session_start"));
+		assert.ok(extension.handlers.has("session_shutdown"));
+		runner = new ExtensionRunner(
+			loaded.extensions,
+			loaded.runtime,
+			root,
+			SessionManager.inMemory(root),
+			{} as ModelRegistry,
+		);
+		const errors: unknown[] = [];
+		runner.onError((error) => errors.push(error));
+		await runner.emit({ type: "session_shutdown", reason: "quit" });
+		await runner.emit({ type: "session_start", reason: "startup" });
+		await runner.emit({ type: "session_shutdown", reason: "quit" });
+		await runner.emit({ type: "session_shutdown", reason: "quit" });
+		assert.deepEqual(errors, []);
 	} finally {
+		if (runner) {
+			await runner.emit({ type: "session_shutdown", reason: "quit" });
+			runner.invalidate();
+		}
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(root, { force: true, recursive: true });

--- a/packages/pi-lsp/test/transport.test.ts
+++ b/packages/pi-lsp/test/transport.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { test } from "vitest";
+import { LspClient } from "../src/lsp-client.js";
+import type { LspServerAdapter } from "../src/types.js";
+
+function fixture(scenario: string, name = "transport") {
+	const root = mkdtempSync(path.join(os.tmpdir(), "pi-lsp-transport-"));
+	const log = path.join(root, "events.jsonl");
+	const adapter: LspServerAdapter = {
+		name,
+		isDefault: false,
+		defaultCommand: {
+			command: process.execPath,
+			args: [path.resolve("packages/pi-lsp/test/fixtures/transport-server.mjs"), scenario, log],
+		},
+		missingCommandHint: "Node is required",
+		extensions: [".go"],
+		skipDirectories: new Set(),
+		diagnosticsSettleMs: 20,
+		isSupportedFile: () => true,
+		languageIdFor: () => "go",
+	};
+	const client = new LspClient(adapter, adapter.defaultCommand, root, 300);
+	const uri = pathToFileURL(path.join(root, "語🙂.go")).href;
+	function events(): Array<{ pid: number; method: string }> {
+		return existsSync(log)
+			? readFileSync(log, "utf8")
+					.trim()
+					.split("\n")
+					.filter(Boolean)
+					.map((line) => JSON.parse(line))
+			: [];
+	}
+	async function ready(method: string) {
+		while (!events().some((event) => event.method === method)) await setTimeout(5);
+	}
+	async function start() {
+		await client.start();
+		await ready("ready");
+		// Request deadlines begin after the real subprocess has acknowledged readiness.
+	}
+	async function dispose() {
+		client.close();
+		client.close();
+		await client.shutdown();
+		await client.shutdown();
+		const pid = events()[0]?.pid;
+		if (pid) assert.throws(() => process.kill(pid, 0), /ESRCH/);
+		rmSync(root, { recursive: true, force: true });
+	}
+	return { client, uri, root, start, ready, dispose };
+}
+
+for (const scenario of ["split", "multiple", "out-of-order", "late"]) {
+	test(`transport: ${scenario} preserves response correlation and UTF-8`, async () => {
+		const f = fixture(scenario);
+		try {
+			await f.start();
+			await f.client.initialize(f.root);
+			const request = (kind: string) => f.client.codeActions(f.uri, "語🙂", [], kind);
+			if (scenario === "late") {
+				await assert.rejects(request("expired"), /timed out/);
+				assert.deepEqual(await request("current"), [{ title: "current" }]);
+			} else if (scenario === "out-of-order") {
+				assert.deepEqual(await Promise.all([request("first"), request("second")]), [
+					[{ title: "first" }],
+					[{ title: "second" }],
+				]);
+			} else assert.deepEqual(await request("語🙂"), [{ title: "語🙂" }]);
+		} finally {
+			await f.dispose();
+		}
+	});
+}
+
+for (const name of ["ty", "ruff"]) {
+	test(`transport: ${name} configuration, workspace, capability and unknown server requests`, async () => {
+		const f = fixture("server-requests", name);
+		try {
+			await f.start();
+			await f.client.initialize(f.root);
+		} finally {
+			await f.dispose();
+		}
+	});
+}
+
+for (const scenario of ["bad-header", "bad-json", "partial", "exit", "stdout-close", "hang"]) {
+	test(`transport: ${scenario} rejects pending work and repeated disposal drains the child`, async () => {
+		const f = fixture(scenario);
+		try {
+			await f.start();
+			await f.client.initialize(f.root);
+			await assert.rejects(
+				f.client.codeActions(f.uri, "", [], "source.fixAll"),
+				scenario === "bad-header" || scenario === "bad-json"
+					? /JSON|transport/i
+					: scenario === "exit"
+						? /intentional transport exit/
+						: /timed out|closed/,
+			);
+		} finally {
+			await f.dispose();
+		}
+	});
+}
+
+for (const scenario of ["bad-header", "bad-json", "exit"]) {
+	test(`transport: ${scenario} rejects a concurrent push waiter as well as its request`, async () => {
+		const f = fixture(scenario);
+		try {
+			await f.start();
+			await f.client.initialize(f.root);
+			const results = await Promise.allSettled([
+				f.client.codeActions(f.uri, "", [], "source.fixAll"),
+				f.client.diagnostics(f.uri),
+			]);
+			for (const result of results) {
+				assert.equal(result.status, "rejected");
+				if (result.status === "rejected") {
+					assert.match(
+						String(result.reason),
+						scenario === "exit" ? /intentional transport exit/ : /JSON|transport/i,
+					);
+				}
+			}
+		} finally {
+			await f.dispose();
+		}
+	});
+}
+
+test("transport: stdin stream errors remain observable", async () => {
+	const f = fixture("stdin-close");
+	try {
+		await f.start();
+		await assert.rejects(f.client.initialize(f.root), /write|EPIPE|transport/i);
+	} finally {
+		await f.dispose();
+	}
+});
+
+for (const kind of ["request", "diagnostics"] as const) {
+	test(`transport: close rejects all pending ${kind}, never returns clean diagnostics`, async () => {
+		const f = fixture("hang");
+		try {
+			await f.start();
+			await f.client.initialize(f.root);
+			const tasks = [1, 2].map(() =>
+				kind === "request"
+					? f.client.codeActions(f.uri, "", [], "source.fixAll")
+					: f.client.diagnostics(f.uri),
+			);
+			const rejected = tasks.map((task) => assert.rejects(task, /cancelled/));
+			if (kind === "request") await f.ready("textDocument/codeAction");
+			f.client.close();
+			await Promise.all(rejected);
+		} finally {
+			await f.dispose();
+		}
+	});
+}
+
+test("transport: silent push-only server without an explicit grace fails", async () => {
+	const f = fixture("hang");
+	try {
+		await f.start();
+		await f.client.initialize(f.root);
+		await assert.rejects(f.client.diagnostics(f.uri), /before timeout/);
+	} finally {
+		await f.dispose();
+	}
+});


### PR DESCRIPTION
## Summary

Retain pi-lsp's existing transport after evaluating `vscode-jsonrpc@9.0.2`. The candidate deleted 90 production lines but introduced an unhandled `write EPIPE` rejection on closed stdin. It was rejected and fully removed; production source, manifests, lockfile, and packed output are unchanged.

- Add 19 subprocess transport regressions and a repeatable package-load harness.
- Exercise the declared package entry through Pi's Jiti loader, including partial/repeated lifecycle cleanup.
- Extend local/packed RPC smokes with cancellation and launch-failure cleanup.
- Record measurements, implementation findings, and audit in `docs/research/2026-09-05_pi-lsp-jsonrpc-transport.md`; delete the completed supplied plan.

## Verification

- `npm run check` passes; `npm test`: 356 files / 3,598 tests pass.
- Explicit workspace build, `npm run package:pack -- lsp`, pack dry run, and tarball inspection pass; tarball identical to baseline.
- Local and production-only packed Pi RPC smokes pass diagnostics, preview/write, cancellation, reload, and shutdown: five exited fake servers each; loopback provider only.
- Candidate gate intentionally failed with an unhandled EPIPE error; baseline regression passes. Measured installed delta: +218,024 bytes including peers/lockfile; median load: 9.845 → 19.219 ms (host/cache-dependent).

## Risks and scope

Reviewed `docs/extension-conventions.md`, `docs/extension-settings.md`, and package instructions, including lifecycle, protocol, settings, edit/output, and package-boundary audits. Existing B1 sibling-status, B2 mutation-queue, and B3 output-bound defects remain explicitly deferred and unchanged. No live-provider, real-server, or Windows-host smoke is claimed; deterministic Windows launch tests remain passing. No dependency adoption, Changeset, publication, tag, or release workflow.
