### PR TITLE
fix(usage): safely report Z.AI credentials without a coding plan

### DIFF
--- a/.changeset/plenty-hoops-shine.md
+++ b/.changeset/plenty-hoops-shine.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Report the explicit Z.AI no-GLM-Coding-Plan response as unsupported instead of publishing a usage error to the statusline. Preserve query failures and scheduled retries for malformed quota responses, and omit provider error messages to avoid exposing echoed credentials.

--- a/.changeset/plenty-hoops-shine.md
+++ b/.changeset/plenty-hoops-shine.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-usage": patch
 ---
 
-Report the explicit Z.AI no-GLM-Coding-Plan response as unsupported instead of publishing a usage error to the statusline. Preserve query failures and scheduled retries for malformed quota responses, and omit provider error messages to avoid exposing echoed credentials.
+Report the explicit Z.AI no-GLM-Coding-Plan response as unsupported instead of publishing a usage error to the statusline. Invalidate previously cached usage when a credential becomes unsupported. Preserve query failures and scheduled retries for malformed quota responses, and omit provider error messages to avoid exposing echoed credentials.

--- a/packages/pi-usage/docs/providers.md
+++ b/packages/pi-usage/docs/providers.md
@@ -259,6 +259,8 @@ The extension classifies both forms by the provider's window unit and does not l
 The quota monitor expects a raw API key without a `Bearer` prefix.
 The extension removes that prefix from resolved authorization before sending it to the monitor endpoint.
 Fingerprinting and redaction keep using the original resolved credential.
-A credential with no coding plan answers HTTP 200 without a data object; that is reported as `Unsupported` rather than a query failure, so the statusline stays empty.
+The observed no-plan response (HTTP 200, `code: 500`, `success: false`, `msg: "当前用户不存在coding plan"`, and absent or null `data`) is reported as `Unsupported`, so the statusline stays empty.
+Other missing or malformed quota data remains a query failure with scheduled retries.
+These quota validation errors do not echo the provider's `msg`, which may contain credentials.
 The plan endpoint only contributes the plan name and renewal date; when it is unavailable or fails, the quota windows remain reported and the plan note falls back to the quota response's plan level.
 Only the official `api.z.ai` and `open.bigmodel.cn` origins are queried; other origins fail before sending the credential.

--- a/packages/pi-usage/src/core.ts
+++ b/packages/pi-usage/src/core.ts
@@ -36,6 +36,10 @@ export class UsageCache {
 		this.entries.set(key, { createdAt: now, report });
 	}
 
