### PR TITLE
fix(sync): ask directly for a sync setup name

### DIFF
--- a/.changeset/clear-sync-setup-name.md
+++ b/.changeset/clear-sync-setup-name.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Replace the initial setup purpose menu with direct name input, examples, and a brief explanation of suggested storage paths and separate sync choices.

--- a/.changeset/clear-sync-setup-name.md
+++ b/.changeset/clear-sync-setup-name.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-sync": patch
 ---
 
-Replace the initial setup purpose menu with direct name input, examples, and a brief explanation of suggested storage paths and separate sync choices.
+Replace the initial setup purpose menu with direct name input, examples, and a brief explanation of suggested storage paths and separate sync choices. Blank names use `default`.

--- a/.changeset/clear-sync-setup-name.md
+++ b/.changeset/clear-sync-setup-name.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-sync": patch
 ---
 
-Replace the initial setup purpose menu with direct name input, examples, and a brief explanation of suggested storage paths and separate sync choices. Blank names use `default`.
+Replace the initial setup purpose menu with direct name input, examples, and a brief explanation of suggested storage paths and separate sync choices. Blank names use `default`. Validate names and suggested backend locations before collecting connection details, and allow invalid names to be corrected immediately.

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -38,6 +38,7 @@ import {
 	updateSyncSetup,
 } from "./settings-management.js";
 import { showSyncSettings } from "./settings-ui.js";
+import { promptInitialSetupName } from "./setup-name-ui.js";
 import { useSyncSetup } from "./setup-switch.js";
 import { showAddStorageConnection, showStorageConnections } from "./storage-connections-ui.js";
 import { DEFAULT_SYNC_INCLUDE, syncIncludeSelection } from "./sync-policy.js";
@@ -355,18 +356,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 		{ signal },
 	);
 	if (signal?.aborted || !preset || preset === "Cancel") return false;
-	const targetName = await requiredInput(
-		ctx,
-		[
-			"Name this sync setup",
-			"",
-			"Examples: home, work, personal. Leave blank to use default.",
-			"Used in suggested storage paths and Git branches.",
-			"Sync content and automatic sync are chosen separately.",
-		].join("\n"),
-		"default",
-		signal,
-	);
+	const targetName = await promptInitialSetupName(ctx, preset, signal);
 	if (!targetName) return false;
 	if (preset === "WebDAV") {
 		const saved = await showWebDavSetup(ctx, targetName, signal);

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -355,7 +355,18 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 		{ signal },
 	);
 	if (signal?.aborted || !preset || preset === "Cancel") return false;
