### PR TITLE
fix(sync): use shared editor widget separator

### DIFF
--- a/.changeset/quiet-sync-separator.md
+++ b/.changeset/quiet-sync-separator.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Add a themed horizontal separator above the sync attention widget to match other widgets above the editor.

--- a/docs/extension-conventions.md
+++ b/docs/extension-conventions.md
@@ -300,6 +300,14 @@ a distinct setup workflow.
 
 ### Status and persistent UI
 
+- **MUST:** Start each widget displayed above the editor with a full-width horizontal separator using
+  the callback-provided `borderMuted` theme role; keep every line within the supplied width, including
+  zero-width rendering. **Verification:** `Test` separator placement, theme role, and width bounds.
+
+Prefer `@narumitw/pi-tui-kit`'s `EditorStatusWidget` for passive widgets above the editor; it owns the
+standard separator and width bounds while the extension renders its body. Use `HorizontalRule` for
+standalone dividers instead of repeating the drawing logic.
+
 - **MUST:** Use a stable package-specific key for statuses or widgets, clear the exact key that was
   set, and clear session-owned UI on shutdown, replacement, and failed initialization.
   **Verification:** `Test` of lifecycle cleanup and `Review` of key ownership.

--- a/packages/pi-sync/src/commands/command-handler.ts
+++ b/packages/pi-sync/src/commands/command-handler.ts
@@ -53,7 +53,7 @@ export async function handleCommand(
 			ctx.ui.notify(errorMessage(error), "error");
 		}
 		await reconcileObservation(attention, sessionSignal);
-		if (!sessionSignal.aborted) attention.publish(ctx);
+		if (!sessionSignal.aborted) await attention.publish(ctx, sessionSignal);
 		return;
 	}
 	const result = await run(rawArgs);
@@ -79,7 +79,7 @@ export async function handleCommand(
 	await clearAttentionAfterCompletedOperation(rawArgs, result, ctx, attention, sessionSignal);
 	await reconcileSelectionAttention(ctx, attention, sessionSignal);
 	await reconcileObservation(attention, sessionSignal);
-	if (!sessionSignal.aborted) attention.publish(ctx);
+	if (!sessionSignal.aborted) await attention.publish(ctx, sessionSignal);
 }
 
 function observationCommitCallback(

--- a/packages/pi-sync/src/sync/startup-check.ts
+++ b/packages/pi-sync/src/sync/startup-check.ts
@@ -107,7 +107,7 @@ export function createStartupCheck(
 						);
 					} finally {
 						clearTimeout(timer);
-						if (isCurrent() && checking) attention.publish(ctx);
+						if (isCurrent() && checking) await attention.publish(ctx, sessionSignal);
 						if (active === task) active = undefined;
 					}
 				})

--- a/packages/pi-sync/src/ui/attention-widget.ts
+++ b/packages/pi-sync/src/ui/attention-widget.ts
@@ -1,0 +1,1 @@
+export { EditorStatusWidget } from "@narumitw/pi-tui-kit";

