### PR TITLE
feat(accounts): add default account picker for new sessions

### DIFF
--- a/.changeset/tidy-accounts-default.md
+++ b/.changeset/tidy-accounts-default.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-accounts": minor
+---
+
+Add a Set default account picker to `/accounts` for each provider. New sessions use the saved default, while current, resumed, and reloaded sessions retain their own account selections. Preserve unknown settings fields during saves and order asynchronous reads after queued writes.

--- a/packages/pi-accounts/README.md
+++ b/packages/pi-accounts/README.md
@@ -13,6 +13,7 @@ Each Pi session keeps its own selection for every provider, and choosing `defaul
 
 - Manages named OpenAI Codex, Anthropic Claude Pro/Max, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts through `/accounts`.
 - Selects an account—or Pi's default login—independently for each provider and Pi session.
+- Saves a default account for each provider to use in new sessions without changing existing sessions.
 - Restores session selections after resume or reload while allowing concurrent sessions to use different accounts.
 - Applies provider-specific credentials, endpoints, headers, and model availability through Pi's built-in providers.
 - Refreshes rotating credentials and verifies the effective authentication before reporting success.
@@ -55,7 +56,8 @@ The package declares `dist/index.ts`, so an unbuilt local checkout must be built
 ## 🚀 Quick start
 
 Run `/accounts` in TUI or RPC mode.
-Use the manager to log in, switch accounts, restore a provider's default Pi login, or remove an account.
+Log in to save a named account, then choose **Set default account → provider → account** to use it when starting a new Pi session.
+Use **Switch … account** to change only the current session.
 
 ## 🔌 Supported providers
 
@@ -71,7 +73,7 @@ Use the manager to log in, switch accounts, restore a provider's default Pi logi
 
 ## 💬 Commands
 
-Run `/accounts` to log in, switch provider accounts for the current Pi session, or remove saved accounts in TUI or RPC mode.
+Run `/accounts` to log in, switch provider accounts for the current Pi session, set defaults for new sessions, or remove saved accounts in TUI or RPC mode.
 Arguments are ignored for compatibility; print and JSON modes provide no account-manager output.
 Login uses Pi's native OAuth flow, including device codes and cancellation, with equivalent RPC dialogs.
 
@@ -79,6 +81,26 @@ Login uses Pi's native OAuth flow, including device codes and cancellation, with
 Switching affects account identity for the chosen provider, not the model or other sessions' selections.
 Replacing an existing provider/account name or removing an account requires confirmation.
 Removal returns the current session's affected selection to `default`, but other sessions using the removed shared credential fail closed until they choose another account or `default`; see [Security and privacy](#-security-and-privacy).
+
+## ⚙️ Settings
+
+Open `/accounts` → **Set default account**, choose a provider, then select a saved account or **Pi built-in login**.
+The picker shows the saved default and saves your selection immediately; leaving it before selecting changes nothing.
+
+Defaults are user-wide settings in `<getAgentDir()>/pi-accounts.json` (normally `~/.pi/agent/pi-accounts.json`); project overrides are not supported.
+The existing `providers.<provider-id>.active` field stores the saved account name, so previous values remain compatible without migration.
+An absent or `null` value means Pi's built-in login; named values must match a saved account under that provider.
+The menu clears `active` when you choose **Pi built-in login** or remove the configured default account.
+
+New sessions, including `/new`, forks, and clones, snapshot these defaults.
+A session's saved selection takes precedence on restart, resume, and `/reload`; changing a default never switches that session or other existing sessions.
+Login and **Switch … account** still change only the current session, not the startup default.
+Sessions predating session-local selection support snapshot the current default once because their historical choice cannot be inferred.
+If a manually configured default names a missing account, affected sessions fail closed until you choose an available account or Pi's built-in login.
+
+Saves preserve unknown settings fields and use the credential store's cross-process lock and private atomic replacement.
+Within one store, asynchronous reads follow queued writes; failed writes leave the queue usable.
+Malformed settings block saves instead of being replaced, and failed saves do not change the session's authentication.
 
 ## 🔒 Security and privacy
 
@@ -134,11 +156,7 @@ The canonical file is:
 ```
 
 When `PI_CODING_AGENT_DIR` is set, the file is stored at `$PI_CODING_AGENT_DIR/pi-accounts.json` instead.
