### PR TITLE
fix(usage): report Z.AI credentials without a coding plan as unsupported

### DIFF
--- a/.changeset/plenty-hoops-shine.md
+++ b/.changeset/plenty-hoops-shine.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Report a Z.AI credential with no GLM Coding Plan as unsupported instead of publishing a usage error to the statusline.

--- a/packages/pi-usage/docs/providers.md
+++ b/packages/pi-usage/docs/providers.md
@@ -259,7 +259,6 @@ The extension classifies both forms by the provider's window unit and does not l
 The quota monitor expects a raw API key without a `Bearer` prefix.
 The extension removes that prefix from resolved authorization before sending it to the monitor endpoint.
 Fingerprinting and redaction keep using the original resolved credential.
-API and coding plan credentials share the same base URL, so the quota answer is what distinguishes them: a credential with no coding plan receives HTTP 200 with no data object, as `{"code":500,"msg":"当前用户不存在coding plan","success":false}`.
-That is reported as `Unsupported` rather than a query failure, so the statusline stays empty instead of holding an error chip that no retry can clear.
+A credential with no coding plan answers HTTP 200 without a data object; that is reported as `Unsupported` rather than a query failure, so the statusline stays empty.
 The plan endpoint only contributes the plan name and renewal date; when it is unavailable or fails, the quota windows remain reported and the plan note falls back to the quota response's plan level.
 Only the official `api.z.ai` and `open.bigmodel.cn` origins are queried; other origins fail before sending the credential.

--- a/packages/pi-usage/docs/providers.md
+++ b/packages/pi-usage/docs/providers.md
@@ -259,5 +259,7 @@ The extension classifies both forms by the provider's window unit and does not l
 The quota monitor expects a raw API key without a `Bearer` prefix.
 The extension removes that prefix from resolved authorization before sending it to the monitor endpoint.
 Fingerprinting and redaction keep using the original resolved credential.
+API and coding plan credentials share the same base URL, so the quota answer is what distinguishes them: a credential with no coding plan receives HTTP 200 with no data object, as `{"code":500,"msg":"当前用户不存在coding plan","success":false}`.
+That is reported as `Unsupported` rather than a query failure, so the statusline stays empty instead of holding an error chip that no retry can clear.
 The plan endpoint only contributes the plan name and renewal date; when it is unavailable or fails, the quota windows remain reported and the plan note falls back to the quota response's plan level.
 Only the official `api.z.ai` and `open.bigmodel.cn` origins are queried; other origins fail before sending the credential.

--- a/packages/pi-usage/src/core.ts
+++ b/packages/pi-usage/src/core.ts
@@ -198,6 +198,10 @@ export function errorMessage(error: unknown): string {
 	return sanitizeDisplayText(error instanceof Error ? error.message : String(error), 600);
 }
 
+// A credential the provider cannot meter is not a query failure: it is reported as unsupported, so
+// the statusline stays empty instead of holding an error chip that no retry will clear.
+export class UsageUnsupportedError extends Error {}
+
 export function abortError(): Error {
 	return Object.assign(new Error("Usage query aborted."), { name: "AbortError" });
 }