--- a/packages/pi-sync/src/ui/sync-attention.ts
+++ b/packages/pi-sync/src/ui/sync-attention.ts
@@ -39,21 +39,24 @@ export interface SyncAttentionController {
 	markOffered(): boolean;
 	clear(ctx: ExtensionContext): void;
 	reset(ctx: ExtensionContext): void;
-	publish(ctx: ExtensionContext): void;
+	publish(ctx: ExtensionContext, signal?: AbortSignal): Promise<void>;
 }
 
 export function createSyncAttentionController(): SyncAttentionController {
 	let state: SyncAttentionState | undefined;
 	let observation: StartupObservation | undefined;
+	let generation = 0;
 
 	return {
 		observe(value) {
+			generation++;
 			observation = value;
 		},
 		observation() {
 			return observation;
 		},
 		clearObservation() {
+			generation++;
 			observation = undefined;
 		},
 		notifyObservation(ctx) {
@@ -62,6 +65,7 @@ export function createSyncAttentionController(): SyncAttentionController {
 			}
 		},
 		set(decision, origin) {
+			generation++;
 			state = { decision, origin, offered: false };
 		},
 		current() {
@@ -73,15 +77,19 @@ export function createSyncAttentionController(): SyncAttentionController {
 			return true;
 		},
 		clear(ctx) {
+			generation++;
 			state = undefined;
 			clearAttentionPresentation(ctx);
 		},
 		reset(ctx) {
+			generation++;
 			state = undefined;
 			observation = undefined;
 			clearAttentionPresentation(ctx);
 		},
-		publish(ctx) {
+		async publish(ctx, signal) {
+			const currentGeneration = ++generation;
+			if (signal?.aborted) return;
 			if (!state && (!observation || !observationNeedsAttention(observation))) {
 				clearAttentionPresentation(ctx);
 				return;
@@ -92,17 +100,27 @@ export function createSyncAttentionController(): SyncAttentionController {
 						status: "changes to review",
 						lines: observationLines(observation as StartupObservation),
 					};
+			if (ctx.mode !== "tui") {
+				ctx.ui.setStatus(STATUS_KEY, presentation.status);
+				return;
+			}
+			// Keep Kit outside the eager startup graph; module loading owns no cancellable resources.
+			const { EditorStatusWidget } = await import("./attention-widget.js");
+			if (generation !== currentGeneration || signal?.aborted) return;
 			ctx.ui.setStatus(STATUS_KEY, presentation.status);
-			if (ctx.mode !== "tui") return;
-			ctx.ui.setWidget(WIDGET_KEY, (_tui, theme) => ({
-				render(width: number) {
-					const safeWidth = Math.max(1, width);
-					return presentation.lines.map((line, index) =>
-						truncateToWidth(theme.fg(index === 0 ? "warning" : "muted", line), safeWidth, "…"),
-					);
-				},
-				invalidate() {},
-			}));
+			ctx.ui.setWidget(
+				WIDGET_KEY,
+				(_tui, theme) =>
+					new EditorStatusWidget({
+						theme,
+						renderBody: (width) =>
+							presentation.lines.map((line, index) =>
+								width === 0
+									? ""
+									: truncateToWidth(theme.fg(index === 0 ? "warning" : "muted", line), width, "…"),
+							),
+					}),
+			);
 		},
 	};
 }

--- a/packages/pi-sync/test/startup-observation.test.ts
+++ b/packages/pi-sync/test/startup-observation.test.ts
@@ -30,7 +30,7 @@ test("advisory widget is read-only, sanitized, narrow, themed at render time, an
 		};
 		const context = createMockContext({ mode: "tui" });
 		attention.observe(observation);
-		attention.publish(context.ctx);
+		await attention.publish(context.ctx);
 		const factory = context.widgets.get("sync:attention") as (
 			_tui: unknown,
 			theme: { fg: (role: string, text: string) => string },
@@ -69,7 +69,7 @@ test("advisory widget is read-only, sanitized, narrow, themed at render time, an
 			},
 			"sync",
 		);
-		attention.publish(context.ctx);
+		await attention.publish(context.ctx);
 		assert.equal(context.statuses.get("sync"), "review needed");
 		attention.reset(context.ctx);
 		assert.equal(attention.observation(), undefined);

--- a/packages/pi-sync/test/sync-attention.test.ts
+++ b/packages/pi-sync/test/sync-attention.test.ts
@@ -4,7 +4,7 @@ import { test } from "vitest";
 import { createMockContext } from "../../../test/support.js";
 import { createSyncAttentionController } from "../src/ui/sync-attention.js";
 
-test("attention presentation is sanitized, textual, bounded, and clearable", () => {
+test("attention presentation is sanitized, textual, bounded, and clearable", async () => {
 	const controller = createSyncAttentionController();
 	const { ctx, statuses, widgets } = createMockContext({ hasUI: true, mode: "tui" });
 	controller.set(
@@ -17,23 +17,38 @@ test("attention presentation is sanitized, textual, bounded, and clearable", () 
 		"sync",
 	);
 
-	controller.publish(ctx);
+	await controller.publish(ctx);
 
 	assert.equal(statuses.get("sync"), "review needed");
 	const factory = widgets.get("sync:attention");
 	assert.equal(typeof factory, "function");
+	const themeCalls: string[] = [];
 	const component = (
 		factory as (
 			tui: unknown,
 			theme: { fg(color: string, text: string): string },
 		) => { render(width: number): string[] }
-	)({}, { fg: (_color, text) => text });
-	for (const width of [32, 60, 100]) {
+	)(
+		{},
+		{
+			fg: (color, text) => {
+				themeCalls.push(color);
+				return text;
+			},
+		},
+	);
+	for (const width of [0, 1, 2, 32, 60, 100]) {
 		const lines = component.render(width);
+		assert.equal(lines[0], "─".repeat(width));
+		assert.equal(themeCalls.includes("borderMuted"), width > 0);
+		themeCalls.length = 0;
+		assert.equal(lines.length, 4);
 		assert.ok(lines.every((line) => visibleWidth(line) <= width));
 		assert.equal(lines.join("\n").includes("\u001b]8"), false);
-		assert.match(lines.join("\n"), /Remote 1 · Device 1/u);
-		assert.match(lines.join("\n"), /No changes/u);
+		if (width >= 32) {
+			assert.match(lines.join("\n"), /Remote 1 · Device 1/u);
+			assert.match(lines.join("\n"), /No changes/u);
+		}
 	}
 
 	controller.clear(ctx);
@@ -41,7 +56,7 @@ test("attention presentation is sanitized, textual, bounded, and clearable", () 
 	assert.equal(widgets.get("sync:attention"), undefined);
 });
 
-test("attention presentation explains an order-only difference", () => {
+test("attention presentation explains an order-only difference", async () => {
 	const controller = createSyncAttentionController();
 	const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
 	controller.set(
@@ -53,7 +68,7 @@ test("attention presentation explains an order-only difference", () => {
 		},
 		"sync",
 	);
-	controller.publish(ctx);
+	await controller.publish(ctx);
 	const factory = widgets.get("sync:attention") as (
 		tui: unknown,
 		theme: { fg(color: string, text: string): string },
@@ -61,3 +76,25 @@ test("attention presentation explains an order-only difference", () => {
 	const component = factory({}, { fg: (_color, text) => text });
 	assert.match(component.render(60).join("\n"), /Only list order differs/u);
 });
+
+for (const action of ["clear", "reset", "abort"] as const) {
+	test(`pending widget publication cannot survive ${action}`, async () => {
+		const controller = createSyncAttentionController();
+		const { ctx, widgets } = createMockContext({ hasUI: true, mode: "tui" });
+		const abort = new AbortController();
+		controller.set(
+			{
+				setupName: "home",
+				configIdentity: "identity",
+				localInclude: ["settings.json"],
+				remoteInclude: ["AGENTS.md"],
+			},
+			"sync",
+		);
+		const pending = controller.publish(ctx, abort.signal);
+		if (action === "abort") abort.abort();
+		else controller[action](ctx);
+		await pending;
+		assert.equal(widgets.get("sync:attention"), undefined);
+	});
+}


### PR DESCRIPTION
## Summary
- Frame sync attention and startup observation widgets with Kit’s EditorStatusWidget and its themed horizontal separator.
- Preserve lazy startup loading and guard awaited widget publication against stale state, reset, and session cancellation.
- Document above-editor separator conventions and shared Kit component reuse; add a patch changeset.

## Verification
- `npm run check` passed.
- `npm test` passed: 378 files, 4,154 tests.
- Pi package-directory RPC loading smoke passed with `pi --no-extensions -e ./packages/pi-sync --mode rpc` (stdin closed).
- Reviewed touched rendering, width/theme, stable UI keys, cancellation, reset/session replacement, and shutdown paths against `docs/extension-conventions.md`. No settings behavior changed; extension-settings guide is not applicable.
- Interactive TUI visual smoke and the new widget lazy boundary through live Pi remain unverified; deterministic tests cover rendering and pending-publication cancellation.