+	delete(providerId: string, fingerprint: string): void {
+		this.entries.delete(cacheKey(providerId, fingerprint));
+	}
+
 	clearProvider(providerId: string): void {
 		for (const key of this.entries.keys()) {
 			if (key.startsWith(`${providerId}:`)) this.entries.delete(key);

--- a/packages/pi-usage/src/providers/zai.ts
+++ b/packages/pi-usage/src/providers/zai.ts
@@ -19,13 +19,21 @@ export function normalizeZaiQuotaPayload(
 	plan?: ZaiPlanInfo,
 ): UsageReport {
 	const data = asObject(payload.data);
-	// A credential with no coding plan answers HTTP 200 with no data object:
-	// {"code":500,"msg":"当前用户不存在coding plan","success":false}. API usage is not metered.
 	if (!data) {
-		const reason = asString(payload.msg);
-		throw new UsageUnsupportedError(
-			`No GLM Coding Plan on this Z.AI credential; API usage is not metered.${reason ? ` Z.AI reported: ${reason}` : ""}`,
-		);
+		// Only the observed no-plan response establishes that this credential cannot be metered.
+		// Missing or malformed data alone can also indicate a transient provider failure.
+		if (
+			(payload.data === undefined || payload.data === null) &&
+			payload.code === 500 &&
+			payload.success === false &&
+			payload.msg === "当前用户不存在coding plan"
+		) {
+			throw new UsageUnsupportedError(
+				"No GLM Coding Plan on this Z.AI credential; API usage is not metered.",
+			);
+		}
+		// Do not echo msg: truncating provider text before redaction can expose secret prefixes.
+		throw new Error("Z.AI quota response data was not an object.");
 	}
 	const limits = Array.isArray(data.limits) ? (data.limits as unknown[]) : [];
 

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -191,6 +191,8 @@ export type OpenCodeZenPayload = {
 };
 
 export type ZaiQuotaPayload = {
+	code?: unknown;
+	success?: unknown;
 	msg?: unknown;
 	data?: unknown;
 };

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -491,6 +491,8 @@ export default function usageExtension(
 			// Unsupported is throttled like a failure, so a credential the provider cannot meter does
 			// not re-query on every turn; the entry carries its status so the replay stays unsupported.
 			if (queryId === undefined || latestQueries.get(failureKey) === queryId) {
+				// A definitive unsupported verdict invalidates ready data even after backoff expires.
+				if (status === "unsupported") cache.delete(adapter.id, queryFingerprint);
 				setBoundedMap(
 					failureBackoff,
 					failureKey,

--- a/packages/pi-usage/test/core.test.ts
+++ b/packages/pi-usage/test/core.test.ts
@@ -60,6 +60,18 @@ test("usage cache isolates identities, expires entries, and remains bounded", ()
 	assert.equal(cache.size, 0);
 });
 
+test("usage cache deletion preserves other credentials and providers", () => {
+	const cache = new UsageCache(300_000);
+	cache.set("zai", "account-a", report, 1_000);
+	cache.set("zai", "account-b", report, 1_000);
+	cache.set("zai-coding-cn", "account-a", report, 1_000);
+	cache.delete("zai", "account-a");
+	cache.delete("zai", "account-a");
+	assert.equal(cache.get("zai", "account-a", 1_001), undefined);
+	assert.equal(cache.get("zai", "account-b", 1_001), report);
+	assert.equal(cache.get("zai-coding-cn", "account-a", 1_001), report);
+});
+
 test("bounded orchestration retains stable partial results and respects cancellation", async () => {
 	let active = 0;
 	let maximumActive = 0;

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
+import { UsageUnsupportedError } from "../src/core.js";
 import {
 	formatUsageReport,
 	formatUsageStatusline,
@@ -288,10 +289,7 @@ test("Z.AI adapter derives window length and label from the payload window numbe
 });
 
 test("Z.AI adapter rejects malformed or empty quota responses", () => {
-	assert.throws(
-		() => normalizeZaiQuotaPayload("zai", "Z.AI", {}, 0),
-		/No GLM Coding Plan on this Z\.AI credential/,
-	);
+	assert.throws(() => normalizeZaiQuotaPayload("zai", "Z.AI", {}, 0), /not an object/);
 	assert.throws(
 		() => normalizeZaiQuotaPayload("zai", "Z.AI", { data: { limits: [] } }, 0),
 		/no displayable usage data/,
@@ -300,6 +298,75 @@ test("Z.AI adapter rejects malformed or empty quota responses", () => {
 		() => normalizeZaiQuotaPayload("zai", "Z.AI", { data: { limits: "broken" } }, 0),
 		/no displayable usage data/,
 	);
+});
+
+test("Z.AI only classifies the explicit no-plan response as unsupported", () => {
+	const noPlan = { code: 500, success: false, msg: "当前用户不存在coding plan" };
+	for (const data of [undefined, null]) {
+		assert.throws(
+			() => normalizeZaiQuotaPayload("zai", "Z.AI", { ...noPlan, data }, 0),
+			(error: unknown) =>
+				error instanceof UsageUnsupportedError &&
+				error.message === "No GLM Coding Plan on this Z.AI credential; API usage is not metered.",
+		);
+	}
+	for (const payload of [
+		{},
+		{ data: [] },
+		{ ...noPlan, data: [] },
+		{ ...noPlan, data: "broken" },
+		{ ...noPlan, data: false },
+		{ ...noPlan, data: 0 },
+		{ ...noPlan, data: {} },
+		{ ...noPlan, code: undefined },
+		{ ...noPlan, code: "500" },
+		{ ...noPlan, code: 401 },
+		{ ...noPlan, success: undefined },
+		{ ...noPlan, success: true },
+		{ ...noPlan, success: "false" },
+		{ ...noPlan, msg: undefined },
+		{ ...noPlan, msg: "Internal server error" },
+		{ ...noPlan, msg: `${noPlan.msg} extra details` },
+	]) {
+		assert.throws(
+			() => normalizeZaiQuotaPayload("zai", "Z.AI", payload, 0),
+			(error: unknown) => error instanceof Error && !(error instanceof UsageUnsupportedError),
+			JSON.stringify(payload),
+		);
+	}
+});
+
+test("Z.AI quota errors do not echo credentials across message truncation boundaries", async () => {
+	const secret = "s".repeat(100);
+	try {
+		for (const [providerId, baseUrl] of ZAI_ORIGINS) {
+			const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === providerId);
+			assert.ok(adapter);
+			const auth = zaiUsageAuth({ ...ZAI_MODEL, provider: providerId, baseUrl }, secret);
+			for (const msg of [secret, `当前用户不存在coding plan ${secret}`, `Invalid key: ${secret}`]) {
+				vi.stubGlobal(
+					"fetch",
+					zaiFetchStub(
+						[],
+						() => new Response(JSON.stringify({ code: 500, success: false, msg }), { status: 200 }),
+					),
+				);
+				await assert.rejects(
+					() =>
+						queryProviderUsage(adapter, auth, new AbortController().signal, 5_000, async () => {}),
+					(error: unknown) => {
+						assert.ok(error instanceof Error);
+						assert.equal(error.message, "Z.AI quota response data was not an object.");
+						assert.ok(!error.message.includes(secret.slice(0, 20)));
+						assert.ok(!(error instanceof UsageUnsupportedError));
+						return true;
+					},
+				);
+			}
+		}
+	} finally {
+		vi.unstubAllGlobals();
+	}
 });
 
 test("Z.AI adapters query the official quota and plan endpoints with the raw API key", async () => {
@@ -590,6 +657,48 @@ test("Z.AI usage resolves only official origins", async () => {
 		});
 		const auth = await resolveUsageAuth(ctx, adapter);
 		assert.deepEqual(auth?.headers, { Authorization: "Bearer official-key" });
+	}
+});
+
+test("malformed Z.AI quota responses keep the error chip and scheduled recovery", async () => {
+	vi.useFakeTimers();
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const { ctx, statuses } = createMockContext({
+		model: ZAI_MODEL,
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: "zai-secret-key" } }),
+			getAvailable: () => [ZAI_MODEL],
+			getAll: () => [ZAI_MODEL],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: () => "Z.AI",
+		},
+	});
+	let quotaPayload: object = {};
+	vi.stubGlobal(
+		"fetch",
+		zaiFetchStub(
+			[],
+			(url) =>
+				new Response(
+					JSON.stringify(
+						url.endsWith("/subscription/list") ? ZAI_SUBSCRIPTION_PAYLOAD : quotaPayload,
+					),
+					{ status: 200 },
+				),
+		),
+	);
+	try {
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await vi.advanceTimersByTimeAsync(0);
+		assert.equal(statuses.get("usage"), "usage err: Z.AI quota response data was not an object.");
+		quotaPayload = ZAI_QUOTA_PAYLOAD;
+		await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+		assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk");
+	} finally {
+		await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
 	}
 });
 

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -702,9 +702,70 @@ test("malformed Z.AI quota responses keep the error chip and scheduled recovery"
 	}
 });
 
+test("a no-plan refresh invalidates ready usage beyond the unsupported backoff", async () => {
+	const mock = createMockPi();
+	usageExtension(mock.pi);
+	const actions = ["Refresh current usage", "Close"];
+	const { ctx, statuses } = createMockContext({
+		hasUI: true,
+		mode: "rpc",
+		model: ZAI_MODEL,
+		select: async () => actions.shift() ?? "Close",
+		modelRegistry: {
+			getProviderAuth: async () => ({ auth: { apiKey: "zai-secret-key" } }),
+			getAvailable: () => [ZAI_MODEL],
+			getAll: () => [ZAI_MODEL],
+			getProviderAuthStatus: () => ({ configured: true }),
+			getProviderDisplayName: () => "Z.AI",
+		},
+	});
+	let quotaPayload: object = ZAI_QUOTA_PAYLOAD;
+	const requests: Array<{ url: string; authorization: string | undefined }> = [];
+	const now = Date.now();
+	const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+	vi.stubGlobal(
+		"fetch",
+		zaiFetchStub(
+			requests,
+			(url) =>
+				new Response(
+					JSON.stringify(
+						url.endsWith("/subscription/list") ? ZAI_SUBSCRIPTION_PAYLOAD : quotaPayload,
+					),
+					{ status: 200 },
+				),
+		),
+	);
+	try {
+		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await vi.waitFor(() => assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk"));
+		assert.equal(requests.length, 2);
+		quotaPayload = { code: 500, success: false, msg: "当前用户不存在coding plan" };
+		await mock.commands.get("usage")?.handler("", ctx);
+		assert.equal(statuses.get("usage"), undefined);
+		assert.equal(requests.length, 4);
+		await mock.events.get("turn_start")?.[0]?.({}, ctx);
+		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
+		assert.equal(requests.length, 4);
+		clock.mockReturnValue(now + 30_001);
+		await mock.events.get("turn_start")?.[0]?.({}, ctx);
+		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
+		assert.equal(requests.length, 6);
+		quotaPayload = ZAI_QUOTA_PAYLOAD;
+		clock.mockReturnValue(now + 60_002);
+		await mock.events.get("turn_start")?.[0]?.({}, ctx);
+		await vi.waitFor(() => assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk"));
+		assert.equal(requests.length, 8);
+	} finally {
+		await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+		clock.mockRestore();
+		vi.unstubAllGlobals();
+	}
+});
+
 // Both API and coding plan credentials use the same coding base URL, so the no-plan answer is the
 // only signal that a credential carries no subscription.
-test("a Z.AI credential with no coding plan leaves the statusline empty", async () => {
+test("a Z.AI credential with no coding plan leaves the statusline empty", async (t) => {
 	const noCodingPlan = { code: 500, msg: "当前用户不存在coding plan", success: false };
 	vi.stubGlobal(
 		"fetch",
@@ -724,10 +785,11 @@ test("a Z.AI credential with no coding plan leaves the statusline empty", async 
 			},
 		});
 
+		t.onTestFinished(async () => {
+			await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+		});
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
-		for (let index = 0; index < 8; index += 1) {
-			await new Promise<void>((resolve) => setImmediate(resolve));
-		}
+		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
 
 		assert.equal(statuses.get("usage"), undefined);
 	} finally {
@@ -737,7 +799,7 @@ test("a Z.AI credential with no coding plan leaves the statusline empty", async 
 
 // The verdict does not change on retry, so it is throttled like a failure instead of re-querying
 // the quota and plan endpoints on every turn.
-test("an unsupported Z.AI credential is throttled instead of re-queried each turn", async () => {
+test("an unsupported Z.AI credential is throttled instead of re-queried each turn", async (t) => {
 	const noCodingPlan = { code: 500, msg: "当前用户不存在coding plan", success: false };
 	const requests: Array<{ url: string; authorization: string | undefined }> = [];
 	vi.stubGlobal(
@@ -758,12 +820,14 @@ test("an unsupported Z.AI credential is throttled instead of re-queried each tur
 			},
 		});
 
+		t.onTestFinished(async () => {
+			await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+		});
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
+		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
 		for (let turn = 0; turn < 3; turn += 1) {
 			await mock.events.get("turn_start")?.[0]?.({}, ctx);
-			for (let index = 0; index < 8; index += 1) {
-				await new Promise<void>((resolve) => setImmediate(resolve));
-			}
+			await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
 		}
 
 		assert.equal(statuses.get("usage"), undefined);


### PR DESCRIPTION
## Summary

Follow-up to #1227, including its original implementation and two review fixes. This PR targets main directly and can replace #1227; it does not require that PR to merge first.

- Report the explicit Z.AI no-coding-plan response as unsupported, keeping the statusline empty and preserving the 30-second request backoff.
- Keep malformed or unrelated error responses as query failures, preserving the error chip and scheduled recovery.
- Omit provider error messages to prevent echoed credential prefixes from escaping redaction through truncation.
- Add classification, credential-exposure, and scheduled-recovery regression tests; update provider documentation and the patch changeset.

## Verification

- Regression tests failed before the fixes and passed afterward.
- npm run check passed.
- All 241 pi-usage tests passed with two workers, including generated-entry coverage.
- Full npm test hit the 300-second command limit after failures outside pi-usage.
- The affected-test run had one generated-entry timeout; that test passed in the package rerun.
- Audited against docs/extension-conventions.md for error classification, message handling, backoff, status cleanup, and release scope.
- Live-provider and interactive smokes were not run. No settings or runtime-loading changes.