### PR TITLE
fix(sync): reserve persistent attention for review conditions

### DIFF
--- a/.changeset/quiet-sync-attention.md
+++ b/.changeset/quiet-sync-attention.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Reserve persistent sync widgets and RPC warnings for review conditions. Show ordinary one-sided changes through status, keep setup and empty-remote initialization guidance in the manager, and preserve observations and transfer safety checks.

--- a/packages/pi-sync/README.md
+++ b/packages/pi-sync/README.md
@@ -131,14 +131,15 @@ Then choose one reviewed direction:
 Cancelling a preparation or confirmation returns to conflict resolution with no side effects.
 Back returns to the sync manager, and Ctrl+C closes the complete flow.
 
-Startup checks never open a dialog. Detected changes leave a compact hint above the editor; open `/sync` when ready. An included-content mismatch puts **Review synced content (recommended)** in the manager, where a fresh review verifies the remote snapshot before offering changes.
+Startup checks never open a dialog. With a sync baseline and no content-list mismatch, ordinary one-sided changes appear only as **local changes pending** or **remote changes pending** in status. A persistent widget above the editor is reserved for both sides changing, first sync with an existing remote snapshot, a differing content list (including order-only differences), or a missing remote snapshot despite an existing baseline. Both sides changing is a reason to review, not a confirmed file conflict.
+No selected content and first sync with an empty remote stay quiet outside `/sync`, which provides setup or initialization guidance. Legacy remote metadata without an authoritative content list does not independently trigger a widget; the baseline and change conditions still apply. An included-content mismatch puts **Review synced content (recommended)** in the manager, where a fresh review verifies the remote snapshot before offering changes.
 Check results are advisory observations against the last sync baseline, not proof of a file conflict or current equality. Opening the manager uses local information and shows when the check completed; it does not contact remote storage. Transfer actions recheck current content.
-Attention stays in memory and is invalidated by relevant settings/state changes or a foreground transfer's commit boundary, and cleared on session replacement or shutdown. Cancelling a review or a failure before commit preserves a still-valid hint.
+The widget has no expiry timer. Attention stays in memory and is invalidated by relevant settings/state changes or a foreground transfer's commit boundary, and cleared on session replacement or shutdown. A newer observation replaces the presentation, clearing the widget when only status or no reminder is needed. Cancelling a review or a failure before commit preserves a still-valid observation and its appropriate presentation.
 
 Interactive TUI `/sync sync`, `/sync pull`, and `/sync push` routes without `--yes` open the same review flow when they detect the mismatch.
 Explicit `--yes` routes remain non-interactive and report exact remote-only, device-only, or order-only guidance while leaving visible attention for later review.
 Shutdown automatic sync never opens a dialog because Pi is exiting.
-RPC startup check results use nonblocking notifications; included-content review remains read-only.
+RPC startup checks use status for one-sided changes and nonblocking warning notifications for review conditions; included-content review remains read-only.
 Print and JSON modes do not support `/sync` because UI output is not observable there.
 
 ## ⚙️ Settings
@@ -149,7 +150,7 @@ Missing settings stay unconfigured without creating files or locks.
 
 ### Background startup checks
 
