### PR TITLE
fix(sync): preserve exact initial S3 setup paths

### DIFF
--- a/.changeset/exact-sync-setup-path.md
+++ b/.changeset/exact-sync-setup-path.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Reject trailing slashes in initial R2/S3 setup names before collecting connection details, so suggested paths match the exact path reviewed and used for sync. Allow immediate correction without changing valid WebDAV names.

--- a/packages/pi-sync/src/setup-name-ui.ts
+++ b/packages/pi-sync/src/setup-name-ui.ts
@@ -19,12 +19,15 @@ export async function promptInitialSetupName(
 			validateConfigName(name, "sync setup");
 			// Validate the same suggestions the backend prompts will offer, without changing the name.
 			const suggestedPath = `pi-sync/${name}`;
-			normalizeStoragePath(suggestedPath);
+			const normalizedPath = normalizeStoragePath(suggestedPath);
 			if (preset === "Git") {
 				normalizeGitBranch(suggestedPath);
 				normalizeGitDirectory(suggestedPath);
 			} else if (preset === "WebDAV") {
 				normalizeWebDavPath(suggestedPath);
+			} else if (normalizedPath !== suggestedPath) {
+				// S3 reviews the raw suggestion; WebDAV normalizes its path before review.
+				throw new Error("S3 setup names must not end with a slash.");
 			}
 			return name;
 		} catch (error) {

--- a/packages/pi-sync/test/settings-management.test.ts
+++ b/packages/pi-sync/test/settings-management.test.ts
@@ -106,6 +106,62 @@ test.each([
 	});
 });
 
