### PR TITLE
feat(btw): configure side-thread keybindings

### DIFF
--- a/.changeset/quiet-btw-keybindings.md
+++ b/.changeset/quiet-btw-keybindings.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": minor
+---
+
+Add BTW-only exit, thinking-cycle, and bring-to-main keybindings in `/btw` → Settings, with conflict validation and per-action reset. Preserve Ctrl+C as hard cancel and keep pasted input out of shortcut handling.

--- a/docs/plans/2026-09-08_pi-btw-keybindings-plan.md
+++ b/docs/plans/2026-09-08_pi-btw-keybindings-plan.md
@@ -1,0 +1,103 @@
+# Pi BTW configurable keybindings
+
+## Goal
+
+Make `exit`, `cycleThinkingLevel`, and `bringToMain` configurable through `/btw` → Settings without changing Pi's global keybindings or existing defaults. Implementation was explicitly authorized in the follow-up execution request.
+
+| Setting | Default | Behavior |
+| --- | --- | --- |
+| `exit` | `Ctrl+C` | Exit BTW with the existing cancellation semantics: cancel the response, discard drafts and queued questions, and retain completed exchanges for resumption. |
+| `cycleThinkingLevel` | Inherit Pi's `app.thinking.cycle` | Cycle through the current model's supported thinking levels. |
+| `bringToMain` | `Ctrl+R` | Open the existing bring-to-main flow when available. |
+
+`Ctrl+C` remains an unconditional hard-cancel path. A configured exit key adds an exit path rather than removing this safeguard.
+
+## Context
+
+`packages/pi-btw/src/settings.ts` already owns validation, ordered mutations, unknown-field preservation, and temporary-file-plus-rename publication in `<getAgentDir()>/pi-btw.json`. `src/menu.ts` provides the existing Settings screen through Pi TUI Kit. `src/fullscreen-ui.ts` handles terminal ownership and hard cancellation, while `src/transcript-pager.ts` handles conversation shortcuts and hints.
+
+Apply `docs/extension-conventions.md` and `docs/extension-settings.md` to the touched areas. Read the installed Pi documentation, relevant examples, and linked API references before implementation; inspect the installed implementation before defining matching or conflict rules.
+
+## Non-Goals
+
+- Do not add a literal `/btw settings` route; preserve `/btw <question>` and use `/btw` → Settings.
+- Do not configure scrolling, submission, newline, or editor navigation.
+- Do not add multiple bindings per action, key-recording UI, dependencies, or project-scoped settings.
+- Do not modify Pi's global keybinding file or unrelated extensions.
+
+## Architecture
+
+Store optional overrides in a `keybindings` object in the existing user settings file. Each action accepts one key-combination string; omission restores its default. Keep binding resolution, validation, and hint generation within pi-btw, with one authoritative policy shared by its UI components.
+
+Add three rows to the existing Settings screen. Show the effective key or inheritance from Pi, use existing UI components for string entry, and provide a reset-to-default action. Save changes immediately; cancellation of an unfinished edit leaves its previous value unchanged. Successful saves apply when BTW is next opened or resumed, without requiring `/reload`.
+
+Reject invalid or conflicting edits with an actionable explanation. Preserve standard editor actions and the reserved hard-cancel path. Determine runtime handling for overrides that become conflicting after Pi keybindings change during the initial discovery task; never display an unusable binding as active.
+
+## Plan
+
+- [x] Inspect installed Pi key matching, Editor input handling, terminal modes, listener ordering, and BTW's existing shortcut filters; document the complete relevant equivalence classes, reserved keys, precedence, and runtime conflict fallback, backed by a table of expected matching outcomes. Evidence: installed `keys.js`, `components/editor.js`, `keybindings.js`, and `tui-alt-screen.js`; see discovery below.
+- [x] Extend `packages/pi-btw/src/settings.ts` with optional overrides and field-level reset semantics; verify defaults, accepted and invalid values, side-effect-free reads, nested unknown-field preservation, ordered saves, stale-read prevention, and atomic-write failure recovery through settings tests.
+- [x] Add a focused package-owned keybinding policy module that resolves defaults, validates overrides, and derives effective hints; verify aliases, modifier order, legacy collisions, terminal-mode differences, invalid strings, inherited Pi bindings, and the first usable fallback with table-driven tests.
+- [x] Extend `packages/pi-btw/src/menu.ts` with three editable shortcut rows and reset actions using existing UI components; verify effective-value display, invalid/conflicting edit rejection, save ordering, failed-save rollback, cancellation, and non-TUI guards through menu tests.
+- [x] Integrate the resolved bindings into `packages/pi-btw/src/fullscreen-ui.ts` and `packages/pi-btw/src/transcript-pager.ts`, auditing related bring-to-main screens; verify idle and streaming shortcuts, existing availability conditions, dynamic hints, editor focus, paste behavior, and non-default Pi keybindings through component tests.
+- [x] Audit asynchronous flows for user cancellation, disposal, session replacement, shutdown, and post-await validity; verify task release, repeated cleanup, root and nested-overlay hard cancellation, input-drain ordering, unrelated overlay preservation, and the first input after terminal restoration through lifecycle and handoff tests.
+- [x] Update `packages/pi-btw/README.md` with settings access, defaults, accepted syntax, persistence and activation timing, conflicts, resets, and permanent `Ctrl+C` behavior; add a feature Changeset and review documentation against `docs/readme-conventions.md`.
+- [ ] Run `npm run check` and `npm test` sequentially, ensuring Kit is built before consumer tests; perform the smallest practical terminal smoke and record any manual verification that cannot be performed without launching an interactive process.
+- [ ] Review the final diff against both extension guides' touched-area and verification checklists; record checks, smokes, deviations, and unverified paths, and delete this plan only after all completion criteria pass or remaining limitations are explicitly accepted.
+
+## Discovery and execution evidence
+
+Work started on `narumi/feat/btw-keybindings` from `origin/main`; the only pre-existing worktree change was this untracked plan. `npm install` restored installed Pi packages to the versions already required by manifests and lockfile; no dependency files changed. An initial typecheck exposed the stale installation rather than a need to change compatibility floors.
+
+The policy reserves Pi TUI editor, input, selection, and fullscreen actions, fixed Editor newline/deletion/space fallbacks, BTW paging, and manual selection copying when enabled. It validates candidate input with Pi's public matcher rather than reproducing its parser. Inherited thinking bindings retain explicitly configured printable Pi shortcuts for compatibility; new BTW overrides cannot claim ordinary text. Custom conflicts fall back to usable defaults, then no shortcut with a warning if none remains. An explicitly unbound inherited thinking action stays unbound without a warning.
+
+| Input class | Expected matching / conflict behavior |
+| --- | --- |
+| `esc` / `escape`, `return` / `enter`, case and modifier order | Canonicalize aliases and order; reject unknown or repeated modifiers in new settings. |
+| Raw Ctrl bytes | Detect Ctrl+I/Tab, Ctrl+M/Enter, Ctrl+J/newline, Ctrl+[/Escape, Ctrl+-/Ctrl+_, and Ctrl+H/Backspace collisions through Pi. |
+| ESC-prefixed raw input | Detect Alt+B/F/P/N versus Alt+arrows and Ctrl+Alt+H/M versus Alt+Backspace/Enter where Pi matches them; Ctrl+Alt+I does not match Alt+Tab. |
+| Kitty versus legacy mode | Use live matcher branches for Alt raw input, Ctrl+Space, Enter and Shift+Enter; do not mutate global terminal mode. |
+| Windows Terminal and SSH | Let Pi choose whether raw BS means Backspace or Ctrl+Backspace. |
+| CSI-u, modifyOtherKeys, keypad, shifted letters, lock bits and base-layout fallback | Use the matcher-normalized key/modifier identity; test representative encodings and releases. |
+| Function keys, Clear, modified Escape and unsupported syntax | Only expose candidates that match a representative input; reject modified function keys and unsupported Clear/Escape modifiers. |
+| Bracketed paste, including split payloads | Bypass all new screen shortcuts until paste ends; preserve Editor payload handling. |
+| Earlier listeners and nested overlays | Preserve standard bindings and unconditional Ctrl+C; route a configured exit through the same synchronous root cancellation and deferred terminal handoff. |
+
+The Settings rows reuse Kit's existing settings, actions, and input screens. A field opens Edit / Restore default, avoiding a new custom input component. Shortcut resolution is associated with the owning TUI through a WeakMap, avoiding configuration plumbing through domain-level thinking and request controls.
+
+Initial focused verification found partial keybinding mocks and absent notification methods in existing UI harnesses; fixtures and policy API use were corrected. The first affected-test invocation selected no files because its base selector considers committed differences; it is not passing test evidence. Use direct focused Vitest runs during implementation and root `npm test` for the required full gate.
+
+Focused verification now passes: `npm exec -- vitest run packages/pi-btw/test` reports 13 files and 297 tests; `npx tsc -p tsconfig.test.json --noEmit` and the package build pass. New settings, policy, menu, component, command-propagation, and native terminal-pipeline tests cover the planned behaviors. Native `TuiMainScreen` / `TuiAltScreen` smokes use a controllable Terminal instead of opening an interactive process: they exercise custom exit and permanent Ctrl+C under root/nested focus, thinking cycling, bring-to-main with a large expanded paste, streaming abort, drain ordering, and restored parent input. Physical terminal/emulator keyboard reporting and live-provider behavior are not claimed; no interactive process is launched under the execution constraints.
+
+Hardening found two additional in-scope failure paths: queued shortcut edits now revalidate against the latest settings document inside the mutation queue, and both transcript renderers clamp output at narrow widths (including zero-width rendering). Runtime key resolution also refreshes after asynchronous Kitty negotiation. Existing `btw.ts` is just over 1,000 lines; an adjacent comment documents retaining its injectable command-coordination seams while policy, settings, terminal ownership, and rendering remain separate.
+
+Touched-area MUST audit evidence: settings protection/order/atomicity/rollback (settings and menu tests); TUI bounds, focus, paste and effective hints (component tests); cancellation/disposal/root-and-nested handoff/input restoration (fullscreen tests); safe non-TUI entry guards and retained command surface (existing menu/command tests); independent package and generated-runtime boundaries (passing root Validator and generated Jiti loader tests); published behavior versioning (minor Changeset). No model-visible context, provider payload, tool definitions, commands, dependencies, or global Pi settings changed.
+
+## Final verification and remaining blocker
+
+Final `npm run check` passes (build, Biome, boundaries, all workspace typechecks). Final focused Vitest run passes all 297 tests in 13 files; test TypeScript compilation passes. `npm run package:pack -- btw` passes; a separate actual `npm pack --workspace @narumitw/pi-btw` tarball inspection confirms all 17 expected manifest, license, documentation, source, and generated runtime files. Generated Jiti loader tests pass. `git diff --check` passes.
+
+The complete root `npm test` exits 1: 20 failed files, 361 passed; 55 failed tests, 4,191 passed, one skipped. No BTW tests fail. Failures are outside this package, predominantly five-second timeouts, plus the github-pr periodic-refresh assertion. A focused reproduction on unchanged `origin/main` (`09d0f4d4`) reproduces the github-pr assertion and sync timeouts; this does not prove every root failure is baseline. No timeout was raised and no unrelated package was changed. Logs: `/tmp/pi-btw-root-tests-complete.log` and `/tmp/pi-btw-baseline-tests.log` (local, not published artifacts).
+
+Final semantic Review against `docs/extension-conventions.md` and `docs/extension-settings.md` covers compatibility, settings read/write protection, unknown fields, atomicity, async cancellation and stale state, terminal ownership, paste, effective hints, and unchanged model-visible context. README review follows `docs/readme-conventions.md`. Test, Review, Validator, and deterministic native-terminal Smoke evidence is recorded above. Physical emulator and live-provider smokes remain unverified under the non-interactive execution constraint; no acceptance of that limitation is inferred.
+
+The full-test acceptance gate remains blocked. Retain this plan and submit the focused changes as a draft pull request, rather than deleting it or claiming end-to-end completion. The final review itself is complete; its combined review/delete task remains unchecked because deletion depends on the blocked criteria.
+
+## Risks
+
+The main complexity is actual input reachability, not JSON storage. Different key strings can match the same terminal input, and an earlier listener or Editor action can consume a key before BTW sees it. Validation must follow installed runtime behavior rather than compare raw strings alone.
+
+Custom exit handling touches shared-terminal ownership. Preserve synchronous logical cancellation and deferred physical terminal transfer; do not replay bytes coalesced behind the exit key.
+
+## Completion Checklist
+
+- [x] All three bindings can be edited, persisted, reset, and used after opening or resuming BTW; old settings retain existing behavior.
+- [x] Settings tests prove invalid-file protection, unknown-field preservation, ordered reads and writes, and failure rollback.
+- [x] Keybinding tests cover non-default Pi bindings, aliases, modifier order, legacy collisions, terminal modes, invalid strings, and usable fallbacks.
+- [x] Component tests prove effective hints, preserved editor and paste behavior, and existing thinking-level and bring-to-main semantics.
+- [x] Lifecycle tests prove cancellation and disposal release owned tasks and safely restore terminal input under root and nested-overlay focus.
+- [x] Non-TUI behavior remains safe and observable where claimed, without entering custom TUI work.
+- [ ] `npm run check` and `npm test` pass; any applicable runtime-loading build/load checks are completed or explicitly documented as not applicable.
+- [ ] A terminal smoke confirms custom exit, permanent `Ctrl+C`, thinking cycling, and bring-to-main, or the user explicitly accepts the recorded unverified paths.
+- [x] README and Changeset are complete, and the semantic audit names applicable MUST rules and their Test, Review, Validator, or Smoke evidence.
+- [ ] Implementation is explicitly authorized, all plan tasks and completion checks are satisfied, and this saved plan is deleted in the final handoff.

--- a/packages/pi-btw/README.md
+++ b/packages/pi-btw/README.md
@@ -13,6 +13,7 @@ Only context you explicitly bring back is loaded into the main editor.
 - Keeps side questions and answers out of the main conversation by default.
 - Brings back the latest answer, a question suffix, an exact range, or the complete thread only when requested.
 - Uses Pi's current model and thinking level or saved pi-btw choices.
+- Offers BTW-only exit, thinking-cycle, and bring-to-main keybindings.
 
 ## 📦 Install
 
@@ -102,6 +103,44 @@ A failed Settings-screen save instead restores the previous displayed value.
 `fullscreenCopyOnSelect` controls only pi-btw's dedicated fullscreen view and defaults to `true` when omitted.
 Turn **Copy selection automatically** off to retain highlighted selections and copy them with Pi's effective `app.message.copy` binding.
 Pi-btw does not inherit Pi core's setting of the same name because Pi's public extension API does not expose its effective value.
+
+### Keybindings
+
+Open `/btw` → **Settings**, select a shortcut row, then choose **Edit key combination…** or **Restore default**.
+Type a key name such as `ctrl+q` or `f6`; this is not a key-recording prompt.
+Changes save immediately and apply when opening or resuming BTW, without `/reload`. Escape cancels an unfinished edit, not earlier saves.
+The literal `/btw settings` remains a side question, not a settings subcommand.
+
+| JSON field under `keybindings` | Default | Action |
+| --- | --- | --- |
+| `exit` | `ctrl+c` | Cancel and leave the dedicated side-thread workspace, including its nested dialogs. |
+| `cycleThinkingLevel` | Inherit Pi's `app.thinking.cycle` | Cycle supported levels while composing or generating. |
+| `bringToMain` | `ctrl+r` | Open the bring-to-main chooser after a completed answer. |
+
+For example, merge these overrides into `pi-btw.json`:
+
+```json
+{
+  "keybindings": {
+    "exit": "ctrl+q",
+    "cycleThinkingLevel": "f6",
+    "bringToMain": "f7"
+  }
+}
+```
+
+Each override accepts one Pi key name with optional `ctrl`, `shift`, `alt`, and `super` modifiers; modifier order and letter case do not matter.
+Letters, digits, Pi special keys and symbols are recognized, except the literal `+`, which Pi's matcher cannot parse as a base key.
+Function keys `f1`–`f12` and Escape accept no modifiers; Clear accepts only no modifier, Shift, or Ctrl.
+Actual availability depends on the terminal; `super` and some modified combinations require extended keyboard reporting.
+
+New overrides cannot take ordinary typing keys or conflict with BTW actions, Pi editing, selection, search, scrolling, or enabled manual-copy bindings.
+Pi's explicitly configured printable thinking shortcuts remain inherited for compatibility.
+If a saved override becomes conflicting, BTW warns and uses an available default; if none is usable, that shortcut is unavailable and its activation hint is omitted.
+An explicitly unbound Pi thinking action stays unbound. Remove an override field to restore its default; neither saving nor resetting modifies Pi's global keybindings.
+**Ctrl+C always remains available as hard cancel**, even after configuring another exit key. Shortcut handling does not interpret bracketed-paste payloads as commands.
+
+### Persistence
 
 Reading a missing settings file has no side effects.
 Pi-btw creates it only after a Settings change or a remembered shortcut change.

--- a/packages/pi-btw/docs/workflows.md
+++ b/packages/pi-btw/docs/workflows.md
@@ -39,7 +39,8 @@ Click it or use Pi's effective `tui.altScreen.bottom` binding (`End` by default)
 ## Thinking and queued questions
 
 The header shows the current side-thread thinking level.
-Use Pi's `app.thinking.cycle` shortcut (`Shift+Tab` by default) in the composer to cycle supported levels for later questions.
+Use the thinking-cycle shortcut shown in the composer to cycle supported levels for later questions.
+It inherits Pi's `app.thinking.cycle` (`Shift+Tab` by default) unless overridden in [Keybindings](../README.md#keybindings).
 Whether that change is remembered depends on [Settings](../README.md#-settings); it never changes the main session's thinking level.
 
 During a response, submit another question to queue it as `Steering`.
@@ -47,12 +48,12 @@ Queued questions run in order after the current response, using the thinking lev
 A failed response remains visible without discarding later queued questions.
 Steering does not append to the main conversation or editor.
 
-Ctrl+C cancels the active response and discards the current draft and steering queue.
+The configured exit shortcut, or the permanent Ctrl+C hard-cancel key, cancels the active response and discards the current draft and steering queue.
 Completed questions, answers, and visible errors remain resumable until the extension instance ends.
 
 ## Bring context to the main editor
 
-After a successful answer, press `Ctrl+R` to choose the latest question and answer, everything from one question onward, an exact range, or the full thread.
+After a successful answer, use the bring-to-main shortcut (`Ctrl+R` by default) to choose the latest question and answer, everything from one question onward, an exact range, or the full thread.
 The scope chooser reports the latest exchange and full-thread sizes.
 Question-suffix, exact-range, and full-thread choices preview an editable context block before closing the side thread.
 Escape returns; Ctrl+C closes without bringing context back.

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -216,6 +216,9 @@ function notifySafely(
 	}
 }
 
+// Keep this slightly-over-1,000-line command coordinator intact: its injectable menu,
+// request, resume, and delivery flows share the same thread-state and test seams;
+// settings, keybinding policy, terminal ownership, and rendering live in separate modules.
 export interface BtwExtensionDependencies {
 	showCommandMenu?: (
 		pi: ExtensionAPI,
@@ -342,7 +345,10 @@ export default function btw(pi: ExtensionAPI, dependencies: BtwExtensionDependen
 							ctx: fullscreenCtx,
 						});
 					},
-					{ copyOnSelect: effectiveFullscreenCopyOnSelect(settings) },
+					{
+						copyOnSelect: effectiveFullscreenCopyOnSelect(settings),
+						...(settings.keybindings ? { keybindings: settings.keybindings } : {}),
+					},
 				);
 			} finally {
 				if (state?.title && state.thread.turns.length > 0) {

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -485,13 +485,21 @@ class BtwFullscreenHost<T> implements Component {
 				this.options.copyOnSelect ?? true,
 			);
 			setBtwShortcuts(this.fullscreen, shortcuts);
-			for (const warning of shortcuts.warnings) {
-				try {
-					this.ctx.ui.notify(`Pi BTW: ${warning}`, "warning");
-				} catch {
-					/* A replaced context must not prevent terminal cleanup. */
+			// Negotiate before warning when possible: the first dispatched user input uses
+			// the current mode. Recheck each input, including later mode transitions.
+			let previousWarnings: readonly string[] = [];
+			const reportWarnings = () => {
+				const warnings = shortcuts.warnings;
+				for (const warning of warnings) {
+					if (previousWarnings.includes(warning)) continue;
+					try {
+						this.ctx.ui.notify(`Pi BTW: ${warning}`, "warning");
+					} catch {
+						/* A replaced context must not prevent terminal cleanup. */
+					}
 				}
-			}
+				previousWarnings = warnings;
+			};
 			const pasteGuard = new BtwPasteGuard();
 			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.
 			const addHardCancelListener =
@@ -499,6 +507,7 @@ class BtwFullscreenHost<T> implements Component {
 				this.fullscreen.addInputListenerBeforeViewport?.bind(this.fullscreen) ??
 				this.fullscreen.addInputListener.bind(this.fullscreen);
 			this.removeHardCancelListener = addHardCancelListener((data) => {
+				reportWarnings();
 				if (pasteGuard.consume(data) || !shortcuts.matches(data, "exit")) return undefined;
 				this.disposed = true;
 				try {

--- a/packages/pi-btw/src/fullscreen-ui.ts
+++ b/packages/pi-btw/src/fullscreen-ui.ts
@@ -10,7 +10,6 @@ import {
 	isKeyRelease,
 	isKittyProtocolActive,
 	Key,
-	matchesKey,
 	type OverlayHandle,
 	parseKey,
 	type TUI,
@@ -19,6 +18,12 @@ import {
 	type TuiInputListenerResult,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
+import {
+	type BtwKeybindingOverrides,
+	BtwPasteGuard,
+	resolveBtwShortcuts,
+	setBtwShortcuts,
+} from "./keybindings.js";
 import { formatKeyLabel, sanitizeSingleLine } from "./text.js";
 
 type BtwCustomOptions = Parameters<ExtensionCommandContext["ui"]["custom"]>[1];
@@ -41,6 +46,7 @@ export interface BtwFullscreenLayoutComponent extends Component {
 }
 
 export interface BtwFullscreenOptions {
+	keybindings?: BtwKeybindingOverrides;
 	copyOnSelect?: boolean;
 }
 
@@ -473,13 +479,28 @@ class BtwFullscreenHost<T> implements Component {
 			this.fullscreen = this.createTui(this.parent, this.theme, this.keybindings, this.options);
 			this.fullscreenCreated = true;
 			this.fullscreen.start();
+			const shortcuts = resolveBtwShortcuts(
+				this.options.keybindings,
+				this.keybindings,
+				this.options.copyOnSelect ?? true,
+			);
+			setBtwShortcuts(this.fullscreen, shortcuts);
+			for (const warning of shortcuts.warnings) {
+				try {
+					this.ctx.ui.notify(`Pi BTW: ${warning}`, "warning");
+				} catch {
+					/* A replaced context must not prevent terminal cleanup. */
+				}
+			}
+			const pasteGuard = new BtwPasteGuard();
 			// Waiting for the custom promise would leave follow-up keys bound to the side TUI.
 			const addHardCancelListener =
 				this.fullscreen.addInputListenerBeforeAll?.bind(this.fullscreen) ??
 				this.fullscreen.addInputListenerBeforeViewport?.bind(this.fullscreen) ??
 				this.fullscreen.addInputListener.bind(this.fullscreen);
 			this.removeHardCancelListener = addHardCancelListener((data) => {
-				if (isKeyRelease(data) || !matchesKey(data, Key.ctrl("c"))) return undefined;
+				if (pasteGuard.consume(data) || !shortcuts.matches(data, "exit")) return undefined;
+				this.disposed = true;
 				try {
 					this.hardCancelActiveCustom?.();
 				} finally {

--- a/packages/pi-btw/src/keybindings.ts
+++ b/packages/pi-btw/src/keybindings.ts
@@ -197,39 +197,68 @@ function resolveShortcutSnapshot(
 		cycleThinkingLevel: keybindings.getKeys("app.thinking.cycle"),
 		bringToMain: ["ctrl+r"],
 	};
+	const usable = (
+		action: BtwShortcutAction,
+		candidate: string,
+		inherited = false,
+	): string | undefined => {
+		const key = normalizeBtwKey(candidate);
+		if (!key || (!inherited && isTextKey(key))) return undefined;
+		const inputs = inputsFor(key);
+		if (!inputs.length) return undefined;
+		if (action === "exit" && key === "ctrl+c") return key;
+		if (
+			reserved.some(
+				(other) =>
+					typeof other === "string" && inputs.some((input) => matchesKey(input, other as KeyId)),
+			)
+		)
+			return undefined;
+		return key;
+	};
+	const candidates: BtwKeybindingOverrides = {};
+	const availableDefaults = { ...defaults };
 	for (const action of BTW_SHORTCUT_ACTIONS) {
-		const usable = (candidate: string, inherited = false): string | undefined => {
-			const key = normalizeBtwKey(candidate);
-			if (!key || (!inherited && isTextKey(key))) return undefined;
-			const inputs = inputsFor(key);
-			if (!inputs.length) return undefined;
-			if (action === "exit" && key === "ctrl+c") return key;
-			if (
-				reserved.some(
-					(other) =>
-						typeof other === "string" && inputs.some((input) => matchesKey(input, other as KeyId)),
-				)
-			)
-				return undefined;
-			if (
-				BTW_SHORTCUT_ACTIONS.some(
-					(other) => other !== action && keys[other].some((used) => btwKeysOverlap(key, used)),
-				)
-			)
-				return undefined;
-			return key;
-		};
+		availableDefaults[action] = defaults[action]
+			.map((key) => usable(action, key, action === "cycleThinkingLevel"))
+			.filter((key): key is string => key !== undefined);
 		const override = overrides[action];
-		const selected = override === undefined ? undefined : usable(override);
+		if (override !== undefined) candidates[action] = usable(action, override);
+	}
+	// Compare the complete proposal, not only actions visited earlier. Reject conflicts
+	// together, then repeat because a rejected override restores its default bindings.
+	for (;;) {
+		const rejected = BTW_SHORTCUT_ACTIONS.filter((action) => {
+			const candidate = candidates[action];
+			return (
+				candidate !== undefined &&
+				BTW_SHORTCUT_ACTIONS.some(
+					(other) =>
+						other !== action &&
+						(candidates[other] ? [candidates[other]] : availableDefaults[other]).some((key) =>
+							btwKeysOverlap(candidate, key),
+						),
+				)
+			);
+		});
+		if (!rejected.length) break;
+		for (const action of rejected) delete candidates[action];
+	}
+	for (const action of BTW_SHORTCUT_ACTIONS) {
+		const override = overrides[action];
+		const selected = candidates[action];
 		if (override !== undefined && !selected)
 			warnings.push(
 				`${action}: configured shortcut is invalid or conflicts with a reserved action; using an available default.`,
 			);
 		const effective = selected
 			? [selected]
-			: defaults[action]
-					.map((key) => usable(key, action === "cycleThinkingLevel"))
-					.filter((key): key is string => key !== undefined);
+			: availableDefaults[action].filter(
+					(key) =>
+						!BTW_SHORTCUT_ACTIONS.some(
+							(other) => other !== action && keys[other].some((used) => btwKeysOverlap(key, used)),
+						),
+				);
 		keys[action] = action === "exit" ? [...new Set([...effective, "ctrl+c"])] : effective;
 		if (!keys[action].length && (override !== undefined || defaults[action].length > 0))
 			warnings.push(`${action}: no usable shortcut; change Pi BTW Settings or Pi keybindings.`);

--- a/packages/pi-btw/src/keybindings.ts
+++ b/packages/pi-btw/src/keybindings.ts
@@ -1,0 +1,301 @@
+import {
+	isKeyRelease,
+	isKittyProtocolActive,
+	KeybindingsManager,
+	type KeyId,
+	matchesKey,
+	type TUI,
+	TUI_KEYBINDINGS,
+} from "@earendil-works/pi-tui";
+import { formatKeyLabel } from "./text.js";
+
+export const BTW_SHORTCUT_ACTIONS = ["exit", "cycleThinkingLevel", "bringToMain"] as const;
+export type BtwShortcutAction = (typeof BTW_SHORTCUT_ACTIONS)[number];
+export type BtwKeybindingOverrides = Partial<Record<BtwShortcutAction, string>>;
+
+const MODIFIERS = ["shift", "alt", "ctrl", "super"] as const;
+const SYMBOLS = "`-=[]\\;',./!@#$%^&*()_|~{}:<>?";
+const SPECIAL: Record<string, number> = {
+	escape: 27,
+	tab: 9,
+	enter: 13,
+	space: 32,
+	backspace: 127,
+	insert: 57425,
+	delete: 57426,
+	home: 57423,
+	end: 57424,
+	pageup: 57421,
+	pagedown: 57422,
+	left: 57417,
+	right: 57418,
+	up: 57419,
+	down: 57420,
+};
+const FUNCTION_INPUTS = [
+	"OP",
+	"OQ",
+	"OR",
+	"OS",
+	"[15~",
+	"[17~",
+	"[18~",
+	"[19~",
+	"[20~",
+	"[21~",
+	"[23~",
+	"[24~",
+];
+// All cross-identity legacy collisions in Pi's matchesKey(): raw Ctrl bytes,
+// ESC-prefixed bytes (including Alt+arrows), BS/DEL, Enter and Shift+Tab.
+// CSI-u, keypad, lock bits, shifted letters and modifyOtherKeys normalize to
+// the same key+modifiers; probe that identity instead of duplicating the parser.
+const LEGACY_INPUTS = [
+	...Array.from({ length: 128 }, (_, code) => String.fromCharCode(code)),
+	...Array.from({ length: 128 }, (_, code) => `\u001b${String.fromCharCode(code)}`),
+	"\u001b[Z",
+	"\u001bOM",
+	"\u001b[E",
+	"\u001b[e",
+	"\u001bOe",
+	...FUNCTION_INPUTS.map((suffix) => `\u001b${suffix}`),
+];
+
+/** Strict settings syntax; Pi itself ignores unknown/duplicate modifier tokens. */
+export function normalizeBtwKey(value: unknown): string | undefined {
+	if (typeof value !== "string" || value.length > 80 || /[\s\p{Cc}]/u.test(value)) return undefined;
+	const parts = value.toLowerCase().split("+");
+	let base = parts.pop();
+	if (!base) return undefined;
+	if (base === "esc") base = "escape";
+	if (base === "return") base = "enter";
+	if (
+		new Set(parts).size !== parts.length ||
+		parts.some((part) => !MODIFIERS.includes(part as never))
+	)
+		return undefined;
+	if (
+		!Object.hasOwn(SPECIAL, base) &&
+		base !== "clear" &&
+		!/^f(?:[1-9]|1[0-2])$/u.test(base) &&
+		!(base.length === 1 && (/^[a-z0-9]$/u.test(base) || SYMBOLS.includes(base)))
+	)
+		return undefined;
+	if ((base === "escape" || (base.startsWith("f") && base.length > 1)) && parts.length)
+		return undefined;
+	if (
+		base === "clear" &&
+		(parts.length > 1 || (parts.length === 1 && !["ctrl", "shift"].includes(parts[0] ?? "")))
+	)
+		return undefined;
+	return [...MODIFIERS.filter((part) => parts.includes(part)), base].join("+");
+}
+
+/** Representative inputs are checked by Pi, including its live terminal-mode branches. */
+function inputsFor(key: string): string[] {
+	const parts = key.split("+");
+	const base = parts.pop() ?? "";
+	const modifier = MODIFIERS.reduce(
+		(mask, part, bit) => mask | (parts.includes(part) ? 1 << bit : 0),
+		0,
+	);
+	const code = SPECIAL[base] ?? (base.length === 1 ? base.charCodeAt(0) : undefined);
+	const inputs =
+		code === undefined ? LEGACY_INPUTS : [...LEGACY_INPUTS, `\u001b[${code};${modifier + 1}u`];
+	return inputs.filter((input) => matchesKey(input, key as KeyId));
+}
+
+export function btwKeysOverlap(first: string, second: string): boolean {
+	const normalized = normalizeBtwKey(first);
+	return (
+		normalized !== undefined &&
+		inputsFor(normalized).some((input) => matchesKey(input, second as KeyId))
+	);
+}
+
+export interface BtwShortcuts {
+	keys: Record<BtwShortcutAction, readonly string[]>;
+	warnings: readonly string[];
+	matches(data: string, action: BtwShortcutAction): boolean;
+	label(action: BtwShortcutAction): string;
+}
+
+function reservedKeys(keybindings: KeybindingsManager, copyOnSelect: boolean): string[] {
+	// Editor has no autocomplete provider here. Select bindings are still reserved
+	// because exit also applies to BTW-owned nested review/menu components.
+	return [
+		"ctrl+c",
+		"shift+backspace",
+		"shift+delete",
+		"shift+space",
+		// Exact-range review uses these fixed selection actions even if Editor is remapped.
+		"shift+left",
+		"shift+right",
+		"shift+up",
+		"shift+down",
+		"left",
+		"right",
+		"enter",
+		"alt+enter",
+		"ctrl+j",
+		"pageUp",
+		"pageDown",
+		...Object.keys(TUI_KEYBINDINGS).flatMap((id) =>
+			keybindings.getKeys(id as keyof typeof TUI_KEYBINDINGS),
+		),
+		...(!copyOnSelect ? keybindings.getKeys("app.message.copy") : []),
+	];
+}
+
+function isTextKey(key: string): boolean {
+	const parts = key.split("+");
+	const base = parts.at(-1) ?? "";
+	return (
+		(base.length === 1 || base === "space") &&
+		!parts.some((part) => ["ctrl", "alt", "super"].includes(part))
+	);
+}
+
+export function resolveBtwShortcuts(
+	overrides: BtwKeybindingOverrides = {},
+	keybindings: KeybindingsManager,
+	copyOnSelect = true,
+): BtwShortcuts {
+	let mode = isKittyProtocolActive();
+	let snapshot = resolveShortcutSnapshot(overrides, keybindings, copyOnSelect);
+	const current = () => {
+		if (mode !== isKittyProtocolActive()) {
+			mode = isKittyProtocolActive();
+			snapshot = resolveShortcutSnapshot(overrides, keybindings, copyOnSelect);
+		}
+		return snapshot;
+	};
+	// ProcessTerminal negotiates Kitty asynchronously after the dedicated TUI starts.
+	// Hints and matching must use the same policy after that mode transition.
+	return {
+		get keys() {
+			return current().keys;
+		},
+		get warnings() {
+			return current().warnings;
+		},
+		matches: (data, action) => current().matches(data, action),
+		label: (action) => current().label(action),
+	};
+}
+
+function resolveShortcutSnapshot(
+	overrides: BtwKeybindingOverrides = {},
+	keybindings: KeybindingsManager,
+	copyOnSelect = true,
+): BtwShortcuts {
+	const reserved = reservedKeys(keybindings, copyOnSelect);
+	const keys: BtwShortcuts["keys"] = { exit: ["ctrl+c"], cycleThinkingLevel: [], bringToMain: [] };
+	const warnings: string[] = [];
+	const defaults: Record<BtwShortcutAction, readonly string[]> = {
+		exit: ["ctrl+c"],
+		cycleThinkingLevel: keybindings.getKeys("app.thinking.cycle"),
+		bringToMain: ["ctrl+r"],
+	};
+	for (const action of BTW_SHORTCUT_ACTIONS) {
+		const usable = (candidate: string, inherited = false): string | undefined => {
+			const key = normalizeBtwKey(candidate);
+			if (!key || (!inherited && isTextKey(key))) return undefined;
+			const inputs = inputsFor(key);
+			if (!inputs.length) return undefined;
+			if (action === "exit" && key === "ctrl+c") return key;
+			if (
+				reserved.some(
+					(other) =>
+						typeof other === "string" && inputs.some((input) => matchesKey(input, other as KeyId)),
+				)
+			)
+				return undefined;
+			if (
+				BTW_SHORTCUT_ACTIONS.some(
+					(other) => other !== action && keys[other].some((used) => btwKeysOverlap(key, used)),
+				)
+			)
+				return undefined;
+			return key;
+		};
+		const override = overrides[action];
+		const selected = override === undefined ? undefined : usable(override);
+		if (override !== undefined && !selected)
+			warnings.push(
+				`${action}: configured shortcut is invalid or conflicts with a reserved action; using an available default.`,
+			);
+		const effective = selected
+			? [selected]
+			: defaults[action]
+					.map((key) => usable(key, action === "cycleThinkingLevel"))
+					.filter((key): key is string => key !== undefined);
+		keys[action] = action === "exit" ? [...new Set([...effective, "ctrl+c"])] : effective;
+		if (!keys[action].length && (override !== undefined || defaults[action].length > 0))
+			warnings.push(`${action}: no usable shortcut; change Pi BTW Settings or Pi keybindings.`);
+	}
+	return {
+		keys,
+		warnings,
+		matches: (data, action) =>
+			!isKeyRelease(data) && keys[action].some((key) => matchesKey(data, key as KeyId)),
+		label: (action) =>
+			keys[action].length ? formatKeyLabel(keys[action][0] ?? "") : "Unavailable",
+	};
+}
+
+export function validateBtwShortcutEdit(
+	action: BtwShortcutAction,
+	value: string | undefined,
+	overrides: BtwKeybindingOverrides,
+	keybindings: KeybindingsManager,
+	copyOnSelect: boolean,
+): string | undefined {
+	// Reset must remain available even when several existing overrides conflict.
+	if (value === undefined) return undefined;
+	if (!normalizeBtwKey(value))
+		return "Invalid key combination. Use a Pi key name such as ctrl+q or f6.";
+	const next = { ...overrides, [action]: value };
+	const resolved = resolveBtwShortcuts(next, keybindings, copyOnSelect);
+	const previous = resolveBtwShortcuts(overrides, keybindings, copyOnSelect);
+	// Reject edits that disable another binding as well as the edited binding.
+	for (const item of BTW_SHORTCUT_ACTIONS) {
+		if (
+			(item === action && !resolved.keys[item].includes(normalizeBtwKey(value) ?? "")) ||
+			(item !== action && previous.keys[item].some((key) => !resolved.keys[item].includes(key)))
+		) {
+			return `${item} conflicts with another BTW shortcut, editing, selection, search, scrolling, or copying. Choose a different key.`;
+		}
+	}
+	return undefined;
+}
+
+const bindingsByTui = new WeakMap<TUI, BtwShortcuts>();
+export function setBtwShortcuts(tui: TUI, shortcuts: BtwShortcuts): void {
+	bindingsByTui.set(tui, shortcuts);
+}
+export function getBtwShortcuts(tui: TUI, keybindings?: KeybindingsManager): BtwShortcuts {
+	return (
+		bindingsByTui.get(tui) ??
+		resolveBtwShortcuts(
+			{},
+			keybindings ??
+				new KeybindingsManager({
+					...TUI_KEYBINDINGS,
+					"app.thinking.cycle": { defaultKeys: "shift+tab" },
+				}),
+		)
+	);
+}
+
+/** Keep split bracketed-paste payloads away from screen-level shortcuts. */
+export class BtwPasteGuard {
+	private active = false;
+	consume(data: string): boolean {
+		const wasActive = this.active;
+		const starts = data.includes("\u001b[200~");
+		if (starts) this.active = true;
+		if (this.active && data.includes("\u001b[201~")) this.active = false;
+		return wasActive || starts;
+	}
+}

--- a/packages/pi-btw/src/menu.ts
+++ b/packages/pi-btw/src/menu.ts
@@ -6,6 +6,13 @@ import type {
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import type { MenuContext, RunMenuResult } from "@narumitw/pi-tui-kit";
 import {
+	BTW_SHORTCUT_ACTIONS,
+	type BtwShortcutAction,
+	normalizeBtwKey,
+	resolveBtwShortcuts,
+	validateBtwShortcutEdit,
+} from "./keybindings.js";
+import {
 	type BtwSettings,
 	type BtwSettingsPatch,
 	btwSettingsPath,
@@ -16,7 +23,7 @@ import {
 	updateBtwSettings,
 } from "./settings.js";
 import { BTW_THINKING_LEVELS, type BtwThinkingLevel } from "./side-thread.js";
-import { sanitizeSingleLine } from "./text.js";
+import { formatKeyLabel, sanitizeSingleLine } from "./text.js";
 
 interface BtwMenuState {
 	kind: "valid" | "invalid";
@@ -48,14 +55,17 @@ export type BtwCommandMenuResult =
 	| "closed"
 	| { kind: "resume"; threadId: string };
 
-type BtwMenuScreen = "main" | "resume" | "settings" | "invalid";
+type BtwMenuScreen = "main" | "resume" | "settings" | "invalid" | "shortcut" | "shortcut-input";
 type BtwMenuAction =
 	| "start"
 	| "start-tree"
 	| "resume"
 	| "set-thinking"
 	| "set-remember"
-	| "set-fullscreen-copy";
+	| "set-fullscreen-copy"
+	| "edit-shortcut"
+	| "save-shortcut"
+	| "reset-shortcut";
 const SAME_AS_MAIN_THREAD = "Same as main thread";
 type BtwCustomOptions = Parameters<ExtensionCommandContext["ui"]["custom"]>[1];
 
@@ -85,6 +95,74 @@ export async function showBtwCommandMenu(
 	let startSelected = false;
 	let treeSelected = false;
 	let resumedThreadId: string | undefined;
+	let keybindings: KeybindingsManager | undefined;
+	let shortcut: BtwShortcutAction = "exit";
+	const shortcutLabels: Record<BtwShortcutAction, string> = {
+		exit: "Exit shortcut",
+		cycleThinkingLevel: "Cycle thinking level shortcut",
+		bringToMain: "Bring to main shortcut",
+	};
+	const shortcutValue = (settings: BtwSettings, action: BtwShortcutAction): string => {
+		if (!keybindings) return "Default";
+		const effective = resolveBtwShortcuts(
+			settings.keybindings,
+			keybindings,
+			effectiveFullscreenCopyOnSelect(settings),
+		);
+		const configured = settings.keybindings?.[action];
+		if (configured !== undefined && !effective.keys[action].includes(configured)) {
+			return `Fallback (${effective.label(action)}; saved ${formatKeyLabel(configured)})`;
+		}
+		const source =
+			configured === undefined
+				? action === "cycleThinkingLevel"
+					? "Inherit Pi"
+					: "Default"
+				: "Custom";
+		return `${source} (${effective.label(action)})`;
+	};
+	const saveShortcut = async (
+		state: BtwMenuState,
+		value: string | undefined,
+		signal: AbortSignal,
+	) => {
+		if (!keybindings || state.kind !== "valid" || signal.aborted)
+			return { kind: "rejected" } as const;
+		const action = shortcut;
+		const manager = keybindings;
+		const validate = (settings: BtwSettings) =>
+			validateBtwShortcutEdit(
+				action,
+				value,
+				settings.keybindings ?? {},
+				manager,
+				effectiveFullscreenCopyOnSelect(settings),
+			);
+		const error = validate(state.settings);
+		if (error) {
+			notifySafely(ctx, error, "error");
+			return { kind: "rejected" } as const;
+		}
+		try {
+			await updateSettings(
+				{ keybindings: { [action]: value === undefined ? undefined : normalizeBtwKey(value) } },
+				{
+					settingsPath,
+					signal,
+					validateCurrent: (settings) => {
+						const conflict = validate(settings);
+						if (conflict) throw new Error(conflict);
+					},
+				},
+			);
+			if (signal.aborted) return { kind: "rejected" } as const;
+			notifySafely(ctx, "Pi BTW shortcut saved; applies when opening or resuming BTW.", "info");
+			return { kind: "back" } as const;
+		} catch (error) {
+			if (!signal.aborted) notifySaveFailure(ctx, error);
+			return { kind: "rejected" } as const;
+		}
+	};
 
 	const loadState = async (): Promise<BtwMenuState> => {
 		const loaded = await readSettings(settingsPath);
@@ -146,7 +224,7 @@ export async function showBtwCommandMenu(
 					{
 						id: "settings",
 						label: "Settings",
-						description: "Choose thinking, shortcut memory, and selection copying",
+						description: "Choose thinking, keybindings, and selection copying",
 						to: state.kind === "invalid" ? "invalid" : "settings",
 					},
 				],
@@ -195,7 +273,33 @@ export async function showBtwCommandMenu(
 						values: ["On", "Off"],
 						action: "set-fullscreen-copy",
 					},
+					...BTW_SHORTCUT_ACTIONS.map((action) => ({
+						id: action,
+						label: shortcutLabels[action],
+						description:
+							"Edit a BTW-only key combination or restore its default. Ctrl+C always hard-cancels.",
+						currentValue: shortcutValue(state.settings, action),
+						action: "edit-shortcut" as const,
+					})),
 				],
+			}),
+			shortcut: ({ state }) => ({
+				kind: "actions",
+				title: shortcutLabels[shortcut],
+				lines: [shortcutValue(state.settings, shortcut), "Ctrl+C always hard-cancels BTW."],
+				items: [
+					{ id: "edit", label: "Edit key combination…", to: "shortcut-input" },
+					{ id: "reset", label: "Restore default", action: "reset-shortcut" },
+				],
+				hint: "back",
+			}),
+			"shortcut-input": () => ({
+				kind: "input",
+				title: shortcutLabels[shortcut],
+				lines: ["Type a key name, not the shortcut itself. For example: ctrl+q or f6."],
+				placeholder: "Key combination",
+				action: "save-shortcut",
+				hint: "back",
 			}),
 			invalid: ({ state }) => ({
 				kind: "detail",
@@ -208,6 +312,15 @@ export async function showBtwCommandMenu(
 			}),
 		},
 		actions: {
+			"edit-shortcut": ({ itemId }) => {
+				if (!BTW_SHORTCUT_ACTIONS.includes(itemId as BtwShortcutAction))
+					return { kind: "rejected" };
+				shortcut = itemId as BtwShortcutAction;
+				return { kind: "to", screen: "shortcut" };
+			},
+			"save-shortcut": ({ state, value, signal }) =>
+				saveShortcut(state, value?.trim() ?? "", signal),
+			"reset-shortcut": ({ state, signal }) => saveShortcut(state, undefined, signal),
 			start: async () => {
 				startSelected = true;
 				return { kind: "close" };
@@ -275,8 +388,12 @@ export async function showBtwCommandMenu(
 		},
 	});
 
-	const result = await runBtwMenuPreservingEditor(ctx, (menuContext) =>
-		runMenu(menuContext, menu, { getState: loadState }),
+	const result = await runBtwMenuPreservingEditor(
+		ctx,
+		(menuContext) => runMenu(menuContext, menu, { getState: loadState }),
+		(manager) => {
+			keybindings = manager;
+		},
 	);
 	if (result.kind !== "closed" || result.reason !== "close") return "closed";
 	if (resumedThreadId) return { kind: "resume", threadId: resumedThreadId };
@@ -314,6 +431,7 @@ export async function showBtwCustomPreservingEditor<T>(
 export async function runBtwMenuPreservingEditor(
 	ctx: ExtensionCommandContext,
 	run: (menuContext: MenuContext) => Promise<RunMenuResult>,
+	onKeybindings?: (keybindings: KeybindingsManager) => void,
 ): Promise<RunMenuResult> {
 	let liveEditorText = ctx.ui.getEditorText();
 	let completed = false;
@@ -321,19 +439,18 @@ export async function runBtwMenuPreservingEditor(
 		get(target, property) {
 			if (property === "custom") {
 				return <Value>(factory: BtwCustomFactory<Value>, customOptions?: BtwCustomOptions) =>
-					target.custom<Value>(
-						(tui, theme, keybindings, done) =>
-							factory(tui, theme, keybindings, (value) => {
-								try {
-									liveEditorText = target.getEditorText();
-								} catch {
-									// Keep completion finite if session replacement invalidates the editor context.
-								}
-								completed = true;
-								done(value);
-							}),
-						customOptions,
-					);
+					target.custom<Value>((tui, theme, keybindings, done) => {
+						onKeybindings?.(keybindings);
+						return factory(tui, theme, keybindings, (value) => {
+							try {
+								liveEditorText = target.getEditorText();
+							} catch {
+								// Keep completion finite if session replacement invalidates the editor context.
+							}
+							completed = true;
+							done(value);
+						});
+					}, customOptions);
 			}
 			const value = Reflect.get(target, property, target) as unknown;
 			return typeof value === "function" ? value.bind(target) : value;

--- a/packages/pi-btw/src/settings.ts
+++ b/packages/pi-btw/src/settings.ts
@@ -3,6 +3,11 @@ import { constants } from "node:fs";
 import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import {
+	BTW_SHORTCUT_ACTIONS,
+	type BtwKeybindingOverrides,
+	normalizeBtwKey,
+} from "./keybindings.js";
 import { BTW_THINKING_LEVELS, type BtwThinkingLevel } from "./side-thread.js";
 
 export const BTW_SETTINGS_FILE = "pi-btw.json";
@@ -11,6 +16,7 @@ export const DEFAULT_REMEMBER_THINKING_LEVEL_CHANGES = true;
 const MAX_SETTINGS_BYTES = 64 * 1024;
 
 export interface BtwSettings {
+	keybindings?: BtwKeybindingOverrides;
 	model?: string;
 	thinkingLevel?: BtwThinkingLevel;
 	rememberThinkingLevelChanges?: boolean;
@@ -23,12 +29,15 @@ export type BtwSettingsLoadResult =
 	| { kind: "loaded"; settings: BtwSettings };
 
 export interface BtwSettingsPatch {
+	keybindings?: BtwKeybindingOverrides;
 	thinkingLevel?: BtwThinkingLevel;
 	rememberThinkingLevelChanges?: boolean;
 	fullscreenCopyOnSelect?: boolean;
 }
 
 export interface UpdateBtwSettingsOptions {
+	/** Validate against the latest document inside the mutation queue, before applying the patch. */
+	validateCurrent?: (settings: BtwSettings) => void;
 	settingsPath?: string;
 	signal?: AbortSignal;
 	beforeRename?: (temporaryPath: string, settingsPath: string) => Promise<void>;
@@ -46,6 +55,17 @@ export function normalizeBtwSettings(value: unknown): BtwSettings | undefined {
 	if (!isSettingsDocument(value)) return undefined;
 
 	const settings: BtwSettings = {};
+	if (Object.hasOwn(value, "keybindings")) {
+		const keys = value.keybindings;
+		if (!isSettingsDocument(keys)) return undefined;
+		settings.keybindings = {};
+		for (const action of BTW_SHORTCUT_ACTIONS) {
+			if (!Object.hasOwn(keys, action)) continue;
+			const key = normalizeBtwKey(keys[action]);
+			if (!key) return undefined;
+			settings.keybindings[action] = key;
+		}
+	}
 	if (Object.hasOwn(value, "model")) {
 		const model = Reflect.get(value, "model");
 		if (typeof model !== "string" || !parseBtwModelReference(model)) return undefined;
@@ -101,6 +121,8 @@ export function updateBtwSettings(
 	return enqueueMutation(settingsPath, async () => {
 		options.signal?.throwIfAborted();
 		const current = await readSettingsDocumentForUpdate(settingsPath);
+		options.signal?.throwIfAborted();
+		options.validateCurrent?.(normalizeBtwSettings(current) ?? {});
 		const updated = applyBtwSettingsPatch(current, patch);
 		const settings = normalizeBtwSettings(updated);
 		if (!settings) throw invalidSettingsError(settingsPath, "invalid settings shape");
@@ -238,6 +260,16 @@ function applyBtwSettingsPatch(
 	patch: BtwSettingsPatch,
 ): SettingsDocument {
 	const updated: SettingsDocument = { ...current };
+	if (patch.keybindings) {
+		const keys = isSettingsDocument(current.keybindings) ? { ...current.keybindings } : {};
+		for (const action of BTW_SHORTCUT_ACTIONS) {
+			if (!Object.hasOwn(patch.keybindings, action)) continue;
+			if (patch.keybindings[action] === undefined) delete keys[action];
+			else keys[action] = patch.keybindings[action];
+		}
+		if (Object.keys(keys).length) updated.keybindings = keys;
+		else delete updated.keybindings;
+	}
 	if (Object.hasOwn(patch, "thinkingLevel")) {
 		if (patch.thinkingLevel === undefined) delete updated.thinkingLevel;
 		else updated.thinkingLevel = patch.thinkingLevel;

--- a/packages/pi-btw/src/transcript-pager.ts
+++ b/packages/pi-btw/src/transcript-pager.ts
@@ -23,8 +23,9 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import type { BtwFullscreenLayoutComponent } from "./fullscreen-ui.js";
+import { BtwPasteGuard, type BtwShortcuts, getBtwShortcuts } from "./keybindings.js";
 import type { BtwThinkingLevel, SideThreadTurn } from "./side-thread.js";
-import { formatKeyLabel, sanitizeSingleLine } from "./text.js";
+import { sanitizeSingleLine } from "./text.js";
 
 const TRANSCRIPT_CHROME_LINES = 2;
 const MAX_STEERING_DISPLAY_LINES = 3;
@@ -68,6 +69,8 @@ export interface BtwAnsweringViewOptions {
 }
 
 export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusable {
+	private readonly shortcuts: BtwShortcuts;
+	private readonly pasteGuard = new BtwPasteGuard();
 	private readonly transcriptComponents: Component[];
 	private readonly editor: Editor;
 	private readonly canBringToMain: boolean;
@@ -90,6 +93,7 @@ export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusab
 			thinking?: BtwThinkingControl;
 		} = {},
 	) {
+		this.shortcuts = getBtwShortcuts(tui, options.thinking?.keybindings);
 		this.transcriptComponents = buildTranscriptComponents(turns, this.theme);
 		this.canBringToMain = turns.some((turn) => turn.kind === "answered");
 		this.thinkingLevel = options.thinking?.level;
@@ -144,6 +148,7 @@ export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusab
 	}
 
 	render(width: number): string[] {
+		if (width <= 0) return [];
 		const safeWidth = Math.max(1, width);
 		const editorLines = this.editor.render(safeWidth);
 		const availableRows = Math.max(1, this.tui.terminal.rows - RESERVED_APP_LINES);
@@ -163,17 +168,22 @@ export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusab
 			this.renderFooter(safeWidth),
 			editorLines,
 			availableRows,
-		);
+		).map((line) => truncateToWidth(line, safeWidth));
 	}
 
 	handleInput(data: string): void {
 		if (this.finished) return;
-		if (matchesKey(data, Key.ctrl("c"))) {
+		if (this.pasteGuard.consume(data)) {
+			this.editor.handleInput(data);
+			this.tui.requestRender();
+			return;
+		}
+		if (this.shortcuts.matches(data, "exit")) {
 			this.finished = true;
 			this.onAction({ kind: "close" });
 			return;
 		}
-		if (this.canBringToMain && matchesKey(data, Key.ctrl("r"))) {
+		if (this.canBringToMain && this.shortcuts.matches(data, "bringToMain")) {
 			this.finished = true;
 			this.onAction({ kind: "bringToMain", questionDraft: this.editor.getExpandedText() });
 			return;
@@ -182,7 +192,7 @@ export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusab
 		if (
 			thinking &&
 			thinking.levels.length > 1 &&
-			thinking.keybindings.matches(data, "app.thinking.cycle")
+			this.shortcuts.matches(data, "cycleThinkingLevel")
 		) {
 			const currentIndex = thinking.levels.indexOf(this.thinkingLevel ?? thinking.level);
 			const nextLevel = thinking.levels[(currentIndex + 1) % thinking.levels.length];
@@ -219,22 +229,28 @@ export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusab
 	}
 
 	private renderFooter(width: number): string {
+		const exit = this.shortcuts.label("exit");
+		const bring = this.canBringToMain && this.shortcuts.keys.bringToMain.length > 0;
+		const bringKey = this.shortcuts.label("bringToMain");
 		if (this.warning) {
-			const warning = width < 32 ? "Empty • Ctrl+C" : `${this.warning} • Ctrl+C exit`;
+			const warning = width < 32 ? `Empty • ${exit}` : `${this.warning} • ${exit} exit`;
 			return truncateToWidth(this.theme.fg("warning", warning), width);
 		}
 		const scrollable = this.getMaxScrollOffset() > 0;
 		const thinking = this.options.thinking;
 		const cycleHint =
-			thinking && thinking.levels.length > 1 && this.thinkingLevel
-				? ` • thinking ${this.thinkingLevel} • ${thinkingKeyLabel(thinking.keybindings)} cycle`
+			thinking &&
+			thinking.levels.length > 1 &&
+			this.thinkingLevel &&
+			this.shortcuts.keys.cycleThinkingLevel.length
+				? ` • thinking ${this.thinkingLevel} • ${this.shortcuts.label("cycleThinkingLevel")} cycle`
 				: "";
-		const base = this.canBringToMain
-			? "btw • Enter send • Ctrl+R bring to main • Ctrl+C exit"
-			: "btw • Enter send • Ctrl+C exit";
+		const base = bring
+			? `btw • Enter send • ${bringKey} bring to main • ${exit} exit`
+			: `btw • Enter send • ${exit} exit`;
 		const fullBase = `${base}${cycleHint}`;
-		const fallbackBase = "btw • Enter • Ctrl+C";
-		const compactBase = this.canBringToMain ? "btw • Enter • Ctrl+R • Ctrl+C" : fallbackBase;
+		const fallbackBase = `btw • Enter • ${exit}`;
+		const compactBase = bring ? `btw • Enter • ${bringKey} • ${exit}` : fallbackBase;
 		const compactWithThinking = `${compactBase}${cycleHint}`;
 		let hints =
 			visibleWidth(fullBase) <= width
@@ -247,8 +263,8 @@ export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusab
 		if (scrollable) {
 			const history = ` • ${this.scrollView.scrollTop > 0 ? "↑ older" : "↓ newer"} • PgUp/PgDn history`;
 			const compactHistory = " • PgUp/PgDn";
-			const compactScrollable = this.canBringToMain
-				? "Enter • Ctrl+R • Ctrl+C • PgUp/PgDn"
+			const compactScrollable = bring
+				? `Enter • ${bringKey} • ${exit} • PgUp/PgDn`
 				: `${fallbackBase}${compactHistory}`;
 			if (visibleWidth(`${hints}${history}`) <= width) {
 				hints += history;
@@ -298,6 +314,8 @@ export class BtwTranscriptPager implements BtwFullscreenLayoutComponent, Focusab
 }
 
 export class BtwAnsweringView implements BtwFullscreenLayoutComponent, Focusable {
+	private readonly shortcuts: BtwShortcuts;
+	private readonly pasteGuard = new BtwPasteGuard();
 	private readonly transcriptComponents: Component[];
 	private readonly loader: Loader;
 	private readonly editor: Editor | undefined;
@@ -319,6 +337,7 @@ export class BtwAnsweringView implements BtwFullscreenLayoutComponent, Focusable
 		thinkingLevel?: BtwThinkingLevel,
 		private readonly options: BtwAnsweringViewOptions = {},
 	) {
+		this.shortcuts = getBtwShortcuts(tui, options.steering?.thinking?.keybindings);
 		this.transcriptComponents = buildTranscriptComponents(turns, this.theme, pendingQuestion);
 		this.thinkingLevel = options.steering?.thinking?.level ?? thinkingLevel;
 		this.loader = new Loader(
@@ -389,6 +408,7 @@ export class BtwAnsweringView implements BtwFullscreenLayoutComponent, Focusable
 	}
 
 	render(width: number): string[] {
+		if (width <= 0) return [];
 		const safeWidth = Math.max(1, width);
 		const availableRows = Math.max(1, this.tui.terminal.rows - RESERVED_APP_LINES);
 		const editorLines = this.editor?.render(safeWidth) ?? [];
@@ -419,12 +439,17 @@ export class BtwAnsweringView implements BtwFullscreenLayoutComponent, Focusable
 			editorLines,
 			availableRows,
 			steeringLines,
-		);
+		).map((line) => truncateToWidth(line, safeWidth));
 	}
 
 	handleInput(data: string): void {
 		if (this.finished) return;
-		if (matchesKey(data, Key.ctrl("c"))) {
+		if (this.pasteGuard.consume(data)) {
+			this.editor?.handleInput(data);
+			this.tui.requestRender();
+			return;
+		}
+		if (this.shortcuts.matches(data, "exit")) {
 			this.finished = true;
 			this.loader.stop();
 			this.controller.abort();
@@ -435,7 +460,7 @@ export class BtwAnsweringView implements BtwFullscreenLayoutComponent, Focusable
 		if (
 			thinking &&
 			thinking.levels.length > 1 &&
-			thinking.keybindings.matches(data, "app.thinking.cycle")
+			this.shortcuts.matches(data, "cycleThinkingLevel")
 		) {
 			const currentIndex = thinking.levels.indexOf(this.thinkingLevel ?? thinking.level);
 			const nextLevel = thinking.levels[(currentIndex + 1) % thinking.levels.length];
@@ -483,19 +508,23 @@ export class BtwAnsweringView implements BtwFullscreenLayoutComponent, Focusable
 	}
 
 	private renderFooter(width: number): string {
+		const exit = this.shortcuts.label("exit");
 		if (this.warning) {
-			const warning = width < 32 ? "Empty • Ctrl+C" : `${this.warning} • Ctrl+C cancel`;
+			const warning = width < 32 ? `Empty • ${exit}` : `${this.warning} • ${exit} cancel`;
 			return truncateToWidth(this.theme.fg("warning", warning), width);
 		}
-		const baseHint = this.editor ? "Enter steer • Ctrl+C cancel" : "Ctrl+C cancel";
+		const baseHint = this.editor ? `Enter steer • ${exit} cancel` : `${exit} cancel`;
 		const thinking = this.options.steering?.thinking;
 		const cycleHint =
-			thinking && thinking.levels.length > 1 && this.thinkingLevel
-				? ` • thinking ${this.thinkingLevel} • ${thinkingKeyLabel(thinking.keybindings)} cycle`
+			thinking &&
+			thinking.levels.length > 1 &&
+			this.thinkingLevel &&
+			this.shortcuts.keys.cycleThinkingLevel.length
+				? ` • thinking ${this.thinkingLevel} • ${this.shortcuts.label("cycleThinkingLevel")} cycle`
 				: "";
 		const scrollHint = this.getMaxScrollOffset() > 0 ? " • PgUp/PgDn history" : "";
 		const hints = `${baseHint}${cycleHint}${scrollHint}`;
-		const compactHints = this.editor ? "Enter • Ctrl+C" : "Ctrl+C";
+		const compactHints = this.editor ? `Enter • ${exit}` : exit;
 		const selectedHints = visibleWidth(hints) <= width ? hints : compactHints;
 		const loaderWidth = Math.max(1, width - visibleWidth(selectedHints) - 3);
 		const loaderLine = this.loader.render(loaderWidth).at(-1) ?? "Answering…";
@@ -610,13 +639,6 @@ function renderSideThreadHeader(
 	const title = truncateToWidth(`─ btw · side thread${thinking} `, width);
 	const ruleWidth = Math.max(0, width - visibleWidth(title));
 	return theme.fg("muted", `${title}${"─".repeat(ruleWidth)}`);
-}
-
-function thinkingKeyLabel(keybindings: KeybindingsManager): string {
-	return (
-		formatKeyLabel(String(keybindings.getKeys("app.thinking.cycle")[0] ?? "shift+tab")) ||
-		"Shift+Tab"
-	);
 }
 
 function fitComposerLayout(

--- a/packages/pi-btw/test/btw.test.ts
+++ b/packages/pi-btw/test/btw.test.ts
@@ -409,20 +409,26 @@ test("btw command routes no arguments through the menu and preserves direct ques
 	assert.deepEqual(mock.thinkingLevels, []);
 });
 
-test("btw resolves automatic selection copying once from each invocation's loaded settings", async () => {
+test("btw resolves copying and shortcut overrides from each invocation's loaded settings", async () => {
 	const mock = createMockPi();
 	const selected = {
 		model: { provider: "test", id: "side" } as Model<Api>,
 		auth: { apiKey: "key" },
 	};
-	const loaded = [{}, {}, { fullscreenCopyOnSelect: false }] as const;
+	const loaded = [
+		{},
+		{ keybindings: { exit: "ctrl+q" } },
+		{ fullscreenCopyOnSelect: false, keybindings: { cycleThinkingLevel: "f6", bringToMain: "f7" } },
+	] as const;
 	const copyModes: Array<boolean | undefined> = [];
+	const shortcutOverrides: unknown[] = [];
 	let settingsReads = 0;
 	btw(mock.pi, {
 		loadSettings: async () => loaded[settingsReads++] ?? {},
 		resolveModel: async () => ({ kind: "selected", selected }),
 		runFullscreen: async (ctx, run, options) => {
 			copyModes.push(options?.copyOnSelect);
+			shortcutOverrides.push(options?.keybindings);
 			return run(ctx);
 		},
 		runThread: async () => ({ kind: "closed" }),
@@ -437,6 +443,11 @@ test("btw resolves automatic selection copying once from each invocation's loade
 
 	assert.equal(settingsReads, 3);
 	assert.deepEqual(copyModes, [true, true, false]);
+	assert.deepEqual(shortcutOverrides, [
+		undefined,
+		{ exit: "ctrl+q" },
+		{ cycleThinkingLevel: "f6", bringToMain: "f7" },
+	]);
 });
 
 test("btw same-as-main mode starts fresh threads from the current main level without remembering shortcut changes", async () => {

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import {
 	type Component,
 	Container,
@@ -15,6 +16,11 @@ import {
 } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { type BtwFullscreenTuiFactory, runBtwFullscreen } from "../src/fullscreen-ui.js";
+import {
+	BtwAnsweringView,
+	BtwTranscriptPager,
+	type TranscriptPagerAction,
+} from "../src/transcript-pager.js";
 
 // Keep these tests together because selection, input priority, and cleanup share stateful harnesses.
 interface FakeComponent extends Component {
@@ -23,6 +29,7 @@ interface FakeComponent extends Component {
 
 const BTW_TEST_KEYBINDINGS = {
 	...TUI_KEYBINDINGS,
+	"app.thinking.cycle": { defaultKeys: "shift+tab", description: "Cycle thinking" },
 	"app.message.copy": {
 		defaultKeys: "ctrl+y",
 		description: "Copy the active fullscreen selection",
@@ -143,7 +150,7 @@ function createHarness(
 						fg: (_color: string, text: string) => text,
 						bold: (text: string) => text,
 					} as never,
-					{} as never,
+					createBtwTestKeybindings() as never,
 					((value: unknown) => outerDone?.(value)) as never,
 				);
 				customOptions?.onHandle?.({
@@ -491,6 +498,174 @@ async function startClipboardSelection(
 		copyInput: inputForCopyBinding(keybindings),
 	};
 }
+
+test.each([
+	["custom exit", "\u0011", false],
+	["hard cancel", "\u0003", false],
+	["custom exit with overlay", "\u0011", true],
+	["hard cancel with overlay", "\u0003", true],
+] as const)(
+	"native terminal smoke: %s restores parent input after cycling thinking",
+	async (_label, exitInput, nested) => {
+		initTheme("dark");
+		const keys = createBtwTestKeybindings();
+		const previous = getKeybindings();
+		setKeybindings(keys);
+		const harness = createInputHandoffHarness(keys);
+		let cycleCount = 0;
+		let overlayInput = 0;
+		let side: TUI | undefined;
+		const running = runBtwFullscreen(
+			harness.ctx,
+			(ctx) =>
+				ctx.ui.custom<TranscriptPagerAction>((tui, theme, keybindings, done) => {
+					side = tui;
+					return new BtwTranscriptPager(tui, theme, [], done, {
+						thinking: {
+							level: "low",
+							levels: ["low", "high"],
+							keybindings,
+							onChange: () => {
+								cycleCount += 1;
+							},
+						},
+					});
+				}),
+			{ keybindings: { exit: "ctrl+q", cycleThinkingLevel: "f6", bringToMain: "f7" } },
+		);
+		try {
+			await flushAsyncWork();
+			assert.ok(side);
+			side.renderNow(true);
+			harness.terminal.send("\u001b[17~");
+			assert.equal(cycleCount, 1);
+			if (nested)
+				side.showOverlay({
+					render: () => ["nested"],
+					invalidate() {},
+					handleInput() {
+						overlayInput += 1;
+					},
+				});
+			harness.terminal.deferDrain();
+			harness.terminal.send(exitInput);
+			await flushAsyncWork();
+			assert.deepEqual(harness.terminal.lifecycle, ["start", "stop", "start"]);
+			assert.deepEqual(harness.terminal.lifecycleDuringInput, []);
+			assert.equal(overlayInput, 0);
+			harness.terminal.resolveDrain();
+			assert.deepEqual(await running, { kind: "close" });
+			harness.terminal.send("restored");
+			assert.equal(harness.mainInput.text, "restored");
+			assert.deepEqual(harness.terminal.lifecycleDuringInput, []);
+		} finally {
+			harness.terminal.resolveDrain();
+			harness.parent.stop();
+			setKeybindings(previous);
+		}
+	},
+);
+
+test("native terminal smoke: custom bring-to-main preserves an expanded pasted draft", async () => {
+	initTheme("dark");
+	const keys = createBtwTestKeybindings();
+	const previous = getKeybindings();
+	setKeybindings(keys);
+	const harness = createInputHandoffHarness(keys);
+	let side: TUI | undefined;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(ctx) =>
+			ctx.ui.custom<TranscriptPagerAction>((tui, theme, _keys, done) => {
+				side = tui;
+				return new BtwTranscriptPager(
+					tui,
+					theme,
+					[
+						{
+							kind: "answered",
+							question: "Q",
+							answer: "A",
+							response: {
+								role: "assistant",
+								content: [{ type: "text", text: "A" }],
+								stopReason: "stop",
+							} as never,
+						},
+					],
+					done,
+				);
+			}),
+		{ keybindings: { bringToMain: "f7" } },
+	);
+	try {
+		await flushAsyncWork();
+		assert.ok(side);
+		side.renderNow(true);
+		const draft = "pasted draft ".repeat(300);
+		harness.terminal.send(`\u001b[200~${draft}\u001b[201~`);
+		harness.terminal.send("\u001b[18~");
+		assert.deepEqual(await running, { kind: "bringToMain", questionDraft: draft });
+		harness.terminal.send("main");
+		assert.equal(harness.mainInput.text, "main");
+	} finally {
+		harness.parent.stop();
+		setKeybindings(previous);
+	}
+});
+
+test("native terminal smoke: split pasted exit bytes do not cancel streaming; explicit exit aborts once", async () => {
+	initTheme("dark");
+	const keys = createBtwTestKeybindings();
+	const previous = getKeybindings();
+	setKeybindings(keys);
+	const harness = createInputHandoffHarness(keys);
+	let view: BtwAnsweringView | undefined;
+	let cancellations = 0;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		(ctx) =>
+			ctx.ui.custom<"closed">((tui, theme, keybindings, done) => {
+				view = new BtwAnsweringView(
+					tui,
+					theme,
+					[],
+					"question",
+					() => {
+						cancellations += 1;
+						done("closed");
+					},
+					"low",
+					{
+						steering: {
+							questions: [],
+							onSubmit() {},
+							thinking: { level: "low", levels: ["low", "high"], keybindings, onChange() {} },
+						},
+					},
+				);
+				return view;
+			}),
+		{ keybindings: { exit: "ctrl+q" } },
+	);
+	try {
+		await flushAsyncWork();
+		assert.ok(view);
+		for (const data of ["\u001b[200~", "\u0011", "\u0003", "\u001b[201~"])
+			harness.terminal.send(data);
+		assert.equal(view.signal.aborted, false);
+		assert.equal(cancellations, 0);
+		harness.terminal.send("\u0011");
+		assert.equal(await running, "closed");
+		assert.equal(view.signal.aborted, true);
+		view.dispose();
+		assert.equal(cancellations, 1);
+	} finally {
+		view?.dispose();
+		harness.parent.stop();
+		setKeybindings(previous);
+	}
+});
 
 test("Ctrl+C waits for terminal input drain before restoring the parent", async () => {
 	const harness = createInputHandoffHarness();
@@ -890,7 +1065,7 @@ test("default fullscreen enables application-owned mouse selection and restores 
 				factory(
 					parent as never,
 					{ fg: (_color: string, text: string) => text } as never,
-					{} as never,
+					createBtwTestKeybindings() as never,
 					((value: unknown) => outerDone?.(value)) as never,
 				);
 				return result;
@@ -1286,7 +1461,7 @@ test("default fullscreen activates OSC-8 links through the configured URL opener
 				factory(
 					parent as never,
 					{ fg: (_color: string, text: string) => text } as never,
-					{} as never,
+					createBtwTestKeybindings() as never,
 					((value: unknown) => outerDone?.(value)) as never,
 				);
 				return result;

--- a/packages/pi-btw/test/fullscreen-ui.test.ts
+++ b/packages/pi-btw/test/fullscreen-ui.test.ts
@@ -6,8 +6,10 @@ import {
 	Container,
 	type Focusable,
 	getKeybindings,
+	isKittyProtocolActive,
 	KeybindingsManager,
 	setKeybindings,
+	setKittyProtocolActive,
 	type Terminal,
 	type TUI,
 	TUI_KEYBINDINGS,
@@ -55,6 +57,7 @@ function inputForCopyBinding(keybindings: KeybindingsManager): string {
 
 function createHarness(
 	options: {
+		keybindings?: KeybindingsManager;
 		fullscreenStopError?: Error;
 		hardCancelRemoveError?: Error;
 		layoutMountError?: Error;
@@ -150,7 +153,7 @@ function createHarness(
 						fg: (_color: string, text: string) => text,
 						bold: (text: string) => text,
 					} as never,
-					createBtwTestKeybindings() as never,
+					(options.keybindings ?? createBtwTestKeybindings()) as never,
 					((value: unknown) => outerDone?.(value)) as never,
 				);
 				customOptions?.onHandle?.({
@@ -188,6 +191,51 @@ function createHarness(
 		},
 	};
 }
+
+test("shortcut warnings follow negotiated mode, deduplicate, and stop at disposal", async () => {
+	const initialMode = isKittyProtocolActive();
+	setKittyProtocolActive(false);
+	const harness = createHarness({
+		keybindings: new KeybindingsManager(BTW_TEST_KEYBINDINGS, {
+			"tui.editor.cursorWordLeft": "alt+left",
+		}),
+	});
+	let finish!: (value: string) => void;
+	const running = runBtwFullscreen(
+		harness.ctx,
+		() =>
+			new Promise<string>((resolve) => {
+				finish = resolve;
+			}),
+		{ keybindings: { exit: "alt+b" } },
+		{ createTui: harness.createTui },
+	);
+	try {
+		await flushAsyncWork();
+		assert.deepEqual(harness.notifications, []);
+		setKittyProtocolActive(true);
+		harness.input("x");
+		assert.deepEqual(harness.notifications, []);
+		setKittyProtocolActive(false);
+		harness.input("x");
+		assert.equal(harness.notifications.length, 1);
+		assert.match(harness.notifications[0] ?? "", /exit: configured shortcut/);
+		harness.input("x");
+		assert.equal(harness.notifications.length, 1);
+		setKittyProtocolActive(true);
+		harness.input("x");
+		setKittyProtocolActive(false);
+		harness.input("x");
+		assert.equal(harness.notifications.length, 2);
+		finish("done");
+		assert.equal(await running, "done");
+		assert.throws(() => harness.input("x"));
+	} finally {
+		finish?.("done");
+		await running;
+		setKittyProtocolActive(initialMode);
+	}
+});
 
 function immediateComponent(done: (value: string) => void, events: string[]): FakeComponent {
 	done("side result");

--- a/packages/pi-btw/test/keybinding-components.test.ts
+++ b/packages/pi-btw/test/keybinding-components.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import {
+	getKeybindings,
+	KeybindingsManager,
+	setKeybindings,
+	TUI_KEYBINDINGS,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { resolveBtwShortcuts, setBtwShortcuts } from "../src/keybindings.js";
+import {
+	BtwAnsweringView,
+	BtwTranscriptPager,
+	type TranscriptPagerAction,
+} from "../src/transcript-pager.js";
+
+const definitions = {
+	...TUI_KEYBINDINGS,
+	"app.thinking.cycle": { defaultKeys: "shift+tab" },
+} as const;
+const turns = [
+	{
+		kind: "answered" as const,
+		question: "Q",
+		answer: "A",
+		response: {
+			role: "assistant",
+			content: [{ type: "text", text: "A" }],
+			stopReason: "stop",
+		} as never,
+	},
+];
+
+test("composer hints reflect custom keys, fallback preserves non-default editing, and paste stays a draft", async () => {
+	initTheme("dark");
+	const previous = getKeybindings();
+	const keys = new KeybindingsManager(definitions, { "tui.editor.deleteCharBackward": "ctrl+q" });
+	setKeybindings(keys);
+	const harness = createTuiHarness({ width: 160, rows: 24, keybindings: keys as never });
+	let cycles = 0;
+	const running = harness.custom<TranscriptPagerAction>((tui, theme, keybindings, done) => {
+		setBtwShortcuts(
+			tui,
+			resolveBtwShortcuts({ exit: "ctrl+q", cycleThinkingLevel: "f6", bringToMain: "f7" }, keys),
+		);
+		return new BtwTranscriptPager(tui, theme, turns, done, {
+			thinking: {
+				level: "low",
+				levels: ["low", "high"],
+				keybindings,
+				onChange: () => {
+					cycles += 1;
+				},
+			},
+		});
+	});
+	try {
+		await harness.waitForOpen();
+		const lines = harness.render().join("\n");
+		assert.match(lines, /F7 bring to main/);
+		assert.match(lines, /F6 cycle/);
+		assert.match(lines, /Ctrl\+C exit/);
+		assert.doesNotMatch(lines, /Ctrl\+R bring|Ctrl\+Q exit|Shift\+Tab cycle/);
+		harness.type("abc");
+		harness.send("\u0011");
+		harness.send("\u001b[200~");
+		harness.send("\u001b[17~");
+		harness.send("\u001b[201~");
+		assert.equal(cycles, 0);
+		harness.send("\u001b[17~");
+		assert.equal(cycles, 1);
+		for (const width of [1, 12, 32, 80])
+			assert.ok(harness.render(width).every((line) => visibleWidth(line) <= width));
+		harness.send("\u001b[18~");
+		const result = await running;
+		assert.equal(result.kind, "bringToMain");
+		if (result.kind === "bringToMain") assert.ok(result.questionDraft.startsWith("ab"));
+	} finally {
+		harness.dispose();
+		setKeybindings(previous);
+	}
+});
+
+test("answering view cycles via custom key, preserves steering submission and aborts on custom exit", async () => {
+	initTheme("dark");
+	const harness = createTuiHarness({ width: 160, rows: 24 });
+	const keys = new KeybindingsManager(definitions);
+	const submitted: string[] = [];
+	let cycles = 0;
+	let view: BtwAnsweringView | undefined;
+	const running = harness.custom<string>((tui, theme, keybindings, done) => {
+		setBtwShortcuts(tui, resolveBtwShortcuts({ exit: "ctrl+q", cycleThinkingLevel: "f6" }, keys));
+		view = new BtwAnsweringView(tui, theme, [], "Q", () => done("cancelled"), "low", {
+			steering: {
+				questions: [],
+				onSubmit: (question) => submitted.push(question),
+				thinking: {
+					level: "low",
+					levels: ["low", "high"],
+					keybindings,
+					onChange: () => {
+						cycles += 1;
+					},
+				},
+			},
+		});
+		return view;
+	});
+	try {
+		await harness.waitForOpen();
+		assert.match(harness.render().join("\n"), /Ctrl\+Q cancel/);
+		assert.match(harness.render().join("\n"), /F6 cycle/);
+		assert.deepEqual(view?.render(0), []);
+		for (const width of [1, 12, 32, 80])
+			assert.ok(harness.render(width).every((line) => visibleWidth(line) <= width));
+		harness.send("\u001b[17~");
+		assert.equal(cycles, 1);
+		harness.type("steering");
+		harness.press("tui.input.submit");
+		assert.deepEqual(submitted, ["steering"]);
+		harness.send("\u001b[113;5:3u");
+		assert.equal(view?.signal.aborted, false);
+		harness.send("\u0011");
+		assert.equal(await running, "cancelled");
+		assert.equal(view?.signal.aborted, true);
+	} finally {
+		harness.dispose();
+	}
+});
+
+test("unavailable shortcuts have no activation hint and bring-to-main stays unavailable without answered turns", async () => {
+	initTheme("dark");
+	const harness = createTuiHarness({ width: 160, rows: 24 });
+	let changes = 0;
+	const keys = new KeybindingsManager(definitions, {
+		"app.thinking.cycle": "ctrl+c",
+		"tui.editor.undo": "ctrl+r",
+	});
+	const running = harness.custom<TranscriptPagerAction>((tui, theme, keybindings, done) => {
+		setBtwShortcuts(tui, resolveBtwShortcuts({}, keys));
+		return new BtwTranscriptPager(tui, theme, [], done, {
+			thinking: {
+				level: "low",
+				levels: ["low", "high"],
+				keybindings,
+				onChange() {
+					changes += 1;
+				},
+			},
+		});
+	});
+	try {
+		await harness.waitForOpen();
+		assert.doesNotMatch(harness.render().join("\n"), /cycle|bring to main/);
+		harness.press("ctrl+c");
+		assert.deepEqual(await running, { kind: "close" });
+		assert.equal(changes, 0);
+	} finally {
+		harness.dispose();
+	}
+});

--- a/packages/pi-btw/test/keybinding-settings.test.ts
+++ b/packages/pi-btw/test/keybinding-settings.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { normalizeBtwSettings, readBtwSettings, updateBtwSettings } from "../src/settings.js";
+
+function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+async function withSettings(run: (path: string) => Promise<void>) {
+	const directory = await mkdtemp(join(tmpdir(), "btw-keybindings-"));
+	try {
+		await run(join(directory, "pi-btw.json"));
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}
+
+test.each([
+	null,
+	[],
+	"ctrl+q",
+	{ exit: [] },
+	{ exit: null },
+	{ exit: "meta+q" },
+	{ cycleThinkingLevel: "ctrl+f1" },
+	{ bringToMain: "\u001b" },
+])("invalid keybindings protect the file from writes: %j", async (keybindings) => {
+	assert.equal(normalizeBtwSettings({ keybindings }), undefined);
+	await withSettings(async (path) => {
+		const original = JSON.stringify({ keybindings, future: true });
+		await writeFile(path, original);
+		assert.equal((await readBtwSettings(path)).kind, "invalid");
+		await assert.rejects(
+			updateBtwSettings({ keybindings: { exit: "ctrl+q" } }, { settingsPath: path }),
+			/invalid/,
+		);
+		assert.equal(await readFile(path, "utf8"), original);
+	});
+});
+
+test("keybinding writes normalize reads, preserve nested unknowns and reset only owned fields", async () => {
+	await withSettings(async (path) => {
+		assert.deepEqual(await readBtwSettings(path), { kind: "missing" });
+		await assert.rejects(readFile(path), { code: "ENOENT" });
+		await updateBtwSettings(
+			{ keybindings: { exit: "CTRL+Q", cycleThinkingLevel: "f6" } },
+			{ settingsPath: path },
+		);
+		assert.deepEqual(await readBtwSettings(path), {
+			kind: "loaded",
+			settings: { keybindings: { exit: "ctrl+q", cycleThinkingLevel: "f6" } },
+		});
+		await writeFile(
+			path,
+			JSON.stringify({
+				future: { keep: true },
+				thinkingLevel: "low",
+				keybindings: { exit: "ctrl+q", cycleThinkingLevel: "f6", future: { keep: true } },
+			}),
+		);
+		await updateBtwSettings(
+			{ keybindings: { exit: undefined, bringToMain: "f7" } },
+			{ settingsPath: path },
+		);
+		const saved = JSON.parse(await readFile(path, "utf8"));
+		assert.deepEqual(saved, {
+			future: { keep: true },
+			thinkingLevel: "low",
+			keybindings: { cycleThinkingLevel: "f6", bringToMain: "f7", future: { keep: true } },
+		});
+		await updateBtwSettings(
+			{ keybindings: { cycleThinkingLevel: undefined, bringToMain: undefined } },
+			{ settingsPath: path },
+		);
+		assert.deepEqual(JSON.parse(await readFile(path, "utf8")).keybindings, {
+			future: { keep: true },
+		});
+	});
+});
+
+test("reset removes an empty override object without materializing default keys", async () => {
+	await withSettings(async (path) => {
+		await updateBtwSettings({ keybindings: { exit: "f6" } }, { settingsPath: path });
+		await updateBtwSettings({ keybindings: { exit: undefined } }, { settingsPath: path });
+		assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {});
+	});
+});
+
+test("queued key edits and resets merge against latest data, coordinate reads, and recover after failure", async () => {
+	await withSettings(async (path) => {
+		const reached = deferred();
+		const release = deferred();
+		const first = updateBtwSettings(
+			{ keybindings: { exit: "f6" } },
+			{
+				settingsPath: path,
+				beforeRename: async () => {
+					reached.resolve();
+					await release.promise;
+				},
+			},
+		);
+		await reached.promise;
+		const second = updateBtwSettings(
+			{ keybindings: { bringToMain: "f7" } },
+			{ settingsPath: path },
+		);
+		const reset = updateBtwSettings({ keybindings: { exit: undefined } }, { settingsPath: path });
+		const reading = readBtwSettings(path);
+		release.resolve();
+		await Promise.all([first, second, reset]);
+		assert.deepEqual(await reading, {
+			kind: "loaded",
+			settings: { keybindings: { bringToMain: "f7" } },
+		});
+		const original = await readFile(path, "utf8");
+		await assert.rejects(
+			updateBtwSettings(
+				{ keybindings: { exit: "f8" } },
+				{
+					settingsPath: path,
+					beforeRename: async () => {
+						throw new Error("disk failed");
+					},
+				},
+			),
+			/disk failed/,
+		);
+		assert.equal(await readFile(path, "utf8"), original);
+		await updateBtwSettings({ keybindings: { exit: "f9" } }, { settingsPath: path });
+		assert.deepEqual(JSON.parse(await readFile(path, "utf8")).keybindings, {
+			exit: "f9",
+			bringToMain: "f7",
+		});
+		assert.deepEqual(await readdir(join(path, "..")), ["pi-btw.json"]);
+	});
+});

--- a/packages/pi-btw/test/keybindings.test.ts
+++ b/packages/pi-btw/test/keybindings.test.ts
@@ -3,6 +3,7 @@ import {
 	isKittyProtocolActive,
 	KeybindingsManager,
 	matchesKey,
+	StdinBuffer,
 	setKittyProtocolActive,
 	TUI_KEYBINDINGS,
 } from "@earendil-works/pi-tui";
@@ -219,6 +220,48 @@ test("keypad input follows the same conflict and activation identity", () => {
 	const shortcuts = resolveBtwShortcuts({ exit: "ctrl+1" }, manager());
 	assert.equal(shortcuts.matches("\u001b[57399;5u", "exit"), false);
 	assert.equal(shortcuts.matches("\u001b[57400;5u", "exit"), true);
+});
+
+test.each([
+	[{ exit: "shift+tab" }, ["ctrl+c"], ["shift+tab"], ["ctrl+r"]],
+	[{ cycleThinkingLevel: "ctrl+r" }, ["ctrl+c"], ["shift+tab"], ["ctrl+r"]],
+	[{ exit: "f6", cycleThinkingLevel: "f6" }, ["ctrl+c"], ["shift+tab"], ["ctrl+r"]],
+	[{ exit: "shift+tab", cycleThinkingLevel: "ctrl+r" }, ["ctrl+c"], ["shift+tab"], ["ctrl+r"]],
+	[{ exit: "shift+tab", cycleThinkingLevel: "f6" }, ["shift+tab", "ctrl+c"], ["f6"], ["ctrl+r"]],
+] as const)("resolves the complete shortcut proposal %j", (overrides, exit, cycle, bring) => {
+	const resolved = resolveBtwShortcuts(overrides, manager());
+	assert.deepEqual(resolved.keys, { exit, cycleThinkingLevel: cycle, bringToMain: bring });
+	if (exit.length === 1) assert.ok(resolved.warnings.length);
+});
+
+test("Pi stdin buffering delivers complete pastes across every delimiter split", () => {
+	const start = "\u001b[200~";
+	const end = "\u001b[201~";
+	for (let opening = 1; opening < start.length; opening++) {
+		for (let closing = 1; closing < end.length; closing++) {
+			const buffer = new StdinBuffer();
+			const guard = new BtwPasteGuard();
+			const events: boolean[] = [];
+			buffer.on("data", (data) => events.push(guard.consume(data)));
+			// ProcessTerminal.setupStdinBuffer uses this exact paste rewrapping boundary.
+			buffer.on("paste", (data) => events.push(guard.consume(`${start}${data}${end}`)));
+			try {
+				for (const chunk of [
+					start.slice(0, opening),
+					start.slice(opening),
+					"x".repeat(10000),
+					"\u0003",
+					end.slice(0, closing),
+					end.slice(closing),
+					"\u0003",
+				])
+					buffer.process(chunk);
+				assert.deepEqual(events, [true, false]);
+			} finally {
+				buffer.destroy();
+			}
+		}
+	}
 });
 
 test("paste guard covers whole, split, repeated and closed bracketed payloads", () => {

--- a/packages/pi-btw/test/keybindings.test.ts
+++ b/packages/pi-btw/test/keybindings.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import {
+	isKittyProtocolActive,
+	KeybindingsManager,
+	matchesKey,
+	setKittyProtocolActive,
+	TUI_KEYBINDINGS,
+} from "@earendil-works/pi-tui";
+import { afterEach, test, vi } from "vitest";
+import {
+	BtwPasteGuard,
+	btwKeysOverlap,
+	normalizeBtwKey,
+	resolveBtwShortcuts,
+	validateBtwShortcutEdit,
+} from "../src/keybindings.js";
+
+const initialKitty = isKittyProtocolActive();
+afterEach(() => {
+	setKittyProtocolActive(initialKitty);
+	vi.unstubAllEnvs();
+});
+function manager(bindings: Record<string, string | string[]> = {}) {
+	return new KeybindingsManager(
+		{
+			...TUI_KEYBINDINGS,
+			"app.thinking.cycle": { defaultKeys: "shift+tab" },
+			"app.message.copy": { defaultKeys: "ctrl+x" },
+		},
+		bindings as never,
+	);
+}
+
+test.each([
+	["CTRL+SHIFT+P", "shift+ctrl+p"],
+	["alt+ctrl+x", "alt+ctrl+x"],
+	["esc", "escape"],
+	["return", "enter"],
+	["pageUp", "pageup"],
+	["shift+clear", "shift+clear"],
+	["ctrl+clear", "ctrl+clear"],
+	["f12", "f12"],
+	["super+k", "super+k"],
+	["ctrl+_", "ctrl+_"],
+	["meta+x", undefined],
+	["ctrl+ctrl+x", undefined],
+	["ctrl+", undefined],
+	["ctrl++", undefined],
+	["ctrl+escape", undefined],
+	["shift+f1", undefined],
+	["alt+clear", undefined],
+	["constructor", undefined],
+	[" ctrl+x", undefined],
+	["ctrl+\u001b", undefined],
+	["f13", undefined],
+	["ctrl+unknown", undefined],
+])("normalizes strict BTW key syntax %s", (input, expected) => {
+	assert.equal(normalizeBtwKey(input), expected);
+});
+
+test.each([
+	["esc", "escape"],
+	["return", "enter"],
+	["ctrl+shift+p", "shift+ctrl+p"],
+	["ctrl+i", "tab"],
+	["ctrl+m", "enter"],
+	["ctrl+j", "enter"],
+	["ctrl+[", "escape"],
+	["ctrl+-", "ctrl+_"],
+	["ctrl+h", "backspace"],
+	["alt+b", "alt+left"],
+	["alt+f", "alt+right"],
+	["alt+p", "alt+up"],
+	["alt+n", "alt+down"],
+	["ctrl+alt+h", "alt+backspace"],
+	["ctrl+alt+m", "alt+enter"],
+	["ctrl+x", "unknown+ctrl+x"],
+])("detects live legacy matcher overlap: %s / %s", (first, second) => {
+	setKittyProtocolActive(false);
+	vi.stubEnv("WT_SESSION", "");
+	assert.equal(btwKeysOverlap(first, second), true);
+});
+
+test("mode-dependent and Windows Terminal collisions follow Pi rather than string identity", () => {
+	setKittyProtocolActive(true);
+	assert.equal(btwKeysOverlap("alt+b", "alt+left"), false);
+	assert.equal(btwKeysOverlap("ctrl+j", "shift+enter"), true);
+	assert.equal(btwKeysOverlap("ctrl+j", "enter"), false);
+	assert.equal(btwKeysOverlap("ctrl+alt+m", "alt+enter"), false);
+	setKittyProtocolActive(false);
+	assert.equal(btwKeysOverlap("ctrl+alt+i", "alt+tab"), false);
+	vi.stubEnv("WT_SESSION", "test");
+	for (const name of ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]) vi.stubEnv(name, "");
+	assert.equal(btwKeysOverlap("ctrl+h", "ctrl+backspace"), true);
+	assert.equal(btwKeysOverlap("ctrl+h", "backspace"), false);
+	vi.stubEnv("SSH_TTY", "/dev/pts/1");
+	assert.equal(btwKeysOverlap("ctrl+h", "backspace"), true);
+});
+
+test("defaults, explicit overrides, first usable inherited fallback and release filtering", () => {
+	const defaults = resolveBtwShortcuts({}, manager());
+	assert.deepEqual(defaults.keys, {
+		exit: ["ctrl+c"],
+		cycleThinkingLevel: ["shift+tab"],
+		bringToMain: ["ctrl+r"],
+	});
+	assert.deepEqual(defaults.warnings, []);
+	const custom = resolveBtwShortcuts(
+		{ exit: "ctrl+q", cycleThinkingLevel: "f6", bringToMain: "f7" },
+		manager(),
+	);
+	assert.equal(custom.matches("\u0011", "exit"), true);
+	assert.equal(custom.matches("\u0003", "exit"), true);
+	assert.equal(custom.matches("\u001b[17~", "cycleThinkingLevel"), true);
+	assert.equal(custom.matches("\u001b[18~", "bringToMain"), true);
+	assert.equal(custom.matches("\u0012", "bringToMain"), false);
+	assert.equal(custom.matches("\u001b[113;5:3u", "exit"), false);
+	assert.equal(custom.label("exit"), "Ctrl+Q");
+	const fallback = resolveBtwShortcuts(
+		{},
+		manager({ "app.thinking.cycle": ["ctrl+c", "alt+clear", "ctrl+i", "f6", "f7"] }),
+	);
+	assert.deepEqual(fallback.keys.cycleThinkingLevel, ["f6", "f7"]);
+	assert.equal(fallback.label("cycleThinkingLevel"), "F6");
+});
+
+test("explicit Pi printable thinking bindings remain inherited but new overrides cannot take text", () => {
+	const inherited = resolveBtwShortcuts({}, manager({ "app.thinking.cycle": "t" }));
+	assert.equal(inherited.matches("t", "cycleThinkingLevel"), true);
+	assert.ok(validateBtwShortcutEdit("cycleThinkingLevel", "t", {}, manager(), true));
+	assert.deepEqual(resolveBtwShortcuts({}, manager({ "app.thinking.cycle": [] })).warnings, []);
+});
+
+test.each([
+	"ctrl+b",
+	"ctrl+i",
+	"ctrl+j",
+	"ctrl+m",
+	"ctrl+[",
+	"alt+enter",
+	"shift+space",
+	"shift+backspace",
+	"ctrl+shift+f",
+	"pageup",
+	"escape",
+	"x",
+	"shift+x",
+])("rejects reserved editor, viewport and text binding %s", (key) => {
+	assert.ok(validateBtwShortcutEdit("exit", key, {}, manager(), true));
+});
+
+test("edits reject alias conflicts, preserve other defaults, and allow recovery resets", () => {
+	assert.ok(validateBtwShortcutEdit("exit", "ctrl+r", {}, manager(), true));
+	assert.ok(validateBtwShortcutEdit("exit", "shift+tab", {}, manager(), true));
+	assert.ok(
+		validateBtwShortcutEdit("bringToMain", "alt+ctrl+x", { exit: "ctrl+alt+x" }, manager(), true),
+	);
+	assert.equal(validateBtwShortcutEdit("exit", "ctrl+q", {}, manager(), true), undefined);
+	assert.equal(validateBtwShortcutEdit("exit", "ctrl+c", {}, manager(), true), undefined);
+	assert.equal(
+		validateBtwShortcutEdit(
+			"exit",
+			undefined,
+			{ exit: "ctrl+b", bringToMain: "ctrl+b" },
+			manager(),
+			true,
+		),
+		undefined,
+	);
+});
+
+test("non-default editor/viewport/copy bindings win; stale overrides warn and fall back", () => {
+	const keys = manager({ "tui.editor.historyPrevious": "ctrl+q", "tui.altScreen.bottom": "f6" });
+	assert.ok(validateBtwShortcutEdit("exit", "ctrl+q", {}, keys, true));
+	assert.ok(validateBtwShortcutEdit("cycleThinkingLevel", "f6", {}, keys, true));
+	assert.equal(validateBtwShortcutEdit("exit", "ctrl+x", {}, keys, true), undefined);
+	assert.ok(validateBtwShortcutEdit("exit", "ctrl+x", {}, keys, false));
+	const fallback = resolveBtwShortcuts({ exit: "ctrl+q", cycleThinkingLevel: "f6" }, keys);
+	assert.deepEqual(fallback.keys.exit, ["ctrl+c"]);
+	assert.deepEqual(fallback.keys.cycleThinkingLevel, ["shift+tab"]);
+	assert.equal(fallback.warnings.length, 2);
+	const unavailable = resolveBtwShortcuts(
+		{},
+		manager({ "tui.editor.undo": "ctrl+r", "app.thinking.cycle": "ctrl+c" }),
+	);
+	assert.deepEqual(unavailable.keys.bringToMain, []);
+	assert.deepEqual(unavailable.keys.cycleThinkingLevel, []);
+	assert.equal(unavailable.label("bringToMain"), "Unavailable");
+});
+
+test.each([
+	"\u001b[112;6u",
+	"\u001b[80;6u",
+	"\u001b[112;70u",
+	"\u001b[27;6;80~",
+	"\u001b[1095::112;6u",
+])("matches normalized terminal encoding %j", (input) => {
+	const shortcuts = resolveBtwShortcuts({ cycleThinkingLevel: "ctrl+shift+p" }, manager());
+	assert.equal(matchesKey(input, "ctrl+shift+p"), true);
+	assert.equal(shortcuts.matches(input, "cycleThinkingLevel"), true);
+});
+
+test("hints and matching revalidate after asynchronous terminal negotiation changes mode", () => {
+	setKittyProtocolActive(true);
+	const shortcuts = resolveBtwShortcuts(
+		{ exit: "alt+b" },
+		manager({ "tui.editor.cursorWordLeft": "alt+left" }),
+	);
+	assert.equal(shortcuts.label("exit"), "Alt+B");
+	setKittyProtocolActive(false);
+	assert.equal(shortcuts.label("exit"), "Ctrl+C");
+	assert.equal(shortcuts.matches("\u001bb", "exit"), false);
+	assert.equal(shortcuts.matches("\u0003", "exit"), true);
+	setKittyProtocolActive(true);
+	assert.equal(shortcuts.label("exit"), "Alt+B");
+});
+
+test("keypad input follows the same conflict and activation identity", () => {
+	const shortcuts = resolveBtwShortcuts({ exit: "ctrl+1" }, manager());
+	assert.equal(shortcuts.matches("\u001b[57399;5u", "exit"), false);
+	assert.equal(shortcuts.matches("\u001b[57400;5u", "exit"), true);
+});
+
+test("paste guard covers whole, split, repeated and closed bracketed payloads", () => {
+	const guard = new BtwPasteGuard();
+	assert.equal(guard.consume("normal"), false);
+	assert.equal(guard.consume("\u001b[200~text"), true);
+	assert.equal(guard.consume("\u0003"), true);
+	assert.equal(guard.consume("\u001b[201~"), true);
+	assert.equal(guard.consume("\u0003"), false);
+	assert.equal(guard.consume("\u001b[200~\u0011\u001b[201~"), true);
+	assert.equal(guard.consume("\u0011"), false);
+});

--- a/packages/pi-btw/test/menu.test.ts
+++ b/packages/pi-btw/test/menu.test.ts
@@ -3,9 +3,9 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { KeybindingsManager, TUI_KEYBINDINGS, visibleWidth } from "@earendil-works/pi-tui";
 import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import { createMockContext } from "../../../test/support.js";
 import { runBtwMenuPreservingEditor, showBtwCommandMenu } from "../src/menu.js";
 import { BTW_SETTINGS_FILE } from "../src/settings.js";
@@ -19,7 +19,14 @@ async function withMenu(
 	}) => Promise<void>,
 ): Promise<void> {
 	const directory = await mkdtemp(join(tmpdir(), "pi-btw-menu-test-"));
-	const tui = createTuiHarness({ width: 80, rows: 24 });
+	const tui = createTuiHarness({
+		width: 80,
+		rows: 24,
+		keybindings: new KeybindingsManager({
+			...TUI_KEYBINDINGS,
+			"app.thinking.cycle": { defaultKeys: "shift+tab" },
+		}) as never,
+	});
 	const mock = createMockContext({
 		mode: "tui",
 		hasUI: true,
@@ -214,6 +221,133 @@ test("btw Resume choice returns to the main menu with Back and closes with Ctrl+
 		assert.equal(await running, "closed");
 		assert.equal(ctx.ui.getEditorText(), "draft");
 		await assert.rejects(readFile(settingsPath, "utf8"), { code: "ENOENT" });
+	});
+});
+
+test.each([
+	["exit", "Exit shortcut", "ctrl+q", "Ctrl+Q"],
+	["cycleThinkingLevel", "Cycle thinking level shortcut", "f6", "F6"],
+	["bringToMain", "Bring to main shortcut", "f7", "F7"],
+])(
+	"BTW Settings edits and resets %s without changing the main draft",
+	async (action, label, key, display) => {
+		await withMenu(async ({ settingsPath, tui, ctx }) => {
+			const running = showBtwCommandMenu(ctx, {
+				settingsPath,
+				currentThinkingLevel: "low",
+				availableThinkingLevels: ["off", "low"],
+			});
+			await openSettings(tui);
+			tui.type(label);
+			tui.press("tui.select.confirm");
+			await vi.waitFor(() => assert.match(tui.render().join("\n"), /Edit key combination/));
+			tui.press("tui.select.confirm");
+			await vi.waitFor(() => assert.match(tui.render().join("\n"), /Type a key name/));
+			tui.type(key);
+			tui.press("tui.input.submit");
+			await vi.waitFor(() => assert.ok(tui.render().join("\n").includes(`Custom (${display})`)));
+			assert.equal(JSON.parse(await readFile(settingsPath, "utf8")).keybindings[action], key);
+			tui.press("tui.select.down");
+			tui.press("tui.select.confirm");
+			await vi.waitFor(() => assert.match(tui.render().join("\n"), /Pi BTW Settings/));
+			assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {});
+			tui.press("ctrl+c");
+			assert.equal(await running, "closed");
+			assert.equal(ctx.ui.getEditorText(), "draft");
+		});
+	},
+);
+
+test.each(["invalid", "cancel", "failed-save", "dispose", "concurrent"])(
+	"shortcut editing handles %s without publishing a changed binding",
+	async (scenario) => {
+		await withMenu(async ({ settingsPath, tui, ctx, notifications }) => {
+			await writeFile(settingsPath, '{"keybindings":{"exit":"f6"},"future":true}');
+			let started = false;
+			let aborted = false;
+			const running = showBtwCommandMenu(ctx, {
+				settingsPath,
+				currentThinkingLevel: "low",
+				availableThinkingLevels: ["off", "low"],
+				...(scenario === "failed-save" || scenario === "dispose"
+					? {
+							updateSettings: async (_patch: unknown, options: { signal?: AbortSignal }) => {
+								started = true;
+								if (scenario === "failed-save") throw new Error("disk unavailable");
+								await new Promise<void>((resolve) =>
+									options.signal?.addEventListener(
+										"abort",
+										() => {
+											aborted = true;
+											resolve();
+										},
+										{ once: true },
+									),
+								);
+								throw new Error("disposed");
+							},
+						}
+					: {}),
+			});
+			await openSettings(tui);
+			tui.type("Exit shortcut");
+			tui.press("tui.select.confirm");
+			await vi.waitFor(() => assert.match(tui.render().join("\n"), /Edit key combination/));
+			tui.press("tui.select.confirm");
+			await vi.waitFor(() => assert.match(tui.render().join("\n"), /Type a key name/));
+			tui.type(scenario === "invalid" ? "ctrl+i" : "ctrl+q");
+			if (scenario === "cancel") {
+				tui.press("tui.select.cancel");
+				await vi.waitFor(() => assert.match(tui.render().join("\n"), /Custom \(F6\)/));
+			} else {
+				if (scenario === "concurrent")
+					await writeFile(
+						settingsPath,
+						JSON.stringify({
+							keybindings: { exit: "f6", cycleThinkingLevel: "ctrl+q" },
+							future: true,
+						}),
+					);
+				tui.press("tui.input.submit");
+				if (scenario === "dispose") {
+					await vi.waitFor(() => assert.equal(started, true));
+					tui.dispose();
+				} else {
+					await vi.waitFor(() =>
+						assert.ok(notifications.some((notice) => notice.level === "error")),
+					);
+				}
+			}
+			if (scenario !== "dispose") tui.press("ctrl+c");
+			assert.equal(await running, "closed");
+			assert.equal(aborted, scenario === "dispose");
+			assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+				keybindings: {
+					exit: "f6",
+					...(scenario === "concurrent" ? { cycleThinkingLevel: "ctrl+q" } : {}),
+				},
+				future: true,
+			});
+		});
+	},
+);
+
+test("Settings distinguishes a conflicting saved shortcut from its effective fallback", async () => {
+	await withMenu(async ({ settingsPath, tui, ctx }) => {
+		await writeFile(settingsPath, '{"keybindings":{"exit":"ctrl+b"}}');
+		const running = showBtwCommandMenu(ctx, {
+			settingsPath,
+			currentThinkingLevel: "low",
+			availableThinkingLevels: ["off", "low"],
+		});
+		await openSettings(tui);
+		tui.type("Exit shortcut");
+		assert.match(tui.render(160).join("\n"), /Fallback \(Ctrl\+C; saved Ctrl\+B\)/);
+		tui.press("ctrl+c");
+		assert.equal(await running, "closed");
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			keybindings: { exit: "ctrl+b" },
+		});
 	});
 });
 

--- a/packages/pi-btw/test/side-thread.test.ts
+++ b/packages/pi-btw/test/side-thread.test.ts
@@ -753,7 +753,7 @@ test("side-thread sends custom APIs through Pi core's effective provider", async
 							fg: (_color: string, text: string) => text,
 							bold: (text: string) => text,
 						} as never,
-						{} as never,
+						keybindings() as never,
 						resolve as never,
 					);
 				});


### PR DESCRIPTION
## Summary
Configure Exit, Cycle thinking level, and Bring to main through `/btw` → Settings. Preserve existing defaults, Pi's global bindings, and permanent Ctrl+C hard cancellation. Add conflict-aware matching and effective hints, field-level resets, atomic ordered persistence, and regression coverage. Includes a minor Changeset; no publication requested or performed.

## Verification
- `npm run check`: passed (build, Biome, boundaries, workspace typechecks).
- `npm exec -- vitest run packages/pi-btw/test`: 297 tests passed in 13 files.
- `npx tsc -p tsconfig.test.json --noEmit`: passed.
- `npm run package:pack -- btw`: passed; actual npm-pack tarball inspected (17 expected files).
- Generated runtime/Jiti loader tests and native TuiMainScreen/TuiAltScreen deterministic smokes passed: custom exit, permanent Ctrl+C, thinking cycling, bring-to-main, expanded/split paste, streaming cancellation, nested overlays, input drain and parent restoration.
- Signed commit and staged Biome/affected build/typecheck hooks passed.

## Blockers and unverified paths
Draft because the complete root `npm test` fails outside BTW: 20 failed files, 361 passed; 55 failed tests, 4,191 passed, one skipped. No BTW failures. Predominantly five-second timeouts plus the github-pr periodic-refresh assertion. Focused tests on unchanged `origin/main` (`09d0f4d4`) reproduce that assertion and sync timeouts; not every root failure is proven baseline. No unrelated packages changed and no test timeout increased.

Physical terminal/emulator and live-provider smokes were not run: interactive processes are prohibited in this execution environment. Native terminal-pipeline tests are deterministic substitutes, not a claim of manual verification.

Retained [execution plan](docs/plans/2026-09-08_pi-btw-keybindings-plan.md) with unchecked full-gate/manual-acceptance/deletion criteria; end-to-end completion is not claimed.

## Semantic audit
Reviewed `docs/extension-conventions.md`, `docs/extension-settings.md`, and `docs/readme-conventions.md`. Test/Review/Validator/Smoke evidence covers settings protection, unknown-field preservation, queued revalidation, atomicity and rollback; cancellation/disposal/session invalidation and terminal handoff; real Pi matcher aliases, legacy/Kitty collisions and negotiation changes; input focus, paste, narrow rendering, effective hints and fallback; non-TUI guards and standalone generated runtime boundaries. Model-visible context, tool definitions, command routing, dependencies and global settings remain unchanged. The slightly over-1,000-line command coordinator retains its existing injectable seams with an adjacent rationale comment.