-With **Automatic sync** enabled, session startup schedules a background check instead of waiting for a transfer. Pi remains usable while Git, WebDAV, R2, or S3 checks local hashes and remote metadata. Unchanged results are quiet; changes or failures provide `/sync` guidance without opening a dialog. Use **Sync now** to start a reviewed transfer, or `/sync status` to retry a check. Foreground `/sync` cancels and drains the background check before starting.
+With **Automatic sync** enabled, session startup schedules a background check instead of waiting for a transfer. Pi remains usable while Git, WebDAV, R2, or S3 checks local hashes and remote metadata. Results follow the [status and review classifications](#resolve-conflicts-in-the-manager); check failures provide `/sync` guidance without opening a dialog. Use **Sync now** to start a reviewed transfer, or `/sync status` to retry a check. Foreground `/sync` cancels and drains the background check before starting.
 
 Checks run once per session start, including `/reload`, new, resumed, and forked sessions, in TUI and RPC only. Print/JSON skip startup checks. There is no polling or automatic check retry loop. The overall deadline is 30 seconds, followed by underlying cleanup where needed; Git process termination and temporary-ref cleanup can take additional time. Git checks can still fetch objects and update the extension's private bare cache, but never push, apply managed files, update the sync baseline, or reload Pi.
 

--- a/packages/pi-sync/src/ui/sync-attention.ts
+++ b/packages/pi-sync/src/ui/sync-attention.ts
@@ -60,7 +60,7 @@ export function createSyncAttentionController(): SyncAttentionController {
 			observation = undefined;
 		},
 		notifyObservation(ctx) {
-			if (observation && observationNeedsAttention(observation)) {
+			if (ctx.hasUI && observation && observationNeedsAttention(observation)) {
 				ctx.ui.notify(observationLines(observation).join("\n"), "warning");
 			}
 		},
@@ -89,9 +89,20 @@ export function createSyncAttentionController(): SyncAttentionController {
 		},
 		async publish(ctx, signal) {
 			const currentGeneration = ++generation;
-			if (signal?.aborted) return;
-			if (!state && (!observation || !observationNeedsAttention(observation))) {
+			if (signal?.aborted || !ctx.hasUI) return;
+			const classification = observation ? classifyObservation(observation) : "none";
+			if (!state && (classification === "none" || classification === "guidance")) {
 				clearAttentionPresentation(ctx);
+				return;
+			}
+			if (!state && classification === "status") {
+				ctx.ui.setWidget(WIDGET_KEY, undefined);
+				ctx.ui.setStatus(
+					STATUS_KEY,
+					observation?.inspection.remoteChanged
+						? "remote changes pending"
+						: "local changes pending",
+				);
 				return;
 			}
 			const presentation = state
@@ -101,11 +112,15 @@ export function createSyncAttentionController(): SyncAttentionController {
 						lines: observationLines(observation as StartupObservation),
 					};
 			if (ctx.mode !== "tui") {
+				ctx.ui.setWidget(WIDGET_KEY, undefined);
 				ctx.ui.setStatus(STATUS_KEY, presentation.status);
 				return;
 			}
 			// Keep Kit outside the eager startup graph; module loading owns no cancellable resources.
-			const { EditorStatusWidget } = await import("./attention-widget.js");
+			const { EditorStatusWidget } = await import("./attention-widget.js").catch((error) => {
+				if (generation === currentGeneration && !signal?.aborted) clearAttentionPresentation(ctx);
+				throw error;
+			});
 			if (generation !== currentGeneration || signal?.aborted) return;
 			ctx.ui.setStatus(STATUS_KEY, presentation.status);
 			ctx.ui.setWidget(
@@ -161,16 +176,24 @@ export function observationSummary(observation: StartupObservation) {
 	return "No changes detected since last sync";
 }
 
-export function observationNeedsAttention(observation: StartupObservation) {
+export type ObservationClassification = "none" | "guidance" | "status" | "review";
+
+/** Presentation only: never discard an observation or authorize a transfer here. */
+export function classifyObservation(observation: StartupObservation): ObservationClassification {
 	const result = observation.inspection;
-	return (
-		result.emptyInclude ||
-		result.firstSync ||
-		!result.head ||
-		result.localChanged ||
-		result.remoteChanged ||
-		result.selectionState?.kind !== "same"
-	);
+	// Sync now exits before reading remote content when nothing is selected.
+	if (result.emptyInclude) return "guidance";
+	// Ordering is part of the existing transfer policy, not merely display order.
+	if (result.selectionState?.kind === "different") return "review";
+	if (result.firstSync) return result.head ? "review" : "guidance";
+	if (!result.head || (result.localChanged && result.remoteChanged)) return "review";
+	if (result.localChanged || result.remoteChanged) return "status";
+	// Legacy metadata alone requires no scope confirmation in transfer operations.
+	return "none";
+}
+
+export function observationNeedsAttention(observation: StartupObservation) {
+	return classifyObservation(observation) === "review";
 }
 
 function observationLines(observation: StartupObservation) {
@@ -182,6 +205,7 @@ function observationLines(observation: StartupObservation) {
 }
 
 function clearAttentionPresentation(ctx: ExtensionContext) {
+	if (!ctx.hasUI) return;
 	ctx.ui.setStatus(STATUS_KEY, undefined);
 	ctx.ui.setWidget(WIDGET_KEY, undefined);
 }

--- a/packages/pi-sync/test/observation-retention.test.ts
+++ b/packages/pi-sync/test/observation-retention.test.ts
@@ -80,7 +80,8 @@ test("cancelling a real push confirmation preserves the hint and all content wit
 		assert.equal(headReads, 1);
 		assert.equal(confirmations, 1);
 		assert.equal(attention.observation(), observation);
-		assert.equal(context.statuses.get("sync"), "changes to review");
+		assert.equal(context.statuses.get("sync"), "local changes pending");
+		assert.equal(context.widgets.get("sync:attention"), undefined);
 		assert.deepEqual(await fs.readFile(localConfigPath()), settingsBefore);
 		assert.equal(await fs.readFile(managedPath, "utf8"), managedBytes);
 		await assert.rejects(fs.access(statePathForConfig(config)), { code: "ENOENT" });
@@ -113,7 +114,8 @@ for (const route of ["sync", "push", "pull", "rollback snapshot"]) {
 				assert.equal(runs, 1);
 				const committed = outcome.startsWith("commit");
 				assert.equal(attention.observation(), committed ? undefined : observation);
-				assert.equal(context.statuses.get("sync"), committed ? undefined : "changes to review");
+				assert.equal(context.statuses.get("sync"), committed ? undefined : "local changes pending");
+				assert.equal(context.widgets.get("sync:attention"), undefined);
 			});
 		});
 	}
@@ -152,7 +154,7 @@ test("a busy manager hides unavailable baseline data without discarding the stor
 			),
 		);
 		assert.equal(attention.observation(), observation);
-		assert.equal(context.statuses.get("sync"), "changes to review");
+		assert.equal(context.statuses.get("sync"), "local changes pending");
 	});
 });
 

