### PR TITLE
feat(herdr): add persistent widget settings menu

### DIFF
--- a/.changeset/tidy-herdr-widget-settings.md
+++ b/.changeset/tidy-herdr-widget-settings.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-herdr": minor
+---
+
+Add a /herdr menu with a persistent agent-widget toggle, status, and help. Keep the widget enabled by default and lifecycle reporting independent of visibility.

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -8,7 +8,7 @@ Connect Pi's interactive lifecycle to Herdr and bootstrap the operating guidance
 
 - Reports Pi session identity and `working`, `blocked`, and `idle` lifecycle states to the current Herdr pane.
 - Publishes bounded `model`, `provider`, `thinking`, `session`, and `context_usage` tokens for Herdr sidebar rows.
-- Shows recognized sibling agents from the current Herdr workspace in a passive widget above Pi's editor.
+- Shows recognized sibling agents from the current Herdr workspace in a passive widget above Pi's editor, with a saved visibility toggle in `/herdr`.
 - Updates the widget from Herdr pane lifecycle and agent-status events without polling the CLI.
 - Coalesces rapid state changes and retries short-lived local socket failures without interrupting Pi.
 - Derives blocked state from Pi's public `ui_prompt_start` and `ui_prompt_end` lifecycle events.
@@ -55,6 +55,31 @@ rm -rf ~/.agents/skills/herdr
 ```
 
 Run `/reload` or restart Pi after changing the installed resources.
+
+## 💬 Commands
+
+`/herdr` opens a menu to toggle the agent widget and view status or help, inspired by `/tool`.
+It accepts no arguments and is available inside Herdr in TUI and RPC modes; print and JSON modes reject it.
+RPC can save the preference but does not display the widget.
+Changes apply immediately and closing the menu does not undo saved changes.
+
+## ⚙️ Settings
+
+Toggle **Agent widget** in `/herdr`, or edit `<getAgentDir()>/pi-herdr.json` (normally `~/.pi/agent/pi-herdr.json`):
+
+```json
+{
+  "widget": false
+}
+```
+
+`widget` accepts only `true` or `false` and defaults to `true` when absent.
+Only user settings are supported; project files are not read.
+Manual edits apply after `/reload` or the next session start.
+Missing files are not created until an explicit save. Invalid files trigger a warning, use defaults, and block saves until repaired.
+Saves preserve unknown fields and use atomic temporary-file-plus-rename publication, with reads and writes ordered within one Pi process, not across processes.
+Failed saves restore the previous effective value and leave the existing file untouched.
+Turning the widget off closes its subscription and pending requests without disabling lifecycle or metadata reporting.
 
 ## 🔄 Lifecycle reporting
 
@@ -135,7 +160,7 @@ Command recipes, approval handling, and other operating safety rules come from t
 ## 🚧 Limitations
 
 - Lifecycle reporting, metadata reporting, and the agent widget are disabled in RPC, JSON, and print modes.
-- The widget has no settings for placement, workspace scope, visibility, or row count.
+- The widget has no settings for placement, workspace scope, or row count.
 - The widget cannot show blocked prompt text because Herdr does not expose it through public pane responses.
 - Herdr exposes no rename event, so agent and pane renames appear after the next topology refresh, reconnect, Pi `/reload`, or session start rather than immediately.
 - Integration requires a running compatible Herdr session and valid injected environment variables.

--- a/packages/pi-herdr/src/herdr-agent-state.ts
+++ b/packages/pi-herdr/src/herdr-agent-state.ts
@@ -11,6 +11,11 @@ import {
 } from "./herdr-metadata.js";
 import { createHerdrWidgetObserver, type HerdrWidgetObserver } from "./herdr-observer.js";
 
+import {
+	createHerdrSettingsController,
+	type HerdrSettingsOptions,
+} from "./herdr-settings-controller.js";
+
 const SOURCE = "herdr:pi";
 
 export type AgentState = "working" | "blocked" | "idle";
@@ -35,7 +40,7 @@ interface QueuedMetadata {
 	generation: number;
 }
 
-export interface HerdrAgentStateOptions {
+export interface HerdrAgentStateOptions extends HerdrSettingsOptions {
 	environment?: HerdrEnvironment;
 	now?: () => number;
 	random?: () => number;
@@ -89,6 +94,7 @@ export function createHerdrAgentStateExtension(
 
 	return function herdrAgentState(pi: ExtensionAPI): void {
 		if (!environment.enabled) return;
+		const widget = createHerdrSettingsController(pi, widgetObserver, options);
 
 		let sessionGeneration = 0;
 		let sessionController = new AbortController();
@@ -340,18 +346,21 @@ export function createHerdrAgentStateExtension(
 			sessionController = new AbortController();
 			activeSession = ctx.sessionManager;
 			rootSession = ctx.mode === "tui";
-			if (rootSession) widgetObserver.start(ctx);
+			const widgetStart = widget.start(ctx);
 			agentActive = false;
 			blockedCount = 0;
 			blockedMessage = undefined;
 			lastState = undefined;
 			lastMessage = undefined;
-			if (!rootSession) return;
+			if (!rootSession) {
+				await widgetStart;
+				return;
+			}
 
 			updateSessionRef(ctx);
 			const sessionReport = reportSession(event.reason);
 			publishMetadata(ctx);
-			await sessionReport;
+			await Promise.all([sessionReport, widgetStart]);
 			if (generation !== sessionGeneration || sessionController.signal.aborted || !rootSession) {
 				return;
 			}
@@ -382,7 +391,7 @@ export function createHerdrAgentStateExtension(
 
 		pi.on("session_shutdown", async (_event, ctx) => {
 			if (ctx.sessionManager !== activeSession) {
-				await Promise.allSettled([widgetObserver.shutdown(ctx)]);
+				await Promise.allSettled([widget.shutdown(ctx)]);
 				return;
 			}
 			if (shutdownTask && shutdownSession === ctx.sessionManager) {
@@ -400,7 +409,7 @@ export function createHerdrAgentStateExtension(
 				sessionController.abort(new DOMException("Herdr session shut down", "AbortError"));
 				queuedState = undefined;
 				queuedMetadata = undefined;
-				await Promise.allSettled([drainTask, metadataDrainTask, widgetObserver.shutdown(ctx)]);
+				await Promise.allSettled([drainTask, metadataDrainTask, widget.shutdown(ctx)]);
 				const stillOwnsShutdown =
 					shutdownGeneration === sessionGeneration && activeSession === session && !rootSession;
 				if (shouldClearMetadata && stillOwnsShutdown) {

--- a/packages/pi-herdr/src/herdr-menu.ts
+++ b/packages/pi-herdr/src/herdr-menu.ts
@@ -1,0 +1,55 @@
+import type { MenuDefinition } from "@narumitw/pi-tui-kit";
+
+export function createHerdrMenu(options: {
+	settingsPath: string;
+	isEnabled(): boolean;
+	toggle(signal: AbortSignal): Promise<boolean>;
+}): MenuDefinition<undefined, "main" | "status" | "help", "toggle"> {
+	return {
+		start: "main",
+		screens: {
+			// One setting stays on the main menu, matching /tool rather than adding a submenu.
+			main: () => ({
+				kind: "actions",
+				title: "Herdr",
+				items: [
+					{
+						id: "widget",
+						label: `Agent widget: ${options.isEnabled() ? "On" : "Off"}`,
+						description: "Show or hide sibling agents above the editor",
+						action: "toggle",
+					},
+					{ id: "status", label: "Status", to: "status" },
+					{ id: "help", label: "Help", to: "help" },
+					{ id: "close", label: "Close", close: true },
+				],
+				hint: "close",
+			}),
+			status: () => ({
+				kind: "detail",
+				title: "Herdr Status",
+				lines: [
+					`Agent widget setting: ${options.isEnabled() ? "on" : "off"}`,
+					"The widget appears only in TUI mode with recognized sibling agents.",
+					"Lifecycle and metadata reporting are independent of this setting.",
+					`User settings file: ${options.settingsPath}`,
+				],
+				hint: "back",
+			}),
+			help: () => ({
+				kind: "detail",
+				title: "Herdr Help",
+				lines: [
+					"Toggle Agent widget from /herdr. Changes are saved immediately; closing does not undo them.",
+					"Manual pi-herdr.json changes apply after /reload or the next session start.",
+					"The widget defaults to on. Project overrides are not read.",
+				],
+				hint: "back",
+			}),
+		},
+		actions: {
+			toggle: async ({ signal }) =>
+				(await options.toggle(signal)) ? { kind: "stay" } : { kind: "rejected" },
+		},
+	};
+}

--- a/packages/pi-herdr/src/herdr-settings-controller.ts
+++ b/packages/pi-herdr/src/herdr-settings-controller.ts
@@ -1,0 +1,135 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { HerdrWidgetObserver } from "./herdr-observer.js";
+import {
+	awaitHerdrSettingsWrites,
+	herdrSettingsPath,
+	readHerdrSettings,
+	updateHerdrSettings,
+} from "./settings.js";
+
+export interface HerdrSettingsOptions {
+	settingsPath?: string;
+}
+
+export function createHerdrSettingsController(
+	pi: ExtensionAPI,
+	observer: HerdrWidgetObserver,
+	options: HerdrSettingsOptions = {},
+) {
+	const settingsPath = options.settingsPath ?? herdrSettingsPath();
+	let generation = 0;
+	let owner: ExtensionContext | undefined;
+	let controller = new AbortController();
+	let enabled = true;
+	let changes = Promise.resolve();
+	let menuOpen = false;
+	const current = (expected: number) => expected === generation && !controller.signal.aborted;
+
+	pi.registerCommand("herdr", {
+		description: "Configure the Herdr agent widget",
+		handler: async (args, ctx) => {
+			if (args.trim()) throw new Error("/herdr does not accept arguments.");
+			if (!ctx.hasUI || (ctx.mode !== "tui" && ctx.mode !== "rpc")) {
+				throw new Error("/herdr requires TUI or RPC mode.");
+			}
+			if (!owner || ctx.sessionManager !== owner.sessionManager || menuOpen) return;
+			const expected = generation;
+			const signal = controller.signal;
+			menuOpen = true;
+			try {
+				const [{ runMenu }, { createHerdrMenu }] = await Promise.all([
+					import("@narumitw/pi-tui-kit"),
+					import("./herdr-menu.js"),
+				]);
+				if (!current(expected)) return;
+				await runMenu(
+					ctx,
+					createHerdrMenu({
+						settingsPath,
+						isEnabled: () => enabled,
+						toggle: (actionSignal) => {
+							const result = changes.then(async () => {
+								if (actionSignal.aborted || !current(expected) || !owner) return false;
+								// Once accepted, finish the explicit save even if the menu closes.
+								// Session replacement still prevents stale runtime publication.
+								const previous = enabled;
+								const actionOwner = owner;
+								try {
+									enabled = !previous;
+									if (enabled && actionOwner.mode === "tui") observer.start(actionOwner);
+									else await observer.shutdown(actionOwner);
+									if (!current(expected)) return false;
+									await updateHerdrSettings({ widget: enabled }, { settingsPath });
+									return current(expected);
+								} catch {
+									if (!current(expected)) return false;
+									enabled = previous;
+									try {
+										if (previous && actionOwner.mode === "tui") observer.start(actionOwner);
+										else await observer.shutdown(actionOwner);
+									} finally {
+										if (current(expected))
+											ctx.ui.notify(
+												"Herdr settings were not saved; the previous widget setting was restored. Check pi-herdr.json and its permissions.",
+												"warning",
+											);
+									}
+									return false;
+								}
+							});
+							changes = result.then(
+								() => undefined,
+								() => undefined,
+							);
+							return result;
+						},
+					}),
+					{
+						getState: () => undefined,
+						signal,
+						isCurrent: () => current(expected),
+						onError: () => {
+							if (current(expected))
+								ctx.ui.notify("The Herdr menu could not be displayed.", "error");
+						},
+					},
+				);
+			} finally {
+				if (expected === generation) menuOpen = false;
+			}
+		},
+	});
+
+	return {
+		async start(ctx: ExtensionContext) {
+			const expected = ++generation;
+			controller.abort();
+			controller = new AbortController();
+			menuOpen = false;
+			const previous = owner;
+			owner = ctx;
+			if (previous) await observer.shutdown(previous);
+			if (!current(expected)) return;
+			await changes;
+			if (!current(expected)) return;
+			const loaded = await readHerdrSettings(settingsPath);
+			if (!current(expected)) return;
+			enabled = loaded.settings.widget;
+			if (loaded.kind === "invalid" && ctx.hasUI)
+				ctx.ui.notify(
+					"Herdr ignored invalid pi-herdr.json settings and kept the widget enabled. Fix the file before saving.",
+					"warning",
+				);
+			if (enabled && ctx.mode === "tui") observer.start(ctx);
+		},
+		async shutdown(ctx: ExtensionContext) {
+			if (ctx.sessionManager !== owner?.sessionManager) return;
+			generation += 1;
+			controller.abort();
+			owner = undefined;
+			menuOpen = false;
+			await Promise.all([observer.shutdown(ctx), changes]);
+			await awaitHerdrSettingsWrites(settingsPath);
+		},
+	};
+}

--- a/packages/pi-herdr/src/settings.ts
+++ b/packages/pi-herdr/src/settings.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const HERDR_SETTINGS_FILE = "pi-herdr.json";
+const MAX_SETTINGS_BYTES = 64 * 1024;
+
+export interface HerdrSettings {
+	widget: boolean;
+}
+
+export type HerdrSettingsLoadResult =
+	| { kind: "missing"; settings: HerdrSettings }
+	| { kind: "invalid"; reason: string; settings: HerdrSettings }
+	| { kind: "loaded"; settings: HerdrSettings };
+
+export interface UpdateHerdrSettingsOptions {
+	settingsPath?: string;
+	beforeRename?: (temporaryPath: string, settingsPath: string) => Promise<void>;
+}
+
+type SettingsDocument = Record<string, unknown>;
+const DEFAULT_SETTINGS: HerdrSettings = { widget: true };
+const queues = new Map<string, Promise<void>>();
+
+export function herdrSettingsPath(): string {
+	return join(getAgentDir(), HERDR_SETTINGS_FILE);
+}
+
+export function normalizeHerdrSettings(value: unknown): HerdrSettings | undefined {
+	if (!isRecord(value)) return undefined;
+	if (Object.hasOwn(value, "widget") && typeof value.widget !== "boolean") {
+		return undefined;
+	}
+	return {
+		widget: typeof value.widget === "boolean" ? value.widget : DEFAULT_SETTINGS.widget,
+	};
+}
+
+export function readHerdrSettings(
+	settingsPath = herdrSettingsPath(),
+): Promise<HerdrSettingsLoadResult> {
+	return enqueue(settingsPath, async () => {
+		let document: SettingsDocument;
+		try {
+			document = await readSettingsDocument(settingsPath);
+		} catch (error) {
+			if (isNodeError(error) && error.code === "ENOENT") {
+				return { kind: "missing", settings: { ...DEFAULT_SETTINGS } };
+			}
+			return {
+				kind: "invalid",
+				reason: `${settingsPath}: ${safeError(error)}`,
+				settings: { ...DEFAULT_SETTINGS },
+			};
+		}
+		const settings = normalizeHerdrSettings(document);
+		return settings
+			? { kind: "loaded", settings }
+			: {
+					kind: "invalid",
+					reason: `${settingsPath}: invalid settings shape`,
+					settings: { ...DEFAULT_SETTINGS },
+				};
+	});
+}
+
+export function updateHerdrSettings(
+	patch: Partial<HerdrSettings>,
+	options: UpdateHerdrSettingsOptions = {},
+): Promise<HerdrSettings> {
+	const settingsPath = options.settingsPath ?? herdrSettingsPath();
+	return enqueue(settingsPath, async () => {
+		const current = await readDocumentForUpdate(settingsPath);
+		const updated = { ...current, ...patch };
+		const settings = normalizeHerdrSettings(updated);
+		if (!settings) throw new Error(`Pi Herdr settings at ${settingsPath} have an invalid shape.`);
+		await publishSettings(settingsPath, updated, options);
+		return settings;
+	});
+}
+
+export async function awaitHerdrSettingsWrites(settingsPath = herdrSettingsPath()): Promise<void> {
+	await queues.get(settingsPath);
+}
+
+function enqueue<T>(path: string, operation: () => Promise<T>): Promise<T> {
+	const previous = queues.get(path) ?? Promise.resolve();
+	const result = previous.then(operation, operation);
+	const settled = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	queues.set(path, settled);
+	void settled.finally(() => {
+		if (queues.get(path) === settled) queues.delete(path);
+	});
+	return result;
+}
+
+async function readDocumentForUpdate(path: string): Promise<SettingsDocument> {
+	try {
+		const document = await readSettingsDocument(path);
+		if (!normalizeHerdrSettings(document)) throw new Error("invalid settings shape");
+		return document;
+	} catch (error) {
+		if (isNodeError(error) && error.code === "ENOENT") return {};
+		throw new Error(`Pi Herdr settings at ${path} are invalid: ${safeError(error)}`);
+	}
+}
+
+async function readSettingsDocument(path: string): Promise<SettingsDocument> {
+	const pathStats = await lstat(path);
+	if (pathStats.isSymbolicLink() || !pathStats.isFile()) {
+		throw new Error("settings path is not a regular file");
+	}
+	if (pathStats.size > MAX_SETTINGS_BYTES) {
+		throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+	}
+	const noFollow = constants.O_NOFOLLOW ?? 0;
+	const handle = await open(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0) | noFollow);
+	try {
+		const stats = await handle.stat();
+		if (!stats.isFile() || stats.dev !== pathStats.dev || stats.ino !== pathStats.ino) {
+			throw new Error("settings path changed while opening");
+		}
+		const buffer = Buffer.alloc(MAX_SETTINGS_BYTES + 1);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+		}
+		if (offset > MAX_SETTINGS_BYTES) {
+			throw new Error(`settings file exceeds ${MAX_SETTINGS_BYTES} bytes`);
+		}
+		let contents: string;
+		try {
+			contents = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+				buffer.subarray(0, offset),
+			);
+		} catch {
+			throw new Error("settings file is not valid UTF-8");
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(contents) as unknown;
+		} catch {
+			throw new Error("invalid JSON");
+		}
+		if (!isRecord(parsed)) throw new Error("settings document must be a JSON object");
+		return parsed;
+	} finally {
+		await handle.close();
+	}
+}
+
+async function publishSettings(
+	path: string,
+	document: SettingsDocument,
+	options: UpdateHerdrSettingsOptions,
+): Promise<void> {
+	const contents = `${JSON.stringify(document, null, 2)}\n`;
+	if (Buffer.byteLength(contents) > MAX_SETTINGS_BYTES) {
+		throw new Error(`Pi Herdr settings document exceeds ${MAX_SETTINGS_BYTES} bytes.`);
+	}
+	const directory = dirname(path);
+	await mkdir(directory, { recursive: true });
+	const temporaryPath = join(directory, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporaryPath, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		await options.beforeRename?.(temporaryPath, path);
+		await rename(temporaryPath, path);
+	} catch (error) {
+		await rm(temporaryPath, { force: true }).catch(() => undefined);
+		throw error;
+	}
+}
+
+function isRecord(value: unknown): value is SettingsDocument {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}
+
+function safeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-herdr/test/herdr-agent-state.test.ts
+++ b/packages/pi-herdr/test/herdr-agent-state.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -585,6 +585,26 @@ test("shutdown aborts a delayed session report before it can publish state", asy
 	);
 	await flushReporting();
 	assert.equal(requests.length, requestCount);
+});
+
+test("a disabled widget does not disable lifecycle or metadata reporting", async () => {
+	const settingsPath = join(agentDir, "disabled-widget.json");
+	await writeFile(settingsPath, JSON.stringify({ widget: false }));
+	const requests: HerdrRequest[] = [];
+	const mock = createMockPi();
+	const start = vi.fn();
+	herdrModule.createHerdrAgentStateExtension({
+		...enabledOptions(requests),
+		settingsPath,
+		widgetObserver: { start, async shutdown() {} },
+	})(mock.pi);
+	const ctx = tuiContext().ctx;
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	await flushReporting();
+	assert.equal(start.mock.calls.length, 0);
+	assert.ok(requests.some(({ method }) => method === "pane.report_metadata"));
+	assert.equal(stateRequests(requests).at(-1)?.params.state, "idle");
+	await emit(mock, "session_shutdown", {}, ctx);
 });
 
 test("package resources load one extension and the bundled herdr skill", async () => {

--- a/packages/pi-herdr/test/herdr-settings-controller.test.ts
+++ b/packages/pi-herdr/test/herdr-settings-controller.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { type ExtensionCommandContext, initTheme } from "@earendil-works/pi-coding-agent";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test, vi } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import { createHerdrSettingsController } from "../src/herdr-settings-controller.js";
+
+import { updateHerdrSettings } from "../src/settings.js";
+
+initTheme("dark", false);
+
+async function setup(mode: "tui" | "rpc" = "tui") {
+	const root = await mkdtemp(join(tmpdir(), "herdr-menu-"));
+	const settingsPath = join(root, "pi-herdr.json");
+	const mock = createMockPi();
+	const observer = { start: vi.fn(), shutdown: vi.fn(async () => {}) };
+	const controller = createHerdrSettingsController(mock.pi, observer, { settingsPath });
+	const context = createMockContext({ mode, hasUI: true });
+	await controller.start(context.ctx);
+	const command = mock.commands.get("herdr");
+	assert.ok(command);
+	return {
+		...context,
+		ctx: context.ctx as ExtensionCommandContext,
+		controller,
+		observer,
+		command,
+		settingsPath,
+		async close() {
+			await controller.shutdown(context.ctx);
+			await rm(root, { recursive: true, force: true });
+		},
+	};
+}
+
+test("RPC toggles persist in order without starting a widget and reload the saved value", async () => {
+	const h = await setup("rpc");
+	try {
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "Agent widget: On" },
+			{ kind: "select", response: "Agent widget: Off" },
+			{ kind: "select", response: "Agent widget: On" },
+			{ kind: "select", response: "Status" },
+			{ kind: "select", response: "Back" },
+			{ kind: "select", response: "Help" },
+			{ kind: "select", response: "Back" },
+			{ kind: "select", response: "Close" },
+		]);
+		await h.command.handler("", { ...h.ctx, ui: { ...h.ctx.ui, ...rpc.ui } });
+		rpc.assertConsumed();
+		assert.deepEqual(JSON.parse(await readFile(h.settingsPath, "utf8")), { widget: false });
+		assert.equal(h.observer.start.mock.calls.length, 0);
+		await h.controller.start({ ...h.ctx, mode: "tui" });
+		assert.equal(h.observer.start.mock.calls.length, 0);
+	} finally {
+		await h.close();
+	}
+});
+
+test("TUI switches the observer immediately and cancellation leaves saved settings intact", async () => {
+	const h = await setup();
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	try {
+		const running = h.command.handler("", { ...h.ctx, ui: { ...h.ctx.ui, custom: tui.custom } });
+		await tui.waitForOpen();
+		assert.match(stripVTControlCharacters(tui.render().join("\n")), /Agent widget: On/u);
+		tui.press("tui.select.confirm");
+		await vi.waitFor(async () =>
+			assert.equal(JSON.parse(await readFile(h.settingsPath, "utf8")).widget, false),
+		);
+		assert.equal(h.observer.shutdown.mock.calls.length, 1);
+		await tui.waitForOpen();
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(JSON.parse(await readFile(h.settingsPath, "utf8")).widget, false);
+	} finally {
+		await h.close();
+	}
+});
+
+test("invalid files block saving, restore the observer, and warn without exposing file contents", async () => {
+	const h = await setup();
+	try {
+		await writeFile(h.settingsPath, '{"widget":"secret"}');
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "Agent widget: On" },
+			{ kind: "select", response: "Close" },
+		]);
+		await h.command.handler("", { ...h.ctx, mode: "rpc", ui: { ...h.ctx.ui, ...rpc.ui } });
+		rpc.assertConsumed();
+		assert.equal(h.observer.start.mock.calls.length, 2);
+		assert.equal(await readFile(h.settingsPath, "utf8"), '{"widget":"secret"}');
+		assert.match(h.notifications[0]?.message ?? "", /previous widget setting was restored/u);
+		await h.controller.start(h.ctx);
+		assert.match(h.notifications.at(-1)?.message ?? "", /ignored invalid/u);
+	} finally {
+		await h.close();
+	}
+});
+
+test("session replacement closes an open menu and stale commands cannot mutate settings", async () => {
+	const h = await setup();
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	try {
+		const running = h.command.handler("", { ...h.ctx, ui: { ...h.ctx.ui, custom: tui.custom } });
+		await tui.waitForOpen();
+		const next = createMockContext({ mode: "tui", hasUI: true });
+		await h.controller.start(next.ctx);
+		await running;
+		assert.equal(h.observer.shutdown.mock.calls.length, 1);
+		await h.command.handler("", h.ctx);
+		await assert.rejects(readFile(h.settingsPath), { code: "ENOENT" });
+		await h.controller.shutdown(h.ctx);
+		assert.equal(h.observer.shutdown.mock.calls.length, 1);
+		await h.controller.shutdown(next.ctx);
+	} finally {
+		await h.close();
+	}
+});
+
+test("replacement waits for pending writes and ignores an older settings load", async () => {
+	const h = await setup();
+	let release!: () => void;
+	let ready!: () => void;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const reached = new Promise<void>((resolve) => {
+		ready = resolve;
+	});
+	const write = updateHerdrSettings(
+		{ widget: false },
+		{
+			settingsPath: h.settingsPath,
+			beforeRename: async () => {
+				ready();
+				await gate;
+			},
+		},
+	);
+	try {
+		await reached;
+		const staleStart = h.controller.start(h.ctx);
+		const next = createMockContext({ mode: "tui", hasUI: true });
+		const currentStart = h.controller.start(next.ctx);
+		release();
+		await Promise.all([write, staleStart, currentStart]);
+		assert.equal(
+			h.observer.start.mock.calls.length,
+			1,
+			"neither start may use the pre-write value",
+		);
+		await h.controller.shutdown(next.ctx);
+	} finally {
+		release();
+		await write;
+		await h.close();
+	}
+});
+
+test("disposing the menu without choosing an action does not create settings", async () => {
+	const h = await setup();
+	const tui = createTuiHarness({ width: 80, rows: 24 });
+	try {
+		const running = h.command.handler("", { ...h.ctx, ui: { ...h.ctx.ui, custom: tui.custom } });
+		await tui.waitForOpen();
+		tui.dispose();
+		await running;
+		await assert.rejects(readFile(h.settingsPath), { code: "ENOENT" });
+	} finally {
+		await h.close();
+	}
+});
+
+test("arguments and headless modes are rejected before opening UI", async () => {
+	const h = await setup();
+	try {
+		await assert.rejects(async () => {
+			await h.command.handler("on", h.ctx);
+		}, /does not accept arguments/u);
+		for (const mode of ["print", "json"] as const) {
+			await assert.rejects(async () => {
+				await h.command.handler("", { ...h.ctx, mode, hasUI: false });
+			}, /requires TUI or RPC/u);
+		}
+	} finally {
+		await h.close();
+	}
+});

--- a/packages/pi-herdr/test/settings.test.ts
+++ b/packages/pi-herdr/test/settings.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { lstat, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { HERDR_SETTINGS_FILE, readHerdrSettings, updateHerdrSettings } from "../src/settings.js";
+
+async function withSettings(run: (path: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "pi-herdr-settings-"));
+	try {
+		await run(join(root, "nested", HERDR_SETTINGS_FILE));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("missing settings are side-effect free and default the widget to on", async () => {
+	await withSettings(async (path) => {
+		assert.deepEqual(await readHerdrSettings(path), {
+			kind: "missing",
+			settings: { widget: true },
+		});
+		await assert.rejects(lstat(path), { code: "ENOENT" });
+	});
+});
+
+test("loads explicit booleans and treats an absent field as on", async () => {
+	await withSettings(async (path) => {
+		await updateHerdrSettings({ widget: true }, { settingsPath: path });
+		assert.deepEqual(await readHerdrSettings(path), {
+			kind: "loaded",
+			settings: { widget: true },
+		});
+		await writeFile(path, JSON.stringify({ future: { keep: true } }), "utf8");
+		assert.deepEqual(await readHerdrSettings(path), {
+			kind: "loaded",
+			settings: { widget: true },
+		});
+	});
+});
+
+test("ordered atomic saves preserve unknown fields", async () => {
+	await withSettings(async (path) => {
+		await updateHerdrSettings({ widget: false }, { settingsPath: path });
+		await writeFile(path, JSON.stringify({ widget: false, future: { keep: true } }), "utf8");
+		const first = updateHerdrSettings({ widget: true }, { settingsPath: path });
+		const second = updateHerdrSettings({ widget: false }, { settingsPath: path });
+		await Promise.all([first, second]);
+		const document = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+		assert.equal(document.widget, false);
+		assert.deepEqual(document.future, { keep: true });
+		if (process.platform !== "win32") assert.equal((await lstat(path)).mode & 0o777, 0o600);
+	});
+});
+
+test("reads wait for earlier writes to publish the latest snapshot", async () => {
+	await withSettings(async (path) => {
+		await updateHerdrSettings({ widget: false }, { settingsPath: path });
+		let releaseRename!: () => void;
+		const renameGate = new Promise<void>((resolve) => {
+			releaseRename = resolve;
+		});
+		const update = updateHerdrSettings(
+			{ widget: true },
+			{ settingsPath: path, beforeRename: async () => renameGate },
+		);
+		const read = readHerdrSettings(path);
+		releaseRename();
+		await update;
+		assert.equal((await read).settings.widget, true);
+	});
+});
+
+test("malformed and invalid files stay untouched and block saves", async () => {
+	await withSettings(async (path) => {
+		await updateHerdrSettings({ widget: false }, { settingsPath: path });
+		for (const contents of ["{broken", '{"widget":"yes"}']) {
+			await writeFile(path, contents, "utf8");
+			const loaded = await readHerdrSettings(path);
+			assert.equal(loaded.kind, "invalid");
+			assert.equal(loaded.settings.widget, true);
+			await assert.rejects(
+				updateHerdrSettings({ widget: true }, { settingsPath: path }),
+				/invalid/u,
+			);
+			assert.equal(await readFile(path, "utf8"), contents);
+		}
+	});
+});
+
+test("publication failure preserves the previous valid document and queue recovery", async () => {
+	await withSettings(async (path) => {
+		await updateHerdrSettings({ widget: false }, { settingsPath: path });
+		const before = await readFile(path, "utf8");
+		await assert.rejects(
+			updateHerdrSettings(
+				{ widget: true },
+				{
+					settingsPath: path,
+					beforeRename: async () => Promise.reject(new Error("injected stop")),
+				},
+			),
+			/injected stop/u,
+		);
+		assert.equal(await readFile(path, "utf8"), before);
+		await updateHerdrSettings({ widget: true }, { settingsPath: path });
+		assert.equal((await readHerdrSettings(path)).settings.widget, true);
+	});
+});


### PR DESCRIPTION
## Summary

Add a `/herdr` menu inspired by `/tool` to enable or disable the agent widget, with Status and Help views. The widget remains enabled by default, and changing its visibility does not disable Herdr lifecycle or metadata reporting.

Persist the user preference in `pi-herdr.json` with validation, ordered atomic saves, unknown-field preservation, and recovery after failed saves. Guard menu and observer work across cancellation, shutdown, and session replacement. Include documentation and a minor Changeset.

## Verification

- `npm run check` passed.
- `npm test` passed: 380 test files, 4,179 tests.
- `npm run package:pack -- herdr` passed; actual npm tarball contents inspected.
- Pi package-directory RPC smoke passed: command registration and lazy menu open/close.
- README heading audit passed for all 29 packages.
- Audited commands, settings persistence, cancellation/disposal, session replacement, and shutdown against `docs/extension-conventions.md` and `docs/extension-settings.md`.
- The single setting stays on the main menu, matching `/tool`, rather than adding a Settings submenu.
- Live terminal TUI and trusted-project `/reload` were not manually exercised; deterministic TUI and lifecycle tests cover these paths.