-Its versioned structure keeps shared credential maps and a compatibility default under separate provider IDs.
-The legacy provider-level `active` value seeds a session that has no owned selection entry, but login, switch, and `default` actions no longer change it.
-A resumed session created before session-local selection support snapshots the current compatibility default once because its historical account choice cannot be inferred.
-Every new session snapshots that compatibility default; forked and cloned sessions do not inherit copied parent selections because their new IDs do not own those entries.
-Removing the credential named by the compatibility default clears that default so new sessions are not seeded with a missing account.
+Its versioned structure keeps shared credential maps and startup defaults under separate provider IDs; see [Settings](#-settings) for editing and session precedence.
 Credential values are private and must not be committed.
 When neither canonical nor legacy storage exists, reads return an empty store without creating a directory or file.
 The first account change creates the private canonical file.
@@ -177,7 +195,7 @@ It is excluded from active workspace checks, version bumps, and publishing.
 - It does not rotate accounts automatically, evade quotas, or report usage.
 - It does not support arbitrary custom providers.
 - Live OAuth login and model requests depend on provider service availability and account entitlement.
-- Sessions created before this behavior cannot recover a historical per-session choice and therefore use the shared compatibility default for their first snapshot.
+- Sessions created before session-local selection support cannot recover a historical per-session choice; see [Settings](#-settings).
 
 ## 🗂️ Package layout
 

--- a/packages/pi-accounts/src/account-menu.ts
+++ b/packages/pi-accounts/src/account-menu.ts
@@ -53,6 +53,7 @@ type ProviderMenuState = {
 	id: AccountProviderId;
 	adapter: AccountProviderAdapter;
 	active: string | undefined;
+	defaultAccount: string | undefined;
 	selectionInvalid: boolean;
 	accounts: Record<string, StoredOAuthCredential>;
 };
@@ -78,8 +79,18 @@ export async function showAccountsMenu(
 		hasAnyStoredAccount: boolean;
 		selectionError?: string;
 	};
-	type Screen = "main" | "login-providers" | "switch-providers" | "switch-accounts" | "remove";
+	type Screen =
+		| "main"
+		| "login-providers"
+		| "switch-providers"
+		| "switch-accounts"
+		| "default-providers"
+		| "default-accounts"
+		| "remove";
 	type Action =
+		| "default-route"
+		| "default-provider"
+		| "default-account"
 		| "login-route"
 		| "login-provider"
 		| "switch-current"
@@ -106,12 +117,20 @@ export async function showAccountsMenu(
 					)
 						.split("\n")
 						.slice(1),
-					items: buildAccountMainItems(
-						state.states,
-						currentState,
-						state.hasAnyStoredAccount,
-						state.selectionError !== undefined,
-					),
+					items: [
+						...buildAccountMainItems(
+							state.states,
+							currentState,
+							state.hasAnyStoredAccount,
+							state.selectionError !== undefined,
+						),
+						{
+							id: "default",
+							label: "Set default account",
+							description: "For new sessions only; keeps this session unchanged",
+							action: "default-route",
+						},
+					],
 					hint: "close",
 				};
 			},
@@ -164,6 +183,48 @@ export async function showAccountsMenu(
 					hint: "back",
 				};
 			},
