### PR TITLE
fix(sync): resolve relative Git cache roots

### DIFF
--- a/.changeset/fix-sync-relative-git-cache.md
+++ b/.changeset/fix-sync-relative-git-cache.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Resolve the Git cache root to an absolute path so snapshot publication works when the cache path is relative and payload hashing changes the subprocess working directory.

--- a/packages/pi-sync/src/git-backend.ts
+++ b/packages/pi-sync/src/git-backend.ts
@@ -74,7 +74,7 @@ export class GitSyncBackend implements SyncBackend {
 		if (!this.allowLocalRemotes) assertProductionRemote(config.profile.remote);
 		this.identity = gitBackendIdentity(config);
 		this.destination = gitDestination(config);
-		this.cacheRoot = options.cacheRoot ?? path.join(stateDir(), "git");
+		this.cacheRoot = path.resolve(options.cacheRoot ?? path.join(stateDir(), "git"));
 		this.cacheDir = path.join(this.cacheRoot, this.identity.slice("git:".length), "repository.git");
 		this.commandTimeoutMs = options.commandTimeoutMs ?? COMMAND_TIMEOUT_MS;
 		this.postCommitTimeoutMs = options.postCommitTimeoutMs ?? POST_COMMIT_TIMEOUT_MS;

--- a/packages/pi-sync/test/git-backend.test.ts
+++ b/packages/pi-sync/test/git-backend.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
+	mkdtempSync,
 	readdirSync,
 	readFileSync,
 	renameSync,
@@ -111,6 +112,33 @@ test("Git backend publishes lease-protected commits and preserves repeated-conte
 			third.head.snapshotRef,
 		);
 	} finally {
+		rmSync(fixture.root, { recursive: true, force: true });
+	}
+});
+
+test("Git backend publishes and reads snapshots with a relative cache root", async () => {
+	const fixture = createBareRemote();
+	const cacheDirectory = mkdtempSync(
+		path.join(process.cwd(), "node_modules", ".pi-sync-relative-cache-"),
+	);
+	try {
+		const cacheRoot = path.relative(process.cwd(), path.join(cacheDirectory, "relative cache"));
+		assert.equal(path.isAbsolute(cacheRoot), false);
+		const backend = new GitSyncBackend(gitConfig(fixture.remote), {
+			cacheRoot,
+			allowLocalRemotes: true,
+		});
+		const content = snapshot([{ path: "settings.json", content: Buffer.from("relative") }]);
+		const publication = await backend.publishSnapshot(content, { kind: "missing" });
+		assert.deepEqual(await backend.readHead(), publication.head);
+		assert.deepEqual(await backend.readSnapshot(publication.head.snapshotRef), content);
+		const identityDirectory = path.join(
+			cacheRoot,
+			gitBackendIdentity(gitConfig(fixture.remote)).slice("git:".length),
+		);
+		assert.deepEqual(readdirSync(identityDirectory), ["repository.git"]);
+	} finally {
+		rmSync(cacheDirectory, { recursive: true, force: true });
 		rmSync(fixture.root, { recursive: true, force: true });
 	}
 });


### PR DESCRIPTION
## Summary
- Resolve the Git cache root to an absolute path before deriving repository and temporary paths.
- Fix snapshot publication when payload hashing changes the subprocess working directory and the cache root is relative.
- Add a regression test covering publication, head/snapshot reads, and temporary cleanup, plus a pi-sync patch Changeset.

## Verification
- Reproduced the original `fatal: not a git repository: '<git-cache>'` failure before the fix.
- Git backend tests: 34 passed.
- `npm run check`: passed.
- `npm test`: 355 files, 3,583 tests passed.
- `npm run changeset:status` and `git diff --check`: passed.
- Precommit Biome and pi-sync typecheck: passed.

## Review
- Audited the diff against `docs/extension-conventions.md` and `docs/extension-settings.md`.
- Reviewed cache path consumers, mutation serialization, cancellation cleanup, and error redaction; existing lifecycle and settings behavior is unchanged.
- No metadata or runtime-loading changes; no package pack or interactive Pi smoke was needed. External Git transport was not exercised; tests use local bare remotes.