--- a/packages/pi-sync/test/startup-observation.test.ts
+++ b/packages/pi-sync/test/startup-observation.test.ts
@@ -26,7 +26,7 @@ test("advisory widget is read-only, sanitized, narrow, themed at render time, an
 			setupName: "測試\u001b]8;;spoof",
 			configIdentity: syncCheckConfigFingerprint(config),
 			checkedAt: "2026-09-06T12:00:00.000Z",
-			inspection: await inspectionFixture(config, { localChanged: true }),
+			inspection: await inspectionFixture(config, { localChanged: true, remoteChanged: true }),
 		};
 		const context = createMockContext({ mode: "tui" });
 		attention.observe(observation);
@@ -199,8 +199,9 @@ test("replacement sessions sharing a UI cannot inherit a late failure or clear n
 		const completion = observeCheckCompletion(second.ctx);
 		await mock.events.get("session_start")?.[0]?.({}, second.ctx);
 		await completion.completed;
-		assert.equal(first.statuses.get("sync"), "changes to review");
-		assert.ok(first.notifications.every((n) => !n.message.includes("obsolete failure")));
+		assert.equal(first.statuses.get("sync"), "local changes pending");
+		assert.equal(first.widgets.get("sync:attention"), undefined);
+		assert.deepEqual(first.notifications, []);
 		await mock.events.get("session_shutdown")?.[0]?.({ reason: "reload" }, second.ctx);
 	});
 });

--- a/packages/pi-sync/test/sync-attention.test.ts
+++ b/packages/pi-sync/test/sync-attention.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import { createMockContext } from "../../../test/support.js";
-import { createSyncAttentionController } from "../src/ui/sync-attention.js";
+import type { StartupObservation, SyncInspection } from "../src/sync/sync-inspection.js";
+import {
+	classifyObservation,
+	createSyncAttentionController,
+	observationNeedsAttention,
+	observationSummary,
+} from "../src/ui/sync-attention.js";
 
 test("attention presentation is sanitized, textual, bounded, and clearable", async () => {
 	const controller = createSyncAttentionController();
@@ -98,3 +104,262 @@ for (const action of ["clear", "reset", "abort"] as const) {
 		assert.equal(widgets.get("sync:attention"), undefined);
 	});
 }
