### PR TITLE
fix(sync): simplify and theme the setup name prompt

### DIFF
--- a/.changeset/tidy-sync-name-prompt.md
+++ b/.changeset/tidy-sync-name-prompt.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Simplify the setup-name prompt and distinguish its guidance with the theme's muted color.

--- a/packages/pi-sync/src/setup-name-ui.ts
+++ b/packages/pi-sync/src/setup-name-ui.ts
@@ -10,18 +10,10 @@ export async function promptInitialSetupName(
 	signal?: AbortSignal,
 ) {
 	while (!signal?.aborted) {
-		const name = await requiredInput(
-			ctx,
-			[
-				"Name this sync setup",
-				"",
-				"Examples: home, work, personal. Leave blank to use default.",
-				"Used in suggested storage paths and Git branches.",
-				"Sync content and automatic sync are chosen separately.",
-			].join("\n"),
-			"default",
-			signal,
-		);
+		const hint = "For example: home or work. Leave blank for default.";
+		// Pi styles the whole input title as accent; give only the guidance a muted role.
+		const guidance = ctx.mode === "tui" ? ctx.ui.theme.fg("muted", hint) : hint;
+		const name = await requiredInput(ctx, `Sync setup name\n${guidance}`, "default", signal);
 		if (!name) return undefined;
 		try {
 			validateConfigName(name, "sync setup");

--- a/packages/pi-sync/test/settings-management.test.ts
+++ b/packages/pi-sync/test/settings-management.test.ts
@@ -95,11 +95,10 @@ test.each([
 			bucket: "pi-sync",
 			path: `pi-sync/${name}`,
 		});
-		assert.match(inputTitles[0], /^Name this sync setup\n/u);
-		assert.match(inputTitles[0], /Examples: home, work, personal/u);
-		assert.match(inputTitles[0], /Leave blank to use default/u);
-		assert.match(inputTitles[0], /suggested storage paths and Git branches/u);
-		assert.match(inputTitles[0], /Sync content and automatic sync are chosen separately/u);
+		assert.equal(
+			inputTitles[0],
+			"Sync setup name\nFor example: home or work. Leave blank for default.",
+		);
 		assert.deepEqual(inputTitles.slice(1), ["Cloudflare R2 endpoint", "Access key ID"]);
 		assert.ok(rendered.join("\n").includes(`Storage location: pi-sync/${name}`));
 		assert.doesNotMatch(rendered.join("\n"), /What will this sync setup be used for/u);
@@ -223,7 +222,7 @@ test.each(["Cloudflare R2", "Other S3-compatible storage", "WebDAV", "Git"])(
 			assert.equal(await showSetupWizard(ctx), false);
 			assert.equal(selections.length, 1);
 			assert.equal(inputs.length, 1);
-			assert.match(inputs[0], /^Name this sync setup\n/u);
+			assert.match(inputs[0], /^Sync setup name\n/u);
 			assert.equal(await readLocalConfigObject(), undefined);
 			assert.equal(existsSync(path.join(agentDir, "pi-sync")), false);
 			assert.equal(existsSync(path.join(agentDir, ".pisync")), false);

--- a/packages/pi-sync/test/setup-name-ui.test.ts
+++ b/packages/pi-sync/test/setup-name-ui.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { stripVTControlCharacters } from "node:util";
-import { ExtensionInputComponent, initTheme } from "@earendil-works/pi-coding-agent";
+import {
+	ExtensionInputComponent,
+	getSelectListTheme,
+	initTheme,
+} from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { createMockContext } from "../../../test/support.js";
@@ -13,41 +17,87 @@ import { withTempHome } from "./helpers.js";
 
 initTheme("dark", false);
 
-test.each([32, 80])("Pi core name input renders guidance within %s columns", async (width) => {
-	let lines: string[] = [];
-	let submitted = false;
+test.each([
+	{ width: 32, themeName: "dark" },
+	{ width: 80, themeName: "dark" },
+	{ width: 32, themeName: "light" },
+	{ width: 80, themeName: "light" },
+])(
+	"Pi core name input renders themed guidance at $width columns ($themeName)",
+	async ({ width, themeName }) => {
+		initTheme(themeName, false);
+		let lines: string[] = [];
+		let submitted = false;
+		const roles: string[] = [];
+		const colors = getSelectListTheme();
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			theme: {
+				fg: (role: string, text: string) => {
+					roles.push(role);
+					return colors.description(text);
+				},
+			},
+			input: async (title: string, placeholder?: string) => {
+				let answer: string | undefined;
+				const input = new ExtensionInputComponent(
+					title,
+					placeholder,
+					(value) => {
+						submitted = true;
+						answer = value;
+					},
+					() => {},
+				);
+				try {
+					input.focused = true;
+					lines = input.render(width);
+					input.handleInput("\r");
+					return answer;
+				} finally {
+					input.dispose();
+				}
+			},
+		});
+		assert.equal(await promptInitialSetupName(ctx, "Git"), "default");
+		assert.equal(submitted, true);
+		assert.ok(lines.every((line) => visibleWidth(line) <= width));
+		const text = stripVTControlCharacters(lines.join(" ")).replace(/\s+/gu, " ");
+		assert.match(text, /Sync setup name/u);
+		assert.match(text, /For example: home or work\. Leave blank for default\./u);
+		assert.doesNotMatch(text, /Git branches|automatic sync/u);
+		const heading = lines.find((line) => line.includes("Sync setup name"));
+		const guidance = lines.find((line) => line.includes("For example:"));
+		const accent = colors.selectedText("sample").split("sample")[0];
+		const muted = colors.description("sample").split("sample")[0];
+		assert.deepEqual(roles, ["muted"]);
+		assert.ok(heading?.includes(`${accent}Sync setup name`));
+		assert.ok(guidance?.includes(`${muted}For example:`));
+		assert.notEqual(accent, muted);
+	},
+);
+
+test("RPC name input keeps guidance free of terminal styling", async () => {
+	let renderedTitle = "";
 	const { ctx } = createMockContext({
 		hasUI: true,
-		mode: "tui",
-		input: async (title: string, placeholder?: string) => {
-			let answer: string | undefined;
-			const input = new ExtensionInputComponent(
-				title,
-				placeholder,
-				(value) => {
-					submitted = true;
-					answer = value;
-				},
-				() => {},
-			);
-			try {
-				input.focused = true;
-				lines = input.render(width);
-				input.handleInput("\r");
-				return answer;
-			} finally {
-				input.dispose();
-			}
+		mode: "rpc",
+		theme: {
+			fg: () => {
+				throw new Error("RPC must not style input titles");
+			},
+		},
+		input: async (title: string) => {
+			renderedTitle = title;
+			return "";
 		},
 	});
 	assert.equal(await promptInitialSetupName(ctx, "Git"), "default");
-	assert.equal(submitted, true);
-	assert.ok(lines.every((line) => visibleWidth(line) <= width));
-	const text = stripVTControlCharacters(lines.join(" ")).replace(/\s+/gu, " ");
-	assert.match(text, /Name this sync setup/u);
-	assert.match(text, /Examples: home, work, personal\. Leave blank to use default\./u);
-	assert.match(text, /Used in suggested storage paths and Git branches\./u);
-	assert.match(text, /Sync content and automatic sync are chosen separately\./u);
+	assert.equal(
+		renderedTitle,
+		"Sync setup name\nFor example: home or work. Leave blank for default.",
+	);
 });
 
 test("Pi core name input cancellation does not accept the default", async () => {
@@ -134,9 +184,9 @@ test.each(invalidCases)(
 			});
 			assert.equal(await showSetupWizard(ctx), false);
 			assert.equal(titles.length, 3);
-			assert.match(titles[0], /^Name this sync setup/u);
+			assert.match(titles[0], /^Sync setup name/u);
 			assert.equal(titles[1], titles[0]);
-			assert.doesNotMatch(titles[2], /^Name this sync setup/u);
+			assert.doesNotMatch(titles[2], /^Sync setup name/u);
 			assert.equal(selectCalls, 1);
 			assert.equal(notifications.length, 1);
 			assert.equal(notifications[0].level, "warning");
@@ -180,7 +230,7 @@ test.each(validCases)("$preset accepts backend-valid name $name", async ({ prese
 		});
 		assert.equal(await showSetupWizard(ctx), false);
 		assert.equal(titles.length, 2);
-		assert.doesNotMatch(titles[1], /^Name this sync setup/u);
+		assert.doesNotMatch(titles[1], /^Sync setup name/u);
 		assert.deepEqual(notifications, []);
 	});
 });

--- a/test/support.ts
+++ b/test/support.ts
@@ -307,6 +307,7 @@ export function createMockContext(overrides: Record<string, unknown> = {}) {
 		hasUI: overrides.hasUI ?? (overrides.mode === "tui" || overrides.mode === "rpc"),
 		model: overrides.model,
 		ui: {
+			theme: overrides.theme ?? { fg: (_role: string, text: string) => text },
 			notify(message: string, level?: string) {
 				notifications.push({ message, level });
 			},


### PR DESCRIPTION
## Summary

Simplify the pi-sync setup-name screen to a short title and one muted hint instead of several accent-colored explanations.

- Show `Sync setup name` with `For example: home or work. Leave blank for default.`
- Preserve native input, default-name, validation, cancellation, and abort behavior; keep RPC titles plain text.
- Add dark/light theme and 32/80-column rendering coverage, plus a patch Changeset.

## Verification

- `npm run check` passed (build, Biome, boundaries, workspace typechecks).
- `npm test` passed: 356 files, 3,711 tests.
- Signed commit's precommit checks passed.
- Reviewed against `docs/extension-conventions.md` and `docs/extension-settings.md`; no persistence or lifecycle logic changes and no new UI-owned tasks.
- Interactive terminal smoke not run because this environment prohibits opening an interactive TUI. Native component rendering is covered deterministically; runtime loading and package metadata are unchanged.
