### PR TITLE
fix(sync): simplify setup prompts and show defaults

### DIFF
--- a/.changeset/clear-sync-setup-prompts.md
+++ b/.changeset/clear-sync-setup-prompts.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-sync": patch
 ---
 
-Simplify initial setup to one name across storage backends. Show input examples, explanations, and blank-to-accept defaults directly in Pi's dialogs without treating example endpoints or credentials as defaults. Default all new storage paths to the repository, WebDAV collection, or bucket root, without literal dot prefixes or changes to existing settings. New Git destinations use main, with existing branch safety checks preserved.
+Simplify initial setup to one name across storage backends. Show input examples, explanations, and blank-to-accept defaults directly in Pi's dialogs without treating example endpoints or credentials as defaults. Default all new storage paths to the repository, WebDAV collection, or bucket root, without literal dot prefixes or changes to existing settings. New Git destinations use main, with existing branch safety checks preserved. Require a different path or Git branch before reviewing an additional setup when its chosen location is already configured. Preserve valid literal angle brackets in WebDAV input and edit defaults.

--- a/.changeset/clear-sync-setup-prompts.md
+++ b/.changeset/clear-sync-setup-prompts.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-sync": patch
 ---
 
-Simplify initial setup to one name across storage backends. Show input examples, explanations, and blank-to-accept defaults directly in Pi's dialogs without treating example endpoints or credentials as defaults. Default new Git destinations to main and the repository root, with root-path support and existing branch safety checks preserved.
+Simplify initial setup to one name across storage backends. Show input examples, explanations, and blank-to-accept defaults directly in Pi's dialogs without treating example endpoints or credentials as defaults. Default all new storage paths to the repository, WebDAV collection, or bucket root, without literal dot prefixes or changes to existing settings. New Git destinations use main, with existing branch safety checks preserved.

--- a/.changeset/clear-sync-setup-prompts.md
+++ b/.changeset/clear-sync-setup-prompts.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Simplify initial setup to one name across storage backends. Show input examples, explanations, and blank-to-accept defaults directly in Pi's dialogs without treating example endpoints or credentials as defaults. Default new Git destinations to main and the repository root, with root-path support and existing branch safety checks preserved.

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -47,6 +47,7 @@ Remote URLs, endpoints, usernames, and credentials require your own values, not 
 All new setups default to storage path `./`: the Git repository root, the WebDAV collection URL, or the selected R2/S3 bucket root.
 Git also suggests branch `main`.
 Use different folders or prefixes for independent setups sharing a WebDAV collection or bucket; existing settings and paths are unchanged.
+If another configured setup already uses the chosen location, setup asks for a different path before the content selection and review; Git requires a different branch, even when the directory differs.
 Before saving, review the storage connection, exact remote path, included content, automatic-sync choice, and masked credentials.
 
 Buckets and remote repositories must already exist.

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -41,10 +41,16 @@ Extensions run with Pi's permissions, so install only packages from sources you 
 ## 🚀 Quick start
 
 Run `/sync` and choose **Set up sync**.
+Name the setup once; its first storage connection uses the same name.
+Input prompts show examples or an explicit default that you can accept by submitting an empty value; cancelling never accepts a default.
+Remote URLs, endpoints, usernames, and credentials require your own values, not the displayed examples.
+Git suggests branch `main` and storage path `./` (repository root); WebDAV and R2/S3 suggest `pi-sync/<setup>` to separate snapshots in shared storage.
 Before saving, review the storage connection, exact remote path, included content, automatic-sync choice, and masked credentials.
 
 Buckets and remote repositories must already exist.
 Git uses existing non-interactive SSH or credential-helper configuration and never stores Git credentials.
+It owns the entire selected branch: use an empty repository or a new branch if `main` already contains unrelated content.
+At `./`, Git stores `manifest.json` and `files/` at the repository root; it does not modify your local working tree.
 
 ## 🧭 Manager, conflicts, and recovery
 

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -44,13 +44,16 @@ Run `/sync` and choose **Set up sync**.
 Name the setup once; its first storage connection uses the same name.
 Input prompts show examples or an explicit default that you can accept by submitting an empty value; cancelling never accepts a default.
 Remote URLs, endpoints, usernames, and credentials require your own values, not the displayed examples.
-Git suggests branch `main` and storage path `./` (repository root); WebDAV and R2/S3 suggest `pi-sync/<setup>` to separate snapshots in shared storage.
+All new setups default to storage path `./`: the Git repository root, the WebDAV collection URL, or the selected R2/S3 bucket root.
+Git also suggests branch `main`.
+Use different folders or prefixes for independent setups sharing a WebDAV collection or bucket; existing settings and paths are unchanged.
 Before saving, review the storage connection, exact remote path, included content, automatic-sync choice, and masked credentials.
 
 Buckets and remote repositories must already exist.
 Git uses existing non-interactive SSH or credential-helper configuration and never stores Git credentials.
 It owns the entire selected branch: use an empty repository or a new branch if `main` already contains unrelated content.
 At `./`, Git stores `manifest.json` and `files/` at the repository root; it does not modify your local working tree.
+WebDAV and R2/S3 store `latest.json`, `history.json`, and `snapshots/` directly under their selected root, not under a literal `./` prefix.
 
 ## 🧭 Manager, conflicts, and recovery
 

--- a/packages/pi-sync/docs/settings.md
+++ b/packages/pi-sync/docs/settings.md
@@ -116,6 +116,9 @@ WebDAV and R2/S3 write `latest.json`, `history.json`, and `snapshots/` there; us
 Existing settings, paths, and local state identities remain unchanged. Editing a setup defaults to its current path.
 Manually written documents still require an explicit non-empty `storage.path`; use `./` rather than an empty string for root.
 Git branches are exclusively managed by pi-sync; an existing branch containing unrelated files is rejected rather than overwritten.
+When adding a setup, locally configured destinations are checked before content selection and review, including equivalent connection aliases.
+An occupied destination requires an explicit different path; Git requires a different branch because directories do not isolate publications on one branch.
+This check does not contact the server or discover setups configured only on other machines.
 
 Every setup requires `sync.include` and explicit `sync.automatic`.
 `activeSyncSetup` must reference an own-property setup when any setups exist and must be absent when the setup catalog is empty.

--- a/packages/pi-sync/docs/settings.md
+++ b/packages/pi-sync/docs/settings.md
@@ -108,6 +108,11 @@ Temporary S3 credentials may additionally include `credentials.sessionToken`.
 - **WebDAV connection:** `type`, HTTPS `url`, and `credentials.username` / `credentials.password`.
 - **WebDAV setup storage:** `connection` and complete relative `path`; `bucket` and `branch` are rejected.
 
+Git accepts `.` or `./` for the repository root; both resolve to `./` and share the same local state identity.
+The setup wizard suggests `main` and `./` without changing existing settings or the required-field rules for manually written documents.
+WebDAV and S3/R2 paths remain non-empty relative folders or prefixes, with `pi-sync/<setup>` suggested during setup.
+Git branches are exclusively managed by pi-sync; an existing branch containing unrelated files is rejected rather than overwritten.
+
 Every setup requires `sync.include` and explicit `sync.automatic`.
 `activeSyncSetup` must reference an own-property setup when any setups exist and must be absent when the setup catalog is empty.
 A referenced connection cannot be removed.

--- a/packages/pi-sync/docs/settings.md
+++ b/packages/pi-sync/docs/settings.md
@@ -108,9 +108,13 @@ Temporary S3 credentials may additionally include `credentials.sessionToken`.
 - **WebDAV connection:** `type`, HTTPS `url`, and `credentials.username` / `credentials.password`.
 - **WebDAV setup storage:** `connection` and complete relative `path`; `bucket` and `branch` are rejected.
 
-Git accepts `.` or `./` for the repository root; both resolve to `./` and share the same local state identity.
-The setup wizard suggests `main` and `./` without changing existing settings or the required-field rules for manually written documents.
-WebDAV and S3/R2 paths remain non-empty relative folders or prefixes, with `pi-sync/<setup>` suggested during setup.
+Every backend accepts `.` or `./` for its root; both resolve to `./` and share the same local state and backend identity.
+New setups default to `./`, independently of the setup name; Git also suggests branch `main`.
+For WebDAV, root means directly under the configured collection URL, not the server root.
+For R2/S3, it means the selected bucket root, with no literal `./` object-key prefix.
+WebDAV and R2/S3 write `latest.json`, `history.json`, and `snapshots/` there; use separate relative folders or prefixes for independent setups sharing storage.
+Existing settings, paths, and local state identities remain unchanged. Editing a setup defaults to its current path.
+Manually written documents still require an explicit non-empty `storage.path`; use `./` rather than an empty string for root.
 Git branches are exclusively managed by pi-sync; an existing branch containing unrelated files is rejected rather than overwritten.
 
 Every setup requires `sync.include` and explicit `sync.automatic`.