+			// One scoped preference uses the existing action picker rather than a separate Settings
+			// manager; current-session status stays in the main summary. No custom key handling.
+			"default-providers": ({ state }) => ({
+				kind: "actions",
+				title: "Default accounts for new sessions",
+				lines: ["User-wide settings. Existing sessions keep their own accounts."],
+				items: sortedProviderStates(state.states).map((provider) => ({
+					id: provider.id,
+					label: provider.adapter.displayName,
+					description: `Default: ${provider.defaultAccount ?? "Pi built-in login"}`,
+					action: "default-provider",
+				})),
+				hint: "back",
+			}),
+			"default-accounts": ({ state }) => {
+				const provider = selectedProviderId ? state.states.get(selectedProviderId) : undefined;
+				return {
+					kind: "actions",
+					title: `Default ${provider?.adapter.displayName ?? "provider"} account`,
+					lines: [
+						`Saved default: ${provider?.defaultAccount ?? "Pi built-in login"}`,
+						"Applies to new sessions only. Selecting an account saves immediately.",
+					],
+					items: provider
+						? [
+								{
+									id: "pi-login",
+									label: "Pi built-in login",
+									action: "default-account" as const,
+									disabled: provider.defaultAccount === undefined,
+								},
+								...accountNames(provider).map((name) => ({
+									id: accountItemId(name),
+									label: name,
+									action: "default-account" as const,
+									disabled: name === provider.defaultAccount,
+								})),
+							]
+						: [],
+					hint: "back",
+				};
+			},
 			remove: ({ state }) => ({
 				kind: "actions",
 				title: "Remove account",
@@ -176,6 +237,39 @@ export async function showAccountsMenu(
 			}),
 		},
 		actions: {
+			"default-route": async () => ({ kind: "to", screen: "default-providers" }),
+			"default-provider": async ({ itemId }) => {
+				if (!isAccountProviderId(itemId)) return { kind: "rejected" };
+				selectedProviderId = itemId;
+				return { kind: "to", screen: "default-accounts" };
+			},
+			"default-account": async ({ itemId, signal }) => {
+				const providerId = selectedProviderId;
+				if (!providerId) return { kind: "rejected" };
+				const isCurrent = () => owner.isCurrent() && !signal.aborted;
+				if (!isCurrent()) return { kind: "close" };
+				try {
+					const saved = await store.updateProvider(providerId, (state) => {
+						if (!isCurrent()) throw new DOMException("Menu closed", "AbortError");
+						const name = Object.keys(state.accounts).find((name) => accountItemId(name) === itemId);
+						if (itemId !== "pi-login" && !name) throw new Error("Account no longer exists");
+						return { ...state, active: itemId === "pi-login" ? undefined : name };
+					});
+					if (!isCurrent()) return { kind: "close" };
+					ctx.ui.notify(
+						`Default ${requireAdapter(adapters, providerId).displayName} account for new sessions: ${saved.active ?? "Pi built-in login"}. This session is unchanged.`,
+						"info",
+					);
+					return { kind: "close" };
+				} catch {
+					if (!isCurrent()) return { kind: "close" };
+					ctx.ui.notify(
+						"Could not save the default account. Check account storage and try again.",
+						"error",
+					);
+					return { kind: "rejected" };
+				}
+			},
 			"login-route": async () => ({ kind: "to", screen: "login-providers" }),
 			"login-provider": async ({ itemId, signal }) => {
 				if (!isAccountProviderId(itemId)) return { kind: "rejected" };
@@ -272,6 +366,7 @@ async function readProviderMenuStates(
 			id,
 			adapter: requireAdapter(adapters, id),
 			active,
+			defaultAccount: state.active,
 			selectionInvalid:
 				session.error !== undefined ||
 				(active !== undefined && !getOwnCredential(state.accounts, active)),

--- a/packages/pi-accounts/src/account-store.ts
+++ b/packages/pi-accounts/src/account-store.ts
@@ -29,11 +29,14 @@ const MIGRATION_TEMP_STALE_MS = 30_000;
 export type StoredOAuthCredential = OAuthCredential;
 
 export type ProviderAccountsData = {
+	[key: string]: unknown;
+	/** Default for sessions without a saved provider selection; not the current session account. */
 	active?: string;
 	accounts: Record<string, StoredOAuthCredential>;
 };
 
 export type AccountsData = {
+	[key: string]: unknown;
 	version: 1;
 	providers: Record<string, ProviderAccountsData>;
 };
@@ -48,7 +51,9 @@ export class AccountStore {
 	}
 
 	async readAsync(): Promise<AccountsData> {
-		return this.backend.readAsync(async (current) => parseAccountsData(current));
+		return this.serialized(() =>
+			this.backend.readAsync(async (current) => parseAccountsData(current)),
+		);
 	}
 
 	async write(data: AccountsData): Promise<void> {
@@ -134,7 +139,7 @@ export function parseAccountName(
 }
 
 export function parseAccountsData(raw: string | undefined): AccountsData {
-	if (!raw?.trim()) return emptyAccountsData();
+	if (raw === undefined) return emptyAccountsData();
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(raw) as unknown;
@@ -161,7 +166,7 @@ function normalizeAccountsData(value: unknown): AccountsData {
 			writable: true,
 		});
 	}
-	return { version: 1, providers };
+	return { ...value, version: 1, providers };
 }
 
 function normalizeProviderState(value: unknown): ProviderAccountsData {
@@ -180,7 +185,10 @@ function normalizeProviderState(value: unknown): ProviderAccountsData {
 			writable: true,
 		});
 	}
-	return active ? { active, accounts } : { accounts };
+	const state: ProviderAccountsData = { ...value, accounts };
+	if (active) state.active = active;
+	else delete state.active;
+	return state;
 }
 
 export function normalizeStoredCredential(
@@ -453,9 +461,7 @@ function emptyProviderState(): ProviderAccountsData {
 
 function cloneProviderState(state: ProviderAccountsData | undefined): ProviderAccountsData {
 	if (!state) return emptyProviderState();
-	return state.active
-		? { active: state.active, accounts: defineOwnMap(state.accounts) }
-		: { accounts: defineOwnMap(state.accounts) };
+	return { ...state, accounts: defineOwnMap(state.accounts) };
 }
 
 export function defineOwnMap<T>(source: Record<string, T>): Record<string, T> {

--- a/packages/pi-accounts/src/accounts.ts
+++ b/packages/pi-accounts/src/accounts.ts
@@ -626,6 +626,7 @@ async function removeAccount(
 		const accounts = defineOwnMap(state.accounts);
 		delete accounts[parsed.name];
 		return {
+			...state,
 			active: state.active === parsed.name ? undefined : state.active,
 			accounts,
 		};

--- a/packages/pi-accounts/test/accounts-storage.test.ts
+++ b/packages/pi-accounts/test/accounts-storage.test.ts
@@ -31,6 +31,106 @@ const credential = (suffix: string, extra: Record<string, unknown> = {}) => ({
 	...extra,
 });
 
+test("default saves preserve unknown settings fields and credential metadata", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.writeRawForTest(
+		JSON.stringify({
+			version: 1,
+			future: { enabled: true },
+			providers: {
+				anthropic: {
+					future: ["keep"],
+					accounts: { work: credential("work", { future: "metadata" }) },
+				},
+			},
+		}),
+	);
+	await store.updateProvider("anthropic", (state) => ({ ...state, active: "work" }));
+	const data = await store.readAsync();
+	assert.deepEqual(data.future, { enabled: true });
+	assert.deepEqual(data.providers.anthropic?.future, ["keep"]);
+	assert.equal(data.providers.anthropic?.accounts.work?.future, "metadata");
+	await store.updateProvider("anthropic", (state) => ({ ...state, active: undefined }));
+	assert.equal(Object.hasOwn((await store.readAsync()).providers.anthropic ?? {}, "active"), false);
+});
+
+test("account reads follow queued default writes and recover after a failed write", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	let release!: () => void;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const first = store.updateProviderAsync("anthropic", async () => {
+		await gate;
+		return { active: "first", accounts: {} };
+	});
+	const second = store.updateProvider("anthropic", (state) => ({ ...state, active: "second" }));
+	const read = store.readAsync();
+	release();
+	await Promise.all([first, second]);
+	assert.equal((await read).providers.anthropic?.active, "second");
+	await assert.rejects(
+		store.updateProvider("anthropic", () => {
+			throw new Error("write failed");
+		}),
+		/write failed/,
+	);
+	assert.equal((await store.readProviderAsync("anthropic")).active, "second");
+	await store.updateProvider("anthropic", (state) => ({ ...state, active: undefined }));
+	assert.equal((await store.readProviderAsync("anthropic")).active, undefined);
+});
+
+test("default saves reject invalid existing documents without replacing them", async () => {
+	for (const raw of [
+		"",
+		"  ",
+		"{",
+		"[]",
+		'{"version":1,"providers":{"anthropic":{"active":42,"accounts":{}}}}',
+	]) {
+		const backend = new InMemoryAccountStorageBackend();
+		const store = new AccountStore(backend);
+		await store.writeRawForTest(raw);
+		await assert.rejects(
+			store.updateProvider("anthropic", (state) => ({ ...state, active: "work" })),
+		);
+		assert.equal(
+			backend.read((value) => value),
+			raw,
+		);
+	}
+});
+
+test("default publication failure retains private settings and permits retry", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-accounts-default-failure-"));
+	const file = join(dir, ACCOUNTS_FILE);
+	try {
+		const backend = new FileAccountStorageBackend(file);
+		const store = new AccountStore(backend);
+		await store.updateProvider("anthropic", () => ({
+			active: "work",
+			accounts: { work: credential("work") },
+		}));
+		const before = await readFile(file, "utf8");
+		const writer = backend as unknown as { writePrivate(contents: string): void };
+		const publish = writer.writePrivate.bind(backend);
+		writer.writePrivate = () => {
+			throw new Error("publication failed");
+		};
+		await assert.rejects(
+			store.updateProvider("anthropic", (state) => ({ ...state, active: undefined })),
+			/publication failed/,
+		);
+		assert.equal(await readFile(file, "utf8"), before);
+		assert.equal((await lstat(file)).mode & 0o777, 0o600);
+		writer.writePrivate = publish;
+		await store.updateProvider("anthropic", (state) => ({ ...state, active: undefined }));
+		assert.equal((await store.readProviderAsync("anthropic")).active, undefined);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
 test("provider-scoped storage preserves independent active accounts and OAuth metadata", async () => {
 	const store = new AccountStore(new InMemoryAccountStorageBackend());
 	await store.write({

--- a/packages/pi-accounts/test/accounts.test.ts
+++ b/packages/pi-accounts/test/accounts.test.ts
@@ -553,7 +553,7 @@ test("accounts command ignores arguments but requires interactive UI", async () 
 	assert.equal(notifications.at(-1)?.level, "error");
 });
 
-test("accounts empty state offers only login and ignores command arguments", async () => {
+test("accounts empty state offers login and defaults and ignores command arguments", async () => {
 	const store = new AccountStore(new InMemoryAccountStorageBackend());
 	const mock = createMockPi();
 	accountsExtension(mock.pi, {
@@ -573,7 +573,7 @@ test("accounts empty state offers only login and ignores command arguments", asy
 	await mock.commands.get("accounts")?.handler("anything ignored", ctx);
 
 	assert.match(selectCalls[0]?.title ?? "", /No saved accounts yet/);
-	assert.deepEqual(selectCalls[0]?.options, ["Login new account"]);
+	assert.deepEqual(selectCalls[0]?.options, ["Login new account", "Set default account"]);
 });
 
 test("accounts menu summarizes all supported providers and prioritizes current provider switch", async () => {
@@ -622,6 +622,7 @@ test("accounts menu summarizes all supported providers and prioritizes current p
 		"Login new account",
 		"Remove account",
 		"Switch another provider’s account",
+		"Set default account",
 	]);
 });
 
@@ -652,6 +653,7 @@ test("accounts menu prioritizes login when the current provider has no saved acc
 		"Login new account",
 		"Switch another provider’s account",
 		"Remove account",
+		"Set default account",
 	]);
 });
 
@@ -689,6 +691,7 @@ test("accounts recovery routes to the invalid provider without dead current-prov
 	assert.deepEqual(selectCalls[0]?.options, [
 		"Login new account",
 		"Switch another provider’s account",
+		"Set default account",
 	]);
 });
 
@@ -722,7 +725,131 @@ test("accounts menu uses generic provider switch for unsupported current models"
 		"Login new account",
 		"Switch provider account",
 		"Remove account",
+		"Set default account",
 	]);
+});
+
+test("default account menu seeds new sessions but leaves current and resumed selections unchanged", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.write({
+		version: 1,
+		providers: {
+			anthropic: {
+				active: "alpha",
+				accounts: { alpha: credential("alpha"), beta: credential("beta") },
+			},
+			"openai-codex": { active: "work", accounts: { work: credential("codex") } },
+		},
+	});
+	const mock = createMockPi();
+	const providers = [fakeProvider("anthropic"), fakeProvider("openai-codex")];
+	accountsExtension(mock.pi, { store, providers });
+	const runtime = runtimeHarness(mock);
+	const sessionManager = createTestSessionManager();
+	const current = createInteractiveAccountContext(
+		{
+			sessionManager,
+			model: { provider: "anthropic", id: "claude" },
+			modelRegistry: runtime.registry,
+		},
+		{ selections: ["Set default account", "Anthropic", "beta"] },
+	);
+	await mock.events.get("session_start")?.[0]?.({}, current.ctx);
+	const entriesBefore = sessionManager.getEntries().length;
+	await mock.commands.get("accounts")?.handler("", current.ctx);
+	assert.equal((await store.readProviderAsync("anthropic")).active, "beta");
+	assert.equal((await store.readProviderAsync("openai-codex")).active, "work");
+	assert.equal(runtime.keys.get("anthropic"), "access-alpha");
+	assert.equal(sessionManager.getEntries().length, entriesBefore);
+	assert.match(current.notifications.at(-1)?.message ?? "", /new sessions: beta.*unchanged/);
+
+	for (const reason of ["reload", "resume"]) {
+		await mock.events.get("session_shutdown")?.[0]?.({ reason }, current.ctx);
+		await mock.events.get("session_start")?.[0]?.({ reason }, current.ctx);
+		assert.equal(runtime.keys.get("anthropic"), "access-alpha");
+	}
+	await mock.events.get("session_shutdown")?.[0]?.({}, current.ctx);
+
+	// A fresh extension instance represents a restarted Pi process; copied entries model forks.
+	for (const copiedEntries of [false, true]) {
+		const restarted = createMockPi();
+		accountsExtension(restarted.pi, { store, providers });
+		const nextRuntime = runtimeHarness(restarted);
+		const nextSession = createTestSessionManager();
+		if (copiedEntries) {
+			for (const entry of sessionManager.getEntries()) {
+				if (entry.type === "custom") nextSession.appendCustomEntry(entry.customType, entry.data);
+			}
+		}
+		const next = createMockContext({
+			sessionManager: nextSession,
+			modelRegistry: nextRuntime.registry,
+		});
+		await restarted.events.get("session_start")?.[0]?.({}, next.ctx);
+		assert.equal(nextRuntime.keys.get("anthropic"), "access-beta");
+		assert.equal(latestSessionSelections(nextSession).anthropic, "beta");
+		await restarted.events.get("session_shutdown")?.[0]?.({}, next.ctx);
+	}
+});
+
+test("clearing a startup default keeps the named account active only in the current session", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.updateProvider("anthropic", () => ({
+		active: "work",
+		accounts: { work: credential("work") },
+	}));
+	const mock = createMockPi();
+	accountsExtension(mock.pi, { store, providers: [fakeProvider("anthropic")] });
+	const runtime = runtimeHarness(mock);
+	const current = createInteractiveAccountContext(
+		{ modelRegistry: runtime.registry, model: { provider: "anthropic", id: "claude" } },
+		{ selections: ["Set default account", "Anthropic", "Pi built-in login"] },
+	);
+	await mock.events.get("session_start")?.[0]?.({}, current.ctx);
+	await mock.commands.get("accounts")?.handler("", current.ctx);
+	assert.equal((await store.readProviderAsync("anthropic")).active, undefined);
+	assert.ok((await store.readProviderAsync("anthropic")).accounts.work);
+	assert.equal(runtime.keys.get("anthropic"), "access-work");
+	await mock.events.get("session_shutdown")?.[0]?.({}, current.ctx);
+	const nextSession = createTestSessionManager();
+	const next = createMockContext({
+		sessionManager: nextSession,
+		modelRegistry: runtime.registry,
+	});
+	await mock.events.get("session_start")?.[0]?.({}, next.ctx);
+	assert.equal(latestSessionSelections(nextSession).anthropic, null);
+	assert.equal(runtime.keys.get("anthropic"), undefined);
+	await mock.events.get("session_shutdown")?.[0]?.({}, next.ctx);
+});
+
+test("removing the configured default clears it without changing another session selection", async () => {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.updateProvider("anthropic", () => ({
+		active: "alpha",
+		accounts: { alpha: credential("alpha"), beta: credential("beta") },
+	}));
+	const mock = createMockPi();
+	accountsExtension(mock.pi, { store, providers: [fakeProvider("anthropic")] });
+	const runtime = runtimeHarness(mock);
+	const current = createInteractiveAccountContext(
+		{ modelRegistry: runtime.registry, model: { provider: "anthropic", id: "claude" } },
+		{
+			selections: [
+				"Set default account",
+				"Anthropic",
+				"beta",
+				"Remove account",
+				"Anthropic · beta",
+			],
+			confirms: [true],
+		},
+	);
+	await mock.events.get("session_start")?.[0]?.({}, current.ctx);
+	await mock.commands.get("accounts")?.handler("", current.ctx);
+	await mock.commands.get("accounts")?.handler("", current.ctx);
+	assert.equal((await store.readProviderAsync("anthropic")).active, undefined);
+	assert.equal(runtime.keys.get("anthropic"), "access-alpha");
+	await mock.events.get("session_shutdown")?.[0]?.({}, current.ctx);
 });
 
 test("switch another provider account selects provider before account", async () => {

--- a/packages/pi-accounts/test/build-runtime.test.ts
+++ b/packages/pi-accounts/test/build-runtime.test.ts
@@ -231,6 +231,40 @@ test("generated runtime is loadable by Pi's Jiti resource loader", async () => {
 		assert.ok(command);
 		await command.handler("", ctx as never);
 		assert.match(notifications.at(-1) ?? "", /requires interactive UI/iu);
+
+		const accountsFile = join(agentDir, "pi-accounts.json");
+		await writeFile(
+			accountsFile,
+			JSON.stringify({
+				version: 1,
+				providers: {
+					"openai-codex": {
+						accounts: {
+							work: {
+								type: "oauth",
+								access: "fixture-access",
+								refresh: "fixture-refresh",
+								expires: 2_000_000_000_000,
+							},
+						},
+					},
+				},
+			}),
+			{ mode: 0o600 },
+		);
+		const choices = ["Set default account", "OpenAI Codex", "work"];
+		await command.handler("", {
+			...ctx,
+			mode: "rpc",
+			hasUI: true,
+			ui: { ...ctx.ui, select: async () => choices.shift() },
+		} as never);
+		assert.equal(choices.length, 0);
+		assert.equal(
+			JSON.parse(await readFile(accountsFile, "utf8")).providers["openai-codex"].active,
+			"work",
+		);
+		assert.match(notifications.at(-1) ?? "", /new sessions: work.*unchanged/u);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/packages/pi-accounts/test/default-account-menu.test.ts
+++ b/packages/pi-accounts/test/default-account-menu.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { beforeAll, test } from "vitest";
+import { createCustomSelectorHarness, createMockContext } from "../../../test/support.js";
+import { showAccountsMenu } from "../src/account-menu.js";
+import { AccountStore, InMemoryAccountStorageBackend } from "../src/account-store.js";
+import { createBuiltinProviderAdapters } from "../src/oauth.js";
+
+beforeAll(() => initTheme("dark", false));
+
+const credential = {
+	type: "oauth" as const,
+	access: "secret-access",
+	refresh: "secret-refresh",
+	expires: 2_000_000_000_000,
+};
+const adapters = new Map(createBuiltinProviderAdapters().map((adapter) => [adapter.id, adapter]));
+const handlers = {
+	async login() {
+		throw new Error("Unexpected login");
+	},
+	async switch() {
+		throw new Error("Unexpected switch");
+	},
+	async remove() {
+		throw new Error("Unexpected remove");
+	},
+};
+
+async function setup() {
+	const store = new AccountStore(new InMemoryAccountStorageBackend());
+	await store.updateProvider("anthropic", () => ({
+		active: "alpha",
+		accounts: { alpha: credential, beta: credential },
+	}));
+	const controller = new AbortController();
+	const owner = { signal: controller.signal, isCurrent: () => !controller.signal.aborted };
+	return { store, controller, owner };
+}
+
+for (const cancelAt of [1, 2]) {
+	test(`default picker cancellation at screen ${cancelAt} does not write settings`, async () => {
+		const { store, owner } = await setup();
+		const before = store.read();
+		const choices = ["Set default account", "Anthropic"].slice(0, cancelAt);
+		const { ctx } = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			select: async () => choices.shift(),
+		});
+		await showAccountsMenu(
+			ctx,
+			store,
+			adapters,
+			{ selections: { anthropic: "alpha" } },
+			handlers,
+			owner,
+		);
+		assert.deepEqual(store.read(), before);
+	});
+}
+
+for (const failure of ["removed", "write", "shutdown"] as const) {
+	test(`default picker revalidates ${failure} at the locked mutation boundary`, async () => {
+		const { store, owner, controller } = await setup();
+		const choices = ["Set default account", "Anthropic", "beta"];
+		const update = store.updateProvider.bind(store);
+		const { ctx, notifications } = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			select: async () => {
+				const choice = choices.shift();
+				if (choice === "beta") {
+					store.updateProvider = async (provider, mutator) => {
+						if (failure === "write") throw new Error("secret-access");
+						if (failure === "shutdown") controller.abort();
+						if (failure === "removed")
+							await update(provider, (state) => ({ ...state, accounts: { alpha: credential } }));
+						return update(provider, mutator);
+					};
+				}
+				return choice;
+			},
+		});
+		await showAccountsMenu(
+			ctx,
+			store,
+			adapters,
+			{ selections: { anthropic: "alpha" } },
+			handlers,
+			owner,
+		);
+		assert.equal(store.read().providers.anthropic?.active, "alpha");
+		assert.equal(
+			notifications.some((notice) => notice.message.includes("secret-access")),
+			false,
+		);
+		assert.equal(
+			notifications.some((notice) => notice.level === "error"),
+			failure !== "shutdown",
+		);
+		// A failed action does not poison the next explicit save.
+		store.updateProvider = update;
+		await update("anthropic", (state) => ({ ...state, active: undefined }));
+		assert.equal(store.read().providers.anthropic?.active, undefined);
+	});
+}
+
+for (const finish of ["save", "cancel", "dispose", "shutdown"] as const) {
+	test(`TUI default picker supports ${finish} with injected non-default keybindings`, async () => {
+		const { store, owner, controller } = await setup();
+		const renders: string[] = [];
+		let screen = 0;
+		const { ctx, notifications } = createMockContext({
+			mode: "tui",
+			hasUI: true,
+			custom: async (factory: unknown) => {
+				const bindings: Record<string, string> = {
+					"tui.select.down": "j",
+					"tui.select.up": "k",
+					"tui.select.confirm": "!",
+					"tui.select.cancel": "q",
+				};
+				const harness = createCustomSelectorHarness(factory, 100, {
+					matches: (data, key) => bindings[key] === data,
+					getKeys: (key) => (bindings[key] ? [bindings[key]] : []),
+				});
+				try {
+					renders.push(harness.render().join("\n"));
+					if (screen === 0) {
+						// Unsupported current model: login, switch, remove, set default.
+						for (let i = 0; i < 3; i++) harness.handleInput("j");
+					} else if (screen === 2) {
+						if (finish === "cancel") harness.handleInput("\u0003");
+						else if (finish === "dispose") {
+							harness.dispose();
+							return undefined;
+						} else if (finish === "shutdown") controller.abort();
+						else {
+							// Pi login, disabled alpha, beta.
+							harness.handleInput("j");
+							harness.handleInput("j");
+						}
+					}
+					screen++;
+					if (harness.result === undefined) harness.handleInput("!");
+					return await harness.resultPromise;
+				} finally {
+					harness.dispose();
+				}
+			},
+		});
+		await showAccountsMenu(
+			ctx,
+			store,
+			adapters,
+			{ selections: { anthropic: "alpha" } },
+			handlers,
+			owner,
+		);
+		assert.equal(screen, finish === "dispose" ? 2 : 3);
+		assert.match(renders[2] ?? "", /Default Anthropic account/);
+		assert.match(renders[2] ?? "", /Saved default: alpha/);
+		assert.equal(renders.join("\n").includes("secret-access"), false);
+		assert.equal(store.read().providers.anthropic?.active, finish === "save" ? "beta" : "alpha");
+		assert.equal(
+			notifications.some((notice) => notice.level === "error"),
+			false,
+		);
+	});
+}


### PR DESCRIPTION
## Summary

Add `/accounts` → **Set default account** → provider → account so users can choose the startup account independently of each session's active account. The picker also supports Pi's built-in login and uses the existing provider-level `active` field without migration.

Changing the default never switches the current session:

- Session A switches to `work`.
- Set the default to `personal`: A immediately remains on `work`.
- Resume or reload A: it still uses `work`.
- Start a new session: it uses `personal`.

Preserve unknown settings fields during saves, order asynchronous reads after queued writes, and reject malformed existing documents instead of overwriting them. Include README guidance and a minor Changeset for `@narumitw/pi-accounts`.

## Verification

- `npm run check` passed: build, Biome, package boundaries, and workspace typechecks.
- `npm test` passed: 378 files, 4,151 tests.
- Deterministic TUI/RPC coverage includes non-default keybindings, hard cancellation, disposal, shutdown, missing-account races, and failed saves.
- Session tests cover unchanged current/resumed/reloaded selections, independent new/forked sessions, clearing defaults, and removing the configured default.
- Generated-runtime Jiti loader test exercises the default picker and verifies persistence to private account storage.
- README heading audit passed for all 29 package READMEs; `git diff --check` and precommit checks passed.

## Audit and limits

Reviewed the touched areas against `docs/extension-conventions.md`, `docs/extension-settings.md`, and `docs/readme-conventions.md`, including lifecycle ownership, cancellation, settings read/write ordering, failure recovery, unknown-field preservation, and session precedence. No model-visible prompt or tool-prefix changes.

The single provider-scoped preference uses the existing action picker rather than a separate Settings manager; this deviation is documented beside the screen. Real-terminal package-directory smoke and live OAuth were not run in this non-interactive task; deterministic TUI/RPC and Jiti tests provide coverage. No package metadata or runtime-loading configuration changed, so no pack smoke was required. Nothing has been published.