+test.each(["Cloudflare R2", "Other S3-compatible storage"])(
+	"%s setup corrects a trailing-slash name and uses the exact reviewed path",
+	async (preset) => {
+		await withTempHome(async () => {
+			const r2 = preset === "Cloudflare R2";
+			const choices = [
+				preset,
+				r2
+					? "Use suggested location (recommended)"
+					: "Use existing bucket with suggested path (recommended)",
+				"Store credentials privately",
+				"Minimal settings",
+				"Keep automatic sync off",
+				"Keep sessions off (recommended)",
+				"Save sync setup",
+			];
+			const inputs = [
+				r2 ? "https://account.r2.cloudflarestorage.com" : "https://s3.example.com",
+				...(r2 ? [] : ["us-east-1", "existing-bucket"]),
+				"access-key",
+			];
+			const titles: string[] = [];
+			let nameCalls = 0;
+			let review = "";
+			const { ctx, notifications } = createMockContext({
+				hasUI: true,
+				mode: "tui",
+				select: async (title: string) => {
+					if (title.startsWith("Review sync setup")) review = title;
+					return choices.shift();
+				},
+				input: async (title: string) => {
+					titles.push(title);
+					if (title.startsWith("Sync setup name")) return nameCalls++ === 0 ? "work/" : "work";
+					return inputs.shift();
+				},
+				custom: secretInput("secret-key"),
+			});
+			assert.equal(await showSetupWizard(ctx), true);
+			const reviewedPath = review.split("\n").find((line) => line.startsWith("Storage location: "));
+			assert.equal(reviewedPath, "Storage location: pi-sync/work");
+			assert.match(titles[0], /^Sync setup name/u);
+			assert.equal(titles[1], titles[0]);
+			assert.equal(notifications.filter((item) => item.level === "warning").length, 1);
+			const saved = await readLocalConfigObject();
+			assert.equal(saved?.activeSyncSetup, "work");
+			assert.equal(saved?.syncSetups.work.storage.path, "pi-sync/work");
+			const config = await loadConfig();
+			assert.equal(config.storagePath, "pi-sync/work");
+			assert.equal(config.backend.type, "s3");
+			if (config.backend.type !== "s3") return;
+			assert.equal(config.backend.destination.prefix, "pi-sync/work");
+		});
+	},
+);
+
 test("generic S3 setup reviews one complete custom storage path", async () => {
 	await withTempHome(async (agentDir) => {
 		mkdirSync(agentDir, { recursive: true });

--- a/packages/pi-sync/test/setup-name-ui.test.ts
+++ b/packages/pi-sync/test/setup-name-ui.test.ts
@@ -161,9 +161,12 @@ const invalidGitNames = [
 	"work/",
 ];
 
+const s3Presets = ["Cloudflare R2", "Other S3-compatible storage"];
+const noncanonicalS3Names = ["work/", "work///", "team/work/", "work /", "/", " work/ "];
 const invalidCases = [
 	...presets.flatMap((preset) => invalidCommonNames.map((name) => ({ preset, name }))),
 	...invalidGitNames.map((name) => ({ preset: "Git", name })),
+	...s3Presets.flatMap((preset) => noncanonicalS3Names.map((name) => ({ preset, name }))),
 ];
 
 test.each(invalidCases)(
@@ -209,11 +212,12 @@ const validCases = [
 	...presets
 		.filter((preset) => preset !== "Git")
 		.flatMap((preset) =>
-			["work profile", ".git", "work.lock", "work..profile", "work/"].map((name) => ({
+			["work profile", ".git", "work.lock", "work..profile", "work%2F"].map((name) => ({
 				preset,
 				name,
 			})),
 		),
+	...["work/", "work///", "team/work/"].map((name) => ({ preset: "WebDAV", name })),
 ];
 
 test.each(validCases)("$preset accepts backend-valid name $name", async ({ preset, name }) => {
@@ -235,9 +239,16 @@ test.each(validCases)("$preset accepts backend-valid name $name", async ({ prese
 	});
 });
 
-test.each([false, true])(
-	"name correction cancellation (abort=%s) never advances setup",
-	async (abort) => {
+test.each(
+	[
+		{ preset: "Git", name: "work profile" },
+		{ preset: "WebDAV", name: ".." },
+		{ preset: "Cloudflare R2", name: "work/" },
+		{ preset: "Other S3-compatible storage", name: "work///" },
+	].flatMap((entry) => [false, true].map((abort) => ({ ...entry, abort }))),
+)(
+	"$preset name correction cancellation (abort=$abort) never advances setup",
+	async ({ preset, name, abort }) => {
 		await withTempHome(async () => {
 			const controller = new AbortController();
 			const titles: string[] = [];
@@ -245,11 +256,11 @@ test.each([false, true])(
 			const { ctx, notifications } = createMockContext({
 				hasUI: true,
 				mode: "tui",
-				select: async () => "Git",
+				select: async () => preset,
 				input: async (title: string, _placeholder?: string, options?: { signal?: AbortSignal }) => {
 					titles.push(title);
 					signals.push(options?.signal);
-					if (titles.length === 1) return "work profile";
+					if (titles.length === 1) return name;
 					if (abort) {
 						controller.abort(new DOMException("Session shut down", "AbortError"));
 						return "default";


### PR DESCRIPTION
## Summary

Follow up on [PR #1216 review feedback](https://github.com/narumiruna/pi-extensions/pull/1216#discussion_r3942842797), received after that PR merged and its branch was deleted.

Reject initial R2/S3 setup names when the suggested path differs from `normalizeStoragePath()`'s result. Names such as `work/` now receive an immediate warning and correction prompt before connection details, instead of reviewing `pi-sync/work/` while syncing to `pi-sync/work`. Preserve the newer prompt from #1219, blank-name defaults, and WebDAV-valid names. Includes a pi-sync patch Changeset.

## Review ledger

| Feedback | Outcome and evidence |
| --- | --- |
| S3 trailing-slash path mismatch, comment 3942842797 | **Fixed and verified in this follow-up.** `setup-name-ui.ts` compares the normalized suggestion; `settings-management.test.ts` verifies reviewed, persisted, and effective backend paths for both S3 presets. This is in-scope P2: #1216 moved arbitrary names from Custom onto ordinary first setup. |
| Invalid suggested paths/refs, comment 3942815634 | **Already addressed.** Existing name/backend validators and their invalid-input matrix still pass. |
| Missing human TUI smoke, review 5123963442 | **Unverified human smoke; original verbose prompt superseded by #1219.** Existing real Pi component tests pass at 32/80 columns in dark/light themes, including submission, cancellation, disposal, and RPC styling. Interactive commands are prohibited in this harness; no human smoke is claimed. |
| Related additional-setup/custom-path behavior | **Pre-existing, out of scope, deferred.** These routes and their normalization behavior predate #1216 and are unchanged. No evidence establishes P0 severity. Recommend a separate issue/PR; none created here. |

The original review thread remains open pending integration of this follow-up into main.

## Verification

- `npm run check`: passed build, Biome, boundaries, and workspace typechecks.
- `npm test`: **356 files / 3,734 tests passed**.
- Focused name/settings tests: **173 passed**; **18 regressions fail on the unmodified implementation**, including both S3 presets reviewing the raw trailing slash.
- Tests cover one/multiple/nested trailing slashes, slash-only input, whitespace around the suffix, correction, cancellation, late answers after abort, and preserved WebDAV-valid names.
- `git diff --check` and precommit checks passed. GitHub verifies signed commit `7af24f8200263a211c55968aa2efca328daf5630`; local `git verify-commit` lacks an allowed-signers file, so no Git configuration was changed.
- An initial direct Vitest invocation lacked a compiled subprocess fixture; the canonical npm test runner prepared it. Subsequent pre-fix runs failed only the intended 18 regressions, and all final checks passed.

## Semantic audit

Reviewed root/package `AGENTS.md`, `docs/extension-conventions.md`, and `docs/extension-settings.md`. Audited the original and final diffs for normalization branches: the input helper already trims surrounding whitespace, the fixed prefix prevents leading-slash normalization, Git rejects trailing-slash branches, and WebDAV normalizes before review. Only the raw S3 suggestion needs this guard.

Audited cancellation, Pi-owned component disposal, session replacement/shutdown signals, and stale-answer checks after input awaits. The new guard owns no async resources. Reviewed existing settings read/write ordering, locking, invalid-file protection, preservation, failure recovery, and atomic publication; those boundaries are unchanged. No metadata, runtime-loading, custom keybinding, or persistence changes, so no additional pack/load smoke was required.
