### PR TITLE
fix(btw): forward Pi session headers to OpenCode providers

### DIFF
--- a/.changeset/tidy-btw-opencode-session.md
+++ b/.changeset/tidy-btw-opencode-session.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Forward Pi session headers to OpenCode providers for side-thread requests.

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -204,6 +204,13 @@ function formatError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+function readBtwSessionId(ctx: ExtensionCommandContext): string | undefined {
+	const getSessionId = ctx.sessionManager.getSessionId;
+	if (typeof getSessionId !== "function") return undefined;
+	const sessionId = getSessionId.call(ctx.sessionManager);
+	return sessionId.length > 0 ? sessionId : undefined;
+}
+
 function notifySafely(
 	ctx: ExtensionCommandContext,
 	message: string,
@@ -895,6 +902,7 @@ async function askThreadQuestion(
 				auth: selected.auth,
 				signal: view.signal,
 				completeSimple: createModelRegistryCompleteSimple(ctx.modelRegistry),
+				sessionId: readBtwSessionId(ctx),
 			}).then((result) => {
 				if (settled) return;
 				settled = true;

--- a/packages/pi-btw/src/side-thread.ts
+++ b/packages/pi-btw/src/side-thread.ts
@@ -86,6 +86,7 @@ export interface CompleteSideThreadTurnOptions {
 	auth: SideQuestionAuth;
 	signal?: AbortSignal;
 	completeSimple: CompleteSimpleFunction;
+	sessionId?: string;
 }
 
 export type CompleteSideThreadTurnResult =
@@ -101,13 +102,14 @@ export async function completeSideThreadTurn({
 	auth,
 	signal,
 	completeSimple,
+	sessionId,
 }: CompleteSideThreadTurnOptions): Promise<CompleteSideThreadTurnResult> {
 	if (signal?.aborted) return { kind: "aborted" };
 	try {
 		const response = await completeSimple(
 			model,
 			{ systemPrompt: SYSTEM_PROMPT, messages: buildSideThreadMessages(thread, question) },
-			buildStreamOptions(auth, thinkingLevel, signal),
+			buildStreamOptions(auth, { thinkingLevel, signal, model, sessionId }),
 		);
 		if (signal?.aborted || response?.stopReason === "aborted") return { kind: "aborted" };
 		if (!isAssistantMessage(response)) {
@@ -137,6 +139,7 @@ export interface CompleteSideQuestionOptions {
 	auth: SideQuestionAuth;
 	signal?: AbortSignal;
 	completeSimple: CompleteSimpleFunction;
+	sessionId?: string;
 }
 
 export async function completeSideQuestion({
@@ -147,6 +150,7 @@ export async function completeSideQuestion({
 	auth,
 	signal,
 	completeSimple,
+	sessionId,
 }: CompleteSideQuestionOptions): Promise<AssistantMessage> {
 	return completeSimple(
 		model,
@@ -154,7 +158,7 @@ export async function completeSideQuestion({
 			systemPrompt: SYSTEM_PROMPT,
 			messages: [createUserMessage(buildUserPrompt(question, conversationContext))],
 		},
-		buildStreamOptions(auth, thinkingLevel, signal),
+		buildStreamOptions(auth, { thinkingLevel, signal, model, sessionId }),
 	);
 }
 
@@ -214,14 +218,62 @@ function createUserMessage(text: string): UserMessage {
 	};
 }
 
+// Minimal session-headers fork of Pi core provider-attribution
+// (pinned to @earendil-works/pi-coding-agent@0.85.0 src/core/provider-attribution.ts:getSessionHeaders).
+// Core does not export this helper and extensions have no SettingsManager, so only session
+// headers are mirrored here. Default attribution headers are intentionally out of scope.
+// Keep semantics bug-compatible with core: case-sensitive Object.assign, explicit auth
+// headers win on exact-case match.
+const OPENCODE_HOST = "opencode.ai";
+
+function matchesOpencodeHost(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	try {
+		return new URL(baseUrl).hostname === OPENCODE_HOST;
+	} catch {
+		return false;
+	}
+}
+
+function getOpencodeSessionHeaders(
+	model: Pick<Model<Api>, "provider" | "baseUrl">,
+	sessionId?: string,
+): ProviderHeaders | undefined {
+	if (!sessionId) return undefined;
+	if (
+		model.provider !== "opencode" &&
+		model.provider !== "opencode-go" &&
+		!matchesOpencodeHost(model.baseUrl)
+	) {
+		return undefined;
+	}
+	return { "x-opencode-session": sessionId, "x-opencode-client": "pi" };
+}
+
+function mergeSessionHeaders(
+	authHeaders: ProviderHeaders | undefined,
+	sessionHeaders: ProviderHeaders | undefined,
+): ProviderHeaders | undefined {
+	if (!sessionHeaders && !authHeaders) return undefined;
+	// Bug-compatible with core mergeProviderAttributionHeaders: case-sensitive assign.
+	return { ...sessionHeaders, ...authHeaders };
+}
+
+interface BuildSideThreadStreamOptions {
+	thinkingLevel: BtwThinkingLevel;
+	signal?: AbortSignal;
+	model?: Pick<Model<Api>, "provider" | "baseUrl">;
+	sessionId?: string;
+}
+
 function buildStreamOptions(
 	auth: SideQuestionAuth,
-	thinkingLevel: BtwThinkingLevel,
-	signal?: AbortSignal,
+	{ thinkingLevel, signal, model, sessionId }: BuildSideThreadStreamOptions,
 ): SimpleStreamOptions {
+	const sessionHeaders = model ? getOpencodeSessionHeaders(model, sessionId) : undefined;
 	const options: SimpleStreamOptions = {
 		apiKey: auth.apiKey,
-		headers: auth.headers,
+		headers: mergeSessionHeaders(auth.headers, sessionHeaders),
 		env: auth.env,
 		signal,
 	};

--- a/packages/pi-btw/test/side-thread.test.ts
+++ b/packages/pi-btw/test/side-thread.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../src/btw.js";
 import {
 	buildSideThreadMessages,
+	completeSideQuestion,
 	completeSideThreadTurn,
 	createSideThread,
 	extractAssistantText,
@@ -2879,4 +2880,232 @@ test("answering steering rejects blank questions and bounds unsafe queue display
 	view.dispose();
 	assert.equal(cancelled, 1);
 	assert.equal(view.signal.aborted, true);
+});
+
+test("side thread forwards Pi session headers to OpenCode Go", async () => {
+	const thread = createSideThread("context");
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "opencode-go",
+		id: "mimo-v2.5",
+		baseUrl: "https://opencode.ai/zen/go/v1",
+	} as Model<Api>;
+	const result = await completeSideThreadTurn({
+		thread,
+		question: "Q",
+		model,
+		auth: { apiKey: "key", headers: { "x-test": "yes" } },
+		thinkingLevel: "off",
+		sessionId: "session-123",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.equal(result.kind, "answered");
+	assert.equal(capturedOptions?.apiKey, "key");
+	assert.equal(capturedOptions?.headers?.["x-opencode-session"], "session-123");
+	assert.equal(capturedOptions?.headers?.["x-opencode-client"], "pi");
+	assert.equal(capturedOptions?.headers?.["x-test"], "yes");
+	assert.equal((capturedOptions as { sessionId?: unknown }).sessionId, undefined);
+});
+
+test("side thread forwards Pi session headers to OpenCode Zen for parity", async () => {
+	const thread = createSideThread("context");
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "opencode",
+		id: "zen-model",
+		baseUrl: "https://opencode.ai/zen/v1",
+	} as Model<Api>;
+	await completeSideThreadTurn({
+		thread,
+		question: "Q",
+		model,
+		auth: { apiKey: "key" },
+		thinkingLevel: "off",
+		sessionId: "session-123",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.equal(capturedOptions?.headers?.["x-opencode-session"], "session-123");
+	assert.equal(capturedOptions?.headers?.["x-opencode-client"], "pi");
+});
+
+test("side thread forwards Pi session headers to custom opencode.ai hosts", async () => {
+	const thread = createSideThread("context");
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "custom",
+		id: "m",
+		baseUrl: "https://opencode.ai/zen/go",
+	} as Model<Api>;
+	await completeSideThreadTurn({
+		thread,
+		question: "Q",
+		model,
+		auth: { apiKey: "key" },
+		thinkingLevel: "off",
+		sessionId: "s",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.equal(capturedOptions?.headers?.["x-opencode-session"], "s");
+	assert.equal(capturedOptions?.headers?.["x-opencode-client"], "pi");
+});
+
+test("side thread leaves other providers untouched", async () => {
+	const thread = createSideThread("context");
+	const authHeaders = { "x-test": "yes" };
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "anthropic",
+		id: "claude",
+		baseUrl: "https://api.anthropic.com",
+	} as Model<Api>;
+	await completeSideThreadTurn({
+		thread,
+		question: "Q",
+		model,
+		auth: { apiKey: "key", headers: authHeaders },
+		thinkingLevel: "off",
+		sessionId: "session-123",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.deepEqual(capturedOptions?.headers, { "x-test": "yes" });
+	assert.notEqual(capturedOptions?.headers, authHeaders);
+	assert.deepEqual(authHeaders, { "x-test": "yes" });
+});
+
+test("side thread sends no session headers without a session ID", async () => {
+	for (const sessionId of [undefined, ""] as const) {
+		const thread = createSideThread("context");
+		let capturedOptions: SimpleStreamOptions | undefined;
+		const model = {
+			provider: "opencode-go",
+			id: "mimo-v2.5",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		} as Model<Api>;
+		await completeSideThreadTurn({
+			thread,
+			question: "Q",
+			model,
+			auth: { apiKey: "key", headers: { "x-test": "yes" } },
+			thinkingLevel: "off",
+			sessionId,
+			completeSimple: async (_model, _context, options) => {
+				capturedOptions = options;
+				return response("A");
+			},
+		});
+		assert.deepEqual(capturedOptions?.headers, { "x-test": "yes" });
+	}
+});
+
+test("side thread still sends session headers for OpenCode provider with unparsable URL", async () => {
+	const thread = createSideThread("context");
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "opencode-go",
+		id: "mimo-v2.5",
+		baseUrl: "bad-url",
+	} as Model<Api>;
+	await completeSideThreadTurn({
+		thread,
+		question: "Q",
+		model,
+		auth: { apiKey: "key" },
+		thinkingLevel: "off",
+		sessionId: "session-123",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.equal(capturedOptions?.headers?.["x-opencode-session"], "session-123");
+	assert.equal(capturedOptions?.headers?.["x-opencode-client"], "pi");
+});
+
+test("side thread keeps explicit auth headers with exact-case win like Pi core", async () => {
+	const thread = createSideThread("context");
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "opencode-go",
+		id: "mimo-v2.5",
+		baseUrl: "https://opencode.ai/zen/go/v1",
+	} as Model<Api>;
+	await completeSideThreadTurn({
+		thread,
+		question: "Q",
+		model,
+		auth: { apiKey: "key", headers: { "X-Opencode-Session": "explicit" } },
+		thinkingLevel: "off",
+		sessionId: "session-123",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.equal(capturedOptions?.headers?.["X-Opencode-Session"], "explicit");
+	// Bug-compatible with Pi core mergeProviderAttributionHeaders (case-sensitive assign):
+	// a differently-cased explicit header coexists with the injected lowercase header.
+	assert.equal(capturedOptions?.headers?.["x-opencode-session"], "session-123");
+	assert.equal(capturedOptions?.headers?.["x-opencode-client"], "pi");
+});
+
+test("side thread lets exact-case explicit auth headers win", async () => {
+	const thread = createSideThread("context");
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "opencode-go",
+		id: "mimo-v2.5",
+		baseUrl: "https://opencode.ai/zen/go/v1",
+	} as Model<Api>;
+	await completeSideThreadTurn({
+		thread,
+		question: "Q",
+		model,
+		auth: {
+			apiKey: "key",
+			headers: { "x-opencode-session": "explicit", "x-opencode-client": "custom" },
+		},
+		thinkingLevel: "off",
+		sessionId: "session-123",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.equal(capturedOptions?.headers?.["x-opencode-session"], "explicit");
+	assert.equal(capturedOptions?.headers?.["x-opencode-client"], "custom");
+});
+
+test("side question forwards Pi session headers without setting options.sessionId", async () => {
+	let capturedOptions: SimpleStreamOptions | undefined;
+	const model = {
+		provider: "opencode-go",
+		id: "mimo-v2.5",
+		baseUrl: "https://opencode.ai/zen/go/v1",
+	} as Model<Api>;
+	await completeSideQuestion({
+		model,
+		question: "Q",
+		conversationContext: "context",
+		thinkingLevel: "off",
+		auth: { apiKey: "key" },
+		sessionId: "session-123",
+		completeSimple: async (_model, _context, options) => {
+			capturedOptions = options;
+			return response("A");
+		},
+	});
+	assert.equal(capturedOptions?.headers?.["x-opencode-session"], "session-123");
+	assert.equal((capturedOptions as { sessionId?: unknown }).sessionId, undefined);
 });


### PR DESCRIPTION
## Summary

`/btw` side questions now carry Pi's OpenCode session headers when talking to OpenCode Go (`opencode-go`) or OpenCode Zen (`opencode`), matching what Pi core already sends on the main thread.

The side thread reuses the current Pi session ID for attribution, headers only — it doesn't opt into prompt caching or session affinity. Explicit auth headers win on exact-case match, matching Pi core's `Object.assign` semantics; differently-cased keys coexist. Other providers see no change (headers copied, never mutated).

Core helper isn't exported (`exports` blocks deep imports) and extensions have no `SettingsManager`, so this is a minimal session-headers fork pinned to `@earendil-works/pi-coding-agent@0.85.0:getSessionHeaders`; default telemetry-gated attribution is out of scope.

Includes a patch changeset for `@narumitw/pi-btw`.

## Why

`/btw` streams through the raw provider with only auth headers, so it skipped Pi core's `mergeProviderAttributionHeaders`. Since the 06 Sep Go enforcement that means every `opencode-go/*` side question is refused while the main thread keeps working. Zen is covered too for parity.

## Verification

- `npm --workspace @narumitw/pi-btw run build` passed.
- Focused Vitest: `packages/pi-btw/test/side-thread.test.ts` — 96 passed (Zen parity, custom host, untouched providers, no-session-ID, unparsable-URL + provider match, exact-case win, no-aliasing).
- `npm run check` passed (build, Biome, boundaries, typechecks).
- `npm test` passed: 378 files, 4163 tests.
- `npm run package:pack -- btw`: 16 files inspected.
- `npm run changeset:status`: only `@narumitw/pi-btw` patch → 0.57.1.
- `pi --no-extensions -e ./packages/pi-btw --list-models` loads.
- `git diff --check` clean.
- Live Go check: one headless `opencode-go/qwen3.8-flash` side question (`Reply with exactly: ok`) answered `ok` in ~1.6s with only `x-opencode-session` / `x-opencode-client` added, no `options.sessionId`. No retry.

## Audit and limits

Checked against `docs/extension-conventions.md` and `docs/readme-conventions.md`; no settings changes so `docs/extension-settings.md` doesn't apply.

Non-OpenCode providers get back their original headers untouched (copied, never mutated), and the session ID is never logged. The side thread keeps its own prompt, headers only with no `options.sessionId`, so no prompt-caching or session-affinity opt-in beyond attribution.

Not covered: live Zen call (same path as Go) and interactive TUI beyond the deterministic harness.