+
+function observation(overrides: Partial<SyncInspection> = {}): StartupObservation {
+	return {
+		setupName: "home\u001b]8;;spoof",
+		configIdentity: "identity",
+		checkedAt: "2026-09-08T00:00:00.000Z",
+		inspection: {
+			head: {
+				snapshotRef: "snapshot",
+				snapshotId: "snapshot",
+				revision: "revision",
+				createdAt: "2026-09-08T00:00:00.000Z",
+				machine: "test",
+				syncSessions: false,
+			},
+			selectionState: { kind: "same", include: ["settings.json"] },
+			localFiles: 1,
+			localChanged: false,
+			remoteChanged: false,
+			firstSync: false,
+			emptyInclude: false,
+			stateIdentity: "baseline",
+			destination: "test",
+			capability: "lease-protected",
+			...overrides,
+		},
+	};
+}
+
+// Every head/selection class, crossed with baseline and change flags, proves precedence
+// even for defensive combinations that today's inspector does not produce.
+for (const selection of ["absent", "same", "legacy", "order", "scope"] as const) {
+	for (const firstSync of [false, true]) {
+		for (const emptyInclude of [false, true]) {
+			for (const localChanged of [false, true]) {
+				for (const remoteChanged of [false, true]) {
+					test(`classification ${selection} first=${firstSync} empty=${emptyInclude} local=${localChanged} remote=${remoteChanged}`, async () => {
+						const value = observation({ firstSync, emptyInclude, localChanged, remoteChanged });
+						if (selection === "absent") {
+							value.inspection.head = undefined;
+							value.inspection.selectionState = undefined;
+						} else if (selection === "legacy") {
+							value.inspection.selectionState = { kind: "legacy", discovered: [] };
+						} else if (selection === "order" || selection === "scope") {
+							value.inspection.selectionState = {
+								kind: "different",
+								include: ["AGENTS.md", "settings.json"],
+								remoteOnly: selection === "scope" ? ["AGENTS.md"] : [],
+								localOnly: [],
+							};
+						}
+						const expected = emptyInclude
+							? "guidance"
+							: selection === "order" || selection === "scope"
+								? "review"
+								: firstSync
+									? selection === "absent"
+										? "guidance"
+										: "review"
+									: selection === "absent" || (localChanged && remoteChanged)
+										? "review"
+										: localChanged || remoteChanged
+											? "status"
+											: "none";
+						assert.equal(classifyObservation(value), expected);
+						assert.equal(observationNeedsAttention(value), expected === "review");
+						const before = structuredClone(value);
+						const controller = createSyncAttentionController();
+						const { ctx, statuses, widgets, notifications } = createMockContext({ mode: "tui" });
+						controller.observe(value);
+						await controller.publish(ctx);
+						controller.notifyObservation(ctx);
+						assert.equal(
+							typeof widgets.get("sync:attention"),
+							expected === "review" ? "function" : "undefined",
+						);
+						assert.equal(
+							statuses.get("sync"),
+							expected === "review"
+								? "changes to review"
+								: expected === "status"
+									? remoteChanged
+										? "remote changes pending"
+										: "local changes pending"
+									: undefined,
+						);
+						assert.equal(notifications.length, expected === "review" ? 1 : 0);
+						assert.equal(controller.observation(), value);
+						assert.deepEqual(value, before);
+					});
+				}
+			}
+		}
+	}
+}
+
+for (const inspection of [
+	{},
+	{ emptyInclude: true },
+	{ firstSync: true, head: undefined, selectionState: undefined },
+	{ localChanged: true },
+	{ localChanged: true, remoteChanged: true },
+]) {
+	test(`explicit selection decision overrides observation ${JSON.stringify(inspection)}`, async () => {
+		const controller = createSyncAttentionController();
+		const { ctx, statuses, widgets } = createMockContext({ mode: "tui" });
+		const value = observation(inspection);
+		controller.observe(value);
+		controller.set(
+			{
+				setupName: "home",
+				configIdentity: "test",
+				localInclude: ["settings.json"],
+				remoteInclude: ["AGENTS.md"],
+			},
+			"sync",
+		);
+		await controller.publish(ctx);
+		assert.equal(statuses.get("sync"), "review needed");
+		assert.equal(typeof widgets.get("sync:attention"), "function");
+		assert.equal(controller.markOffered(), true);
+		assert.equal(controller.markOffered(), false);
+		controller.clear(ctx);
+		assert.equal(controller.observation(), value);
+		await controller.publish(ctx);
+		assert.equal(
+			typeof widgets.get("sync:attention"),
+			classifyObservation(value) === "review" ? "function" : "undefined",
+		);
+	});
+}
+
+for (const mode of ["tui", "rpc", "print", "json"] as const) {
+	test(`${mode} review downgrades to status then quiet without deleting observations or unrelated UI`, async () => {
+		const controller = createSyncAttentionController();
+		const { ctx, statuses, widgets, notifications } = createMockContext({ mode });
+		statuses.set("other", "keep");
+		widgets.set("other", ["keep"]);
+		for (const changes of [
+			{ localChanged: true, remoteChanged: true },
+			{ localChanged: true, remoteChanged: false },
+			{ localChanged: false, remoteChanged: true },
+			{ localChanged: false, remoteChanged: false },
+		]) {
+			const value = observation(changes);
+			controller.observe(value);
+			await controller.publish(ctx);
+			controller.notifyObservation(ctx);
+			const review = changes.localChanged && changes.remoteChanged;
+			assert.equal(
+				typeof widgets.get("sync:attention"),
+				mode === "tui" && review ? "function" : "undefined",
+			);
+			assert.equal(
+				statuses.get("sync"),
+				mode === "print" || mode === "json"
+					? undefined
+					: review
+						? "changes to review"
+						: changes.remoteChanged
+							? "remote changes pending"
+							: changes.localChanged
+								? "local changes pending"
+								: undefined,
+			);
+			assert.equal(controller.observation(), value);
+		}
+		assert.equal(notifications.length, mode === "tui" || mode === "rpc" ? 1 : 0);
+		assert.ok(notifications.every((n) => n.level === "warning" && !n.message.includes("\u001b")));
+		controller.reset(ctx);
+		controller.reset(ctx);
+		assert.equal(statuses.get("other"), "keep");
+		assert.deepEqual(widgets.get("other"), ["keep"]);
+		assert.equal(controller.observation(), undefined);
+	});
+}
+
+for (const next of ["status", "none", "guidance", "reset", "abort"] as const) {
+	test(`delayed review import cannot restore obsolete UI after ${next}`, async () => {
+		const controller = createSyncAttentionController();
+		const { ctx, statuses, widgets } = createMockContext({ mode: "tui" });
+		const signal = new AbortController();
+		controller.observe(observation({ localChanged: true, remoteChanged: true }));
+		const pending = controller.publish(ctx, signal.signal);
+		if (next === "reset") controller.reset(ctx);
+		else if (next === "abort") signal.abort();
+		else {
+			controller.observe(
+				observation({ localChanged: next === "status", emptyInclude: next === "guidance" }),
+			);
+			await controller.publish(ctx);
+		}
+		await pending;
+		assert.equal(widgets.get("sync:attention"), undefined);
+		assert.equal(statuses.get("sync"), next === "status" ? "local changes pending" : undefined);
+	});
+}
+
+for (const stale of [false, true]) {
+	test(`failed widget import stale=${stale} clears only its current presentation`, async () => {
+		let release!: () => void;
+		let entered!: () => void;
+		const pending = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const loading = new Promise<void>((resolve) => {
+			entered = resolve;
+		});
+		vi.doMock("../src/ui/attention-widget.js", async () => {
+			entered();
+			await pending;
+			throw new Error("widget load failed");
+		});
+		const controller = createSyncAttentionController();
+		const { ctx, statuses, widgets } = createMockContext({ mode: "tui" });
+		statuses.set("sync", "old review");
+		widgets.set("sync:attention", ["old review"]);
+		controller.observe(observation({ localChanged: true, remoteChanged: true }));
+		const publishing = controller.publish(ctx);
+		const rejected = assert.rejects(publishing, (error: unknown) => {
+			assert.ok(error instanceof Error);
+			assert.ok(error.cause instanceof Error);
+			assert.equal(error.cause.message, "widget load failed");
+			return true;
+		});
+		try {
+			await loading;
+			if (stale) {
+				controller.observe(observation({ localChanged: true }));
+				await controller.publish(ctx);
+			}
+			release();
+			await rejected;
+			assert.equal(widgets.get("sync:attention"), undefined);
+			assert.equal(statuses.get("sync"), stale ? "local changes pending" : undefined);
+		} finally {
+			release();
+			await rejected;
+			vi.doUnmock("../src/ui/attention-widget.js");
+		}
+	});
+}
+
+test("manager summaries retain quiet setup, initialization, and legacy guidance", () => {
+	assert.equal(
+		observationSummary(observation({ emptyInclude: true })),
+		"No included content selected",
+	);
+	assert.equal(
+		observationSummary(
+			observation({ firstSync: true, head: undefined, selectionState: undefined }),
+		),
+		"Remote empty; no sync baseline",
+	);
+	assert.equal(
+		observationSummary(observation({ selectionState: { kind: "legacy", discovered: [] } })),
+		"Legacy remote has no authoritative content list",
+	);
+});