-	const targetName = await chooseInitialTargetName(ctx, signal);
+	const targetName = await requiredInput(
+		ctx,
+		[
+			"Name this sync setup",
+			"",
+			"Examples: home, work, personal. Leave blank to use home.",
+			"Used in suggested storage paths and Git branches.",
+			"Sync content and automatic sync are chosen separately.",
+		].join("\n"),
+		"home",
+		signal,
+	);
 	if (!targetName) return false;
 	if (preset === "WebDAV") {
 		const saved = await showWebDavSetup(ctx, targetName, signal);
@@ -840,18 +851,6 @@ interface ChosenRemoteLocation {
 	connectionName: string;
 	bucket: string;
 	path: string;
-}
-
-async function chooseInitialTargetName(ctx: ExtensionCommandContext, signal?: AbortSignal) {
-	const purpose = await ctx.ui.select(
-		"What will this sync setup be used for?",
-		["Personal / Home", "Work", "Custom", "Cancel"],
-		{ signal },
-	);
-	if (!purpose || purpose === "Cancel") return undefined;
-	if (purpose === "Personal / Home") return "home";
-	if (purpose === "Work") return "work";
-	return requiredInput(ctx, "Name this sync setup", "default", signal);
 }
 
 async function chooseInitialRemoteLocation(

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -360,11 +360,11 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 		[
 			"Name this sync setup",
 			"",
-			"Examples: home, work, personal. Leave blank to use home.",
+			"Examples: home, work, personal. Leave blank to use default.",
 			"Used in suggested storage paths and Git branches.",
 			"Sync content and automatic sync are chosen separately.",
 		].join("\n"),
-		"home",
+		"default",
 		signal,
 	);
 	if (!targetName) return false;

--- a/packages/pi-sync/src/setup-name-ui.ts
+++ b/packages/pi-sync/src/setup-name-ui.ts
@@ -1,0 +1,46 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { normalizeStoragePath, validateConfigName } from "./config.js";
+import { normalizeGitBranch, normalizeGitDirectory } from "./git-config.js";
+import { errorMessage, requiredInput, safeTerminalText } from "./manager-helpers.js";
+import { normalizeWebDavPath } from "./webdav-config.js";
+
+export async function promptInitialSetupName(
+	ctx: ExtensionCommandContext,
+	preset: string,
+	signal?: AbortSignal,
+) {
+	while (!signal?.aborted) {
+		const name = await requiredInput(
+			ctx,
+			[
+				"Name this sync setup",
+				"",
+				"Examples: home, work, personal. Leave blank to use default.",
+				"Used in suggested storage paths and Git branches.",
+				"Sync content and automatic sync are chosen separately.",
+			].join("\n"),
+			"default",
+			signal,
+		);
+		if (!name) return undefined;
+		try {
+			validateConfigName(name, "sync setup");
+			// Validate the same suggestions the backend prompts will offer, without changing the name.
+			const suggestedPath = `pi-sync/${name}`;
+			normalizeStoragePath(suggestedPath);
+			if (preset === "Git") {
+				normalizeGitBranch(suggestedPath);
+				normalizeGitDirectory(suggestedPath);
+			} else if (preset === "WebDAV") {
+				normalizeWebDavPath(suggestedPath);
+			}
+			return name;
+		} catch (error) {
+			ctx.ui.notify(
+				`This name cannot be used for the sync setup or its suggested storage location. ${safeTerminalText(errorMessage(error))} Enter another name (for example, default).`,
+				"warning",
+			);
+		}
+	}
+	return undefined;
+}

--- a/packages/pi-sync/test/settings-management.test.ts
+++ b/packages/pi-sync/test/settings-management.test.ts
@@ -46,7 +46,8 @@ test.each([
 	["home", "home"],
 	["work", "work"],
 	[" personal ", "personal"],
-	["", "home"],
+	["", "default"],
+	["   ", "default"],
 ])("first Cloudflare R2 setup uses entered name %j and masked credentials", async (input, name) => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
@@ -96,7 +97,7 @@ test.each([
 		});
 		assert.match(inputTitles[0], /^Name this sync setup\n/u);
 		assert.match(inputTitles[0], /Examples: home, work, personal/u);
-		assert.match(inputTitles[0], /Leave blank to use home/u);
+		assert.match(inputTitles[0], /Leave blank to use default/u);
 		assert.match(inputTitles[0], /suggested storage paths and Git branches/u);
 		assert.match(inputTitles[0], /Sync content and automatic sync are chosen separately/u);
 		assert.deepEqual(inputTitles.slice(1), ["Cloudflare R2 endpoint", "Access key ID"]);

--- a/packages/pi-sync/test/settings-management.test.ts
+++ b/packages/pi-sync/test/settings-management.test.ts
@@ -20,6 +20,7 @@ import {
 	updateLocalConfig,
 } from "../src/config.js";
 import { withConfigFilePublicationForTest, withLocalConfigFileLock } from "../src/config-file.js";
+import { showSetupWizard } from "../src/manager-ui.js";
 import {
 	addStorageConnection,
 	addSyncSetup,
@@ -41,7 +42,12 @@ function writeSettings(value = v3S3Settings()) {
 	writeFileSync(localConfigPath(), `${JSON.stringify(value, null, "\t")}\n`, { mode: 0o600 });
 }
 
-test("first Cloudflare R2 setup writes exact paths and masked version 3 credentials", async () => {
+test.each([
+	["home", "home"],
+	["work", "work"],
+	[" personal ", "personal"],
+	["", "home"],
+])("first Cloudflare R2 setup uses entered name %j and masked credentials", async (input, name) => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		const mock = createMockPi();
@@ -49,7 +55,6 @@ test("first Cloudflare R2 setup writes exact paths and masked version 3 credenti
 		const choices = [
 			"Set up sync",
 			"Cloudflare R2",
-			"Personal / Home",
 			"Use suggested location (recommended)",
 			"Store credentials privately",
 			"Recommended Pi settings",
@@ -58,7 +63,7 @@ test("first Cloudflare R2 setup writes exact paths and masked version 3 credenti
 			"Save sync setup",
 			undefined,
 		];
-		const inputs = ["https://account.r2.cloudflarestorage.com", "access-key"];
+		const inputs = [input, "https://account.r2.cloudflarestorage.com", "access-key"];
 		const rendered: string[] = [];
 		const inputTitles: string[] = [];
 		const { ctx } = createMockContext({
@@ -83,13 +88,20 @@ test("first Cloudflare R2 setup writes exact paths and masked version 3 credenti
 			region: "auto",
 			credentials: { accessKeyId: "access-key", secretAccessKey: "secret-key" },
 		});
-		assert.deepEqual(saved?.syncSetups.home.storage, {
+		assert.equal(saved?.activeSyncSetup, name);
+		assert.deepEqual(saved?.syncSetups[name].storage, {
 			connection: "r2",
 			bucket: "pi-sync",
-			path: "pi-sync/home",
+			path: `pi-sync/${name}`,
 		});
-		assert.deepEqual(inputTitles, ["Cloudflare R2 endpoint", "Access key ID"]);
-		assert.match(rendered.join("\n"), /Storage location: pi-sync\/home/u);
+		assert.match(inputTitles[0], /^Name this sync setup\n/u);
+		assert.match(inputTitles[0], /Examples: home, work, personal/u);
+		assert.match(inputTitles[0], /Leave blank to use home/u);
+		assert.match(inputTitles[0], /suggested storage paths and Git branches/u);
+		assert.match(inputTitles[0], /Sync content and automatic sync are chosen separately/u);
+		assert.deepEqual(inputTitles.slice(1), ["Cloudflare R2 endpoint", "Access key ID"]);
+		assert.ok(rendered.join("\n").includes(`Storage location: pi-sync/${name}`));
+		assert.doesNotMatch(rendered.join("\n"), /What will this sync setup be used for/u);
 		assert.doesNotMatch(rendered.join("\n"), /profiles\/|secret-key|access-key/u);
 	});
 });
@@ -102,7 +114,6 @@ test("generic S3 setup reviews one complete custom storage path", async () => {
 		const choices = [
 			"Set up sync",
 			"Other S3-compatible storage",
-			"Work",
 			"Customize remote location",
 			"Store credentials privately",
 			"Minimal settings",
@@ -112,6 +123,7 @@ test("generic S3 setup reviews one complete custom storage path", async () => {
 			undefined,
 		];
 		const inputs = [
+			"work",
 			"https://s3.example.com",
 			"ap-northeast-1",
 			"archive",
@@ -151,14 +163,13 @@ test("session inclusion requires privacy acknowledgement before settings publica
 		const choices = [
 			"Set up sync",
 			"Cloudflare R2",
-			"Personal / Home",
 			"Use suggested location (recommended)",
 			"Store credentials privately",
 			"Recommended Pi settings",
 			"Keep automatic sync off",
 			"Include session conversations",
 		];
-		const inputs = ["https://account.r2.cloudflarestorage.com", "access-key"];
+		const inputs = ["home", "https://account.r2.cloudflarestorage.com", "access-key"];
 		const { ctx } = createMockContext({
 			hasUI: true,
 			mode: "tui",
@@ -187,6 +198,58 @@ test("cancelling first setup creates neither settings nor sync state", async () 
 		assert.equal(await readLocalConfigObject(), undefined);
 		assert.equal(existsSync(path.join(agentDir, "pi-sync")), false);
 		assert.equal(existsSync(path.join(agentDir, ".pisync")), false);
+	});
+});
+
+test.each(["Cloudflare R2", "Other S3-compatible storage", "WebDAV", "Git"])(
+	"%s setup asks directly for a name and cancellation creates no settings or state",
+	async (preset) => {
+		await withTempHome(async (agentDir) => {
+			const selections: string[][] = [];
+			const inputs: string[] = [];
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async (_title: string, options: string[]) => {
+					selections.push(options);
+					return selections.length === 1 ? preset : undefined;
+				},
+				input: async (title: string) => {
+					inputs.push(title);
+					return undefined;
+				},
+			});
+			assert.equal(await showSetupWizard(ctx), false);
+			assert.equal(selections.length, 1);
+			assert.equal(inputs.length, 1);
+			assert.match(inputs[0], /^Name this sync setup\n/u);
+			assert.equal(await readLocalConfigObject(), undefined);
+			assert.equal(existsSync(path.join(agentDir, "pi-sync")), false);
+			assert.equal(existsSync(path.join(agentDir, ".pisync")), false);
+		});
+	},
+);
+
+test("aborting the name input ignores a late answer without advancing setup", async () => {
+	await withTempHome(async () => {
+		const controller = new AbortController();
+		let inputCalls = 0;
+		let receivedSignal: AbortSignal | undefined;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => "Cloudflare R2",
+			input: async (_title: string, _placeholder?: string, options?: { signal?: AbortSignal }) => {
+				inputCalls += 1;
+				receivedSignal = options?.signal;
+				controller.abort(new DOMException("Session replaced", "AbortError"));
+				return "home";
+			},
+		});
+		await assert.rejects(showSetupWizard(ctx, controller.signal), { name: "AbortError" });
+		assert.equal(receivedSignal, controller.signal);
+		assert.equal(inputCalls, 1);
+		assert.equal(await readLocalConfigObject(), undefined);
 	});
 });
 

--- a/packages/pi-sync/test/setup-name-ui.test.ts
+++ b/packages/pi-sync/test/setup-name-ui.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { ExtensionInputComponent, initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { readLocalConfigObject } from "../src/config.js";
+import { showSetupWizard } from "../src/manager-ui.js";
+import { promptInitialSetupName } from "../src/setup-name-ui.js";
+import { withTempHome } from "./helpers.js";
+
+initTheme("dark", false);
+
+test.each([32, 80])("Pi core name input renders guidance within %s columns", async (width) => {
+	let lines: string[] = [];
+	let submitted = false;
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		input: async (title: string, placeholder?: string) => {
+			let answer: string | undefined;
+			const input = new ExtensionInputComponent(
+				title,
+				placeholder,
+				(value) => {
+					submitted = true;
+					answer = value;
+				},
+				() => {},
+			);
+			try {
+				input.focused = true;
+				lines = input.render(width);
+				input.handleInput("\r");
+				return answer;
+			} finally {
+				input.dispose();
+			}
+		},
+	});
+	assert.equal(await promptInitialSetupName(ctx, "Git"), "default");
+	assert.equal(submitted, true);
+	assert.ok(lines.every((line) => visibleWidth(line) <= width));
+	const text = stripVTControlCharacters(lines.join(" ")).replace(/\s+/gu, " ");
+	assert.match(text, /Name this sync setup/u);
+	assert.match(text, /Examples: home, work, personal\. Leave blank to use default\./u);
+	assert.match(text, /Used in suggested storage paths and Git branches\./u);
+	assert.match(text, /Sync content and automatic sync are chosen separately\./u);
+});
+
+test("Pi core name input cancellation does not accept the default", async () => {
+	let cancelled = false;
+	const { ctx } = createMockContext({
+		hasUI: true,
+		mode: "tui",
+		input: async (title: string, placeholder?: string) => {
+			const input = new ExtensionInputComponent(
+				title,
+				placeholder,
+				() => {},
+				() => {
+					cancelled = true;
+				},
+			);
+			try {
+				input.handleInput("\u001b");
+				return undefined;
+			} finally {
+				input.dispose();
+			}
+		},
+	});
+	assert.equal(await promptInitialSetupName(ctx, "Git"), undefined);
+	assert.equal(cancelled, true);
+});
+
+const presets = ["Cloudflare R2", "Other S3-compatible storage", "WebDAV", "Git"];
+const invalidCommonNames = [
+	".",
+	"..",
+	"team/../work",
+	"team/./work",
+	"team//work",
+	"/work",
+	"team\\work",
+	"__proto__",
+	"prototype",
+	"constructor",
+	"a".repeat(101),
+	"work\u001b[31m",
+	"work\u0085profile",
+];
+const invalidGitNames = [
+	"work profile",
+	"work..profile",
+	"work@{profile}",
+	"work~profile",
+	"work^profile",
+	"work:profile",
+	"work?profile",
+	"work*profile",
+	"work[profile",
+	"work]profile",
+	".hidden",
+	"team/.hidden",
+	"work.lock",
+	"team.lock/work",
+	"work.",
+	"work/",
+];
+
+const invalidCases = [
+	...presets.flatMap((preset) => invalidCommonNames.map((name) => ({ preset, name }))),
+	...invalidGitNames.map((name) => ({ preset: "Git", name })),
+];
+
+test.each(invalidCases)(
+	"$preset rejects name $name before backend prompts and allows correction",
+	async ({ preset, name }) => {
+		await withTempHome(async (agentDir) => {
+			const answers = [name, "default", undefined];
+			const titles: string[] = [];
+			let selectCalls = 0;
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => (selectCalls++ === 0 ? preset : undefined),
+				input: async (title: string) => {
+					titles.push(title);
+					return answers.shift();
+				},
+			});
+			assert.equal(await showSetupWizard(ctx), false);
+			assert.equal(titles.length, 3);
+			assert.match(titles[0], /^Name this sync setup/u);
+			assert.equal(titles[1], titles[0]);
+			assert.doesNotMatch(titles[2], /^Name this sync setup/u);
+			assert.equal(selectCalls, 1);
+			assert.equal(notifications.length, 1);
+			assert.equal(notifications[0].level, "warning");
+			assert.match(notifications[0].message, /Enter another name/u);
+			assert.equal(notifications[0].message.includes("\u001b"), false);
+			assert.equal(notifications[0].message.includes("\u0085"), false);
+			assert.equal(await readLocalConfigObject(), undefined);
+			assert.equal(existsSync(path.join(agentDir, "pi-sync")), false);
+		});
+	},
+);
+
+const validCases = [
+	...presets.flatMap((preset) =>
+		["default", "team/work", "-work", "refs/work", "@", "工作", "a".repeat(100)].map((name) => ({
+			preset,
+			name,
+		})),
+	),
+	...presets
+		.filter((preset) => preset !== "Git")
+		.flatMap((preset) =>
+			["work profile", ".git", "work.lock", "work..profile", "work/"].map((name) => ({
+				preset,
+				name,
+			})),
+		),
+];
+
+test.each(validCases)("$preset accepts backend-valid name $name", async ({ preset, name }) => {
+	await withTempHome(async () => {
+		const titles: string[] = [];
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			select: async () => preset,
+			input: async (title: string) => {
+				titles.push(title);
+				return titles.length === 1 ? name : undefined;
+			},
+		});
+		assert.equal(await showSetupWizard(ctx), false);
+		assert.equal(titles.length, 2);
+		assert.doesNotMatch(titles[1], /^Name this sync setup/u);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test.each([false, true])(
+	"name correction cancellation (abort=%s) never advances setup",
+	async (abort) => {
+		await withTempHome(async () => {
+			const controller = new AbortController();
+			const titles: string[] = [];
+			const signals: (AbortSignal | undefined)[] = [];
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => "Git",
+				input: async (title: string, _placeholder?: string, options?: { signal?: AbortSignal }) => {
+					titles.push(title);
+					signals.push(options?.signal);
+					if (titles.length === 1) return "work profile";
+					if (abort) {
+						controller.abort(new DOMException("Session shut down", "AbortError"));
+						return "default";
+					}
+					return undefined;
+				},
+			});
+			const setup = showSetupWizard(ctx, controller.signal);
+			if (abort) await assert.rejects(setup, { name: "AbortError" });
+			else assert.equal(await setup, false);
+			assert.equal(titles.length, 2);
+			assert.equal(titles[1], titles[0]);
+			assert.deepEqual(signals, [controller.signal, controller.signal]);
+			assert.equal(notifications.length, 1);
+			assert.equal(await readLocalConfigObject(), undefined);
+		});
+	},
+);


### PR DESCRIPTION
## Summary
- Replace the initial Personal / Home, Work, and Custom menu with direct name input.
- Show home, work, and personal examples, explain the blank-input default, and distinguish suggested paths and Git branches from later sync choices.
- Preserve save confirmation and cancellation behavior; include a pi-sync patch Changeset.

## Verification
- npm run check passed (build, Biome, package boundaries, workspace typechecks).
- npm test passed: 355 files, 3,590 tests.
- Added coverage for entered names, whitespace trimming, blank input, cancellation across all four storage presets, and late answers after abort.
- Reviewed docs/extension-conventions.md and docs/extension-settings.md: cancellation, stale continuations, Pi-owned input disposal, and unchanged persistence boundaries.
- Interactive TUI smoke not run because interactive commands are unavailable in this harness. No package metadata or runtime-loading changes.