--- a/packages/pi-sync/src/config.ts
+++ b/packages/pi-sync/src/config.ts
@@ -194,8 +194,9 @@ function resolveSyncConfig(
 	onSwitch: OnSwitchAction,
 	skipSecretScan: boolean,
 ): AnySyncConfig {
-	const storagePath = normalizeStoragePath(setup.storage.path);
-	const namespace = storagePath.slice(storagePath.lastIndexOf("/") + 1);
+	const storagePath = normalizeStoragePath(setup.storage.path, connection.type === "git");
+	const namespace =
+		storagePath === "./" ? "root" : storagePath.slice(storagePath.lastIndexOf("/") + 1);
 	const include = normalizeSyncInclude(setup.sync.include);
 	const common = {
 		setupName,
@@ -433,7 +434,10 @@ function validateSyncSetup(
 		);
 	}
 	const type = connection.type;
-	normalizeStoragePath(requiredString(storage.path, `storage path for sync setup “${name}”`));
+	normalizeStoragePath(
+		requiredString(storage.path, `storage path for sync setup “${name}”`),
+		type === "git",
+	);
 	if (type === "s3") {
 		normalizeS3Bucket(requiredString(storage.bucket, `S3 bucket for sync setup “${name}”`));
 		if (Object.hasOwn(storage, "branch")) mixedSetupError("S3", name);
@@ -487,7 +491,7 @@ export function effectiveSyncSetupRemoteIdentity(
 	setup: SyncSetupSettings,
 	connection: StorageConnectionSettings,
 ) {
-	const storagePath = normalizeStoragePath(setup.storage.path);
+	const storagePath = normalizeStoragePath(setup.storage.path, connection.type === "git");
 	if (connection.type === "git") {
 		return JSON.stringify([
 			"git",
@@ -602,7 +606,8 @@ function optionalString(value: unknown, field: string) {
 	return value.trim() || undefined;
 }
 
-export function normalizeStoragePath(value: string) {
+export function normalizeStoragePath(value: string, allowRoot = false) {
+	if (allowRoot && (value.trim() === "." || value.trim() === "./")) return "./";
 	const normalized = value.trim().replace(/^\/+|\/+$/gu, "");
 	if (
 		!normalized ||

--- a/packages/pi-sync/src/config.ts
+++ b/packages/pi-sync/src/config.ts
@@ -194,7 +194,7 @@ function resolveSyncConfig(
 	onSwitch: OnSwitchAction,
 	skipSecretScan: boolean,
 ): AnySyncConfig {
-	const storagePath = normalizeStoragePath(setup.storage.path, connection.type === "git");
+	const storagePath = normalizeStoragePath(setup.storage.path);
 	const namespace =
 		storagePath === "./" ? "root" : storagePath.slice(storagePath.lastIndexOf("/") + 1);
 	const include = normalizeSyncInclude(setup.sync.include);
@@ -434,10 +434,7 @@ function validateSyncSetup(
 		);
 	}
 	const type = connection.type;
-	normalizeStoragePath(
-		requiredString(storage.path, `storage path for sync setup “${name}”`),
-		type === "git",
-	);
+	normalizeStoragePath(requiredString(storage.path, `storage path for sync setup “${name}”`));
 	if (type === "s3") {
 		normalizeS3Bucket(requiredString(storage.bucket, `S3 bucket for sync setup “${name}”`));
 		if (Object.hasOwn(storage, "branch")) mixedSetupError("S3", name);
@@ -491,7 +488,7 @@ export function effectiveSyncSetupRemoteIdentity(
 	setup: SyncSetupSettings,
 	connection: StorageConnectionSettings,
 ) {
-	const storagePath = normalizeStoragePath(setup.storage.path, connection.type === "git");
+	const storagePath = normalizeStoragePath(setup.storage.path);
 	if (connection.type === "git") {
 		return JSON.stringify([
 			"git",
@@ -606,8 +603,8 @@ function optionalString(value: unknown, field: string) {
 	return value.trim() || undefined;
 }
 
-export function normalizeStoragePath(value: string, allowRoot = false) {
-	if (allowRoot && (value.trim() === "." || value.trim() === "./")) return "./";
+export function normalizeStoragePath(value: string) {
+	if (value.trim() === "." || value.trim() === "./") return "./";
 	const normalized = value.trim().replace(/^\/+|\/+$/gu, "");
 	if (
 		!normalized ||

--- a/packages/pi-sync/src/git-backend.ts
+++ b/packages/pi-sync/src/git-backend.ts
@@ -604,7 +604,7 @@ export class GitSyncBackend implements SyncBackend {
 	}
 
 	private publicationPath() {
-		return this.config.destination.directory;
+		return this.config.destination.directory === "./" ? "" : this.config.destination.directory;
 	}
 
 	private manifestPath() {

--- a/packages/pi-sync/src/git-config.ts
+++ b/packages/pi-sync/src/git-config.ts
@@ -88,6 +88,7 @@ export function normalizeGitBranch(value: string | undefined) {
 }
 
 export function normalizeGitDirectory(value: string | undefined) {
+	if (value?.trim() === "." || value?.trim() === "./") return "./";
 	const directory = trimSlashes(normalizeOptionalString(value) ?? DEFAULT_GIT_DIRECTORY);
 	if (
 		!directory ||

--- a/packages/pi-sync/src/git-ui.ts
+++ b/packages/pi-sync/src/git-ui.ts
@@ -1,6 +1,6 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { normalizeGitBranch, normalizeGitDirectory, normalizeGitRemote } from "./git-config.js";
-import { requiredInput, safeTerminalText } from "./manager-helpers.js";
+import { requiredInput, requiredValueInput, safeTerminalText } from "./manager-helpers.js";
 import {
 	addStorageConnection,
 	addSyncSetup,
@@ -16,16 +16,10 @@ export async function showGitSetup(
 	targetName: string,
 	signal?: AbortSignal,
 ) {
-	const profileName = await requiredInput(ctx, "Name this Git storage connection", "git", signal);
-	if (!profileName) return false;
-	const remoteInput = await requiredInput(
-		ctx,
-		"Git SSH or HTTPS remote",
-		"git@github.com:owner/private-pi-sync.git",
-		signal,
-	);
+	const profileName = targetName;
+	const remoteInput = await promptGitRemote(ctx, signal);
 	if (!remoteInput) return false;
-	const destination = await promptGitDestination(ctx, targetName, signal);
+	const destination = await promptGitDestination(ctx, signal);
 	if (!destination) return false;
 	const automatic = await ctx.ui.select(
 		"Automatic sync for this setup",
@@ -91,12 +85,7 @@ export async function showGitSetup(
 export async function showAddGitStorageProfile(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	const name = await requiredInput(ctx, "Name this Git storage connection", "git", signal);
 	if (!name) return false;
-	const remoteInput = await requiredInput(
-		ctx,
-		"Git SSH or HTTPS remote",
-		"git@github.com:owner/private-pi-sync.git",
-		signal,
-	);
+	const remoteInput = await promptGitRemote(ctx, signal);
 	if (!remoteInput) return false;
 	let remote: string | undefined;
 	try {
@@ -126,13 +115,10 @@ export async function showEditGitStorageProfile(
 	signal?: AbortSignal,
 	affectedSetups?: string[],
 ) {
-	const remoteInput = await requiredInput(
+	const remoteInput = await promptGitRemote(
 		ctx,
-		"Git SSH or HTTPS remote",
-		typeof profile.remote === "string"
-			? profile.remote
-			: "git@github.com:owner/private-pi-sync.git",
 		signal,
+		typeof profile.remote === "string" ? profile.remote : undefined,
 	);
 	if (!remoteInput) return false;
 	let remote: string | undefined;
@@ -170,7 +156,7 @@ export async function showAddGitTarget(
 	profile: string,
 	signal?: AbortSignal,
 ) {
-	const destination = await promptGitDestination(ctx, name, signal);
+	const destination = await promptGitDestination(ctx, signal);
 	if (!destination) return false;
 	const preset = await ctx.ui.select(
 		"Choose included content",
@@ -221,7 +207,7 @@ export async function showEditGitTarget(
 	signal?: AbortSignal,
 ) {
 	const targetName = partial.setupName;
-	const destination = await promptGitDestination(ctx, targetName, signal, partial);
+	const destination = await promptGitDestination(ctx, signal, partial);
 	if (!destination) return false;
 	if (destination.directory !== partial.storagePath && destination.branch === partial.branch) {
 		ctx.ui.notify(
@@ -259,31 +245,46 @@ export async function showEditGitTarget(
 	return true;
 }
 
+async function promptGitRemote(
+	ctx: ExtensionCommandContext,
+	signal?: AbortSignal,
+	current?: string,
+) {
+	const title =
+		"Git remote URL (SSH or HTTPS)\n\nUse an existing private repository with Git/SSH authentication already configured.";
+	return current
+		? requiredInput(ctx, title, current, signal)
+		: requiredValueInput(
+				ctx,
+				title,
+				"git@github.com:owner/private-pi-sync.git (SSH) or https://github.com/owner/private-pi-sync.git (HTTPS)",
+				signal,
+			);
+}
+
 async function promptGitDestination(
 	ctx: ExtensionCommandContext,
-	targetName: string,
 	signal?: AbortSignal,
 	current: Partial<PartialConfig> = {},
 ) {
 	const branchInput = await requiredInput(
 		ctx,
-		"Owned Git branch",
-		current.branch ?? `pi-sync/${targetName}`,
+		"Git branch for sync snapshots\n\npi-sync manages this entire branch, not your local working branch.\nUse a new branch or one already used by pi-sync; unrelated content is rejected.",
+		current.branch ?? "main",
 		signal,
 	);
 	if (!branchInput) return undefined;
 	const pathInput = await requiredInput(
 		ctx,
-		"Git storage path",
-		current.storagePath ?? `pi-sync/${targetName}`,
+		"Git storage path\n\nRelative to the repository root, not your local filesystem.\n./ stores manifest.json and files/ at the repository root.",
+		current.storagePath ?? "./",
 		signal,
 	);
 	if (!pathInput) return undefined;
 	try {
 		const branch = normalizeGitBranch(branchInput);
 		const directory = normalizeGitDirectory(pathInput);
-		const namespace = directory.slice(directory.lastIndexOf("/") + 1);
-		return { branch, directory, namespace };
+		return { branch, directory };
 	} catch (error) {
 		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 		return undefined;

--- a/packages/pi-sync/src/git-ui.ts
+++ b/packages/pi-sync/src/git-ui.ts
@@ -8,6 +8,7 @@ import {
 	updateStorageConnection,
 	updateSyncSetup,
 } from "./settings-management.js";
+import { promptAvailableSetupStorage } from "./setup-location-ui.js";
 import { DEFAULT_SYNC_INCLUDE } from "./sync-policy.js";
 import type { PartialConfig } from "./types.js";
 
@@ -156,8 +157,15 @@ export async function showAddGitTarget(
 	profile: string,
 	signal?: AbortSignal,
 ) {
-	const destination = await promptGitDestination(ctx, signal);
-	if (!destination) return false;
+	const selected = await promptGitDestination(ctx, signal);
+	if (!selected) return false;
+	const storage = await promptAvailableSetupStorage(
+		ctx,
+		{ connection: profile, branch: selected.branch, path: selected.directory },
+		signal,
+	);
+	if (!storage) return false;
+	const destination = { branch: storage.branch, directory: storage.path };
 	const preset = await ctx.ui.select(
 		"Choose included content",
 		["Recommended Pi settings", "Minimal settings", "Cancel"],

--- a/packages/pi-sync/src/manager-helpers.ts
+++ b/packages/pi-sync/src/manager-helpers.ts
@@ -31,7 +31,7 @@ export async function requiredInput(
 	defaultValue: string,
 	signal?: AbortSignal,
 ) {
-	return promptValue(ctx, title, { defaultValue }, signal);
+	return withoutPlaceholder(await promptTextInput(ctx, title, { defaultValue }, signal));
 }
 
 export async function requiredValueInput(
@@ -40,10 +40,11 @@ export async function requiredValueInput(
 	example: string,
 	signal?: AbortSignal,
 ) {
-	return promptValue(ctx, title, { example }, signal);
+	return withoutPlaceholder(await promptTextInput(ctx, title, { example }, signal));
 }
 
-async function promptValue(
+// Text collection does not impose backend-specific syntax; callers validate the returned value.
+export async function promptTextInput(
 	ctx: ExtensionCommandContext,
 	title: string,
 	options: { defaultValue?: string; example?: string },
@@ -67,7 +68,12 @@ async function promptValue(
 		ctx.ui.notify(`${title.split("\n")[0]} is required.`, "warning");
 		return undefined;
 	}
-	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
+	return normalized;
+}
+
+function withoutPlaceholder(value: string | undefined) {
+	// Preserve the existing Git/S3 placeholder policy; WebDAV permits literal angle brackets.
+	return value?.includes("<") || value?.includes(">") ? undefined : value;
 }
 
 export function storageDescription(

--- a/packages/pi-sync/src/manager-helpers.ts
+++ b/packages/pi-sync/src/manager-helpers.ts
@@ -6,7 +6,11 @@ export async function requiredExistingBucket(
 	example: string,
 	signal?: AbortSignal,
 ) {
-	const value = await ctx.ui.input("Existing bucket", `Example: ${example}`, { signal });
+	const value = await ctx.ui.input(
+		`Existing bucket\n\nThe bucket must already exist; pi-sync will not create it.\nExample: ${safeTerminalText(example)}`,
+		undefined,
+		{ signal },
+	);
 	if (signal?.aborted) {
 		throw signal.reason instanceof Error
 			? signal.reason
@@ -24,17 +28,45 @@ export async function requiredExistingBucket(
 export async function requiredInput(
 	ctx: ExtensionCommandContext,
 	title: string,
-	placeholder: string,
+	defaultValue: string,
 	signal?: AbortSignal,
 ) {
-	const value = await ctx.ui.input(title, placeholder, { signal });
+	return promptValue(ctx, title, { defaultValue }, signal);
+}
+
+export async function requiredValueInput(
+	ctx: ExtensionCommandContext,
+	title: string,
+	example: string,
+	signal?: AbortSignal,
+) {
+	return promptValue(ctx, title, { example }, signal);
+}
+
+async function promptValue(
+	ctx: ExtensionCommandContext,
+	title: string,
+	options: { defaultValue?: string; example?: string },
+	signal?: AbortSignal,
+) {
+	if (signal?.aborted) signal.throwIfAborted();
+	// Pi's TUI ignores input placeholders. Keep guidance visible in the title in every UI mode.
+	const hint =
+		options.defaultValue !== undefined
+			? `Default: ${safeTerminalText(options.defaultValue)} (leave blank to keep)`
+			: `Example: ${safeTerminalText(options.example ?? "")}\nEnter your own value; this example is not a default.`;
+	const value = await ctx.ui.input(`${title}\n\n${hint}`, undefined, { signal });
 	if (signal?.aborted) {
 		throw signal.reason instanceof Error
 			? signal.reason
 			: new DOMException("The operation was aborted", "AbortError");
 	}
 	if (value === undefined) return undefined;
-	const normalized = value.trim() || placeholder;
+	const normalized = value.trim() || options.defaultValue;
+	if (!normalized) {
+		ctx.ui.notify(`${title.split("\n")[0]} is required.`, "warning");
+		return undefined;
+	}
 	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
 }
 

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -4,7 +4,6 @@ import { type RunRoute, runCancellableOperation } from "./cancellable-operation.
 import { setSyncSetupCompletions } from "./command.js";
 import {
 	configuredSyncSetupNames,
-	isCloudflareR2Endpoint,
 	loadConfig,
 	loadOnSwitch,
 	loadPartialConfig,
@@ -23,7 +22,6 @@ import {
 import {
 	errorMessage,
 	ownRecord,
-	requiredExistingBucket,
 	requiredInput,
 	requiredValueInput,
 	safeTerminalText,
@@ -40,6 +38,11 @@ import {
 	updateSyncSetup,
 } from "./settings-management.js";
 import { showSyncSettings } from "./settings-ui.js";
+import {
+	chooseAdditionalRemoteLocation,
+	chooseInitialRemoteLocation,
+	promptAvailableSetupStorage,
+} from "./setup-location-ui.js";
 import { promptInitialSetupName } from "./setup-name-ui.js";
 import { useSyncSetup } from "./setup-switch.js";
 import { showAddStorageConnection, showStorageConnections } from "./storage-connections-ui.js";
@@ -726,7 +729,13 @@ async function showAddTarget(ctx: ExtensionCommandContext, signal?: AbortSignal)
 	}
 	const location = await chooseAdditionalRemoteLocation(ctx, raw, profile, name, signal);
 	if (!location) return;
-	const { bucket, path: storagePath } = location;
+	const storage = await promptAvailableSetupStorage(
+		ctx,
+		{ connection: profile, ...location },
+		signal,
+	);
+	if (!storage) return;
+	const { bucket, path: storagePath } = storage;
 	const preset = await ctx.ui.select(
 		"Choose included content",
 		["Recommended Pi settings", "Minimal settings", "Cancel"],
@@ -849,146 +858,4 @@ async function showRemoveTarget(ctx: ExtensionCommandContext, name: string, sign
 
 async function refreshTargetCompletions() {
 	setSyncSetupCompletions(await configuredSyncSetupNames());
-}
-
-interface ChosenRemoteLocation {
-	connectionName: string;
-	bucket: string;
-	path: string;
-}
-
-async function chooseInitialRemoteLocation(
-	ctx: ExtensionCommandContext,
-	preset: string,
-	setupName: string,
-	signal?: AbortSignal,
-): Promise<ChosenRemoteLocation | undefined> {
-	const connectionName = setupName;
-	const suggested = {
-		connectionName,
-		bucket: "pi-sync",
-		path: "./",
-	};
-	if (preset === "Cloudflare R2") {
-		const choice = await ctx.ui.select(
-			[
-				"Choose storage location",
-				"",
-				`Suggested storage connection: ${safeTerminalText(connectionName)}`,
-				`Suggested bucket: ${suggested.bucket}`,
-				`Remote path: ${safeTerminalText(suggested.path)}`,
-				"Bucket must already exist. pi-sync will not create it.",
-			].join("\n"),
-			["Use suggested location (recommended)", "Customize remote location", "Cancel"],
-			{ signal },
-		);
-		if (signal?.aborted || !choice || choice === "Cancel") return undefined;
-		if (choice === "Use suggested location (recommended)") return suggested;
-		return chooseCustomRemoteLocation(ctx, connectionName, signal);
-	}
-
-	const choice = await ctx.ui.select(
-		[
-			"Choose storage location",
-			"",
-			`Suggested storage connection: ${safeTerminalText(connectionName)}`,
-			`Suggested path: ${safeTerminalText(suggested.path)}`,
-			"S3 bucket names may need to be globally unique and the bucket must already exist.",
-		].join("\n"),
-		[
-			"Use existing bucket with suggested path (recommended)",
-			"Customize remote location",
-			"Cancel",
-		],
-		{ signal },
-	);
-	if (signal?.aborted || !choice || choice === "Cancel") return undefined;
-	if (choice === "Customize remote location") {
-		return chooseCustomRemoteLocation(ctx, connectionName, signal);
-	}
-	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name", signal);
-	return bucket ? { ...suggested, bucket } : undefined;
-}
-
-async function chooseAdditionalRemoteLocation(
-	ctx: ExtensionCommandContext,
-	settings: Record<string, unknown>,
-	connectionName: string,
-	setupName: string,
-	signal?: AbortSignal,
-): Promise<Omit<ChosenRemoteLocation, "connectionName"> | undefined> {
-	const setups = ownRecord(settings.syncSetups) ?? {};
-	const currentSetup =
-		typeof settings.activeSyncSetup === "string" ? settings.activeSyncSetup : undefined;
-	const candidates = Object.entries(setups)
-		.map(([name, value]) => ({ name, storage: ownRecord(ownRecord(value)?.storage) }))
-		.filter(
-			(item): item is { name: string; storage: Record<string, unknown> } =>
-				item.storage?.connection === connectionName && typeof item.storage.bucket === "string",
-		);
-	const source =
-		candidates.find((item) => item.name === currentSetup) ??
-		candidates.sort((left, right) => left.name.localeCompare(right.name))[0];
-	if (source) {
-		const suggestedPath = "./";
-		const sameBucketLabel = `Same bucket as “${safeTerminalText(source.name)}”`;
-		const choice = await ctx.ui.select(
-			[
-				`Storage location for “${safeTerminalText(setupName)}”`,
-				"",
-				`Existing bucket: ${safeTerminalText(String(source.storage.bucket))}`,
-				`Remote path: ${safeTerminalText(suggestedPath)}`,
-				"./ uses the bucket root. Use a different path or bucket for independent setups.",
-			].join("\n"),
-			[sameBucketLabel, "Use a different bucket", "Customize remote location", "Cancel"],
-			{ signal },
-		);
-		if (signal?.aborted || !choice || choice === "Cancel") return undefined;
-		if (choice === sameBucketLabel) {
-			return { bucket: String(source.storage.bucket), path: suggestedPath };
-		}
-		if (choice === "Use a different bucket") {
-			const bucket = await requiredExistingBucket(ctx, "pi-sync", signal);
-			return bucket ? { bucket, path: "./" } : undefined;
-		}
-		const custom = await chooseCustomRemoteLocation(ctx, connectionName, signal);
-		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
-	}
-
-	const connectionSettings = ownRecord(ownRecord(settings.storageConnections)?.[connectionName]);
-	const isR2 = isCloudflareR2Endpoint(String(connectionSettings?.endpoint ?? ""));
-	const suggestedPath = "./";
-	const suggestedLabel = isR2
-		? "Use suggested location (recommended)"
-		: "Use existing bucket with suggested path (recommended)";
-	const choice = await ctx.ui.select(
-		`Storage location for “${safeTerminalText(setupName)}”\n\nSuggested path: ${safeTerminalText(suggestedPath)}`,
-		[suggestedLabel, "Customize remote location", "Cancel"],
-		{ signal },
-	);
-	if (signal?.aborted || !choice || choice === "Cancel") return undefined;
-	if (choice === "Customize remote location") {
-		const custom = await chooseCustomRemoteLocation(ctx, connectionName, signal);
-		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
-	}
-	if (isR2) return { bucket: "pi-sync", path: suggestedPath };
-	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name", signal);
-	return bucket ? { bucket, path: suggestedPath } : undefined;
-}
-
-async function chooseCustomRemoteLocation(
-	ctx: ExtensionCommandContext,
-	connectionName: string,
-	signal?: AbortSignal,
-): Promise<ChosenRemoteLocation | undefined> {
-	const bucket = await requiredExistingBucket(ctx, "pi-sync", signal);
-	if (!bucket) return undefined;
-	const storagePath = await requiredInput(
-		ctx,
-		"Storage path\n\nObject-key prefix inside the bucket, not your local filesystem.\n./ uses the bucket root. Use different prefixes for independent setups.",
-		"./",
-		signal,
-	);
-	if (!storagePath) return undefined;
-	return { connectionName, bucket, path: normalizeStoragePath(storagePath) };
 }

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -24,6 +24,7 @@ import {
 	ownRecord,
 	requiredExistingBucket,
 	requiredInput,
+	requiredValueInput,
 	safeTerminalText,
 } from "./manager-helpers.js";
 import { recoverSyncAccess } from "./manager-recovery.js";
@@ -370,9 +371,11 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 		if (saved) await refreshTargetCompletions();
 		return saved;
 	}
-	const endpoint = await requiredInput(
+	const endpoint = await requiredValueInput(
 		ctx,
-		preset === "Cloudflare R2" ? "Cloudflare R2 endpoint" : "S3-compatible endpoint",
+		preset === "Cloudflare R2"
+			? "Cloudflare R2 endpoint\n\nCopy the S3 API endpoint from your R2 account; replace <account-id>."
+			: "S3-compatible endpoint\n\nUse your provider's S3 API URL, not its web console.",
 		preset === "Cloudflare R2"
 			? "https://<account-id>.r2.cloudflarestorage.com"
 			: "https://s3.example.com",
@@ -381,7 +384,12 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 	if (!endpoint) return false;
 	let region = "auto";
 	if (preset !== "Cloudflare R2") {
-		const selectedRegion = await requiredInput(ctx, "Storage region", "us-east-1", signal);
+		const selectedRegion = await requiredInput(
+			ctx,
+			"Storage region\n\nUse the region assigned to your bucket by the provider.",
+			"us-east-1",
+			signal,
+		);
 		if (!selectedRegion) return false;
 		region = selectedRegion;
 	}
@@ -785,7 +793,12 @@ async function showEditTarget(ctx: ExtensionCommandContext, name: string, signal
 	}
 	const bucket = await requiredInput(ctx, "Bucket", partial.bucket ?? "pi-sync", signal);
 	if (!bucket) return;
-	const storagePath = await requiredInput(ctx, "Storage path", partial.storagePath, signal);
+	const storagePath = await requiredInput(
+		ctx,
+		"Storage path\n\nObject-key prefix inside the bucket, not your local filesystem.",
+		partial.storagePath,
+		signal,
+	);
 	if (!storagePath) return;
 	const normalizedPath = storagePath.replace(/^\/+|\/+$/gu, "");
 	const choice = await ctx.ui.select(
@@ -849,7 +862,7 @@ async function chooseInitialRemoteLocation(
 	setupName: string,
 	signal?: AbortSignal,
 ): Promise<ChosenRemoteLocation | undefined> {
-	const connectionName = preset === "Cloudflare R2" ? "r2" : "s3";
+	const connectionName = setupName;
 	const suggested = {
 		connectionName,
 		bucket: "pi-sync",
@@ -860,7 +873,7 @@ async function chooseInitialRemoteLocation(
 			[
 				"Choose storage location",
 				"",
-				`Suggested storage connection: ${connectionName}`,
+				`Suggested storage connection: ${safeTerminalText(connectionName)}`,
 				`Suggested bucket: ${suggested.bucket}`,
 				`Remote path: ${safeTerminalText(suggested.path)}`,
 				"Bucket must already exist. pi-sync will not create it.",
@@ -870,14 +883,14 @@ async function chooseInitialRemoteLocation(
 		);
 		if (!choice || choice === "Cancel") return undefined;
 		if (choice === "Use suggested location (recommended)") return suggested;
-		return chooseCustomRemoteLocation(ctx, setupName, connectionName, true, signal);
+		return chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
 	}
 
 	const choice = await ctx.ui.select(
 		[
 			"Choose storage location",
 			"",
-			`Suggested storage connection: ${connectionName}`,
+			`Suggested storage connection: ${safeTerminalText(connectionName)}`,
 			`Suggested path: ${safeTerminalText(suggested.path)}`,
 			"S3 bucket names may need to be globally unique and the bucket must already exist.",
 		].join("\n"),
@@ -890,7 +903,7 @@ async function chooseInitialRemoteLocation(
 	);
 	if (!choice || choice === "Cancel") return undefined;
 	if (choice === "Customize remote location") {
-		return chooseCustomRemoteLocation(ctx, setupName, connectionName, true, signal);
+		return chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
 	}
 	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name", signal);
 	return bucket ? { ...suggested, bucket } : undefined;
@@ -942,7 +955,7 @@ async function chooseAdditionalRemoteLocation(
 			const bucket = await requiredExistingBucket(ctx, "pi-sync", signal);
 			return bucket ? { bucket, path: `pi-sync/${setupName}` } : undefined;
 		}
-		const custom = await chooseCustomRemoteLocation(ctx, setupName, connectionName, false, signal);
+		const custom = await chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
 		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
 	}
 
@@ -959,7 +972,7 @@ async function chooseAdditionalRemoteLocation(
 	);
 	if (!choice || choice === "Cancel") return undefined;
 	if (choice === "Customize remote location") {
-		const custom = await chooseCustomRemoteLocation(ctx, setupName, connectionName, false, signal);
+		const custom = await chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
 		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
 	}
 	if (isR2) return { bucket: "pi-sync", path: suggestedPath };
@@ -970,17 +983,17 @@ async function chooseAdditionalRemoteLocation(
 async function chooseCustomRemoteLocation(
 	ctx: ExtensionCommandContext,
 	setupName: string,
-	initialConnectionName: string,
-	customizeConnectionName: boolean,
+	connectionName: string,
 	signal?: AbortSignal,
 ): Promise<ChosenRemoteLocation | undefined> {
-	const connectionName = customizeConnectionName
-		? await requiredInput(ctx, "Storage connection name", initialConnectionName, signal)
-		: initialConnectionName;
-	if (!connectionName) return undefined;
 	const bucket = await requiredExistingBucket(ctx, "pi-sync", signal);
 	if (!bucket) return undefined;
-	const storagePath = await requiredInput(ctx, "Storage path", `pi-sync/${setupName}`, signal);
+	const storagePath = await requiredInput(
+		ctx,
+		"Storage path\n\nObject-key prefix inside the bucket, not your local filesystem.\nA separate prefix keeps this setup's snapshots apart from other content.",
+		`pi-sync/${setupName}`,
+		signal,
+	);
 	if (!storagePath) return undefined;
 	return { connectionName, bucket, path: storagePath.replace(/^\/+|\/+$/gu, "") };
 }

--- a/packages/pi-sync/src/manager-ui.ts
+++ b/packages/pi-sync/src/manager-ui.ts
@@ -9,6 +9,7 @@ import {
 	loadOnSwitch,
 	loadPartialConfig,
 	localConfigPath,
+	normalizeStoragePath,
 	readLocalConfigObject,
 	syncConfigReviewIdentity,
 } from "./config.js";
@@ -357,7 +358,7 @@ export async function showSetupWizard(ctx: ExtensionCommandContext, signal?: Abo
 		{ signal },
 	);
 	if (signal?.aborted || !preset || preset === "Cancel") return false;
-	const targetName = await promptInitialSetupName(ctx, preset, signal);
+	const targetName = await promptInitialSetupName(ctx, signal);
 	if (!targetName) return false;
 	if (preset === "WebDAV") {
 		const saved = await showWebDavSetup(ctx, targetName, signal);
@@ -800,7 +801,7 @@ async function showEditTarget(ctx: ExtensionCommandContext, name: string, signal
 		signal,
 	);
 	if (!storagePath) return;
-	const normalizedPath = storagePath.replace(/^\/+|\/+$/gu, "");
+	const normalizedPath = normalizeStoragePath(storagePath);
 	const choice = await ctx.ui.select(
 		[
 			`Review sync setup “${safeTerminalText(partial.setupName)}”`,
@@ -866,7 +867,7 @@ async function chooseInitialRemoteLocation(
 	const suggested = {
 		connectionName,
 		bucket: "pi-sync",
-		path: `pi-sync/${setupName}`,
+		path: "./",
 	};
 	if (preset === "Cloudflare R2") {
 		const choice = await ctx.ui.select(
@@ -881,9 +882,9 @@ async function chooseInitialRemoteLocation(
 			["Use suggested location (recommended)", "Customize remote location", "Cancel"],
 			{ signal },
 		);
-		if (!choice || choice === "Cancel") return undefined;
+		if (signal?.aborted || !choice || choice === "Cancel") return undefined;
 		if (choice === "Use suggested location (recommended)") return suggested;
-		return chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
+		return chooseCustomRemoteLocation(ctx, connectionName, signal);
 	}
 
 	const choice = await ctx.ui.select(
@@ -901,9 +902,9 @@ async function chooseInitialRemoteLocation(
 		],
 		{ signal },
 	);
-	if (!choice || choice === "Cancel") return undefined;
+	if (signal?.aborted || !choice || choice === "Cancel") return undefined;
 	if (choice === "Customize remote location") {
-		return chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
+		return chooseCustomRemoteLocation(ctx, connectionName, signal);
 	}
 	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name", signal);
 	return bucket ? { ...suggested, bucket } : undefined;
@@ -929,39 +930,34 @@ async function chooseAdditionalRemoteLocation(
 		candidates.find((item) => item.name === currentSetup) ??
 		candidates.sort((left, right) => left.name.localeCompare(right.name))[0];
 	if (source) {
-		const sourcePath =
-			typeof source.storage.path === "string" ? source.storage.path : "pi-sync/home";
-		const sourceParent = sourcePath.includes("/")
-			? sourcePath.slice(0, sourcePath.lastIndexOf("/"))
-			: "pi-sync";
-		const suggestedPath = `${sourceParent}/${setupName}`;
-		const sameBucketLabel = `Same bucket as “${safeTerminalText(source.name)}” (recommended)`;
+		const suggestedPath = "./";
+		const sameBucketLabel = `Same bucket as “${safeTerminalText(source.name)}”`;
 		const choice = await ctx.ui.select(
 			[
 				`Storage location for “${safeTerminalText(setupName)}”`,
 				"",
-				`Recommended bucket: ${safeTerminalText(String(source.storage.bucket))}`,
+				`Existing bucket: ${safeTerminalText(String(source.storage.bucket))}`,
 				`Remote path: ${safeTerminalText(suggestedPath)}`,
-				"The complete path and local sync state remain separate.",
+				"./ uses the bucket root. Use a different path or bucket for independent setups.",
 			].join("\n"),
 			[sameBucketLabel, "Use a different bucket", "Customize remote location", "Cancel"],
 			{ signal },
 		);
-		if (!choice || choice === "Cancel") return undefined;
+		if (signal?.aborted || !choice || choice === "Cancel") return undefined;
 		if (choice === sameBucketLabel) {
 			return { bucket: String(source.storage.bucket), path: suggestedPath };
 		}
 		if (choice === "Use a different bucket") {
 			const bucket = await requiredExistingBucket(ctx, "pi-sync", signal);
-			return bucket ? { bucket, path: `pi-sync/${setupName}` } : undefined;
+			return bucket ? { bucket, path: "./" } : undefined;
 		}
-		const custom = await chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
+		const custom = await chooseCustomRemoteLocation(ctx, connectionName, signal);
 		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
 	}
 
 	const connectionSettings = ownRecord(ownRecord(settings.storageConnections)?.[connectionName]);
 	const isR2 = isCloudflareR2Endpoint(String(connectionSettings?.endpoint ?? ""));
-	const suggestedPath = `pi-sync/${setupName}`;
+	const suggestedPath = "./";
 	const suggestedLabel = isR2
 		? "Use suggested location (recommended)"
 		: "Use existing bucket with suggested path (recommended)";
@@ -970,9 +966,9 @@ async function chooseAdditionalRemoteLocation(
 		[suggestedLabel, "Customize remote location", "Cancel"],
 		{ signal },
 	);
-	if (!choice || choice === "Cancel") return undefined;
+	if (signal?.aborted || !choice || choice === "Cancel") return undefined;
 	if (choice === "Customize remote location") {
-		const custom = await chooseCustomRemoteLocation(ctx, setupName, connectionName, signal);
+		const custom = await chooseCustomRemoteLocation(ctx, connectionName, signal);
 		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
 	}
 	if (isR2) return { bucket: "pi-sync", path: suggestedPath };
@@ -982,7 +978,6 @@ async function chooseAdditionalRemoteLocation(
 
 async function chooseCustomRemoteLocation(
 	ctx: ExtensionCommandContext,
-	setupName: string,
 	connectionName: string,
 	signal?: AbortSignal,
 ): Promise<ChosenRemoteLocation | undefined> {
@@ -990,10 +985,10 @@ async function chooseCustomRemoteLocation(
 	if (!bucket) return undefined;
 	const storagePath = await requiredInput(
 		ctx,
-		"Storage path\n\nObject-key prefix inside the bucket, not your local filesystem.\nA separate prefix keeps this setup's snapshots apart from other content.",
-		`pi-sync/${setupName}`,
+		"Storage path\n\nObject-key prefix inside the bucket, not your local filesystem.\n./ uses the bucket root. Use different prefixes for independent setups.",
+		"./",
 		signal,
 	);
 	if (!storagePath) return undefined;
-	return { connectionName, bucket, path: storagePath.replace(/^\/+|\/+$/gu, "") };
+	return { connectionName, bucket, path: normalizeStoragePath(storagePath) };
 }

--- a/packages/pi-sync/src/s3-backend.ts
+++ b/packages/pi-sync/src/s3-backend.ts
@@ -257,7 +257,7 @@ export function snapshotKey(config: ResolvedS3Backend, id: string) {
 }
 
 export function storageRoot(config: ResolvedS3Backend) {
-	return config.destination.prefix;
+	return config.destination.prefix === "./" ? "" : config.destination.prefix;
 }
 
 export function pointerFor(
@@ -444,6 +444,7 @@ function assertSafeDestination(config: ResolvedS3Backend) {
 		["prefix", config.destination.prefix, true],
 		["namespace", config.destination.namespace, false],
 	] as const) {
+		if (label === "prefix" && value === "./") continue;
 		if (
 			(!allowEmpty && value.length === 0) ||
 			value.includes("\\") ||

--- a/packages/pi-sync/src/s3-credentials-ui.ts
+++ b/packages/pi-sync/src/s3-credentials-ui.ts
@@ -1,4 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { requiredValueInput } from "./manager-helpers.js";
 import { promptSecret } from "./secret-input.js";
 
 export interface ChosenS3Credentials {
@@ -55,7 +56,12 @@ export async function chooseS3Credentials(
 	);
 	throwIfAborted(signal);
 	if (choice !== "Store credentials privately") return undefined;
-	const accessKeyId = await requiredCredentialInput(ctx, "Access key ID", "access-key-id", signal);
+	const accessKeyId = await requiredValueInput(
+		ctx,
+		"Access key ID\n\nUse the S3 API access key ID issued by your provider, not the secret access key.",
+		"access-key-id",
+		signal,
+	);
 	if (!accessKeyId) return undefined;
 	const secretAccessKey = await promptSecret(ctx, "Secret access key", { signal });
 	throwIfAborted(signal);
@@ -65,23 +71,6 @@ export async function chooseS3Credentials(
 		summary: "Stored privately (values hidden)",
 		ready: true,
 	};
-}
-
-async function requiredCredentialInput(
-	ctx: ExtensionCommandContext,
-	title: string,
-	placeholder: string,
-	signal?: AbortSignal,
-) {
-	const value = await ctx.ui.input(title, placeholder, { signal });
-	throwIfAborted(signal);
-	if (value === undefined) return undefined;
-	const normalized = value.trim();
-	if (!normalized) {
-		ctx.ui.notify(`${title} is required.`, "warning");
-		return undefined;
-	}
-	return normalized.includes("<") || normalized.includes(">") ? undefined : normalized;
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/packages/pi-sync/src/settings-management.ts
+++ b/packages/pi-sync/src/settings-management.ts
@@ -40,13 +40,12 @@ export async function saveNewV3Settings(
 			},
 		},
 	};
-	await updateLocalConfig((current) => {
+	return updateLocalConfig((current) => {
 		if (Object.keys(current.storageConnections).length || Object.keys(current.syncSetups).length) {
 			throw new Error(`Settings already exist: ${localConfigPath()}`);
 		}
-		return settings;
+		return { ...current, ...settings };
 	}, signal);
-	return settings;
 }
 
 export async function addStorageConnection(

--- a/packages/pi-sync/src/setup-location-ui.ts
+++ b/packages/pi-sync/src/setup-location-ui.ts
@@ -1,0 +1,216 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+	effectiveSyncSetupRemoteIdentity,
+	isCloudflareR2Endpoint,
+	normalizeStoragePath,
+	readLocalConfigObject,
+} from "./config.js";
+import { normalizeGitBranch } from "./git-config.js";
+import {
+	errorMessage,
+	ownRecord,
+	promptTextInput,
+	requiredExistingBucket,
+	requiredInput,
+	requiredValueInput,
+	safeTerminalText,
+} from "./manager-helpers.js";
+import type { StorageConnectionSettings, SyncSetupSettings } from "./types.js";
+
+interface ChosenRemoteLocation {
+	connectionName: string;
+	bucket: string;
+	path: string;
+}
+
+export async function chooseInitialRemoteLocation(
+	ctx: ExtensionCommandContext,
+	preset: string,
+	setupName: string,
+	signal?: AbortSignal,
+): Promise<ChosenRemoteLocation | undefined> {
+	const connectionName = setupName;
+	const suggested = {
+		connectionName,
+		bucket: "pi-sync",
+		path: "./",
+	};
+	if (preset === "Cloudflare R2") {
+		const choice = await ctx.ui.select(
+			[
+				"Choose storage location",
+				"",
+				`Suggested storage connection: ${safeTerminalText(connectionName)}`,
+				`Suggested bucket: ${suggested.bucket}`,
+				`Remote path: ${safeTerminalText(suggested.path)}`,
+				"Bucket must already exist. pi-sync will not create it.",
+			].join("\n"),
+			["Use suggested location (recommended)", "Customize remote location", "Cancel"],
+			{ signal },
+		);
+		if (signal?.aborted || !choice || choice === "Cancel") return undefined;
+		if (choice === "Use suggested location (recommended)") return suggested;
+		return chooseCustomRemoteLocation(ctx, connectionName, signal);
+	}
+
+	const choice = await ctx.ui.select(
+		[
+			"Choose storage location",
+			"",
+			`Suggested storage connection: ${safeTerminalText(connectionName)}`,
+			`Suggested path: ${safeTerminalText(suggested.path)}`,
+			"S3 bucket names may need to be globally unique and the bucket must already exist.",
+		].join("\n"),
+		[
+			"Use existing bucket with suggested path (recommended)",
+			"Customize remote location",
+			"Cancel",
+		],
+		{ signal },
+	);
+	if (signal?.aborted || !choice || choice === "Cancel") return undefined;
+	if (choice === "Customize remote location") {
+		return chooseCustomRemoteLocation(ctx, connectionName, signal);
+	}
+	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name", signal);
+	return bucket ? { ...suggested, bucket } : undefined;
+}
+
+export async function chooseAdditionalRemoteLocation(
+	ctx: ExtensionCommandContext,
+	settings: Record<string, unknown>,
+	connectionName: string,
+	setupName: string,
+	signal?: AbortSignal,
+): Promise<Omit<ChosenRemoteLocation, "connectionName"> | undefined> {
+	const setups = ownRecord(settings.syncSetups) ?? {};
+	const currentSetup =
+		typeof settings.activeSyncSetup === "string" ? settings.activeSyncSetup : undefined;
+	const candidates = Object.entries(setups)
+		.map(([name, value]) => ({ name, storage: ownRecord(ownRecord(value)?.storage) }))
+		.filter(
+			(item): item is { name: string; storage: Record<string, unknown> } =>
+				item.storage?.connection === connectionName && typeof item.storage.bucket === "string",
+		);
+	const source =
+		candidates.find((item) => item.name === currentSetup) ??
+		candidates.sort((left, right) => left.name.localeCompare(right.name))[0];
+	if (source) {
+		const suggestedPath = "./";
+		const sameBucketLabel = `Same bucket as “${safeTerminalText(source.name)}”`;
+		const choice = await ctx.ui.select(
+			[
+				`Storage location for “${safeTerminalText(setupName)}”`,
+				"",
+				`Existing bucket: ${safeTerminalText(String(source.storage.bucket))}`,
+				`Remote path: ${safeTerminalText(suggestedPath)}`,
+				"./ uses the bucket root. Use a different path or bucket for independent setups.",
+			].join("\n"),
+			[sameBucketLabel, "Use a different bucket", "Customize remote location", "Cancel"],
+			{ signal },
+		);
+		if (signal?.aborted || !choice || choice === "Cancel") return undefined;
+		if (choice === sameBucketLabel) {
+			return { bucket: String(source.storage.bucket), path: suggestedPath };
+		}
+		if (choice === "Use a different bucket") {
+			const bucket = await requiredExistingBucket(ctx, "pi-sync", signal);
+			return bucket ? { bucket, path: "./" } : undefined;
+		}
+		const custom = await chooseCustomRemoteLocation(ctx, connectionName, signal);
+		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
+	}
+
+	const connectionSettings = ownRecord(ownRecord(settings.storageConnections)?.[connectionName]);
+	const isR2 = isCloudflareR2Endpoint(String(connectionSettings?.endpoint ?? ""));
+	const suggestedPath = "./";
+	const suggestedLabel = isR2
+		? "Use suggested location (recommended)"
+		: "Use existing bucket with suggested path (recommended)";
+	const choice = await ctx.ui.select(
+		`Storage location for “${safeTerminalText(setupName)}”\n\nSuggested path: ${safeTerminalText(suggestedPath)}`,
+		[suggestedLabel, "Customize remote location", "Cancel"],
+		{ signal },
+	);
+	if (signal?.aborted || !choice || choice === "Cancel") return undefined;
+	if (choice === "Customize remote location") {
+		const custom = await chooseCustomRemoteLocation(ctx, connectionName, signal);
+		return custom ? { bucket: custom.bucket, path: custom.path } : undefined;
+	}
+	if (isR2) return { bucket: "pi-sync", path: suggestedPath };
+	const bucket = await requiredExistingBucket(ctx, "pi-sync-your-name", signal);
+	return bucket ? { bucket, path: suggestedPath } : undefined;
+}
+
+async function chooseCustomRemoteLocation(
+	ctx: ExtensionCommandContext,
+	connectionName: string,
+	signal?: AbortSignal,
+): Promise<ChosenRemoteLocation | undefined> {
+	const bucket = await requiredExistingBucket(ctx, "pi-sync", signal);
+	if (!bucket) return undefined;
+	const storagePath = await requiredInput(
+		ctx,
+		"Storage path\n\nObject-key prefix inside the bucket, not your local filesystem.\n./ uses the bucket root. Use different prefixes for independent setups.",
+		"./",
+		signal,
+	);
+	if (!storagePath) return undefined;
+	return { connectionName, bucket, path: normalizeStoragePath(storagePath) };
+}
+
+/** Early UI check only; the settings writer still validates uniqueness under its lock. */
+export async function promptAvailableSetupStorage<T extends SyncSetupSettings["storage"]>(
+	ctx: ExtensionCommandContext,
+	initial: T,
+	signal?: AbortSignal,
+): Promise<T | undefined> {
+	let storage = initial;
+	while (!signal?.aborted) {
+		const settings = await readLocalConfigObject();
+		if (signal?.aborted) return undefined;
+		const connection = settings?.storageConnections[storage.connection];
+		if (!settings || !connection) throw new Error("Storage connection changed; reopen setup.");
+		const identity = setupPublicationIdentity(storage, connection);
+		const occupied = Object.entries(settings.syncSetups).find(
+			([, setup]) =>
+				setupPublicationIdentity(
+					setup.storage,
+					settings.storageConnections[setup.storage.connection],
+				) === identity,
+		);
+		if (!occupied) return storage;
+		const git = connection.type === "git";
+		const message = `${git ? "Git branch" : "Storage location"} is already used by “${safeTerminalText(occupied[0])}”. ${git ? "Use a different branch; pi-sync owns the entire branch." : "Enter a different storage path, or cancel to choose another connection or bucket."}`;
+		ctx.ui.notify(message, "warning");
+		const title = `${git ? "Git branch for the new setup" : "Storage path for the new setup"}\n\n${message}`;
+		const example = git ? "pi-sync/work" : "backups/work";
+		const value =
+			connection.type === "webdav"
+				? await promptTextInput(ctx, title, { example }, signal)
+				: await requiredValueInput(ctx, title, example, signal);
+		if (signal?.aborted || value === undefined) return undefined;
+		try {
+			storage = git
+				? { ...storage, branch: normalizeGitBranch(value) }
+				: { ...storage, path: normalizeStoragePath(value) };
+		} catch (error) {
+			ctx.ui.notify(safeTerminalText(errorMessage(error)), "warning");
+		}
+	}
+	return undefined;
+}
+
+function setupPublicationIdentity(
+	storage: SyncSetupSettings["storage"],
+	connection: StorageConnectionSettings,
+) {
+	// Git publications own a complete branch tree; changing only its directory is not isolation.
+	return effectiveSyncSetupRemoteIdentity(
+		{
+			storage: connection.type === "git" ? { ...storage, path: "./" } : storage,
+			sync: { include: [], automatic: false },
+		},
+		connection,
+	);
+}

--- a/packages/pi-sync/src/setup-name-ui.ts
+++ b/packages/pi-sync/src/setup-name-ui.ts
@@ -1,6 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { normalizeStoragePath, validateConfigName } from "./config.js";
-import { normalizeGitBranch, normalizeGitDirectory } from "./git-config.js";
 import { errorMessage, requiredInput, safeTerminalText } from "./manager-helpers.js";
 import { normalizeWebDavPath } from "./webdav-config.js";
 
@@ -15,8 +14,11 @@ export async function promptInitialSetupName(
 			[
 				"Name this sync setup",
 				"",
-				"Examples: home, work, personal. Leave blank to use default.",
-				"Used in suggested storage paths and Git branches.",
+				"Examples: home, work, personal.",
+				"Also names the storage connection; no second name is needed.",
+				preset === "Git"
+					? "Git branch and storage path are chosen separately."
+					: "Used in the suggested storage path.",
 				"Sync content and automatic sync are chosen separately.",
 			].join("\n"),
 			"default",
@@ -27,11 +29,8 @@ export async function promptInitialSetupName(
 			validateConfigName(name, "sync setup");
 			// Validate the same suggestions the backend prompts will offer, without changing the name.
 			const suggestedPath = `pi-sync/${name}`;
-			normalizeStoragePath(suggestedPath);
-			if (preset === "Git") {
-				normalizeGitBranch(suggestedPath);
-				normalizeGitDirectory(suggestedPath);
-			} else if (preset === "WebDAV") {
+			if (preset !== "Git") normalizeStoragePath(suggestedPath);
+			if (preset === "WebDAV") {
 				normalizeWebDavPath(suggestedPath);
 			}
 			return name;

--- a/packages/pi-sync/src/setup-name-ui.ts
+++ b/packages/pi-sync/src/setup-name-ui.ts
@@ -1,13 +1,8 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { normalizeStoragePath, validateConfigName } from "./config.js";
+import { validateConfigName } from "./config.js";
 import { errorMessage, safeTerminalText } from "./manager-helpers.js";
-import { normalizeWebDavPath } from "./webdav-config.js";
 
-export async function promptInitialSetupName(
-	ctx: ExtensionCommandContext,
-	preset: string,
-	signal?: AbortSignal,
-) {
+export async function promptInitialSetupName(ctx: ExtensionCommandContext, signal?: AbortSignal) {
 	while (!signal?.aborted) {
 		const hint = "For example: home or work. Leave blank for default.";
 		// Pi styles the whole input title as accent; give only the guidance a muted role.
@@ -24,16 +19,10 @@ export async function promptInitialSetupName(
 		if (name.includes("<") || name.includes(">")) return undefined;
 		try {
 			validateConfigName(name, "sync setup");
-			// Validate the same suggestions the backend prompts will offer, without changing the name.
-			const suggestedPath = `pi-sync/${name}`;
-			if (preset !== "Git") normalizeStoragePath(suggestedPath);
-			if (preset === "WebDAV") {
-				normalizeWebDavPath(suggestedPath);
-			}
 			return name;
 		} catch (error) {
 			ctx.ui.notify(
-				`This name cannot be used for the sync setup or its suggested storage location. ${safeTerminalText(errorMessage(error))} Enter another name (for example, default).`,
+				`This name cannot be used for the sync setup. ${safeTerminalText(errorMessage(error))} Enter another name (for example, default).`,
 				"warning",
 			);
 		}

--- a/packages/pi-sync/src/storage-connections-ui.ts
+++ b/packages/pi-sync/src/storage-connections-ui.ts
@@ -2,7 +2,13 @@ import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
 import { isCloudflareR2Endpoint, readLocalConfigObject } from "./config.js";
 import { showAddGitStorageProfile, showEditGitStorageProfile } from "./git-ui.js";
-import { errorMessage, ownRecord, requiredInput, safeTerminalText } from "./manager-helpers.js";
+import {
+	errorMessage,
+	ownRecord,
+	requiredInput,
+	requiredValueInput,
+	safeTerminalText,
+} from "./manager-helpers.js";
 import {
 	applyS3CredentialUpdate,
 	chooseS3Credentials,
@@ -220,7 +226,12 @@ async function editStorageConnection(
 		signal,
 	);
 	if (!endpoint || signal?.aborted) return;
-	const region = await requiredInput(ctx, "Region", String(profile.region ?? "auto"), signal);
+	const region = await requiredInput(
+		ctx,
+		"Region\n\nUse your bucket's region; Cloudflare R2 uses auto.",
+		String(profile.region ?? "auto"),
+		signal,
+	);
 	if (!region || signal?.aborted) return;
 	const storedCredentials = ownRecord(profile.credentials) ?? {};
 	const credentials = await chooseS3CredentialUpdate(
@@ -285,14 +296,14 @@ export async function showAddStorageConnection(ctx: ExtensionCommandContext, sig
 	if (preset === "Git") return showAddGitStorageProfile(ctx, signal);
 	const name = await requiredInput(
 		ctx,
-		"Name this storage connection",
+		"Name this storage connection\n\nA local label for a reusable connection; this does not create a bucket.",
 		preset === "Cloudflare R2" ? "r2" : "s3",
 		signal,
 	);
 	if (!name || signal?.aborted) return false;
-	const endpoint = await requiredInput(
+	const endpoint = await requiredValueInput(
 		ctx,
-		"Endpoint",
+		"S3 API endpoint\n\nUse the API URL from your storage provider, not its web console.",
 		preset === "Cloudflare R2"
 			? "https://<account-id>.r2.cloudflarestorage.com"
 			: "https://s3.example.com",
@@ -300,7 +311,14 @@ export async function showAddStorageConnection(ctx: ExtensionCommandContext, sig
 	);
 	if (!endpoint || signal?.aborted) return false;
 	const region =
-		preset === "Cloudflare R2" ? "auto" : await requiredInput(ctx, "Region", "us-east-1", signal);
+		preset === "Cloudflare R2"
+			? "auto"
+			: await requiredInput(
+					ctx,
+					"Region\n\nUse the region assigned to your bucket by the provider.",
+					"us-east-1",
+					signal,
+				);
 	if (!region || signal?.aborted) return false;
 	const credentials = await chooseS3Credentials(ctx, signal);
 	if (!credentials || signal?.aborted) return false;

--- a/packages/pi-sync/src/webdav-backend.ts
+++ b/packages/pi-sync/src/webdav-backend.ts
@@ -250,7 +250,7 @@ export class WebDavSyncBackend implements SyncBackend {
 
 	private async runCapabilityProbe(signal?: AbortSignal) {
 		throwIfAborted(signal);
-		const probeCollection = `${rootPath(this.config)}/.pi-sync-probes/${randomUUID()}`;
+		const probeCollection = joinRemote(rootPath(this.config), ".pi-sync-probes", randomUUID());
 		const probe = `${probeCollection}/conditional.txt`;
 		const client = new WebDavClient(this.config, signal);
 		let created = false;
@@ -382,7 +382,7 @@ export class WebDavSyncBackend implements SyncBackend {
 }
 
 export function rootPath(config: ResolvedWebDavBackend) {
-	return config.destination.path;
+	return config.destination.path === "./" ? "" : config.destination.path;
 }
 
 export function latestPath(config: ResolvedWebDavBackend) {
@@ -410,7 +410,7 @@ export function webDavBackendIdentity(config: ResolvedWebDavBackend) {
 
 function webDavStorageLocation(config: ResolvedWebDavBackend) {
 	const url = new URL(secretFreeUrl(config.profile.url));
-	return `${url.host} · ${rootPath(config)}`;
+	return `${url.host} · ${config.destination.path}`;
 }
 
 function pointerFor(
@@ -586,7 +586,11 @@ function assertSafeDestination(config: ResolvedWebDavBackend) {
 	const url = new URL(config.profile.url);
 	if (url.username || url.password || url.search || url.hash)
 		throw new Error("Invalid WebDAV URL.");
-	for (const value of [config.destination.path, config.destination.namespace]) {
+	for (const [label, value] of [
+		["path", config.destination.path],
+		["namespace", config.destination.namespace],
+	]) {
+		if (label === "path" && value === "./") continue;
 		if (
 			!value ||
 			value.includes("\\") ||

--- a/packages/pi-sync/src/webdav-config.ts
+++ b/packages/pi-sync/src/webdav-config.ts
@@ -41,6 +41,7 @@ export function normalizeWebDavUrl(value: string | undefined) {
 }
 
 export function normalizeWebDavPath(value: string | undefined) {
+	if (value?.trim() === "." || value?.trim() === "./") return "./";
 	const normalized = trimSlashes(normalizeOptionalString(value) ?? DEFAULT_PATH);
 	if (
 		!normalized ||

--- a/packages/pi-sync/src/webdav-ui.ts
+++ b/packages/pi-sync/src/webdav-ui.ts
@@ -1,4 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { requiredInput, requiredValueInput } from "./manager-helpers.js";
 import { promptSecret } from "./secret-input.js";
 import {
 	addStorageConnection,
@@ -21,14 +22,9 @@ export async function showWebDavSetup(
 	targetName: string,
 	signal?: AbortSignal,
 ) {
-	const url = await requiredInput(
-		ctx,
-		"WebDAV collection URL",
-		"https://cloud.example.com/remote.php/dav/files/user",
-		signal,
-	);
+	const url = await promptWebDavUrl(ctx, signal);
 	if (!url) return false;
-	const username = await requiredInput(ctx, "WebDAV username", "user", signal);
+	const username = await requiredValueInput(ctx, "WebDAV username", "user", signal);
 	if (!username) return false;
 	const password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 	if (password === undefined) return false;
@@ -48,14 +44,14 @@ export async function showWebDavSetup(
 	if (!automatic || automatic === "Cancel") return false;
 	const sessions = await chooseSessions(ctx, signal);
 	if (sessions === undefined) return false;
-	const profileName = "webdav";
+	const profileName = targetName;
 	const review = await select(
 		ctx,
 		[
 			"Review WebDAV setup",
 			"",
 			`Sync setup: ${safe(targetName)}`,
-			`Storage connection: ${profileName} (WebDAV)`,
+			`Storage connection: ${safe(profileName)} (WebDAV)`,
 			`URL: ${displayUrl(connection.url)}`,
 			`Storage location: ${safe(destination.path)}`,
 			"Username: stored in the private settings file (value hidden)",
@@ -135,7 +131,7 @@ export async function showEditWebDavTarget(
 	partial: PartialConfig,
 	signal?: AbortSignal,
 ) {
-	const remotePath = await requiredInput(ctx, "WebDAV storage path", partial.storagePath, signal);
+	const remotePath = await requiredInput(ctx, WEBDAV_PATH_TITLE, partial.storagePath, signal);
 	if (!remotePath) return false;
 	const destination = validateDestination(ctx, remotePath);
 	if (!destination) return false;
@@ -168,14 +164,9 @@ export async function showAddWebDavStorageProfile(
 ) {
 	const name = await requiredInput(ctx, "Name this storage connection", "webdav", signal);
 	if (!name) return false;
-	const url = await requiredInput(
-		ctx,
-		"WebDAV collection URL",
-		"https://cloud.example.com/dav",
-		signal,
-	);
+	const url = await promptWebDavUrl(ctx, signal);
 	if (!url) return false;
-	const username = await requiredInput(ctx, "WebDAV username", "user", signal);
+	const username = await requiredValueInput(ctx, "WebDAV username", "user", signal);
 	if (!username) return false;
 	const password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 	if (password === undefined) return false;
@@ -212,17 +203,16 @@ export async function showEditWebDavStorageProfile(
 	signal?: AbortSignal,
 	affectedSetups?: string[],
 ) {
-	const url = await requiredInput(
+	const url = await promptWebDavUrl(
 		ctx,
-		"WebDAV collection URL",
-		String(profile.url ?? "https://cloud.example.com/dav"),
 		signal,
+		typeof profile.url === "string" ? profile.url : undefined,
 	);
 	if (!url) return false;
-	const username = await requiredInput(
+	const username = await requiredValueInput(
 		ctx,
-		"WebDAV username",
-		String(profile.username ?? "user"),
+		"WebDAV username\n\nEnter the account username; the stored value is hidden.",
+		"user",
 		signal,
 	);
 	if (!username) return false;
@@ -287,12 +277,7 @@ async function chooseDestination(
 	targetName: string,
 	signal?: AbortSignal,
 ) {
-	const remotePath = await requiredInput(
-		ctx,
-		"WebDAV storage path",
-		`pi-sync/${targetName}`,
-		signal,
-	);
+	const remotePath = await requiredInput(ctx, WEBDAV_PATH_TITLE, `pi-sync/${targetName}`, signal);
 	return remotePath ? validateDestination(ctx, remotePath) : undefined;
 }
 
@@ -324,20 +309,19 @@ async function chooseSessions(ctx: ExtensionCommandContext, signal?: AbortSignal
 	);
 }
 
-async function requiredInput(
+const WEBDAV_PATH_TITLE =
+	"WebDAV storage path\n\nFolder relative to the collection URL, not your local filesystem.\nA separate folder keeps this setup's snapshots apart from other content.";
+
+async function promptWebDavUrl(
 	ctx: ExtensionCommandContext,
-	title: string,
-	placeholder: string,
 	signal?: AbortSignal,
+	current?: string,
 ) {
-	const value = await awaitActive(signal, ctx.ui.input(title, placeholder, { signal }));
-	if (value === undefined) return undefined;
-	const trimmed = value.trim();
-	if (!trimmed) {
-		ctx.ui.notify(`${title} is required.`, "warning");
-		return undefined;
-	}
-	return trimmed;
+	const title =
+		"WebDAV collection URL\n\nUse the HTTPS WebDAV URL from your provider, not its web login page.";
+	return current
+		? requiredInput(ctx, title, current, signal)
+		: requiredValueInput(ctx, title, "https://cloud.example.com/remote.php/dav/files/user", signal);
 }
 
 async function select(

--- a/packages/pi-sync/src/webdav-ui.ts
+++ b/packages/pi-sync/src/webdav-ui.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { requiredInput, requiredValueInput } from "./manager-helpers.js";
+import { promptTextInput } from "./manager-helpers.js";
 import { promptSecret } from "./secret-input.js";
 import {
 	addStorageConnection,
@@ -8,6 +8,7 @@ import {
 	updateStorageConnection,
 	updateSyncSetup,
 } from "./settings-management.js";
+import { promptAvailableSetupStorage } from "./setup-location-ui.js";
 import { DEFAULT_SYNC_INCLUDE } from "./sync-policy.js";
 import type { PartialConfig } from "./types.js";
 import {
@@ -23,7 +24,7 @@ export async function showWebDavSetup(
 ) {
 	const url = await promptWebDavUrl(ctx, signal);
 	if (!url) return false;
-	const username = await requiredValueInput(ctx, "WebDAV username", "user", signal);
+	const username = await promptTextInput(ctx, "WebDAV username", { example: "user" }, signal);
 	if (!username) return false;
 	const password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 	if (password === undefined) return false;
@@ -98,7 +99,11 @@ export async function showAddWebDavTarget(
 ) {
 	const location = await chooseDestination(ctx, signal);
 	if (!location) return false;
-	const destination = validateDestination(ctx, location.path);
+	const destination = await promptAvailableSetupStorage(
+		ctx,
+		{ connection: profile, path: location.path },
+		signal,
+	);
 	if (!destination) return false;
 	const content = await chooseContent(ctx, signal);
 	if (!content) return false;
@@ -130,7 +135,12 @@ export async function showEditWebDavTarget(
 	partial: PartialConfig,
 	signal?: AbortSignal,
 ) {
-	const remotePath = await requiredInput(ctx, WEBDAV_PATH_TITLE, partial.storagePath, signal);
+	const remotePath = await promptTextInput(
+		ctx,
+		WEBDAV_PATH_TITLE,
+		{ defaultValue: partial.storagePath },
+		signal,
+	);
 	if (!remotePath) return false;
 	const destination = validateDestination(ctx, remotePath);
 	if (!destination) return false;
@@ -161,11 +171,16 @@ export async function showAddWebDavStorageProfile(
 	ctx: ExtensionCommandContext,
 	signal?: AbortSignal,
 ) {
-	const name = await requiredInput(ctx, "Name this storage connection", "webdav", signal);
+	const name = await promptTextInput(
+		ctx,
+		"Name this storage connection",
+		{ defaultValue: "webdav" },
+		signal,
+	);
 	if (!name) return false;
 	const url = await promptWebDavUrl(ctx, signal);
 	if (!url) return false;
-	const username = await requiredValueInput(ctx, "WebDAV username", "user", signal);
+	const username = await promptTextInput(ctx, "WebDAV username", { example: "user" }, signal);
 	if (!username) return false;
 	const password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 	if (password === undefined) return false;
@@ -208,10 +223,10 @@ export async function showEditWebDavStorageProfile(
 		typeof profile.url === "string" ? profile.url : undefined,
 	);
 	if (!url) return false;
-	const username = await requiredValueInput(
+	const username = await promptTextInput(
 		ctx,
 		"WebDAV username\n\nEnter the account username; the stored value is hidden.",
-		"user",
+		{ example: "user" },
 		signal,
 	);
 	if (!username) return false;
@@ -272,7 +287,7 @@ export async function showEditWebDavStorageProfile(
 }
 
 async function chooseDestination(ctx: ExtensionCommandContext, signal?: AbortSignal) {
-	const remotePath = await requiredInput(ctx, WEBDAV_PATH_TITLE, "./", signal);
+	const remotePath = await promptTextInput(ctx, WEBDAV_PATH_TITLE, { defaultValue: "./" }, signal);
 	return remotePath ? validateDestination(ctx, remotePath) : undefined;
 }
 
@@ -314,9 +329,14 @@ async function promptWebDavUrl(
 ) {
 	const title =
 		"WebDAV collection URL\n\nUse the HTTPS WebDAV URL from your provider, not its web login page.";
-	return current
-		? requiredInput(ctx, title, current, signal)
-		: requiredValueInput(ctx, title, "https://cloud.example.com/remote.php/dav/files/user", signal);
+	return promptTextInput(
+		ctx,
+		title,
+		current
+			? { defaultValue: current }
+			: { example: "https://cloud.example.com/remote.php/dav/files/user" },
+		signal,
+	);
 }
 
 async function select(

--- a/packages/pi-sync/src/webdav-ui.ts
+++ b/packages/pi-sync/src/webdav-ui.ts
@@ -14,7 +14,6 @@ import {
 	normalizeWebDavPath,
 	normalizeWebDavUrl,
 	validateWebDavCredentials,
-	validateWebDavNamespace,
 } from "./webdav-config.js";
 
 export async function showWebDavSetup(
@@ -28,7 +27,7 @@ export async function showWebDavSetup(
 	if (!username) return false;
 	const password = await awaitActive(signal, promptSecret(ctx, "WebDAV password", { signal }));
 	if (password === undefined) return false;
-	const location = await chooseDestination(ctx, targetName, signal);
+	const location = await chooseDestination(ctx, signal);
 	if (!location) return false;
 	const connection = validateConnection(ctx, url, username, password);
 	const destination = validateDestination(ctx, location.path);
@@ -97,7 +96,7 @@ export async function showAddWebDavTarget(
 	profile: string,
 	signal?: AbortSignal,
 ) {
-	const location = await chooseDestination(ctx, name, signal);
+	const location = await chooseDestination(ctx, signal);
 	if (!location) return false;
 	const destination = validateDestination(ctx, location.path);
 	if (!destination) return false;
@@ -272,12 +271,8 @@ export async function showEditWebDavStorageProfile(
 	return true;
 }
 
-async function chooseDestination(
-	ctx: ExtensionCommandContext,
-	targetName: string,
-	signal?: AbortSignal,
-) {
-	const remotePath = await requiredInput(ctx, WEBDAV_PATH_TITLE, `pi-sync/${targetName}`, signal);
+async function chooseDestination(ctx: ExtensionCommandContext, signal?: AbortSignal) {
+	const remotePath = await requiredInput(ctx, WEBDAV_PATH_TITLE, "./", signal);
 	return remotePath ? validateDestination(ctx, remotePath) : undefined;
 }
 
@@ -310,7 +305,7 @@ async function chooseSessions(ctx: ExtensionCommandContext, signal?: AbortSignal
 }
 
 const WEBDAV_PATH_TITLE =
-	"WebDAV storage path\n\nFolder relative to the collection URL, not your local filesystem.\nA separate folder keeps this setup's snapshots apart from other content.";
+	"WebDAV storage path\n\nFolder relative to the collection URL, not your local filesystem.\n./ uses the collection root. Use different folders for independent setups.";
 
 async function promptWebDavUrl(
 	ctx: ExtensionCommandContext,
@@ -376,15 +371,9 @@ function validateConnection(
 	}
 }
 
-function validateDestination(ctx: ExtensionCommandContext, path: string, namespace?: string) {
+function validateDestination(ctx: ExtensionCommandContext, path: string) {
 	try {
-		const basePath = normalizeWebDavPath(path);
-		const normalizedPath = namespace
-			? normalizeWebDavPath(`${basePath}/${namespace.trim()}`)
-			: basePath;
-		const resolvedNamespace = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
-		validateWebDavNamespace(resolvedNamespace);
-		return { path: normalizedPath, namespace: resolvedNamespace };
+		return { path: normalizeWebDavPath(path) };
 	} catch (error) {
 		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 		return undefined;

--- a/packages/pi-sync/test/build-runtime.test.ts
+++ b/packages/pi-sync/test/build-runtime.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { DefaultResourceLoader, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
 
 const packageRoot = resolve("packages/pi-sync");
 const builderUrl = pathToFileURL(join(packageRoot, "scripts/build-runtime.mjs")).href;
@@ -44,6 +45,7 @@ test("generated runtime preserves every first-use import boundary", async () => 
 			"src/setup-switch.ts",
 			"src/sync-operations.ts",
 			"src/manager-ui.ts",
+			"src/setup-location-ui.ts",
 			"src/manager-result-dispatcher.ts",
 			"src/file-selection.ts",
 			"src/remote-selection-ui.ts",
@@ -103,7 +105,33 @@ test("generated runtime is mapped, external, self-contained, and loadable by Pi"
 		const loaded = loader.getExtensions();
 		assert.deepEqual(loaded.errors, []);
 		assert.equal(loaded.extensions.length, 1);
-		assert.ok(loaded.extensions[0]?.commands.has("sync"));
+		const command = loaded.extensions[0]?.commands.get("sync");
+		assert.ok(command);
+		const titles: string[] = [];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async (title: string) =>
+				title.startsWith("Sync setup name")
+					? "default"
+					: "https://account.r2.cloudflarestorage.com",
+			select: async (title: string) => {
+				titles.push(title);
+				return title.startsWith("Set up sync") ? "Cloudflare R2" : "Cancel";
+			},
+		});
+		try {
+			await command.handler("init", ctx);
+			assert.ok(
+				titles.some(
+					(title) =>
+						title.startsWith("Choose storage location") && title.includes("Remote path: ./"),
+				),
+				titles.join("\n"),
+			);
+		} finally {
+			loaded.runtime.invalidate("generated setup smoke complete");
+		}
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/packages/pi-sync/test/git-backend-contract.test.ts
+++ b/packages/pi-sync/test/git-backend-contract.test.ts
@@ -4,13 +4,18 @@ import { GitSyncBackend } from "../src/git-backend.js";
 import { registerSyncBackendContractSuite } from "./backend-contract-suite.js";
 import { createBareRemote, gitConfig } from "./git-test-helpers.js";
 
-registerSyncBackendContractSuite("git", () => {
-	const fixture = createBareRemote();
-	return {
-		backend: new GitSyncBackend(gitConfig(fixture.remote), {
-			cacheRoot: path.join(fixture.root, "cache"),
-			allowLocalRemotes: true,
-		}),
-		dispose: () => rmSync(fixture.root, { recursive: true, force: true }),
-	};
-});
+for (const directory of ["pi-sync", "./"]) {
+	registerSyncBackendContractSuite(`git (${directory})`, () => {
+		const fixture = createBareRemote();
+		const config = gitConfig(fixture.remote);
+		config.destination.directory = directory;
+		config.destination.branch = "main";
+		return {
+			backend: new GitSyncBackend(config, {
+				cacheRoot: path.join(fixture.root, "cache"),
+				allowLocalRemotes: true,
+			}),
+			dispose: () => rmSync(fixture.root, { recursive: true, force: true }),
+		};
+	});
+}

--- a/packages/pi-sync/test/git-config.test.ts
+++ b/packages/pi-sync/test/git-config.test.ts
@@ -42,6 +42,30 @@ test("Git v3 config is credential-free and uses the complete reviewed path", asy
 	});
 });
 
+test.each([".", "./", " ./ "])(
+	"Git root path %j resolves canonically and preserves identity",
+	async (rootPath) => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			writeFileSync(localConfigPath(), JSON.stringify(gitSettings(rootPath, "main")), {
+				mode: 0o600,
+			});
+			const config = await loadConfig();
+			assert.equal(config.storagePath, "./");
+			assert.equal(config.snapshotIdentity, "root");
+			assert.equal(config.backend.type, "git");
+			if (config.backend.type !== "git") return;
+			assert.deepEqual(config.backend.destination, {
+				branch: "main",
+				directory: "./",
+				namespace: "root",
+			});
+			writeFileSync(localConfigPath(), JSON.stringify(gitSettings("./", "main")), { mode: 0o600 });
+			assert.equal(statePathForConfig(await loadConfig()), statePathForConfig(config));
+		});
+	},
+);
+
 test("Git state identity changes by remote, branch, and path but not setup name", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
@@ -79,7 +103,17 @@ test("Git normalization rejects secret-bearing and unsafe transports, refs, and 
 	for (const branch of ["-bad", "refs/heads/main", "bad..name", "bad lock.lock"]) {
 		assert.throws(() => normalizeGitBranch(branch), /Git branch/u);
 	}
-	for (const directory of ["../bad", ".git/data", "bad\\path"]) {
+	for (const directory of [
+		"../bad",
+		".git/data",
+		"bad\\path",
+		"./nested",
+		"nested/./bad",
+		"nested/../bad",
+		".//",
+		"/",
+		"/./",
+	]) {
 		assert.throws(() => normalizeGitDirectory(directory), /Git directory/u);
 	}
 });

--- a/packages/pi-sync/test/git-root-storage.test.ts
+++ b/packages/pi-sync/test/git-root-storage.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { test } from "vitest";
+import { GitSyncBackend } from "../src/git-backend.js";
+import { expectedRemoteHead } from "../src/sync-backend.js";
+import { createBareRemote, gitConfig } from "./git-test-helpers.js";
+import { snapshot } from "./helpers.js";
+
+test("Git root publication uses literal root files and survives a fresh cache", async () => {
+	const fixture = createBareRemote();
+	try {
+		const config = gitConfig(fixture.remote);
+		config.destination = { branch: "main", directory: "./", namespace: "root" };
+		const backend = new GitSyncBackend(config, {
+			cacheRoot: path.join(fixture.root, "cache"),
+			allowLocalRemotes: true,
+		});
+		const content = {
+			...snapshot([{ path: "settings.json", content: Buffer.from("root") }]),
+			profile: "root",
+		};
+		const first = await backend.publishSnapshot(content, { kind: "missing" });
+		const tree = execFileSync(
+			"git",
+			["--git-dir", fixture.remote, "ls-tree", "-r", "--name-only", "main"],
+			{ encoding: "utf8" },
+		);
+		assert.deepEqual(tree.trim().split("\n"), ["files/settings.json", "manifest.json"]);
+		const fresh = new GitSyncBackend(config, {
+			cacheRoot: path.join(fixture.root, "fresh-cache"),
+			allowLocalRemotes: true,
+		});
+		assert.deepEqual(await fresh.readSnapshot(first.head.snapshotRef), content);
+		const empty = { ...snapshot([]), id: "empty", profile: "root" };
+		await fresh.publishSnapshot(empty, expectedRemoteHead(first.head));
+		assert.deepEqual(await fresh.readSnapshot("empty"), empty);
+		assert.deepEqual(await fresh.readSnapshot(first.head.snapshotRef), content);
+		assert.equal((await fresh.listHistory()).length, 2);
+	} finally {
+		rmSync(fixture.root, { recursive: true, force: true });
+	}
+});
+
+test("Git root refuses an unrelated existing main branch without changing it", async () => {
+	const fixture = createBareRemote();
+	try {
+		const blob = execFileSync(
+			"git",
+			["--git-dir", fixture.remote, "hash-object", "-w", "--stdin"],
+			{ input: "unrelated", encoding: "utf8" },
+		).trim();
+		const tree = execFileSync("git", ["--git-dir", fixture.remote, "mktree"], {
+			input: `100644 blob ${blob}\tREADME.md\n`,
+			encoding: "utf8",
+		}).trim();
+		const commit = execFileSync(
+			"git",
+			["--git-dir", fixture.remote, "commit-tree", tree, "-m", "existing"],
+			{
+				encoding: "utf8",
+				env: {
+					...process.env,
+					GIT_AUTHOR_NAME: "test",
+					GIT_AUTHOR_EMAIL: "test@example.com",
+					GIT_COMMITTER_NAME: "test",
+					GIT_COMMITTER_EMAIL: "test@example.com",
+				},
+			},
+		).trim();
+		execFileSync("git", ["--git-dir", fixture.remote, "update-ref", "refs/heads/main", commit]);
+		const config = gitConfig(fixture.remote);
+		config.destination = { branch: "main", directory: "./", namespace: "root" };
+		const backend = new GitSyncBackend(config, {
+			cacheRoot: path.join(fixture.root, "cache"),
+			allowLocalRemotes: true,
+		});
+		await assert.rejects(backend.readHead(), /manifest|publication/iu);
+		await assert.rejects(
+			backend.publishSnapshot({ ...snapshot([]), profile: "root" }, { kind: "missing" }),
+		);
+		assert.equal(
+			execFileSync("git", ["--git-dir", fixture.remote, "rev-parse", "main"], {
+				encoding: "utf8",
+			}).trim(),
+			commit,
+		);
+	} finally {
+		rmSync(fixture.root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-sync/test/git-ui.test.ts
+++ b/packages/pi-sync/test/git-ui.test.ts
@@ -52,7 +52,7 @@ for (const remote of [
 test("first Git setup writes the exact version 3 connection and setup shapes", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
-		const inputs = ["github", "git@github.com:user/pi-sync.git", "pi-sync/home", "pi-sync/home"];
+		const inputs = ["git@github.com:user/pi-sync.git", "pi-sync/home", "pi-sync/home"];
 		const choices = ["Enable automatic sync", "Save setup"];
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
@@ -62,12 +62,12 @@ test("first Git setup writes the exact version 3 connection and setup shapes", a
 		});
 		assert.equal(await showGitSetup(ctx, "home"), true);
 		const raw = await readLocalConfigObject();
-		assert.deepEqual(raw?.storageConnections.github, {
+		assert.deepEqual(raw?.storageConnections.home, {
 			type: "git",
 			remote: "git@github.com:user/pi-sync.git",
 		});
 		assert.deepEqual(raw?.syncSetups.home.storage, {
-			connection: "github",
+			connection: "home",
 			branch: "pi-sync/home",
 			path: "pi-sync/home",
 		});
@@ -204,6 +204,48 @@ test("Git setup edit rejects coordinates changed while its review is open", asyn
 		const config = await loadConfig("work");
 		assert.equal(config.connectionName, "archive");
 		assert.equal(config.storagePath, "pi-sync/rebound");
+	});
+});
+
+test("Git setup preserves unknown empty-catalog settings and edit defaults retain the reviewed location", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify({
+				version: 3,
+				onSwitch: "ask-before-pull",
+				storageConnections: {},
+				syncSetups: {},
+				future: { keep: true },
+			}),
+			{ mode: 0o600 },
+		);
+		const inputs = ["git@github.com:user/pi-sync.git", "archives", "backups/home"];
+		const choices = ["Keep automatic sync off", "Save setup"];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => inputs.shift(),
+			select: async () => choices.shift(),
+		});
+		assert.equal(await showGitSetup(ctx, "home"), true);
+		assert.deepEqual((await readLocalConfigObject())?.future, { keep: true });
+		const before = readFileSync(localConfigPath());
+		const titles: string[] = [];
+		const editCtx = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async (title: string) => {
+				titles.push(title);
+				return "";
+			},
+			select: async () => "Save sync setup",
+		});
+		assert.equal(await showEditGitTarget(editCtx.ctx, await loadPartialConfig("home")), true);
+		assert.match(titles[0], /Default: archives/u);
+		assert.match(titles[1], /Default: backups\/home/u);
+		assert.deepEqual(readFileSync(localConfigPath()), before);
 	});
 });
 

--- a/packages/pi-sync/test/object-root-config.test.ts
+++ b/packages/pi-sync/test/object-root-config.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { test } from "vitest";
+import { loadConfig, localConfigPath, statePathForConfig } from "../src/config.js";
+import { addSyncSetup } from "../src/settings-management.js";
+import { normalizeWebDavPath } from "../src/webdav-config.js";
+import { createSyncBackend } from "./backend-factory-eager.js";
+import { v3S3Settings, v3WebDavSettings, withTempHome } from "./helpers.js";
+
+const fixtures = [
+	{ kind: "WebDAV", settings: () => v3WebDavSettings() },
+	{ kind: "R2", settings: () => v3S3Settings() },
+	{
+		kind: "S3",
+		settings: () => {
+			const settings = v3S3Settings();
+			settings.storageConnections.r2.endpoint = "https://s3.example.com";
+			settings.storageConnections.r2.region = "us-east-1";
+			return settings;
+		},
+	},
+];
+
+for (const fixture of fixtures) {
+	test.each([".", "./", " ./ "])(
+		`${fixture.kind} root %j has canonical coordinates and survives renaming`,
+		async (storagePath) => {
+			await withTempHome(async (agentDir) => {
+				mkdirSync(agentDir, { recursive: true });
+				const settings = fixture.settings();
+				settings.syncSetups.home.storage.path = storagePath;
+				const before = JSON.stringify(settings);
+				writeFileSync(localConfigPath(), before, { mode: 0o600 });
+				const config = await loadConfig();
+				assert.equal(config.storagePath, "./");
+				assert.equal(config.snapshotIdentity, "root");
+				assert.equal(config.backend.destination.namespace, "root");
+				assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+				const backend = createSyncBackend(config);
+				const renamed = {
+					...settings,
+					activeSyncSetup: "renamed",
+					syncSetups: {
+						renamed: {
+							...settings.syncSetups.home,
+							storage: { ...settings.syncSetups.home.storage, path: "./" },
+						},
+					},
+				};
+				writeFileSync(localConfigPath(), JSON.stringify(renamed), { mode: 0o600 });
+				const after = await loadConfig();
+				assert.equal(statePathForConfig(after), statePathForConfig(config));
+				assert.equal(createSyncBackend(after).identity, backend.identity);
+			});
+		},
+	);
+
+	test(`${fixture.kind} duplicate root aliases fail without changing settings`, async () => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			const settings = fixture.settings();
+			settings.syncSetups.home.storage.path = "./";
+			const before = JSON.stringify(settings);
+			writeFileSync(localConfigPath(), before, { mode: 0o600 });
+			await assert.rejects(
+				addSyncSetup("other", {
+					...settings.syncSetups.home,
+					storage: { ...settings.syncSetups.home.storage, path: "." },
+				}),
+				/duplicates the storage location/u,
+			);
+			assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+		});
+	});
+
+	test.each([
+		"",
+		"/",
+		"/./",
+		".//",
+		"./nested",
+		"nested/./bad",
+		"nested/../bad",
+		"../bad",
+		"bad\\path",
+	])(`${fixture.kind} root support still rejects unsafe path %j`, async (storagePath) => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			const settings = fixture.settings();
+			settings.syncSetups.home.storage.path = storagePath;
+			writeFileSync(localConfigPath(), JSON.stringify(settings), { mode: 0o600 });
+			await assert.rejects(loadConfig(), /storage[. ]path/u);
+		});
+	});
+
+	test(`${fixture.kind} existing nested paths and settings bytes remain unchanged`, async () => {
+		await withTempHome(async (agentDir) => {
+			mkdirSync(agentDir, { recursive: true });
+			const settings = fixture.settings();
+			settings.syncSetups.home.storage.path = "archives/home";
+			const before = JSON.stringify(settings);
+			writeFileSync(localConfigPath(), before, { mode: 0o600 });
+			const config = await loadConfig();
+			assert.equal(config.storagePath, "archives/home");
+			assert.equal(config.snapshotIdentity, "home");
+			assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+			settings.syncSetups.home.storage.path = "./";
+			writeFileSync(localConfigPath(), JSON.stringify(settings), { mode: 0o600 });
+			assert.notEqual(statePathForConfig(await loadConfig()), statePathForConfig(config));
+		});
+	});
+}
+
+test("WebDAV path normalization accepts only explicit root aliases", () => {
+	for (const value of [".", "./", " ./ "]) assert.equal(normalizeWebDavPath(value), "./");
+	for (const value of ["/", "/./", ".//", "./nested", "nested/./bad", "nested/../bad"]) {
+		assert.throws(() => normalizeWebDavPath(value), /WebDAV path/u);
+	}
+});

--- a/packages/pi-sync/test/object-root-storage.test.ts
+++ b/packages/pi-sync/test/object-root-storage.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { historyKey, latestKey, S3SyncBackend, snapshotKey } from "../src/s3-backend.js";
+import { expectedRemoteHead } from "../src/sync-backend.js";
+import type { ResolvedS3Backend } from "../src/types.js";
+import { historyPath, latestPath, snapshotPath, WebDavSyncBackend } from "../src/webdav-backend.js";
+import { snapshot } from "./helpers.js";
+import { MockWebDavServer, webDavConfig } from "./mock-webdav-server.js";
+
+test("WebDAV root publications and probe cleanup stay under the configured collection", async () => {
+	const server = await new MockWebDavServer().start();
+	try {
+		server.resources.set("/dav/unrelated.txt", Buffer.from("keep"));
+		const config = webDavConfig(server.url);
+		config.destination = { path: "./", namespace: "root" };
+		assert.throws(
+			() => new WebDavSyncBackend({ ...config, destination: { path: "./", namespace: "./" } }),
+			/storage location/u,
+		);
+		assert.equal(latestPath(config), "latest.json");
+		assert.equal(historyPath(config), "history.json");
+		assert.equal(snapshotPath(config, "snap"), "snapshots/snap.json.gz");
+		const backend = new WebDavSyncBackend(config);
+		assert.match(backend.destination, / · \.\/$/u);
+		const first = {
+			...snapshot([{ path: "settings.json", content: Buffer.from("root") }]),
+			profile: "root",
+		};
+		const result = await backend.publishSnapshot(first, { kind: "missing" });
+		assert.deepEqual([...server.resources.keys()].sort(), [
+			"/dav/history.json",
+			"/dav/latest.json",
+			"/dav/snapshots/snap.json.gz",
+			"/dav/unrelated.txt",
+		]);
+		const fresh = new WebDavSyncBackend(config);
+		assert.deepEqual(await fresh.readHead(), result.head);
+		assert.deepEqual(await fresh.readSnapshot(first.id), first);
+		const second = { ...first, id: "second" };
+		await fresh.publishSnapshot(second, expectedRemoteHead(result.head));
+		assert.deepEqual(
+			(await fresh.listHistory()).map((entry) => entry.snapshotId),
+			["snap", "second"],
+		);
+		assert.deepEqual(await fresh.readSnapshot(first.id), first);
+		assert.ok((await fresh.diagnose()).every((entry) => entry.level !== "error"));
+		assert.ok(server.requests.every((request) => request.path.startsWith("/dav/")));
+		assert.ok(
+			server.requests
+				.filter((request) => request.method === "DELETE")
+				.every((request) => /^\/dav\/\.pi-sync-probes\/[^/]+$/u.test(request.path)),
+		);
+		assert.ok(![...server.resources.keys()].some((key) => key.includes(".pi-sync-probes")));
+		assert.deepEqual(server.resources.get("/dav/unrelated.txt"), Buffer.from("keep"));
+	} finally {
+		await server.close();
+	}
+});
+
+for (const kind of ["r2", "s3-compatible"] as const) {
+	test(`${kind} root uses plain object keys and retains history across backend instances`, async () => {
+		const config: ResolvedS3Backend = {
+			type: "s3",
+			profile: {
+				kind,
+				endpoint:
+					kind === "r2"
+						? "https://account.r2.cloudflarestorage.com"
+						: "https://s3.example.com/storage",
+				region: kind === "r2" ? "auto" : "us-east-1",
+				accessKeyId: "access",
+				secretAccessKey: "secret",
+			},
+			destination: { bucket: "bucket", prefix: "./", namespace: "root" },
+		};
+		assert.throws(
+			() =>
+				new S3SyncBackend({ ...config, destination: { ...config.destination, namespace: "./" } }),
+			/storage location/u,
+		);
+		assert.equal(latestKey(config), "latest.json");
+		assert.equal(historyKey(config), "history.json");
+		assert.equal(snapshotKey(config, "snap"), "snapshots/snap.json.gz");
+		const basePath = kind === "r2" ? "/bucket" : "/storage/bucket";
+		const objects = new Map<string, Buffer>([[`${basePath}/unrelated.txt`, Buffer.from("keep")]]);
+		const requests: string[] = [];
+		const original = globalThis.fetch;
+		globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+			const url = new URL(String(input));
+			requests.push(url.pathname);
+			if (init?.method === "PUT") {
+				if (new Headers(init.headers).get("if-none-match") === "*" && objects.has(url.pathname))
+					return new Response(null, { status: 412 });
+				objects.set(url.pathname, Buffer.from(init.body as Uint8Array));
+				return new Response(null, { status: 200 });
+			}
+			const body = objects.get(url.pathname);
+			return body
+				? new Response(new Uint8Array(body), { headers: { etag: '"revision"' } })
+				: new Response(null, { status: 404 });
+		};
+		try {
+			const first = {
+				...snapshot([{ path: "settings.json", content: Buffer.from("root") }]),
+				profile: "root",
+			};
+			const result = await new S3SyncBackend(config).publishSnapshot(first, { kind: "missing" });
+			assert.deepEqual(
+				[...objects.keys()].sort(),
+				["history.json", "latest.json", "snapshots/snap.json.gz", "unrelated.txt"].map(
+					(key) => `${basePath}/${key}`,
+				),
+			);
+			const fresh = new S3SyncBackend(config);
+			assert.deepEqual(await fresh.readSnapshot(first.id), first);
+			const second = { ...first, id: "second" };
+			await fresh.publishSnapshot(second, expectedRemoteHead(result.head));
+			assert.deepEqual(
+				(await fresh.listHistory()).map((entry) => entry.snapshotId),
+				["snap", "second"],
+			);
+			assert.deepEqual(await fresh.readSnapshot(first.id), first);
+			assert.ok(
+				requests.every(
+					(request) =>
+						request.startsWith(`${basePath}/`) &&
+						!request.includes("/./") &&
+						!request.includes("/pi-sync/"),
+				),
+			);
+			assert.deepEqual(objects.get(`${basePath}/unrelated.txt`), Buffer.from("keep"));
+		} finally {
+			globalThis.fetch = original;
+		}
+	});
+}

--- a/packages/pi-sync/test/occupied-setup-location.test.ts
+++ b/packages/pi-sync/test/occupied-setup-location.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	loadConfig,
+	localConfigPath,
+	readLocalConfigObject,
+	validateSettingsDocument,
+} from "../src/config.js";
+import { showSyncManager } from "../src/manager-ui.js";
+import { addSyncSetup } from "../src/settings-management.js";
+import { promptAvailableSetupStorage } from "../src/setup-location-ui.js";
+import { v3S3Settings, v3WebDavSettings, withTempHome } from "./helpers.js";
+
+initTheme("dark", false);
+
+function seed(value: string) {
+	mkdirSync(path.dirname(localConfigPath()), { recursive: true });
+	writeFileSync(localConfigPath(), value, { mode: 0o600 });
+}
+const kinds = ["R2", "S3", "WebDAV", "Git"] as const;
+
+// A separate branch/bucket/path must keep the root default when it is not occupied.
+test.each(kinds)("%s free coordinates do not prompt or mutate settings", async (kind) => {
+	await withTempHome(async () => {
+		const { settings, connection } = fixture(kind, false);
+		const storage = { ...settings.syncSetups.home.storage, connection, path: "./" };
+		if (kind === "Git") storage.branch = "other";
+		else if (kind === "WebDAV") settings.syncSetups.home.storage.path = "archives/home";
+		else storage.bucket = "other-bucket";
+		const before = JSON.stringify(settings);
+		seed(before);
+		let prompts = 0;
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => {
+				prompts++;
+				return undefined;
+			},
+		});
+		assert.deepEqual(await promptAvailableSetupStorage(ctx, storage), storage);
+		assert.equal(prompts, 0);
+		assert.deepEqual(notifications, []);
+		assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+	});
+});
+
+test.each(kinds)(
+	"%s correction rechecks invalid, occupied, and concurrently occupied coordinates",
+	async (kind) => {
+		await withTempHome(async () => {
+			const { settings, connection } = fixture(kind, false);
+			seed(JSON.stringify(settings));
+			const git = kind === "Git";
+			const answers = [
+				git ? "main" : ".",
+				git ? "bad..branch" : "../unsafe",
+				git ? "claimed" : "backups/claimed",
+				git ? "free" : "backups/free",
+			];
+			let prompts = 0;
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				input: async () => {
+					if (prompts === 2) {
+						const competitor = structuredClone(settings.syncSetups.home);
+						if (typeof competitor.storage.branch === "string")
+							competitor.storage.branch = "claimed";
+						else competitor.storage.path = "backups/claimed";
+						await addSyncSetup("competitor", competitor);
+					}
+					return answers[prompts++];
+				},
+			});
+			const storage = await promptAvailableSetupStorage(ctx, {
+				...settings.syncSetups.home.storage,
+				connection,
+				path: "./",
+			});
+			assert.equal(prompts, 4);
+			assert.equal(git ? storage?.branch : storage?.path, git ? "free" : "backups/free");
+			assert.ok(notifications.some((n) => /competitor/u.test(n.message)));
+			assert.ok(notifications.some((n) => /Invalid/u.test(n.message)));
+			assert.deepEqual((await readLocalConfigObject())?.syncSetups.home, settings.syncSetups.home);
+		});
+	},
+);
+
+test("location preflight leaves malformed settings untouched", async () => {
+	await withTempHome(async () => {
+		seed("{invalid");
+		const { ctx } = createMockContext({ hasUI: true, mode: "tui" });
+		await assert.rejects(promptAvailableSetupStorage(ctx, { connection: "dav", path: "./" }));
+		assert.equal(readFileSync(localConfigPath(), "utf8"), "{invalid");
+	});
+});
+
+function fixture(kind: (typeof kinds)[number], alias: boolean) {
+	const settings = validateSettingsDocument(
+		kind === "WebDAV" ? v3WebDavSettings() : v3S3Settings({ path: "./", bucket: "pi-sync" }),
+	);
+	const source = kind === "WebDAV" ? "dav" : "r2";
+	if (kind === "Git") {
+		settings.storageConnections[source] = {
+			type: "git",
+			remote: "git@example.com:private/pi-sync.git",
+		};
+		settings.syncSetups.home.storage = { connection: source, path: "./", branch: "main" };
+	} else if (kind === "S3") {
+		const connection = settings.storageConnections[source];
+		if (connection.type === "s3") connection.endpoint = "https://s3.example.com";
+	}
+	settings.syncSetups.home.storage.path = ".";
+	if (alias) {
+		settings.storageConnections.alias = structuredClone(settings.storageConnections[source]);
+		const connection = settings.storageConnections.alias;
+		if (connection.type === "git")
+			connection.remote = "ssh://git@EXAMPLE.com:22/private/pi-sync.git/";
+		else if (connection.type === "webdav") connection.url += "/";
+		else connection.endpoint += "/";
+	}
+	return { settings, connection: alias ? "alias" : source };
+}
+
+for (const kind of kinds) {
+	test.each(
+		[false, true].flatMap((alias) =>
+			(kind === "Git" ? ["./", "archives/work"] : ["./"]).map((storagePath) => ({
+				alias,
+				storagePath,
+			})),
+		),
+	)(
+		`${kind} occupied location requires correction before review (alias=$alias, path=$storagePath)`,
+		async ({ alias, storagePath }) => {
+			await withTempHome(async () => {
+				const { settings, connection } = fixture(kind, alias);
+				seed(JSON.stringify(settings));
+				const inputs = [
+					"work",
+					...(kind === "Git"
+						? ["", storagePath === "./" ? "" : storagePath]
+						: kind === "WebDAV"
+							? [""]
+							: alias && kind === "S3"
+								? ["pi-sync"]
+								: []),
+					kind === "Git" ? "work-branch" : "backups/work",
+				];
+				const choices = [
+					"More…",
+					"Sync setups…",
+					"Add sync setup",
+					connection,
+					...(kind === "S3" || kind === "R2"
+						? [
+								alias
+									? kind === "R2"
+										? "Use suggested location (recommended)"
+										: "Use existing bucket with suggested path (recommended)"
+									: "Same bucket as “home”",
+							]
+						: []),
+					"Minimal settings",
+					...(kind === "Git" ? ["Keep automatic sync off"] : []),
+					"Add sync setup",
+					undefined,
+				];
+				const titles: string[] = [];
+				const { ctx, notifications } = createMockContext({
+					hasUI: true,
+					mode: "tui",
+					input: async (title: string) => {
+						titles.push(title);
+						return inputs.shift();
+					},
+					select: async (title: string) => {
+						titles.push(title);
+						return choices.shift();
+					},
+				});
+				await showSyncManager(ctx, async () => undefined);
+				const config = await loadConfig("work");
+				assert.equal(config.storagePath, kind === "Git" ? storagePath : "backups/work");
+				if (config.backend.type === "git")
+					assert.equal(config.backend.destination.branch, "work-branch");
+				assert.deepEqual(
+					(await readLocalConfigObject())?.syncSetups.home,
+					settings.syncSetups.home,
+				);
+				const warning = notifications.find((n) => /already used/u.test(n.message));
+				assert.ok(warning, JSON.stringify(notifications));
+				assert.match(warning.message, /home/u);
+				const correction = titles.findIndex((t) => /already used by “/u.test(t));
+				const content = titles.findIndex((t) =>
+					/Choose (included content|an initial sync preset)/u.test(t),
+				);
+				assert.ok(correction >= 0 && correction < content, titles.join("\n"));
+			});
+		},
+	);
+
+	test.each(["cancel", "abort"])(
+		`${kind} occupied-root correction %s leaves settings untouched`,
+		async (action) => {
+			await withTempHome(async () => {
+				const { settings, connection } = fixture(kind, false);
+				const before = JSON.stringify(settings);
+				seed(before);
+				const controller = new AbortController();
+				const inputs = ["work", ...(kind === "Git" ? ["", ""] : kind === "WebDAV" ? [""] : [])];
+				const choices = [
+					"More…",
+					"Sync setups…",
+					"Add sync setup",
+					connection,
+					...(kind === "S3" || kind === "R2" ? ["Same bucket as “home”"] : []),
+					undefined,
+				];
+				let correction = false;
+				let reviewed = false;
+				const { ctx } = createMockContext({
+					hasUI: true,
+					mode: "tui",
+					input: async (title: string) => {
+						if (!/already used by “/u.test(title)) return inputs.shift();
+						correction = true;
+						if (action === "abort") {
+							controller.abort(new DOMException("Session replaced", "AbortError"));
+							return "late";
+						}
+						return undefined;
+					},
+					select: async (title: string) => {
+						if (/Review .*sync setup/u.test(title)) reviewed = true;
+						return choices.shift();
+					},
+				});
+				await showSyncManager(ctx, async () => undefined, controller.signal);
+				assert.equal(correction, true);
+				assert.equal(reviewed, false);
+				assert.equal(readFileSync(localConfigPath(), "utf8"), before);
+			});
+		},
+	);
+}

--- a/packages/pi-sync/test/s3-backend-contract.test.ts
+++ b/packages/pi-sync/test/s3-backend-contract.test.ts
@@ -2,10 +2,15 @@ import type { LatestPointer, SyncConfig } from "../src/types.js";
 import { registerSyncBackendContractSuite } from "./backend-contract-suite.js";
 import { createSyncBackend } from "./backend-factory-eager.js";
 
-registerSyncBackendContractSuite("s3", () => {
-	const harness = new ContractS3Harness();
-	return { backend: createSyncBackend(s3Config()), dispose: harness.install() };
-});
+for (const prefix of ["pi-sync", "./"]) {
+	registerSyncBackendContractSuite(`s3 (${prefix})`, () => {
+		const harness = new ContractS3Harness();
+		const config = s3Config();
+		config.backend.destination.prefix = prefix;
+		config.storagePath = prefix;
+		return { backend: createSyncBackend(config), dispose: harness.install() };
+	});
+}
 
 class ContractS3Harness {
 	private snapshots = new Map<string, Buffer>();

--- a/packages/pi-sync/test/s3-credentials-ui.test.ts
+++ b/packages/pi-sync/test/s3-credentials-ui.test.ts
@@ -29,7 +29,8 @@ test("keeping S3 credentials preserves the session token and unknown fields", as
 		const { ctx, notifications } = createMockContext({
 			hasUI: true,
 			mode: "tui",
-			input: async (title: string) => (title === "Endpoint" ? "https://new.example.com" : "auto"),
+			input: async (title: string) =>
+				title.startsWith("Endpoint\n") ? "https://new.example.com" : "auto",
 			select: async () => choices.shift(),
 			custom: async () => {
 				secretPrompts += 1;

--- a/packages/pi-sync/test/settings-management.test.ts
+++ b/packages/pi-sync/test/settings-management.test.ts
@@ -93,7 +93,7 @@ test.each([
 		assert.deepEqual(saved?.syncSetups[name].storage, {
 			connection: name,
 			bucket: "pi-sync",
-			path: `pi-sync/${name}`,
+			path: "./",
 		});
 		assert.equal(
 			inputTitles[0],
@@ -104,7 +104,7 @@ test.each([
 			["Cloudflare R2 endpoint", "Access key ID"],
 		);
 		assert.match(inputTitles[1], /Example: https:\/\/<account-id>\.r2\.cloudflarestorage\.com/u);
-		assert.ok(rendered.join("\n").includes(`Storage location: pi-sync/${name}`));
+		assert.ok(rendered.join("\n").includes("Storage location: ./"));
 		assert.doesNotMatch(rendered.join("\n"), /What will this sync setup be used for/u);
 		assert.doesNotMatch(rendered.join("\n"), /profiles\/|secret-key|access-key/u);
 	});
@@ -327,7 +327,7 @@ test("replacing stored S3 credentials drops the prior session token", async () =
 	});
 });
 
-test("S3 manager reuses a connection and derives a separate complete path", async () => {
+test("S3 manager reuses a connection and defaults a new setup to the bucket root", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });
 		writeSettings();
@@ -338,7 +338,7 @@ test("S3 manager reuses a connection and derives a separate complete path", asyn
 			"Sync setups…",
 			"Add sync setup",
 			"r2",
-			"Same bucket as “home” (recommended)",
+			"Same bucket as “home”",
 			"Recommended Pi settings",
 			"Add sync setup",
 			undefined,
@@ -358,8 +358,10 @@ test("S3 manager reuses a connection and derives a separate complete path", asyn
 		await mock.commands.get("sync")?.handler("", ctx);
 		const config = await loadConfig("work");
 		assert.equal(config.connectionName, "r2");
-		assert.equal(config.storagePath, "pi-sync/work");
-		assert.match(rendered.join("\n"), /Remote path: pi-sync\/work/u);
+		assert.equal(config.storagePath, "./");
+		assert.equal((await loadConfig("home")).storagePath, "pi-sync/home");
+		assert.match(rendered.join("\n"), /Remote path: \.\//u);
+		assert.match(rendered.join("\n"), /different path or bucket for independent setups/u);
 		assert.doesNotMatch(rendered.join("\n"), /profiles\//u);
 	});
 });

--- a/packages/pi-sync/test/settings-management.test.ts
+++ b/packages/pi-sync/test/settings-management.test.ts
@@ -83,7 +83,7 @@ test.each([
 		await mock.commands.get("sync")?.handler("", ctx);
 		const saved = await readLocalConfigObject();
 		assert.equal(saved?.skipSecretScan, false);
-		assert.deepEqual(saved?.storageConnections.r2, {
+		assert.deepEqual(saved?.storageConnections[name], {
 			type: "s3",
 			endpoint: "https://account.r2.cloudflarestorage.com",
 			region: "auto",
@@ -91,16 +91,20 @@ test.each([
 		});
 		assert.equal(saved?.activeSyncSetup, name);
 		assert.deepEqual(saved?.syncSetups[name].storage, {
-			connection: "r2",
+			connection: name,
 			bucket: "pi-sync",
 			path: `pi-sync/${name}`,
 		});
 		assert.match(inputTitles[0], /^Name this sync setup\n/u);
 		assert.match(inputTitles[0], /Examples: home, work, personal/u);
-		assert.match(inputTitles[0], /Leave blank to use default/u);
-		assert.match(inputTitles[0], /suggested storage paths and Git branches/u);
+		assert.match(inputTitles[0], /Default: default \(leave blank to keep\)/u);
+		assert.match(inputTitles[0], /Used in the suggested storage path/u);
 		assert.match(inputTitles[0], /Sync content and automatic sync are chosen separately/u);
-		assert.deepEqual(inputTitles.slice(1), ["Cloudflare R2 endpoint", "Access key ID"]);
+		assert.deepEqual(
+			inputTitles.slice(1).map((title) => title.split("\n")[0]),
+			["Cloudflare R2 endpoint", "Access key ID"],
+		);
+		assert.match(inputTitles[1], /Example: https:\/\/<account-id>\.r2\.cloudflarestorage\.com/u);
 		assert.ok(rendered.join("\n").includes(`Storage location: pi-sync/${name}`));
 		assert.doesNotMatch(rendered.join("\n"), /What will this sync setup be used for/u);
 		assert.doesNotMatch(rendered.join("\n"), /profiles\/|secret-key|access-key/u);
@@ -127,7 +131,6 @@ test("generic S3 setup reviews one complete custom storage path", async () => {
 			"work",
 			"https://s3.example.com",
 			"ap-northeast-1",
-			"archive",
 			"company-pi",
 			"teams/pi/work",
 			"access-key",
@@ -146,11 +149,12 @@ test("generic S3 setup reviews one complete custom storage path", async () => {
 		await mock.commands.get("sync")?.handler("", ctx);
 		const saved = await readLocalConfigObject();
 		assert.deepEqual(saved?.syncSetups.work.storage, {
-			connection: "archive",
+			connection: "work",
 			bucket: "company-pi",
 			path: "teams/pi/work",
 		});
-		assert.ok(inputTitles.includes("Storage path"));
+		assert.ok(inputTitles.some((title) => title.startsWith("Storage path\n")));
+		assert.equal(inputTitles.filter((title) => /name/iu.test(title.split("\n")[0])).length, 1);
 		assert.ok(!inputTitles.includes("Remote prefix"));
 		assert.ok(!inputTitles.includes("Remote namespace"));
 	});

--- a/packages/pi-sync/test/setup-defaults.test.ts
+++ b/packages/pi-sync/test/setup-defaults.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { stripVTControlCharacters } from "node:util";
+import { ExtensionInputComponent, initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { loadConfig, localConfigPath } from "../src/config.js";
+import { requiredInput, requiredValueInput } from "../src/manager-helpers.js";
+import { showSetupWizard } from "../src/manager-ui.js";
+import { withTempHome } from "./helpers.js";
+
+initTheme("dark", false);
+
+const fixtures = [
+	{
+		preset: "Git",
+		inputs: ["", "git@github.com:owner/private-pi-sync.git", "", ""],
+		choices: ["Keep automatic sync off", "Save setup"],
+		path: "./",
+		hints: [
+			"git@github.com:owner/private-pi-sync.git (SSH)",
+			"https://github.com/owner/private-pi-sync.git (HTTPS)",
+			"entire branch",
+			"Default: main",
+			"Default: ./",
+			"repository root",
+		],
+	},
+	{
+		preset: "WebDAV",
+		inputs: ["", "https://cloud.example.com/dav", "user", ""],
+		choices: [
+			"Minimal settings",
+			"Keep automatic sync off",
+			"Keep sessions off (recommended)",
+			"Save setup",
+		],
+		path: "pi-sync/default",
+		hints: [
+			"Example: https://cloud.example.com/remote.php/dav/files/user",
+			"collection URL",
+			"Default: pi-sync/default",
+		],
+	},
+	...["Cloudflare R2", "Other S3-compatible storage"].map((preset) => ({
+		preset,
+		inputs: [
+			"",
+			preset === "Cloudflare R2"
+				? "https://account.r2.cloudflarestorage.com"
+				: "https://s3.example.com",
+			...(preset === "Cloudflare R2" ? [] : [""]),
+			"existing-bucket",
+			"",
+			"access-key",
+		],
+		choices: [
+			"Customize remote location",
+			"Store credentials privately",
+			"Minimal settings",
+			"Keep automatic sync off",
+			"Keep sessions off (recommended)",
+			"Save sync setup",
+		],
+		path: "pi-sync/default",
+		hints: [
+			"Example: https://",
+			"Example: pi-sync",
+			"bucket must already exist",
+			"Object-key prefix",
+			"Default: pi-sync/default",
+			...(preset === "Cloudflare R2" ? [] : ["Default: us-east-1"]),
+		],
+	})),
+];
+
+for (const fixture of fixtures) {
+	test(`${fixture.preset} setup renders examples and accepts defaults with one name`, async () => {
+		await withTempHome(async () => {
+			const choices = [fixture.preset, ...fixture.choices];
+			const inputs = [...fixture.inputs];
+			const titles: string[] = [];
+			const frames: string[] = [];
+			let bounded = true;
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => choices.shift(),
+				input: async (title: string, placeholder?: string) => {
+					titles.push(title);
+					let answer: string | undefined;
+					const input = new ExtensionInputComponent(
+						title,
+						placeholder,
+						(value) => {
+							answer = value;
+						},
+						() => {},
+					);
+					try {
+						for (const width of [32, 80]) {
+							const lines = input.render(width);
+							bounded &&= lines.every((line) => visibleWidth(line) <= width);
+							frames.push(lines.join(" "));
+						}
+						input.handleInput(inputs.shift() ?? "");
+						input.handleInput("\r");
+						return answer;
+					} finally {
+						input.dispose();
+					}
+				},
+				custom: secretInput,
+			});
+			assert.equal(await showSetupWizard(ctx), true);
+			assert.equal(bounded, true);
+			assert.equal(
+				titles.filter(
+					(title) => /name/iu.test(title.split("\n")[0]) && !title.startsWith("WebDAV username"),
+				).length,
+				1,
+			);
+			const text = stripVTControlCharacters(frames.join(" ")).replace(/\s+/gu, " ");
+			for (const hint of fixture.hints) assert.ok(text.includes(hint), hint);
+			const config = await loadConfig();
+			assert.equal(config.setupName, "default");
+			assert.equal(config.connectionName, "default");
+			assert.equal(config.storagePath, fixture.path);
+			if (config.backend.type === "git") assert.equal(config.backend.destination.branch, "main");
+			if (config.backend.type === "s3")
+				assert.equal(
+					config.backend.profile.region,
+					fixture.preset === "Cloudflare R2" ? "auto" : "us-east-1",
+				);
+		});
+	});
+
+	test.each(fixture.inputs.map((_, index) => index))(
+		`${fixture.preset} cancellation at input %s never saves defaults`,
+		async (cancelAt) => {
+			await withTempHome(async () => {
+				const choices = [fixture.preset, ...fixture.choices];
+				let index = 0;
+				const { ctx } = createMockContext({
+					hasUI: true,
+					mode: "tui",
+					select: async () => choices.shift(),
+					input: async () => (index === cancelAt ? undefined : fixture.inputs[index++]),
+					custom: secretInput,
+				});
+				assert.equal(await showSetupWizard(ctx), false);
+				assert.equal(existsSync(localConfigPath()), false);
+			});
+		},
+	);
+
+	test(`${fixture.preset} blank remote or endpoint is not replaced with an example`, async () => {
+		await withTempHome(async () => {
+			const inputs = ["default", "   "];
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => fixture.preset,
+				input: async () => inputs.shift(),
+			});
+			assert.equal(await showSetupWizard(ctx), false);
+			assert.equal(existsSync(localConfigPath()), false);
+		});
+	});
+
+	test(`${fixture.preset} cancelling final review does not save`, async () => {
+		await withTempHome(async () => {
+			const choices = [fixture.preset, ...fixture.choices.slice(0, -1), "Cancel"];
+			const inputs = [...fixture.inputs];
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async () => choices.shift(),
+				input: async () => inputs.shift(),
+				custom: secretInput,
+			});
+			assert.equal(await showSetupWizard(ctx), false);
+			assert.equal(existsSync(localConfigPath()), false);
+		});
+	});
+}
+
+test.each(["", "   "])(
+	"example-only inputs reject blank %j instead of saving an example",
+	async (value) => {
+		const { ctx, notifications } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => value,
+		});
+		assert.equal(
+			await requiredValueInput(ctx, "Endpoint", "https://example.com", undefined),
+			undefined,
+		);
+		assert.match(notifications[0].message, /required/u);
+	},
+);
+
+test.each([requiredInput, requiredValueInput])(
+	"input ignores answers after session cancellation",
+	async (prompt) => {
+		const controller = new AbortController();
+		let received: AbortSignal | undefined;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async (_title: string, _placeholder?: string, options?: { signal?: AbortSignal }) => {
+				received = options?.signal;
+				controller.abort(new DOMException("Session replaced", "AbortError"));
+				return "late";
+			},
+		});
+		await assert.rejects(prompt(ctx, "Path", "example", controller.signal), { name: "AbortError" });
+		assert.equal(received, controller.signal);
+	},
+);
+
+async function secretInput(factory: unknown) {
+	const tui = createTuiHarness({ width: 48 });
+	const running = tui.custom(factory as Parameters<typeof tui.custom>[0]);
+	await tui.waitForOpen();
+	tui.type("private-password");
+	tui.press("tui.input.submit");
+	return running;
+}

--- a/packages/pi-sync/test/setup-defaults.test.ts
+++ b/packages/pi-sync/test/setup-defaults.test.ts
@@ -37,11 +37,12 @@ const fixtures = [
 			"Keep sessions off (recommended)",
 			"Save setup",
 		],
-		path: "pi-sync/default",
+		path: "./",
 		hints: [
 			"Example: https://cloud.example.com/remote.php/dav/files/user",
 			"collection URL",
-			"Default: pi-sync/default",
+			"Default: ./",
+			"collection root",
 		],
 	},
 	...["Cloudflare R2", "Other S3-compatible storage"].map((preset) => ({
@@ -64,13 +65,14 @@ const fixtures = [
 			"Keep sessions off (recommended)",
 			"Save sync setup",
 		],
-		path: "pi-sync/default",
+		path: "./",
 		hints: [
 			"Example: https://",
 			"Example: pi-sync",
 			"bucket must already exist",
 			"Object-key prefix",
-			"Default: pi-sync/default",
+			"Default: ./",
+			"bucket root",
 			...(preset === "Cloudflare R2" ? [] : ["Default: us-east-1"]),
 		],
 	})),
@@ -128,6 +130,7 @@ for (const fixture of fixtures) {
 			assert.equal(config.setupName, "default");
 			assert.equal(config.connectionName, "default");
 			assert.equal(config.storagePath, fixture.path);
+			assert.equal(config.snapshotIdentity, "root");
 			if (config.backend.type === "git") assert.equal(config.backend.destination.branch, "main");
 			if (config.backend.type === "s3")
 				assert.equal(
@@ -186,6 +189,28 @@ for (const fixture of fixtures) {
 		});
 	});
 }
+
+test.each(
+	fixtures.filter((fixture) => fixture.preset.includes("R2") || fixture.preset.includes("S3")),
+)("$preset ignores a storage-location answer after session replacement", async (fixture) => {
+	await withTempHome(async () => {
+		const controller = new AbortController();
+		let inputCount = 0;
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => fixture.inputs[inputCount++],
+			select: async (title: string) => {
+				if (!title.startsWith("Choose storage location")) return fixture.preset;
+				controller.abort(new DOMException("Session replaced", "AbortError"));
+				return "Customize remote location";
+			},
+		});
+		assert.equal(await showSetupWizard(ctx, controller.signal), false);
+		assert.equal(inputCount, fixture.inputs.indexOf("existing-bucket"));
+		assert.equal(existsSync(localConfigPath()), false);
+	});
+});
 
 test.each(["", "   "])(
 	"example-only inputs reject blank %j instead of saving an example",

--- a/packages/pi-sync/test/setup-name-ui.test.ts
+++ b/packages/pi-sync/test/setup-name-ui.test.ts
@@ -45,8 +45,10 @@ test.each([32, 80])("Pi core name input renders guidance within %s columns", asy
 	assert.ok(lines.every((line) => visibleWidth(line) <= width));
 	const text = stripVTControlCharacters(lines.join(" ")).replace(/\s+/gu, " ");
 	assert.match(text, /Name this sync setup/u);
-	assert.match(text, /Examples: home, work, personal\. Leave blank to use default\./u);
-	assert.match(text, /Used in suggested storage paths and Git branches\./u);
+	assert.match(text, /Examples: home, work, personal\./u);
+	assert.match(text, /Default: default \(leave blank to keep\)/u);
+	assert.match(text, /Also names the storage connection; no second name is needed\./u);
+	assert.match(text, /Git branch and storage path are chosen separately\./u);
 	assert.match(text, /Sync content and automatic sync are chosen separately\./u);
 });
 
@@ -92,7 +94,7 @@ const invalidCommonNames = [
 	"work\u001b[31m",
 	"work\u0085profile",
 ];
-const invalidGitNames = [
+const independentGitNames = [
 	"work profile",
 	"work..profile",
 	"work@{profile}",
@@ -112,8 +114,17 @@ const invalidGitNames = [
 ];
 
 const invalidCases = [
-	...presets.flatMap((preset) => invalidCommonNames.map((name) => ({ preset, name }))),
-	...invalidGitNames.map((name) => ({ preset: "Git", name })),
+	...presets
+		.filter((preset) => preset !== "Git")
+		.flatMap((preset) => invalidCommonNames.map((name) => ({ preset, name }))),
+	...[
+		"__proto__",
+		"prototype",
+		"constructor",
+		"a".repeat(101),
+		"work\u001b[31m",
+		"work\u0085profile",
+	].map((name) => ({ preset: "Git", name })),
 ];
 
 test.each(invalidCases)(
@@ -150,6 +161,7 @@ test.each(invalidCases)(
 );
 
 const validCases = [
+	...independentGitNames.map((name) => ({ preset: "Git", name })),
 	...presets.flatMap((preset) =>
 		["default", "team/work", "-work", "refs/work", "@", "工作", "a".repeat(100)].map((name) => ({
 			preset,
@@ -199,7 +211,7 @@ test.each([false, true])(
 				input: async (title: string, _placeholder?: string, options?: { signal?: AbortSignal }) => {
 					titles.push(title);
 					signals.push(options?.signal);
-					if (titles.length === 1) return "work profile";
+					if (titles.length === 1) return "__proto__";
 					if (abort) {
 						controller.abort(new DOMException("Session shut down", "AbortError"));
 						return "default";

--- a/packages/pi-sync/test/setup-name-ui.test.ts
+++ b/packages/pi-sync/test/setup-name-ui.test.ts
@@ -60,7 +60,7 @@ test.each([
 				}
 			},
 		});
-		assert.equal(await promptInitialSetupName(ctx, "Git"), "default");
+		assert.equal(await promptInitialSetupName(ctx), "default");
 		assert.equal(submitted, true);
 		assert.ok(lines.every((line) => visibleWidth(line) <= width));
 		const text = stripVTControlCharacters(lines.join(" ")).replace(/\s+/gu, " ");
@@ -93,7 +93,7 @@ test("RPC name input keeps guidance free of terminal styling", async () => {
 			return "";
 		},
 	});
-	assert.equal(await promptInitialSetupName(ctx, "Git"), "default");
+	assert.equal(await promptInitialSetupName(ctx), "default");
 	assert.equal(
 		renderedTitle,
 		"Sync setup name\nFor example: home or work. Leave blank for default.",
@@ -122,19 +122,12 @@ test("Pi core name input cancellation does not accept the default", async () => 
 			}
 		},
 	});
-	assert.equal(await promptInitialSetupName(ctx, "Git"), undefined);
+	assert.equal(await promptInitialSetupName(ctx), undefined);
 	assert.equal(cancelled, true);
 });
 
 const presets = ["Cloudflare R2", "Other S3-compatible storage", "WebDAV", "Git"];
 const invalidCommonNames = [
-	".",
-	"..",
-	"team/../work",
-	"team/./work",
-	"team//work",
-	"/work",
-	"team\\work",
 	"__proto__",
 	"prototype",
 	"constructor",
@@ -142,7 +135,14 @@ const invalidCommonNames = [
 	"work\u001b[31m",
 	"work\u0085profile",
 ];
-const independentGitNames = [
+const independentNames = [
+	".",
+	"..",
+	"team/../work",
+	"team/./work",
+	"team//work",
+	"/work",
+	"team\\work",
 	"work profile",
 	"work..profile",
 	"work@{profile}",
@@ -161,19 +161,9 @@ const independentGitNames = [
 	"work/",
 ];
 
-const invalidCases = [
-	...presets
-		.filter((preset) => preset !== "Git")
-		.flatMap((preset) => invalidCommonNames.map((name) => ({ preset, name }))),
-	...[
-		"__proto__",
-		"prototype",
-		"constructor",
-		"a".repeat(101),
-		"work\u001b[31m",
-		"work\u0085profile",
-	].map((name) => ({ preset: "Git", name })),
-];
+const invalidCases = presets.flatMap((preset) =>
+	invalidCommonNames.map((name) => ({ preset, name })),
+);
 
 test.each(invalidCases)(
 	"$preset rejects name $name before backend prompts and allows correction",
@@ -209,7 +199,7 @@ test.each(invalidCases)(
 );
 
 const validCases = [
-	...independentGitNames.map((name) => ({ preset: "Git", name })),
+	...presets.flatMap((preset) => independentNames.map((name) => ({ preset, name }))),
 	...presets.flatMap((preset) =>
 		["default", "team/work", "-work", "refs/work", "@", "工作", "a".repeat(100)].map((name) => ({
 			preset,

--- a/packages/pi-sync/test/webdav-backend-contract.test.ts
+++ b/packages/pi-sync/test/webdav-backend-contract.test.ts
@@ -2,10 +2,14 @@ import { WebDavSyncBackend } from "../src/webdav-backend.js";
 import { registerSyncBackendContractSuite } from "./backend-contract-suite.js";
 import { MockWebDavServer, webDavConfig } from "./mock-webdav-server.js";
 
-registerSyncBackendContractSuite("webdav", async () => {
-	const server = await new MockWebDavServer().start();
-	return {
-		backend: new WebDavSyncBackend(webDavConfig(server.url)),
-		dispose: () => server.close(),
-	};
-});
+for (const storagePath of ["pi-sync", "./"]) {
+	registerSyncBackendContractSuite(`webdav (${storagePath})`, async () => {
+		const server = await new MockWebDavServer().start();
+		const config = webDavConfig(server.url);
+		config.destination.path = storagePath;
+		return {
+			backend: new WebDavSyncBackend(config),
+			dispose: () => server.close(),
+		};
+	});
+}

--- a/packages/pi-sync/test/webdav-backend.test.ts
+++ b/packages/pi-sync/test/webdav-backend.test.ts
@@ -86,21 +86,26 @@ test("WebDAV servers with non-rotating strong ETags remain read-only", async () 
 	}
 });
 
-test("WebDAV servers that ignore preconditions remain read-only", async () => {
-	const server = await new MockWebDavServer({ ignoreConditions: true }).start();
-	try {
-		const backend = new WebDavSyncBackend(webDavConfig(server.url));
-		await assert.rejects(
-			backend.publishSnapshot(snapshot([]), { kind: "missing" }),
-			/ignored If-None-Match|read-only/i,
-		);
-		assert.equal(server.resources.has("/dav/pi-sync/latest.json"), false);
-		assert.ok((await backend.diagnose()).some((item) => item.level === "error"));
-		assert.equal(backend.capability, "conditional-required");
-	} finally {
-		await server.close();
-	}
-});
+test.each(["pi-sync", "./"])(
+	"WebDAV servers that ignore preconditions remain read-only at %s",
+	async (storagePath) => {
+		const server = await new MockWebDavServer({ ignoreConditions: true }).start();
+		try {
+			const config = webDavConfig(server.url);
+			config.destination.path = storagePath;
+			const backend = new WebDavSyncBackend(config);
+			await assert.rejects(
+				backend.publishSnapshot(snapshot([]), { kind: "missing" }),
+				/ignored If-None-Match|read-only/i,
+			);
+			assert.ok(![...server.resources.keys()].some((key) => key.endsWith("/latest.json")));
+			assert.ok((await backend.diagnose()).some((item) => item.level === "error"));
+			assert.equal(backend.capability, "conditional-required");
+		} finally {
+			await server.close();
+		}
+	},
+);
 
 test("WebDAV rejects control-bearing remote pointer metadata and references", async () => {
 	for (const unsafe of [

--- a/packages/pi-sync/test/webdav-input-compatibility.test.ts
+++ b/packages/pi-sync/test/webdav-input-compatibility.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import {
+	loadConfig,
+	loadPartialConfig,
+	localConfigPath,
+	readLocalConfigObject,
+} from "../src/config.js";
+import { WebDavClient } from "../src/webdav-client.js";
+import {
+	showAddWebDavStorageProfile,
+	showAddWebDavTarget,
+	showEditWebDavStorageProfile,
+	showEditWebDavTarget,
+	showWebDavSetup,
+} from "../src/webdav-ui.js";
+import { v3WebDavSettings, withTempHome } from "./helpers.js";
+
+initTheme("dark", false);
+
+function seed(value: unknown) {
+	mkdirSync(path.dirname(localConfigPath()), { recursive: true });
+	writeFileSync(localConfigPath(), JSON.stringify(value), { mode: 0o600 });
+}
+
+for (const storagePath of ["backups/<work>", "backups/work>", "backups/<work"]) {
+	test.each(["", storagePath])("WebDAV edit retains valid path %s", async (answer) => {
+		await withTempHome(async () => {
+			const settings = v3WebDavSettings();
+			settings.syncSetups.home.storage.path = storagePath;
+			seed(settings);
+			const before = await loadConfig();
+			const { ctx } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				input: async () => answer,
+				select: async () => "Save sync setup",
+			});
+			assert.equal(await showEditWebDavTarget(ctx, await loadPartialConfig()), true);
+			assert.equal((await loadConfig()).storagePath, before.storagePath);
+		});
+	});
+}
+
+test.each(["first", "add", "edit"])(
+	"WebDAV %s connection accepts valid brackets without exposing credentials",
+	async (flow) => {
+		await withTempHome(async () => {
+			const settings = v3WebDavSettings();
+			if (flow !== "first") seed(settings);
+			const inputs = [
+				...(flow === "add" ? ["<archive>"] : []),
+				"https://cloud.example.com/<dav>",
+				"<account>",
+				...(flow === "first" ? ["backups/<work>"] : []),
+			];
+			const choices =
+				flow === "first"
+					? [
+							"Minimal settings",
+							"Keep automatic sync off",
+							"Keep sessions off (recommended)",
+							"Save setup",
+						]
+					: flow === "add"
+						? ["Add storage connection"]
+						: ["Keep current password", "Save storage connection"];
+			const titles: string[] = [];
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				input: async (title: string) => {
+					titles.push(title);
+					return inputs.shift();
+				},
+				select: async (title: string) => {
+					titles.push(title);
+					return choices.shift();
+				},
+				custom: async (factory: unknown) => {
+					const tui = createTuiHarness();
+					const running = tui.custom(factory as Parameters<typeof tui.custom>[0]);
+					await tui.waitForOpen();
+					tui.type("private-password");
+					tui.press("tui.input.submit");
+					return running;
+				},
+			});
+			const saved =
+				flow === "first"
+					? await showWebDavSetup(ctx, "home")
+					: flow === "add"
+						? await showAddWebDavStorageProfile(ctx)
+						: await showEditWebDavStorageProfile(ctx, "dav", {
+								...settings.storageConnections.dav,
+								...settings.storageConnections.dav.credentials,
+							});
+			assert.equal(saved, true);
+			const name = flow === "first" ? "home" : flow === "add" ? "<archive>" : "dav";
+			const connection = (await readLocalConfigObject())?.storageConnections[name];
+			assert.equal(connection?.type, "webdav");
+			if (connection?.type !== "webdav") return;
+			assert.equal(connection.url, "https://cloud.example.com/%3Cdav%3E/");
+			assert.equal(connection.credentials.username, "<account>");
+			assert.doesNotMatch(
+				[...titles, ...notifications.map((n) => n.message)].join("\n"),
+				/<account>|private-password/u,
+			);
+		});
+	},
+);
+
+test("WebDAV additional setup accepts a bracket path and cancellation preserves settings", async () => {
+	await withTempHome(async () => {
+		seed(v3WebDavSettings());
+		const choices = ["Minimal settings", "Add sync setup"];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => "backups/<work>",
+			select: async () => choices.shift(),
+		});
+		assert.equal(await showAddWebDavTarget(ctx, "work", "dav"), true);
+		assert.equal((await loadConfig("work")).storagePath, "backups/<work>");
+		const before = readFileSync(localConfigPath());
+		const controller = new AbortController();
+		const late = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async () => {
+				controller.abort(new DOMException("Session replaced", "AbortError"));
+				return "backups/<late>";
+			},
+		});
+		await assert.rejects(showAddWebDavTarget(late.ctx, "late", "dav", controller.signal), {
+			name: "AbortError",
+		});
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+	});
+});
+
+test("WebDAV client percent-encodes literal brackets in each remote segment", async () => {
+	const original = globalThis.fetch;
+	const urls: string[] = [];
+	globalThis.fetch = async (input) => {
+		urls.push(String(input));
+		return new Response(null, { status: 404 });
+	};
+	try {
+		const client = new WebDavClient({
+			type: "webdav",
+			profile: {
+				kind: "webdav",
+				url: "https://cloud.example.com/dav/",
+				username: "user",
+				password: "pass",
+			},
+			destination: { path: "backups/<work>", namespace: "<work>" },
+		});
+		assert.equal((await client.getBuffer("backups/<work>/latest.json")).missing, true);
+		assert.deepEqual(urls, ["https://cloud.example.com/dav/backups/%3Cwork%3E/latest.json"]);
+	} finally {
+		globalThis.fetch = original;
+	}
+});

--- a/packages/pi-sync/test/webdav-ui.test.ts
+++ b/packages/pi-sync/test/webdav-ui.test.ts
@@ -16,7 +16,7 @@ import {
 	showEditWebDavTarget,
 	showWebDavSetup,
 } from "../src/webdav-ui.js";
-import { v3S3Settings, withTempHome } from "./helpers.js";
+import { v3S3Settings, v3WebDavSettings, withTempHome } from "./helpers.js";
 
 test("first WebDAV setup stores masked credentials in the exact version 3 shape", async () => {
 	await withTempHome(async (agentDir) => {
@@ -125,6 +125,32 @@ test("WebDAV setup edit persists one complete path and rejects unsafe paths", as
 		assert.equal(await showEditWebDavTarget(invalid.ctx, await loadPartialConfig("work")), false);
 		assert.match(invalid.notifications.at(-1)?.message ?? "", /Invalid pi-sync WebDAV path/u);
 		assert.deepEqual(readFileSync(localConfigPath()), before);
+	});
+});
+
+test("WebDAV new setups default to root while edits keep the existing nested path", async () => {
+	await withTempHome(async (agentDir) => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(localConfigPath(), JSON.stringify(v3WebDavSettings()), { mode: 0o600 });
+		const titles: string[] = [];
+		const choices = ["Minimal settings", "Add sync setup", "Save sync setup"];
+		const { ctx } = createMockContext({
+			hasUI: true,
+			mode: "tui",
+			input: async (title: string) => {
+				titles.push(title);
+				return "";
+			},
+			select: async () => choices.shift(),
+		});
+		assert.equal(await showAddWebDavTarget(ctx, "work", "dav"), true);
+		assert.equal((await loadConfig("work")).storagePath, "./");
+		const before = readFileSync(localConfigPath());
+		assert.equal(await showEditWebDavTarget(ctx, await loadPartialConfig("home")), true);
+		assert.equal((await loadConfig("home")).storagePath, "pi-sync/home");
+		assert.deepEqual(readFileSync(localConfigPath()), before);
+		assert.match(titles[0], /Default: \.\//u);
+		assert.match(titles[1], /Default: pi-sync\/home/u);
 	});
 });
 

--- a/packages/pi-sync/test/webdav-ui.test.ts
+++ b/packages/pi-sync/test/webdav-ui.test.ts
@@ -41,13 +41,13 @@ test("first WebDAV setup stores masked credentials in the exact version 3 shape"
 		});
 		assert.equal(await showWebDavSetup(ctx, "home"), true);
 		const raw = await readLocalConfigObject();
-		assert.deepEqual(raw?.storageConnections.webdav, {
+		assert.deepEqual(raw?.storageConnections.home, {
 			type: "webdav",
 			url: "https://cloud.example.com/remote.php/dav/files/user/",
 			credentials: { username: "user", password: "app-password" },
 		});
 		assert.deepEqual(raw?.syncSetups.home.storage, {
-			connection: "webdav",
+			connection: "home",
 			path: "pi-sync/home",
 		});
 		assert.doesNotMatch(rendered.join("\n"), /app-password/u);


### PR DESCRIPTION
## Summary

Simplify pi-sync setup across Git, WebDAV, Cloudflare R2, and S3-compatible storage: name the setup once, reuse that name for its first storage connection, and default every new storage path to `./`.

- Show examples, field explanations, and explicit blank-to-accept defaults in dialog titles because Pi's TUI ignores input placeholders. Remote URLs, endpoints, usernames, and credentials never silently accept example values.
- Use the Git repository root, WebDAV collection root, or selected R2/S3 bucket root without literal `./` object keys. Git also defaults to `main` and retains existing-branch safety checks.
- Keep setup names independent of storage coordinates. Reviewed, saved, and resolved paths stay identical, including when a setup name ends with a slash.
- Preserve existing paths, local state identities, and edit defaults, including valid WebDAV angle brackets. Explain that independent setups sharing a WebDAV collection or bucket need separate folders or prefixes.
- Detect occupied configured destinations before additional-setup content selection/review, including equivalent connections. Require another path or Git branch instead of accepting an occupied root; Git branch ownership is independent of directory.
- Preserve unknown settings fields when initializing an empty catalog. Update documentation and patch Changesets.
- Resolve conflicts with the latest main while preserving its compact, muted name prompt and all-backend cancellation coverage.

## Verification

- `npm run check` passed at signed commit `b810a8c5`: build, Biome, package boundaries, and workspace typechecks.
- `npm test` passed: **362 test files, 3,928 tests**. Focused pi-sync tests also passed: 60 files, 771 tests.
- GitHub CI passed at `b810a8c5`; the post-push refresh reported `MERGEABLE` / `CLEAN`.
- Precommit staged Biome and affected pi-sync build/typecheck passed.
- `git diff --check` and the fenced-code-aware README heading audit passed.
- Pi-core input tests cover dark/light themes at 32/80 columns, plain RPC guidance, blank defaults, cancellation at each setup input and final review, stale answers after session cancellation, and setup names independent of backend paths.
- Root configuration tests cover canonical aliases, duplicate destinations, unsafe paths, rename-stable identities, unchanged nested paths, and side-effect-free reads.
- Local HTTP WebDAV tests verify collection-relative root publications, fresh reads, history, conditional-write probes, probe cleanup, and preservation of unrelated files. Mock S3/R2 tests verify exact object keys before URL normalization and root reads/publications.
- Local bare-Git tests cover root publications, fresh-cache reads, history, lease-protected updates, and rejection of unrelated existing `main` content. Backend contracts cover both root and nested storage.
- Integration tests verify exact reviewed/saved/resolved R2/S3 paths for trailing-slash setup names, unknown-field preservation, and retained edit coordinates.
- Regression tests cover WebDAV bracket values and exact HTTP encoding; occupied roots, aliased connections, distinct Git directories on one branch, free destinations, retries, concurrent occupancy, and cancellation before review.
- Generated-runtime tests exercise the lazy `init` → manager → storage-location dialog through Pi's Jiti loader, keep the new location module out of the eager graph, and invalidate the test runtime.

## Review feedback ledger

All feedback was independently checked against current code, base `14649549`, and the full PR diff. Replies include the evidence and test coverage.

| Feedback | Outcome |
| --- | --- |
| [WebDAV username edit default](https://github.com/narumiruna/pi-extensions/pull/1220#discussion_r3942974228) | Valid but pre-existing P2 usability issue; out of scope and deferred. Base already rejected blank usernames and hid review values. Remains unresolved; recommend a separate credential-editing change that does not expose stored values. |
| [WebDAV angle brackets](https://github.com/narumiruna/pi-extensions/pull/1220#discussion_r3942974339) | Introduced input-filtering regression fixed and verified; thread resolved. |
| [Occupied additional-setup roots](https://github.com/narumiruna/pi-extensions/pull/1220#discussion_r3942974485) | Fixed across all four backend flows and verified; thread resolved. |
| [Git branch reuse with different directories](https://github.com/narumiruna/pi-extensions/pull/1220#discussion_r3942974626) | Independently verified and covered by branch-wide occupancy checks/tests; thread resolved. |

No clarification or implementation blocker remains. The separate automated review triggered by the new push was still running at the one post-push refresh; no new feedback item was present then.

## Semantic audit and limits

Reviewed against `docs/extension-conventions.md`, `docs/extension-settings.md`, and `docs/readme-conventions.md`: cancellation/session shutdown, Pi-owned component disposal, post-await cancellation checks, ordered/atomic settings persistence, invalid-file protection, unknown-field preservation, terminal sanitization, root path normalization, backend identities, and WebDAV probe confinement.

No new custom TUI, settings schema migration, command routes, or publication configuration. No guide deviations. Live external-service and manual interactive TUI smokes were not run; deterministic Pi-core rendering and local-backend tests cover the changed paths. Package metadata is unchanged, so no pack was required. The generated-entry/lazy-manager Jiti smoke passed; a manual package-directory interactive CLI smoke was not run.