--- a/packages/pi-usage/src/providers/zai.ts
+++ b/packages/pi-usage/src/providers/zai.ts
@@ -1,4 +1,4 @@
-import { sanitizeDisplayText } from "../core.js";
+import { sanitizeDisplayText, UsageUnsupportedError } from "../core.js";
 import type {
 	UsageBucket,
 	UsageMetric,
@@ -19,7 +19,14 @@ export function normalizeZaiQuotaPayload(
 	plan?: ZaiPlanInfo,
 ): UsageReport {
 	const data = asObject(payload.data);
-	if (!data) throw new Error("Z.AI quota response data was not an object.");
+	// A credential with no coding plan answers HTTP 200 with no data object:
+	// {"code":500,"msg":"当前用户不存在coding plan","success":false}. API usage is not metered.
+	if (!data) {
+		const reason = asString(payload.msg);
+		throw new UsageUnsupportedError(
+			`No GLM Coding Plan on this Z.AI credential; API usage is not metered.${reason ? ` Z.AI reported: ${reason}` : ""}`,
+		);
+	}
 	const limits = Array.isArray(data.limits) ? (data.limits as unknown[]) : [];
 
 	const buckets: UsageBucket[] = [];

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -2,7 +2,12 @@
 // separating that security boundary would duplicate request and redaction policy across providers.
 import { randomBytes } from "node:crypto";
 import { type ExtensionContext, readStoredCredential } from "@earendil-works/pi-coding-agent";
-import { errorMessage, fingerprintResolvedAuth, redactUsageError } from "./core.js";
+import {
+	errorMessage,
+	fingerprintResolvedAuth,
+	redactUsageError,
+	UsageUnsupportedError,
+} from "./core.js";
 import {
 	fallbackOAuthCredentialCandidates,
 	type OAuthCredentialCandidateReader,
@@ -547,7 +552,11 @@ export async function queryProviderUsage(
 		);
 	} catch (error) {
 		if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
-		throw new Error(redactUsageError(errorMessage(error), auth.secrets));
+		const message = redactUsageError(errorMessage(error), auth.secrets);
+		// Redaction rebuilds the error, so the unsupported signal has to be carried across.
+		throw error instanceof UsageUnsupportedError
+			? new UsageUnsupportedError(message)
+			: new Error(message);
 	}
 }
 

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -191,6 +191,7 @@ export type OpenCodeZenPayload = {
 };
 
 export type ZaiQuotaPayload = {
+	msg?: unknown;
 	data?: unknown;
 };
 

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -111,7 +111,10 @@ export default function usageExtension(
 	const createRedemptionId = dependencies.createRedemptionId ?? randomUUID;
 	const settingsRuntime = dependencies.settingsRuntime ?? createUsageSettingsRuntime();
 	const cache = new UsageCache(CACHE_TTL_MS);
-	const failureBackoff = new Map<string, { until: number; message: string }>();
+	const failureBackoff = new Map<
+		string,
+		{ until: number; message: string; status: "query-failed" | "unsupported" }
+	>();
 	const latestQueries = new Map<string, number>();
 	const activeControllers = new Set<AbortController>();
 	let querySequence = 0;
@@ -360,7 +363,7 @@ export default function usageExtension(
 						providerId: adapter.id,
 						providerName,
 						displayState,
-						status: "query-failed",
+						status: previousDiscoveryFailure.status,
 						message: previousDiscoveryFailure.message,
 					},
 					fingerprint: auth.fingerprint,
@@ -421,7 +424,7 @@ export default function usageExtension(
 						providerId: adapter.id,
 						providerName,
 						displayState,
-						status: "query-failed",
+						status: previousFailure.status,
 						message: previousFailure.message,
 					},
 					fingerprint: auth.fingerprint,
@@ -480,16 +483,18 @@ export default function usageExtension(
 				);
 			}
 			const message = errorMessage(error);
-			const unsupported = error instanceof UsageUnsupportedError;
+			const status = error instanceof UsageUnsupportedError ? "unsupported" : "query-failed";
 			const now = Date.now();
 			for (const [key, failure] of failureBackoff) {
 				if (failure.until <= now) failureBackoff.delete(key);
 			}
-			if (!unsupported && (queryId === undefined || latestQueries.get(failureKey) === queryId)) {
+			// Unsupported is throttled like a failure, so a credential the provider cannot meter does
+			// not re-query on every turn; the entry carries its status so the replay stays unsupported.
+			if (queryId === undefined || latestQueries.get(failureKey) === queryId) {
 				setBoundedMap(
 					failureBackoff,
 					failureKey,
-					{ until: now + FAILURE_BACKOFF_MS, message },
+					{ until: now + FAILURE_BACKOFF_MS, message, status },
 					MAX_ACCOUNT_STATES,
 				);
 			}
@@ -498,7 +503,7 @@ export default function usageExtension(
 					providerId: adapter.id,
 					providerName,
 					displayState,
-					status: unsupported ? "unsupported" : "query-failed",
+					status,
 					message,
 				},
 				fingerprint: auth.fingerprint,

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -28,6 +28,7 @@ import {
 	errorMessage,
 	runWithConcurrency,
 	UsageCache,
+	UsageUnsupportedError,
 } from "./core.js";
 import { formatProviderStates, formatUsageStatusline } from "./format.js";
 import { createOAuthCredentialCandidateReader } from "./oauth-credential-source.js";
@@ -479,11 +480,12 @@ export default function usageExtension(
 				);
 			}
 			const message = errorMessage(error);
+			const unsupported = error instanceof UsageUnsupportedError;
 			const now = Date.now();
 			for (const [key, failure] of failureBackoff) {
 				if (failure.until <= now) failureBackoff.delete(key);
 			}
-			if (queryId === undefined || latestQueries.get(failureKey) === queryId) {
+			if (!unsupported && (queryId === undefined || latestQueries.get(failureKey) === queryId)) {
 				setBoundedMap(
 					failureBackoff,
 					failureKey,
@@ -496,7 +498,7 @@ export default function usageExtension(
 					providerId: adapter.id,
 					providerName,
 					displayState,
-					status: "query-failed",
+					status: unsupported ? "unsupported" : "query-failed",
 					message,
 				},
 				fingerprint: auth.fingerprint,

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -625,3 +625,47 @@ test("a Z.AI credential with no coding plan leaves the statusline empty", async 
 		vi.unstubAllGlobals();
 	}
 });
+
+// The verdict does not change on retry, so it is throttled like a failure instead of re-querying
+// the quota and plan endpoints on every turn.
+test("an unsupported Z.AI credential is throttled instead of re-queried each turn", async () => {
+	const noCodingPlan = { code: 500, msg: "当前用户不存在coding plan", success: false };
+	const requests: Array<{ url: string; authorization: string | undefined }> = [];
+	vi.stubGlobal(
+		"fetch",
+		zaiFetchStub(requests, () => new Response(JSON.stringify(noCodingPlan), { status: 200 })),
+	);
+	try {
+		const mock = createMockPi();
+		usageExtension(mock.pi);
+		const { ctx, statuses } = createMockContext({
+			model: ZAI_MODEL,
+			modelRegistry: {
+				getProviderAuth: async () => ({ auth: { apiKey: "zai-secret-key" } }),
+				getAvailable: () => [ZAI_MODEL],
+				getAll: () => [ZAI_MODEL],
+				getProviderAuthStatus: () => ({ configured: true }),
+				getProviderDisplayName: () => "Z.AI",
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		for (let turn = 0; turn < 3; turn += 1) {
+			await mock.events.get("turn_start")?.[0]?.({}, ctx);
+			for (let index = 0; index < 8; index += 1) {
+				await new Promise<void>((resolve) => setImmediate(resolve));
+			}
+		}
+
+		assert.equal(statuses.get("usage"), undefined);
+		assert.deepEqual(
+			requests.map((request) => request.url),
+			[
+				"https://api.z.ai/api/monitor/usage/quota/limit",
+				"https://api.z.ai/api/biz/subscription/list",
+			],
+		);
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
-import { createMockContext } from "../../../test/support.js";
+import { createMockContext, createMockPi } from "../../../test/support.js";
 import {
 	formatUsageReport,
 	formatUsageStatusline,
@@ -11,6 +11,7 @@ import {
 	resolveUsageAuth,
 	SUPPORTED_ADAPTERS,
 } from "../src/index.js";
+import usageExtension from "../src/usage.js";
 
 const ZAI_QUOTA_PAYLOAD = {
 	code: 200,
@@ -287,7 +288,10 @@ test("Z.AI adapter derives window length and label from the payload window numbe
 });
 
 test("Z.AI adapter rejects malformed or empty quota responses", () => {
-	assert.throws(() => normalizeZaiQuotaPayload("zai", "Z.AI", {}, 0), /not an object/);
+	assert.throws(
+		() => normalizeZaiQuotaPayload("zai", "Z.AI", {}, 0),
+		/No GLM Coding Plan on this Z\.AI credential/,
+	);
 	assert.throws(
 		() => normalizeZaiQuotaPayload("zai", "Z.AI", { data: { limits: [] } }, 0),
 		/no displayable usage data/,
@@ -586,5 +590,38 @@ test("Z.AI usage resolves only official origins", async () => {
 		});
 		const auth = await resolveUsageAuth(ctx, adapter);
 		assert.deepEqual(auth?.headers, { Authorization: "Bearer official-key" });
+	}
+});
+
+// Both API and coding plan credentials use the same coding base URL, so the no-plan answer is the
+// only signal that a credential carries no subscription.
+test("a Z.AI credential with no coding plan leaves the statusline empty", async () => {
+	const noCodingPlan = { code: 500, msg: "当前用户不存在coding plan", success: false };
+	vi.stubGlobal(
+		"fetch",
+		zaiFetchStub([], () => new Response(JSON.stringify(noCodingPlan), { status: 200 })),
+	);
+	try {
+		const mock = createMockPi();
+		usageExtension(mock.pi);
+		const { ctx, statuses } = createMockContext({
+			model: ZAI_MODEL,
+			modelRegistry: {
+				getProviderAuth: async () => ({ auth: { apiKey: "zai-secret-key" } }),
+				getAvailable: () => [ZAI_MODEL],
+				getAll: () => [ZAI_MODEL],
+				getProviderAuthStatus: () => ({ configured: true }),
+				getProviderDisplayName: () => "Z.AI",
+			},
+		});
+
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		for (let index = 0; index < 8; index += 1) {
+			await new Promise<void>((resolve) => setImmediate(resolve));
+		}
+
+		assert.equal(statuses.get("usage"), undefined);
+	} finally {
+		vi.unstubAllGlobals();
 	}
 });


### PR DESCRIPTION
## Problem

A Z.AI credential with no GLM Coding Plan gets HTTP 200 from the quota monitor with no `data` object:

```json
{"code":500,"msg":"当前用户不存在coding plan","success":false}
```

`normalizeZaiQuotaPayload` rejected that as a malformed payload, so the statusline held `usage err: Z.AI quota response data was not an object.` permanently — an error chip for a condition no retry can clear, on every session start and model switch.

API and coding plan credentials share the same base URL (`https://api.z.ai/api/coding/paas/v4`), so the base URL cannot distinguish them; the quota answer itself is the only signal.

## Change

- `core.ts` adds `UsageUnsupportedError`: a credential the provider cannot meter, distinct from a query failure.
- The Z.AI normalizer raises it for the no-plan answer, quoting Z.AI's own `msg`.
- `queryProviderUsage` rebuilds every error to redact secrets, so it now preserves that type across the re-wrap.
- `queryAdapterState` reports `unsupported` rather than `query-failed`. The failure-backoff entry now carries its status, so the verdict is throttled by the same 30s `FAILURE_BACKOFF_MS` as a failure and the throttled replay still reports `unsupported` instead of the error chip that path used to hardcode.

`publishStatus` already clears the statusline for `unsupported`, so no change was needed there. `/usage` shows:

```
Z.AI · Current
Unsupported: No GLM Coding Plan on this Z.AI credential; API usage is not metered. Z.AI reported: 当前用户不存在coding plan
```

Nothing in the generic code branches on a provider id — `usage.ts` and `query.ts` only see the error type, so any provider can raise it.

## Scope

Every other failure still reports as a query failure: non-200s, timeouts, auth failures, and a payload whose windows cannot be read. The one behavior change for a subscriber is that a transient 200-without-data would now clear the statusline instead of showing an error, for up to 30s.

## Tests

- An end-to-end test drives `usageExtension` through `session_start` with the payload above and asserts the statusline stays empty. Reverting the `usage.ts` line reproduces the original chip, so the test is load-bearing.
- A second test drives three `turn_start` events and asserts exactly one round of requests (quota + plan), pinning the throttle.
- The existing subscription end-to-end test (`Z.AI providers publish statusline usage and refresh through /usage`) still passes: statusline `zai 90% 5h 80% wk`, cache reuse on `turn_start`, `/usage` bars.
- `packages/pi-usage`: 231 passing. Seven pre-existing failures in the Settings/TUI tests are unrelated to this change (a stale `@narumitw/pi-tui-kit` copy resolving in a local install; they fail on `main` too).

https://claude.ai/code/session_01NzraZBYKB5Xjx85QwDKkLK