--- a/packages/pi-sync/test/sync-decision.test.ts
+++ b/packages/pi-sync/test/sync-decision.test.ts
@@ -12,9 +12,11 @@ import { localConfigPath } from "../src/settings/config-file.js";
 import type { Snapshot } from "../src/snapshot/snapshot-types.js";
 import { statePathForConfig, writeStateForConfig } from "../src/state/sync-state-store.js";
 import { SyncDecisionRequiredError } from "../src/sync/sync-decision.js";
+import { inspectSync } from "../src/sync/sync-inspection.js";
 import { pull, push, status, syncBoth } from "../src/sync/sync-operations.js";
 import { RemoteSelectionMismatchError } from "../src/sync/sync-policy.js";
 import sync from "../src/sync.js";
+import { classifyObservation } from "../src/ui/sync-attention.js";
 import { snapshot, v3S3Settings, withTempHome } from "./helpers.js";
 import { MemorySyncBackend } from "./memory-sync-backend.js";
 
@@ -425,6 +427,76 @@ test("pull from an empty remote offers only a structured push decision", async (
 		assert.equal(await backend.readHead(), undefined);
 	});
 });
+
+test("order-only selection differences still block sync, forced pull, and ordinary push", async () => {
+	await withInitializedSync(async ({ backend }) => {
+		writeFileSync(
+			localConfigPath(),
+			JSON.stringify(v3S3Settings({ include: ["settings.json", "AGENTS.md"] })),
+		);
+		const remote = {
+			...namedSnapshot("reordered", '{"base":true}\n'),
+			selection: { version: 1 as const, include: ["AGENTS.md", "settings.json"] },
+		};
+		await backend.publishSnapshot(remote, expectedRemoteHead(await backend.readHead()));
+		const before = await backend.readHead();
+		const { ctx } = createMockContext({ mode: "tui" });
+		for (const run of [
+			() => syncBoth(ctx, options, () => backend),
+			() => pull(ctx, { ...options, force: true }, () => backend),
+			() => push(ctx, options, undefined, () => backend),
+		]) {
+			await assert.rejects(run(), (error: unknown) => {
+				assert.ok(error instanceof RemoteSelectionMismatchError);
+				assert.match(error.message, /Only ordering differs/u);
+				return true;
+			});
+		}
+		assert.deepEqual(await backend.readHead(), before);
+	});
+});
+
+for (const legacy of [false, true]) {
+	test(`status-only remote change legacy=${legacy} still requires pull confirmation`, async () => {
+		await withInitializedSync(async ({ agentDir, backend, config }) => {
+			const remote = {
+				...namedSnapshot("remote-change", '{"remote":true}\n'),
+				...(legacy ? {} : { selection: { version: 1 as const, include: config.include } }),
+			};
+			await backend.publishSnapshot(remote, expectedRemoteHead(await backend.readHead()));
+			const inspection = await inspectSync(
+				config,
+				{ include: config.include },
+				undefined,
+				() => backend,
+			);
+			assert.equal(inspection.selectionState?.kind, legacy ? "legacy" : "same");
+			assert.equal(
+				classifyObservation({
+					setupName: config.setupName,
+					configIdentity: "test",
+					checkedAt: "test",
+					inspection,
+				}),
+				"status",
+			);
+			const stateBefore = readFileSync(statePathForConfig(config));
+			let confirmations = 0;
+			const { ctx } = createMockContext({
+				mode: "tui",
+				confirm: async () => {
+					confirmations++;
+					return false;
+				},
+			});
+			assert.equal(await pull(ctx, { ...options, yes: false }, () => backend), "cancelled");
+			assert.equal(confirmations, 1);
+			assert.equal(readFileSync(path.join(agentDir, "settings.json"), "utf8"), '{"base":true}\n');
+			assert.deepEqual(readFileSync(statePathForConfig(config)), stateBefore);
+			assert.equal((await backend.readHead())?.snapshotId, "remote-change");
+		});
+	});
+}
 
 async function withInitializedSync(
 	run: (state: {

--- a/packages/pi-sync/test/sync-inspection.test.ts
+++ b/packages/pi-sync/test/sync-inspection.test.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "../src/settings/config.js";
 import { localConfigPath } from "../src/settings/config-file.js";
 import { statePathForConfig, writeStateForConfig } from "../src/state/sync-state-store.js";
 import { inspectSync } from "../src/sync/sync-inspection.js";
+import { classifyObservation } from "../src/ui/sync-attention.js";
 import { snapshot, v3S3Settings, withTempHome } from "./helpers.js";
 
 const head: RemoteHead = {
@@ -85,6 +86,22 @@ const cases = [
 	},
 ];
 
+const presentations: Record<string, string> = {
+	"unchanged baseline": "none",
+	"local edit": "status",
+	"local deletion": "status",
+	"remote snapshot changed": "status",
+	"revision only changed": "status",
+	"both changed": "review",
+	"remote removed": "review",
+	"first sync": "review",
+	"both empty without baseline": "guidance",
+	"empty include": "guidance",
+	"ordered selection mismatch": "review",
+	"content selection mismatch": "review",
+	"unknown legacy selection": "none",
+};
+
 for (const scenario of cases) {
 	test(`inspection: ${scenario.name} remains advisory and read-only`, async () => {
 		await withTempHome(async (agentDir) => {
@@ -142,6 +159,15 @@ for (const scenario of cases) {
 			assert.equal(
 				result.selectionState?.kind,
 				scenario.missingRemote ? undefined : (scenario.selection ?? "same"),
+			);
+			assert.equal(
+				classifyObservation({
+					setupName: config.setupName,
+					configIdentity: "test",
+					checkedAt: "test",
+					inspection: result,
+				}),
+				presentations[scenario.name],
 			);
 			assert.equal("files" in result, false);
 			assert.deepEqual(await readFile(localConfigPath()), settingsBefore);


### PR DESCRIPTION
## Summary
- Reserve persistent review widgets and RPC warnings for decision-required or data-risk observations; show ordinary one-sided changes through status only.
- Keep quiet observations available to `/sync`, preserve transfer confirmations and safety checks, and clear obsolete UI on downgrades or current-generation widget-load failure.
- Document the classifications and lack of widget expiry; add a pi-sync patch Changeset.

Classification precedence: explicit selection decision → review; empty selection → manager guidance; differing ordered content list → review; first sync → review with a remote snapshot, otherwise manager guidance; missing remote with a baseline or both sides changed → review; one-sided changes → status; otherwise quiet. Ordering remains review-worthy because existing transfer checks compare ordered lists. Legacy metadata alone requires no scope confirmation and adds no widget.

## Verification
- `npm run check` passed: builds, Biome, boundaries, workspace typechecks.
- `npm test` passed: **378 files, 4,265 tests**, with Kit rebuilt before consumers and unchanged test timeouts.
- Coverage includes 80 classification/precedence combinations, explicit-decision overrides, four modes, exact-key cleanup, transitions, delayed imports and failures, cancellation, setup/state changes, replacement/shutdown, retained manager observations, real order-only transfer rejection, and modern/legacy pull confirmation cancellation.
- Isolated built-package Pi RPC smoke passed: registration, lazy `/sync help`, observable notification, clean EOF exit; no model or external storage requests. Generated Jiti lifecycle/lazy-boundary tests passed.
- Fenced-code-aware heading audit passed for 29 READMEs; `npm run changeset:status`, `git diff --check`, and precommit checks passed.

## Audit and limitations
Reviewed `docs/extension-conventions.md` touched-area/verification checklists and `docs/readme-conventions.md`, plus installed Pi widget/status/RPC behavior. Audited lifecycle ownership, cancellation/disposal, stale contexts, exact-key cleanup, mode safety, theme/terminal sanitization/width bounds, observation retention, and independent transfer authorization. No settings, persistence, command routes, automatic-sync behavior, dependencies, metadata, model context, or loading boundaries changed.

Interactive TUI and live external-backend smokes remain unverified; deterministic rendering, lifecycle, and backend tests cover the changed policy. Pack-specific gates are not applicable because package metadata and published file lists are unchanged. Initial lint/test-harness failures were fixed and both gates rerun successfully.

Completed and deleted the supplied untracked plan at `/home/narumi/workspace/pi-extensions/docs/plans/2026-09-08_pi-sync-attention-plan.md`. No packages published, version tags created, or release workflows dispatched.
