### PR TITLE
fix(usage): show documented Z.AI error hints

### DIFF
--- a/.changeset/bright-zai-errors.md
+++ b/.changeset/bright-zai-errors.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Show fixed English hints for documented Z.AI business error codes, with HTTP-status and unknown-code fallbacks. Stop classifying credentials from provider message text or echoing error bodies. Z.AI quota failures now retain the error statusline, request backoff, and scheduled recovery instead of being reported as unsupported.

--- a/.changeset/bright-zai-errors.md
+++ b/.changeset/bright-zai-errors.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-usage": patch
 ---
 
-Show fixed English hints for documented Z.AI business error codes, with HTTP-status and unknown-code fallbacks. Stop classifying credentials from provider message text or echoing error bodies. Z.AI quota failures now retain the error statusline, request backoff, and scheduled recovery instead of being reported as unsupported.
+Show fixed English hints for documented Z.AI business error codes, with HTTP-status and unknown-code fallbacks. Use the top-level code when the nested code is absent. Stop classifying credentials from provider message text or echoing error bodies. Z.AI quota failures now retain the error statusline, request backoff, and scheduled recovery instead of being reported as unsupported. Invalidate the matching cached Z.AI report on query failure so expired backoff retries do not restore stale usage.

--- a/packages/pi-usage/docs/providers.md
+++ b/packages/pi-usage/docs/providers.md
@@ -259,8 +259,11 @@ The extension classifies both forms by the provider's window unit and does not l
 The quota monitor expects a raw API key without a `Bearer` prefix.
 The extension removes that prefix from resolved authorization before sending it to the monitor endpoint.
 Fingerprinting and redaction keep using the original resolved credential.
-The observed no-plan response (HTTP 200, `code: 500`, `success: false`, `msg: "当前用户不存在coding plan"`, and absent or null `data`) is reported as `Unsupported`, so the statusline stays empty.
-Other missing or malformed quota data remains a query failure with scheduled retries.
-These quota validation errors do not echo the provider's `msg`, which may contain credentials.
+Quota errors use fixed English hints for the [documented Z.AI business error codes](https://docs.z.ai/api-reference/api-code), accepting nested `error.code` and the monitor endpoint's top-level `code` as strings or numbers.
+For example, `1113` reports insufficient balance or no resource package, and `1309` reports an expired GLM Coding Plan.
+When a failed HTTP response has no business error code, the hint uses its HTTP status; unknown business codes use a generic API failure message.
+The monitor's top-level `code: 500` is not a documented business code and is not treated as HTTP 500 or proof that the credential has no Coding Plan.
+Error classification never matches or echoes provider `msg` or `error.message` text, which may contain credentials.
+Quota errors and missing or malformed quota data remain query failures with a statusline error hint, a 30-second request backoff, and scheduled retries; they no longer clear the statusline as unsupported.
 The plan endpoint only contributes the plan name and renewal date; when it is unavailable or fails, the quota windows remain reported and the plan note falls back to the quota response's plan level.
 Only the official `api.z.ai` and `open.bigmodel.cn` origins are queried; other origins fail before sending the credential.

--- a/packages/pi-usage/docs/providers.md
+++ b/packages/pi-usage/docs/providers.md
@@ -260,10 +260,12 @@ The quota monitor expects a raw API key without a `Bearer` prefix.
 The extension removes that prefix from resolved authorization before sending it to the monitor endpoint.
 Fingerprinting and redaction keep using the original resolved credential.
 Quota errors use fixed English hints for the [documented Z.AI business error codes](https://docs.z.ai/api-reference/api-code), accepting nested `error.code` and the monitor endpoint's top-level `code` as strings or numbers.
+An explicit nested code takes precedence; when it is absent, the top-level code is used.
 For example, `1113` reports insufficient balance or no resource package, and `1309` reports an expired GLM Coding Plan.
 When a failed HTTP response has no business error code, the hint uses its HTTP status; unknown business codes use a generic API failure message.
 The monitor's top-level `code: 500` is not a documented business code and is not treated as HTTP 500 or proof that the credential has no Coding Plan.
 Error classification never matches or echoes provider `msg` or `error.message` text, which may contain credentials.
 Quota errors and missing or malformed quota data remain query failures with a statusline error hint, a 30-second request backoff, and scheduled retries; they no longer clear the statusline as unsupported.
+An accepted Z.AI query failure discards the matching cached report, so the next turn after backoff expires retries instead of restoring stale usage.
 The plan endpoint only contributes the plan name and renewal date; when it is unavailable or fails, the quota windows remain reported and the plan note falls back to the quota response's plan level.
 Only the official `api.z.ai` and `open.bigmodel.cn` origins are queried; other origins fail before sending the credential.

--- a/packages/pi-usage/src/core.ts
+++ b/packages/pi-usage/src/core.ts
@@ -36,6 +36,10 @@ export class UsageCache {
 		this.entries.set(key, { createdAt: now, report });
 	}
 
+	delete(providerId: string, fingerprint: string): void {
+		this.entries.delete(cacheKey(providerId, fingerprint));
+	}
+
 	clearProvider(providerId: string): void {
 		for (const key of this.entries.keys()) {
 			if (key.startsWith(`${providerId}:`)) this.entries.delete(key);

--- a/packages/pi-usage/src/core.ts
+++ b/packages/pi-usage/src/core.ts
@@ -36,10 +36,6 @@ export class UsageCache {
 		this.entries.set(key, { createdAt: now, report });
 	}
 
-	delete(providerId: string, fingerprint: string): void {
-		this.entries.delete(cacheKey(providerId, fingerprint));
-	}
-
 	clearProvider(providerId: string): void {
 		for (const key of this.entries.keys()) {
 			if (key.startsWith(`${providerId}:`)) this.entries.delete(key);
@@ -201,10 +197,6 @@ export function redactUsageError(value: string, secrets: readonly string[] = [])
 export function errorMessage(error: unknown): string {
 	return sanitizeDisplayText(error instanceof Error ? error.message : String(error), 600);
 }
-
-// A credential the provider cannot meter is not a query failure: it is reported as unsupported, so
-// the statusline stays empty instead of holding an error chip that no retry will clear.
-export class UsageUnsupportedError extends Error {}
 
 export function abortError(): Error {
 	return Object.assign(new Error("Usage query aborted."), { name: "AbortError" });

--- a/packages/pi-usage/src/providers/zai-errors.ts
+++ b/packages/pi-usage/src/providers/zai-errors.ts
@@ -49,7 +49,8 @@ export function zaiPayloadError(payload: unknown): string | undefined {
 	const object = asObject(payload);
 	if (!object) return undefined;
 	const nested = asObject(object.error);
-	const rawCode = nested ? nested.code : object.code;
+	// Missing nested metadata must not hide a top-level code; explicit nested values retain priority.
+	const rawCode = nested?.code === undefined ? object.code : nested.code;
 	const code = errorCode(rawCode);
 	if (
 		object.error === undefined &&

--- a/packages/pi-usage/src/providers/zai-errors.ts
+++ b/packages/pi-usage/src/providers/zai-errors.ts
@@ -1,0 +1,93 @@
+// Fixed messages from https://docs.z.ai/api-reference/api-code. Never interpolate provider text:
+// error messages and their template parameters can contain credentials or terminal controls.
+const ERROR_MESSAGES: Readonly<Record<string, string>> = {
+	"1000": "Authentication failed. Check your API key.",
+	"1001": "Authentication header missing. Check your API key.",
+	"1003": "Authentication token expired. Obtain a new token.",
+	"1005": "Two-factor authentication required.",
+	"1113": "Insufficient balance or no resource package. Recharge your account.",
+	"1200": "API call error. Try again later.",
+	"1210": "Invalid API parameter. Check the API documentation.",
+	"1211": "Unknown model. Check the model ID.",
+	"1212": "This model does not support the requested method.",
+	"1213": "A required parameter is missing.",
+	"1214": "Invalid parameter. Check the API documentation.",
+	"1215": "Conflicting parameters. Check the API documentation.",
+	"1220": "Access denied. Check your permissions.",
+	"1221": "This API has been taken offline.",
+	"1222": "This API does not exist.",
+	"1230": "API processing error. Try again later.",
+	"1234": "Network error. Try again later.",
+	"1261": "Prompt too long. Reduce the input length.",
+	"1301": "Content rejected by the safety policy.",
+	"1302": "Request rate limit reached. Try again later.",
+	"1305": "Service overloaded. Try again later.",
+	"1308": "Usage limit reached. Wait for the quota reset.",
+	"1309": "GLM Coding Plan expired. Renew your subscription.",
+	"1310": "Weekly or monthly limit exhausted. Wait for the quota reset.",
+	"1311": "Your subscription does not include this model.",
+	"1313": "Request frequency restricted by the Fair Usage Policy. Contact support.",
+	"1314": "Enterprise package expired. Contact your administrator.",
+	"1315": "This API key requires an enterprise coding package scenario. Replace the key.",
+	"1316": "5-hour limit reached; insufficient balance for extra usage. Wait for reset.",
+	"1317": "7-day limit reached; insufficient balance for extra usage. Wait for reset.",
+	"1318": "5-hour limit reached; extra usage blocked by monthly spend limit.",
+	"1319": "7-day limit reached; extra usage blocked by monthly spend limit.",
+	"1320": "5-hour limit reached; extra usage blocked by monthly spend limit.",
+	"1321": "7-day limit reached; extra usage blocked by monthly spend limit.",
+};
+
+const HTTP_MESSAGES: Readonly<Record<number, string>> = {
+	400: "Invalid request. Check the API documentation.",
+	401: "Authentication failed. Check your API key.",
+	403: "Access denied. Check your permissions.",
+	429: "Request or usage limit reached. Try again later.",
+	500: "Internal error. Try again later.",
+};
+
+export function zaiPayloadError(payload: unknown): string | undefined {
+	const object = asObject(payload);
+	if (!object) return undefined;
+	const nested = asObject(object.error);
+	const rawCode = nested ? nested.code : object.code;
+	const code = errorCode(rawCode);
+	if (
+		object.error === undefined &&
+		object.success !== false &&
+		(rawCode === undefined || code === "0" || code === "200")
+	) {
+		return undefined;
+	}
+	return code && code !== "0" && code !== "200"
+		? `Z.AI ${code}: ${ERROR_MESSAGES[code] ?? "API request failed."}`
+		: "Z.AI: API request failed.";
+}
+
+export function zaiResponseError(status: number, text: string): string | undefined {
+	let payload: unknown;
+	try {
+		payload = JSON.parse(text) as unknown;
+	} catch {
+		// Do not expose JSON parser excerpts, response bodies, or statusText.
+		if (status >= 200 && status < 300) return "Z.AI: Invalid JSON response.";
+	}
+	const error = zaiPayloadError(payload);
+	if (error) return error;
+	if (status < 200 || status >= 300) {
+		return `Z.AI HTTP ${status}: ${HTTP_MESSAGES[status] ?? "API request failed."}`;
+	}
+	return undefined;
+}
+
+function errorCode(value: unknown): string | undefined {
+	if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 9999) {
+		return String(value);
+	}
+	return typeof value === "string" && /^(?:0|[1-9]\d{0,3})$/u.test(value) ? value : undefined;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}

--- a/packages/pi-usage/src/providers/zai.ts
+++ b/packages/pi-usage/src/providers/zai.ts
@@ -1,4 +1,4 @@
-import { sanitizeDisplayText, UsageUnsupportedError } from "../core.js";
+import { sanitizeDisplayText } from "../core.js";
 import type {
 	UsageBucket,
 	UsageMetric,
@@ -7,6 +7,8 @@ import type {
 	ZaiQuotaPayload,
 	ZaiSubscriptionPayload,
 } from "../types.js";
+
+import { zaiPayloadError } from "./zai-errors.js";
 
 const FIVE_HOUR_WINDOW_MINUTES = 300;
 const WEEKLY_WINDOW_MINUTES = 10_080;
@@ -18,23 +20,10 @@ export function normalizeZaiQuotaPayload(
 	capturedAt: number,
 	plan?: ZaiPlanInfo,
 ): UsageReport {
+	const error = zaiPayloadError(payload);
+	if (error) throw new Error(error);
 	const data = asObject(payload.data);
-	if (!data) {
-		// Only the observed no-plan response establishes that this credential cannot be metered.
-		// Missing or malformed data alone can also indicate a transient provider failure.
-		if (
-			(payload.data === undefined || payload.data === null) &&
-			payload.code === 500 &&
-			payload.success === false &&
-			payload.msg === "当前用户不存在coding plan"
-		) {
-			throw new UsageUnsupportedError(
-				"No GLM Coding Plan on this Z.AI credential; API usage is not metered.",
-			);
-		}
-		// Do not echo msg: truncating provider text before redaction can expose secret prefixes.
-		throw new Error("Z.AI quota response data was not an object.");
-	}
+	if (!data) throw new Error("Z.AI quota response data was not an object.");
 	const limits = Array.isArray(data.limits) ? (data.limits as unknown[]) : [];
 
 	const buckets: UsageBucket[] = [];
@@ -96,10 +85,7 @@ export function normalizeZaiQuotaPayload(
 export function normalizeZaiSubscriptionPayload(
 	payload: ZaiSubscriptionPayload,
 ): ZaiPlanInfo | undefined {
-	if (payload.success === false) return undefined;
-	if (typeof payload.code === "number" && payload.code !== 0 && payload.code !== 200) {
-		return undefined;
-	}
+	if (zaiPayloadError(payload)) return undefined;
 	if (!Array.isArray(payload.data)) return undefined;
 
 	const candidates: Array<{

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -262,6 +262,7 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 	{
 		id: "zai",
 		displayName: "Z.AI",
+		invalidateCacheOnFailure: true,
 		semantics: { kind: "consumer-subscription", label: "GLM Coding Plan usage" },
 		async query(auth, signal, timeoutMs, guard) {
 			return queryZaiUsage("zai", "Z.AI", auth, signal, timeoutMs, guard);
@@ -270,6 +271,7 @@ export const SUPPORTED_ADAPTERS: readonly UsageProviderAdapter[] = [
 	{
 		id: "zai-coding-cn",
 		displayName: "Z.AI Coding CN",
+		invalidateCacheOnFailure: true,
 		semantics: { kind: "consumer-subscription", label: "GLM Coding Plan usage" },
 		async query(auth, signal, timeoutMs, guard) {
 			return queryZaiUsage("zai-coding-cn", "Z.AI Coding CN", auth, signal, timeoutMs, guard);

--- a/packages/pi-usage/src/query.ts
+++ b/packages/pi-usage/src/query.ts
@@ -2,12 +2,7 @@
 // separating that security boundary would duplicate request and redaction policy across providers.
 import { randomBytes } from "node:crypto";
 import { type ExtensionContext, readStoredCredential } from "@earendil-works/pi-coding-agent";
-import {
-	errorMessage,
-	fingerprintResolvedAuth,
-	redactUsageError,
-	UsageUnsupportedError,
-} from "./core.js";
+import { errorMessage, fingerprintResolvedAuth, redactUsageError } from "./core.js";
 import {
 	fallbackOAuthCredentialCandidates,
 	type OAuthCredentialCandidateReader,
@@ -29,6 +24,7 @@ import { normalizeOpenRouterKeyPayload } from "./providers/openrouter.js";
 import { normalizeVercelAIGatewayCreditsPayload } from "./providers/vercel-ai-gateway.js";
 import { normalizeXaiBillingPayload } from "./providers/xai.js";
 import { normalizeZaiQuotaPayload, normalizeZaiSubscriptionPayload } from "./providers/zai.js";
+import { zaiResponseError } from "./providers/zai-errors.js";
 import type {
 	BasetenBillingUsagePayload,
 	CodexBackendPayload,
@@ -552,11 +548,7 @@ export async function queryProviderUsage(
 		);
 	} catch (error) {
 		if (isStaleExtensionContextError(error) || isAbortError(error)) throw error;
-		const message = redactUsageError(errorMessage(error), auth.secrets);
-		// Redaction rebuilds the error, so the unsupported signal has to be carried across.
-		throw error instanceof UsageUnsupportedError
-			? new UsageUnsupportedError(message)
-			: new Error(message);
+		throw new Error(redactUsageError(errorMessage(error), auth.secrets));
 	}
 }
 
@@ -636,6 +628,7 @@ export async function fetchProviderJson(
 		body?: Record<string, unknown>;
 		redirect?: RequestRedirect;
 		userAgent?: boolean;
+		responseError?: (status: number, text: string) => string | undefined;
 	} = {},
 ): Promise<Record<string, unknown>> {
 	const controller = new AbortController();
@@ -674,6 +667,8 @@ export async function fetchProviderJson(
 		);
 		if (controller.signal.aborted)
 			throw Object.assign(new Error("Usage query aborted."), { name: "AbortError" });
+		const responseError = request.responseError?.(response.status, text);
+		if (responseError) throw new Error(responseError);
 		if (!response.ok) {
 			throw new Error(
 				`${description} returned ${response.status} ${response.statusText}: ${redactUsageError(text, auth.secrets)}`,
@@ -1110,6 +1105,7 @@ async function queryZaiUsage(
 		signal,
 		remainingTimeout(timeoutMs, startedAt, `fetching ${providerName} quota`),
 		`${providerName} quota endpoint`,
+		{ responseError: zaiResponseError },
 	)) as ZaiQuotaPayload;
 	await guard();
 	const planTimeoutMs = timeoutMs - (Date.now() - startedAt);
@@ -1134,6 +1130,7 @@ async function fetchZaiPlan(
 			signal,
 			timeoutMs,
 			`${providerName} plan endpoint`,
+			{ responseError: zaiResponseError },
 		)) as ZaiSubscriptionPayload;
 		return normalizeZaiSubscriptionPayload(payload);
 	} catch (error) {

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -191,13 +191,14 @@ export type OpenCodeZenPayload = {
 };
 
 export type ZaiQuotaPayload = {
+	error?: unknown;
 	code?: unknown;
 	success?: unknown;
-	msg?: unknown;
 	data?: unknown;
 };
 
 export type ZaiSubscriptionPayload = {
+	error?: unknown;
 	code?: unknown;
 	success?: unknown;
 	data?: unknown;

--- a/packages/pi-usage/src/types.ts
+++ b/packages/pi-usage/src/types.ts
@@ -91,6 +91,8 @@ export interface UsageProviderAdapter {
 	displayName: string;
 	semantics: UsageSemantics;
 	publishesStatusline?: boolean;
+	/** Invalidate the matching ready report when the latest query fails; default preserves it. */
+	invalidateCacheOnFailure?: boolean;
 	targets?: UsageTargetResolver;
 	query(
 		auth: ResolvedUsageAuth,

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -28,7 +28,6 @@ import {
 	errorMessage,
 	runWithConcurrency,
 	UsageCache,
-	UsageUnsupportedError,
 } from "./core.js";
 import { formatProviderStates, formatUsageStatusline } from "./format.js";
 import { createOAuthCredentialCandidateReader } from "./oauth-credential-source.js";
@@ -111,10 +110,7 @@ export default function usageExtension(
 	const createRedemptionId = dependencies.createRedemptionId ?? randomUUID;
 	const settingsRuntime = dependencies.settingsRuntime ?? createUsageSettingsRuntime();
 	const cache = new UsageCache(CACHE_TTL_MS);
-	const failureBackoff = new Map<
-		string,
-		{ until: number; message: string; status: "query-failed" | "unsupported" }
-	>();
+	const failureBackoff = new Map<string, { until: number; message: string }>();
 	const latestQueries = new Map<string, number>();
 	const activeControllers = new Set<AbortController>();
 	let querySequence = 0;
@@ -363,7 +359,7 @@ export default function usageExtension(
 						providerId: adapter.id,
 						providerName,
 						displayState,
-						status: previousDiscoveryFailure.status,
+						status: "query-failed",
 						message: previousDiscoveryFailure.message,
 					},
 					fingerprint: auth.fingerprint,
@@ -424,7 +420,7 @@ export default function usageExtension(
 						providerId: adapter.id,
 						providerName,
 						displayState,
-						status: previousFailure.status,
+						status: "query-failed",
 						message: previousFailure.message,
 					},
 					fingerprint: auth.fingerprint,
@@ -483,20 +479,15 @@ export default function usageExtension(
 				);
 			}
 			const message = errorMessage(error);
-			const status = error instanceof UsageUnsupportedError ? "unsupported" : "query-failed";
 			const now = Date.now();
 			for (const [key, failure] of failureBackoff) {
 				if (failure.until <= now) failureBackoff.delete(key);
 			}
-			// Unsupported is throttled like a failure, so a credential the provider cannot meter does
-			// not re-query on every turn; the entry carries its status so the replay stays unsupported.
 			if (queryId === undefined || latestQueries.get(failureKey) === queryId) {
-				// A definitive unsupported verdict invalidates ready data even after backoff expires.
-				if (status === "unsupported") cache.delete(adapter.id, queryFingerprint);
 				setBoundedMap(
 					failureBackoff,
 					failureKey,
-					{ until: now + FAILURE_BACKOFF_MS, message, status },
+					{ until: now + FAILURE_BACKOFF_MS, message },
 					MAX_ACCOUNT_STATES,
 				);
 			}
@@ -505,7 +496,7 @@ export default function usageExtension(
 					providerId: adapter.id,
 					providerName,
 					displayState,
-					status,
+					status: "query-failed",
 					message,
 				},
 				fingerprint: auth.fingerprint,

--- a/packages/pi-usage/src/usage.ts
+++ b/packages/pi-usage/src/usage.ts
@@ -484,6 +484,7 @@ export default function usageExtension(
 				if (failure.until <= now) failureBackoff.delete(key);
 			}
 			if (queryId === undefined || latestQueries.get(failureKey) === queryId) {
+				if (adapter.invalidateCacheOnFailure) cache.delete(adapter.id, queryFingerprint);
 				setBoundedMap(
 					failureBackoff,
 					failureKey,

--- a/packages/pi-usage/test/core.test.ts
+++ b/packages/pi-usage/test/core.test.ts
@@ -60,6 +60,18 @@ test("usage cache isolates identities, expires entries, and remains bounded", ()
 	assert.equal(cache.size, 0);
 });
 
+test("usage cache deletion preserves other credentials and providers", () => {
+	const cache = new UsageCache(300_000);
+	cache.set("zai", "account-a", report, 1_000);
+	cache.set("zai", "account-b", report, 1_000);
+	cache.set("zai-coding-cn", "account-a", report, 1_000);
+	cache.delete("zai", "account-a");
+	cache.delete("zai", "account-a");
+	assert.equal(cache.get("zai", "account-a", 1_001), undefined);
+	assert.equal(cache.get("zai", "account-b", 1_001), report);
+	assert.equal(cache.get("zai-coding-cn", "account-a", 1_001), report);
+});
+
 test("bounded orchestration retains stable partial results and respects cancellation", async () => {
 	let active = 0;
 	let maximumActive = 0;

--- a/packages/pi-usage/test/core.test.ts
+++ b/packages/pi-usage/test/core.test.ts
@@ -60,18 +60,6 @@ test("usage cache isolates identities, expires entries, and remains bounded", ()
 	assert.equal(cache.size, 0);
 });
 
-test("usage cache deletion preserves other credentials and providers", () => {
-	const cache = new UsageCache(300_000);
-	cache.set("zai", "account-a", report, 1_000);
-	cache.set("zai", "account-b", report, 1_000);
-	cache.set("zai-coding-cn", "account-a", report, 1_000);
-	cache.delete("zai", "account-a");
-	cache.delete("zai", "account-a");
-	assert.equal(cache.get("zai", "account-a", 1_001), undefined);
-	assert.equal(cache.get("zai", "account-b", 1_001), report);
-	assert.equal(cache.get("zai-coding-cn", "account-a", 1_001), report);
-});
-
 test("bounded orchestration retains stable partial results and respects cancellation", async () => {
 	let active = 0;
 	let maximumActive = 0;

--- a/packages/pi-usage/test/zai-errors.test.ts
+++ b/packages/pi-usage/test/zai-errors.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { zaiPayloadError, zaiResponseError } from "../src/providers/zai-errors.js";
+
+// Inventory the business codes documented at https://docs.z.ai/api-reference/api-code.
+const documented = [
+	[1000, /Authentication failed/],
+	[1001, /Authentication header missing/],
+	[1003, /token expired/],
+	[1005, /Two-factor/],
+	[1113, /Insufficient balance or no resource package/],
+	[1200, /API call error/],
+	[1210, /Invalid API parameter/],
+	[1211, /Unknown model/],
+	[1212, /does not support the requested method/],
+	[1213, /required parameter is missing/],
+	[1214, /Invalid parameter/],
+	[1215, /Conflicting parameters/],
+	[1220, /Access denied/],
+	[1221, /taken offline/],
+	[1222, /does not exist/],
+	[1230, /API processing error/],
+	[1234, /Network error/],
+	[1261, /Prompt too long/],
+	[1301, /safety policy/],
+	[1302, /Request rate limit/],
+	[1305, /Service overloaded/],
+	[1308, /Usage limit reached/],
+	[1309, /GLM Coding Plan expired/],
+	[1310, /Weekly or monthly limit/],
+	[1311, /subscription does not include this model/],
+	[1313, /Fair Usage Policy/],
+	[1314, /Enterprise package expired/],
+	[1315, /enterprise coding package scenario/],
+	[1316, /5-hour limit reached; insufficient balance/],
+	[1317, /7-day limit reached; insufficient balance/],
+	[1318, /5-hour limit reached; extra usage blocked by monthly spend limit/],
+	[1319, /7-day limit reached; extra usage blocked by monthly spend limit/],
+	[1320, /5-hour limit reached; extra usage blocked by monthly spend limit/],
+	[1321, /7-day limit reached; extra usage blocked by monthly spend limit/],
+] as const;
+
+test("every documented Z.AI business code has a fixed message in both response shapes", () => {
+	for (const [code, expected] of documented) {
+		for (const value of [code, String(code)]) {
+			for (const payload of [
+				{ error: { code: value, message: "untrusted" } },
+				{ code: value, success: false, msg: "untrusted" },
+			]) {
+				const message = zaiPayloadError(payload);
+				assert.ok(message);
+				assert.ok(message.startsWith(`Z.AI ${code}: `));
+				assert.match(message, expected);
+				assert.doesNotMatch(message, /untrusted/);
+			}
+		}
+	}
+});
+
+test("Z.AI errors do not depend on message text or replace quota success", () => {
+	for (const msg of [undefined, "", "任意訊息", "No subscription", "\u001b[31msecret"]) {
+		assert.equal(zaiPayloadError({ msg, data: {} }), undefined);
+		for (const code of [0, "0", 200, "200"]) {
+			assert.equal(zaiPayloadError({ code, success: true, msg, data: {} }), undefined);
+		}
+		assert.equal(
+			zaiPayloadError({ code: 500, msg, success: false }),
+			"Z.AI 500: API request failed.",
+		);
+	}
+});
+
+test("Z.AI handles unknown, malformed, and conflicting codes without echoing raw values", () => {
+	assert.equal(zaiPayloadError({ error: { code: "9999" } }), "Z.AI 9999: API request failed.");
+	for (const code of [undefined, null, {}, [], true, -1, 1.5, 10000, "01309", "1309secret"]) {
+		assert.equal(zaiPayloadError({ error: { code } }), "Z.AI: API request failed.");
+		assert.equal(zaiPayloadError({ code, success: false }), "Z.AI: API request failed.");
+	}
+	for (const error of [null, [], "secret", {}, { code: "0" }, { code: "200" }]) {
+		assert.equal(zaiPayloadError({ error }), "Z.AI: API request failed.");
+	}
+	assert.match(zaiPayloadError({ code: 500, error: { code: "1309" } }) ?? "", /1309: .*expired/);
+	for (const payload of [null, [], "secret", false]) {
+		assert.equal(zaiPayloadError(payload), undefined);
+	}
+});
+
+test("Z.AI uses HTTP fallbacks only when no business error is available", () => {
+	for (const [status, expected] of [
+		[400, /Invalid request/],
+		[401, /Authentication failed/],
+		[403, /Access denied/],
+		[429, /Request or usage limit/],
+		[500, /Internal error/],
+		[503, /API request failed/],
+	] as const) {
+		for (const text of ["secret", "{}", "null", "[]", '{"code":200}']) {
+			const error = zaiResponseError(status, text);
+			assert.ok(error);
+			assert.ok(error.startsWith(`Z.AI HTTP ${status}: `));
+			assert.match(error, expected);
+			assert.doesNotMatch(error, /secret/);
+		}
+		assert.match(
+			zaiResponseError(status, '{"error":{"code":"1113"}}') ?? "",
+			/1113: Insufficient balance or no resource package/,
+		);
+	}
+	assert.equal(zaiResponseError(200, "secret"), "Z.AI: Invalid JSON response.");
+	assert.equal(zaiResponseError(200, '{"code":200,"data":{}}'), undefined);
+	assert.match(zaiResponseError(200, '{"error":{"code":"1309"}}') ?? "", /1309: .*expired/);
+});

--- a/packages/pi-usage/test/zai-errors.test.ts
+++ b/packages/pi-usage/test/zai-errors.test.ts
@@ -85,6 +85,34 @@ test("Z.AI handles unknown, malformed, and conflicting codes without echoing raw
 	}
 });
 
+test("Z.AI falls back to top-level codes only when the nested code is absent", () => {
+	for (const code of [1113, "1113"]) {
+		for (const error of [
+			undefined,
+			null,
+			[],
+			"ignored",
+			{},
+			{ message: "ignored" },
+			{ code: undefined },
+		]) {
+			const payload = { code, error, success: false };
+			const expected =
+				"Z.AI 1113: Insufficient balance or no resource package. Recharge your account.";
+			assert.equal(zaiPayloadError(payload), expected);
+			assert.equal(zaiResponseError(429, JSON.stringify(payload)), expected);
+		}
+	}
+	for (const code of [null, false, [], {}, "1309secret", "0", "200"]) {
+		assert.equal(zaiPayloadError({ code: 1113, error: { code } }), "Z.AI: API request failed.");
+	}
+	assert.equal(
+		zaiPayloadError({ code: 1113, error: { code: "9999" } }),
+		"Z.AI 9999: API request failed.",
+	);
+	assert.match(zaiPayloadError({ code: 1113, error: { code: "1309" } }) ?? "", /1309: .*expired/);
+});
+
 test("Z.AI uses HTTP fallbacks only when no business error is available", () => {
 	for (const [status, expected] of [
 		[400, /Invalid request/],

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
 import { createMockContext, createMockPi } from "../../../test/support.js";
-import { UsageUnsupportedError } from "../src/core.js";
 import {
 	formatUsageReport,
 	formatUsageStatusline,
@@ -300,39 +299,14 @@ test("Z.AI adapter rejects malformed or empty quota responses", () => {
 	);
 });
 
-test("Z.AI only classifies the explicit no-plan response as unsupported", () => {
-	const noPlan = { code: 500, success: false, msg: "当前用户不存在coding plan" };
-	for (const data of [undefined, null]) {
-		assert.throws(
-			() => normalizeZaiQuotaPayload("zai", "Z.AI", { ...noPlan, data }, 0),
-			(error: unknown) =>
-				error instanceof UsageUnsupportedError &&
-				error.message === "No GLM Coding Plan on this Z.AI credential; API usage is not metered.",
-		);
-	}
-	for (const payload of [
-		{},
-		{ data: [] },
-		{ ...noPlan, data: [] },
-		{ ...noPlan, data: "broken" },
-		{ ...noPlan, data: false },
-		{ ...noPlan, data: 0 },
-		{ ...noPlan, data: {} },
-		{ ...noPlan, code: undefined },
-		{ ...noPlan, code: "500" },
-		{ ...noPlan, code: 401 },
-		{ ...noPlan, success: undefined },
-		{ ...noPlan, success: true },
-		{ ...noPlan, success: "false" },
-		{ ...noPlan, msg: undefined },
-		{ ...noPlan, msg: "Internal server error" },
-		{ ...noPlan, msg: `${noPlan.msg} extra details` },
-	]) {
-		assert.throws(
-			() => normalizeZaiQuotaPayload("zai", "Z.AI", payload, 0),
-			(error: unknown) => error instanceof Error && !(error instanceof UsageUnsupportedError),
-			JSON.stringify(payload),
-		);
+test("Z.AI quota classification depends on error codes, not message text or quota data", () => {
+	for (const data of [undefined, null, [], false, 0, {}, ZAI_QUOTA_PAYLOAD.data]) {
+		for (const msg of [undefined, "No subscription", "Server error", "任意訊息"]) {
+			const payload = { code: 500, success: false, msg, data };
+			assert.throws(() => normalizeZaiQuotaPayload("zai", "Z.AI", payload, 0), {
+				message: "Z.AI 500: API request failed.",
+			});
+		}
 	}
 });
 
@@ -343,7 +317,7 @@ test("Z.AI quota errors do not echo credentials across message truncation bounda
 			const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === providerId);
 			assert.ok(adapter);
 			const auth = zaiUsageAuth({ ...ZAI_MODEL, provider: providerId, baseUrl }, secret);
-			for (const msg of [secret, `当前用户不存在coding plan ${secret}`, `Invalid key: ${secret}`]) {
+			for (const msg of [secret, `No subscription: ${secret}`, `Invalid key: ${secret}`]) {
 				vi.stubGlobal(
 					"fetch",
 					zaiFetchStub(
@@ -356,12 +330,61 @@ test("Z.AI quota errors do not echo credentials across message truncation bounda
 						queryProviderUsage(adapter, auth, new AbortController().signal, 5_000, async () => {}),
 					(error: unknown) => {
 						assert.ok(error instanceof Error);
-						assert.equal(error.message, "Z.AI quota response data was not an object.");
+						assert.equal(error.message, "Z.AI 500: API request failed.");
 						assert.ok(!error.message.includes(secret.slice(0, 20)));
-						assert.ok(!(error instanceof UsageUnsupportedError));
 						return true;
 					},
 				);
+			}
+		}
+	} finally {
+		vi.unstubAllGlobals();
+	}
+});
+
+test("Z.AI queries surface safe coded and HTTP errors on both official origins", async () => {
+	const secret = "s".repeat(100);
+	const cases = [
+		{
+			status: 429,
+			body: JSON.stringify({ error: { code: "1113", message: secret } }),
+			expected: "Z.AI 1113: Insufficient balance or no resource package. Recharge your account.",
+		},
+		{
+			status: 200,
+			body: JSON.stringify({ code: 1309, success: false, msg: secret }),
+			expected: "Z.AI 1309: GLM Coding Plan expired. Renew your subscription.",
+		},
+		{
+			status: 200,
+			body: JSON.stringify({ error: { code: "1309", message: secret } }),
+			expected: "Z.AI 1309: GLM Coding Plan expired. Renew your subscription.",
+		},
+		{ status: 500, body: secret, expected: "Z.AI HTTP 500: Internal error. Try again later." },
+		{
+			status: 401,
+			body: JSON.stringify({ error: { code: "1000", message: secret.repeat(50) } }),
+			expected: "Z.AI HTTP 401: Authentication failed. Check your API key.",
+		},
+		{ status: 200, body: `broken ${secret}`, expected: "Z.AI: Invalid JSON response." },
+	];
+	try {
+		for (const [providerId, baseUrl] of ZAI_ORIGINS) {
+			const adapter = SUPPORTED_ADAPTERS.find((candidate) => candidate.id === providerId);
+			assert.ok(adapter);
+			const auth = zaiUsageAuth({ ...ZAI_MODEL, provider: providerId, baseUrl }, secret);
+			for (const { status, body, expected } of cases) {
+				const requests: Array<{ url: string; authorization: string | undefined }> = [];
+				vi.stubGlobal(
+					"fetch",
+					zaiFetchStub(requests, () => new Response(body, { status, statusText: secret })),
+				);
+				await assert.rejects(
+					() =>
+						queryProviderUsage(adapter, auth, new AbortController().signal, 5_000, async () => {}),
+					{ message: expected },
+				);
+				assert.equal(requests.length, 1, "quota errors do not query optional plan details");
 			}
 		}
 	} finally {
@@ -498,6 +521,17 @@ test("Z.AI adapter propagates cancellation from the plan endpoint", async () => 
 		);
 	} finally {
 		vi.unstubAllGlobals();
+	}
+});
+
+test("Z.AI subscription errors cannot contribute plan details", () => {
+	for (const payload of [
+		{ ...ZAI_SUBSCRIPTION_PAYLOAD, error: { code: "1309" } },
+		{ ...ZAI_SUBSCRIPTION_PAYLOAD, code: "1309" },
+		{ ...ZAI_SUBSCRIPTION_PAYLOAD, code: 1309 },
+		{ ...ZAI_SUBSCRIPTION_PAYLOAD, success: false },
+	]) {
+		assert.equal(normalizeZaiSubscriptionPayload(payload), undefined);
 	}
 });
 
@@ -702,15 +736,20 @@ test("malformed Z.AI quota responses keep the error chip and scheduled recovery"
 	}
 });
 
-test("a no-plan refresh invalidates ready usage beyond the unsupported backoff", async () => {
+test("a coded Z.AI refresh failure shows its reason and recovers on the scheduled retry", async () => {
+	vi.useFakeTimers();
 	const mock = createMockPi();
 	usageExtension(mock.pi);
 	const actions = ["Refresh current usage", "Close"];
+	const titles: string[] = [];
 	const { ctx, statuses } = createMockContext({
 		hasUI: true,
 		mode: "rpc",
 		model: ZAI_MODEL,
-		select: async () => actions.shift() ?? "Close",
+		select: async (title: string) => {
+			titles.push(title);
+			return actions.shift() ?? "Close";
+		},
 		modelRegistry: {
 			getProviderAuth: async () => ({ auth: { apiKey: "zai-secret-key" } }),
 			getAvailable: () => [ZAI_MODEL],
@@ -721,8 +760,6 @@ test("a no-plan refresh invalidates ready usage beyond the unsupported backoff",
 	});
 	let quotaPayload: object = ZAI_QUOTA_PAYLOAD;
 	const requests: Array<{ url: string; authorization: string | undefined }> = [];
-	const now = Date.now();
-	const clock = vi.spyOn(Date, "now").mockReturnValue(now);
 	vi.stubGlobal(
 		"fetch",
 		zaiFetchStub(
@@ -738,38 +775,39 @@ test("a no-plan refresh invalidates ready usage beyond the unsupported backoff",
 	);
 	try {
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
-		await vi.waitFor(() => assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk"));
+		await vi.advanceTimersByTimeAsync(0);
+		assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk");
 		assert.equal(requests.length, 2);
-		quotaPayload = { code: 500, success: false, msg: "当前用户不存在coding plan" };
+		quotaPayload = { error: { code: "1003", message: "ignored" } };
 		await mock.commands.get("usage")?.handler("", ctx);
-		assert.equal(statuses.get("usage"), undefined);
-		assert.equal(requests.length, 4);
+		assert.ok(
+			titles.some((title) =>
+				title.includes("Z.AI 1003: Authentication token expired. Obtain a new token."),
+			),
+		);
+		const chip = "usage err: Z.AI 1003: Authentication token expired. Obtain a ";
+		assert.equal(statuses.get("usage"), chip);
+		assert.equal(requests.length, 3);
 		await mock.events.get("turn_start")?.[0]?.({}, ctx);
-		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
-		assert.equal(requests.length, 4);
-		clock.mockReturnValue(now + 30_001);
-		await mock.events.get("turn_start")?.[0]?.({}, ctx);
-		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
-		assert.equal(requests.length, 6);
+		await vi.advanceTimersByTimeAsync(0);
+		assert.equal(statuses.get("usage"), chip);
+		assert.equal(requests.length, 3);
 		quotaPayload = ZAI_QUOTA_PAYLOAD;
-		clock.mockReturnValue(now + 60_002);
-		await mock.events.get("turn_start")?.[0]?.({}, ctx);
-		await vi.waitFor(() => assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk"));
-		assert.equal(requests.length, 8);
+		await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+		assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk");
+		assert.equal(requests.length, 5);
 	} finally {
 		await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
-		clock.mockRestore();
+		vi.useRealTimers();
 		vi.unstubAllGlobals();
 	}
 });
 
-// Both API and coding plan credentials use the same coding base URL, so the no-plan answer is the
-// only signal that a credential carries no subscription.
-test("a Z.AI credential with no coding plan leaves the statusline empty", async (t) => {
-	const noCodingPlan = { code: 500, msg: "当前用户不存在coding plan", success: false };
+test("an unknown Z.AI business error stays visible instead of becoming unsupported", async (t) => {
+	const failure = { code: 500, success: false };
 	vi.stubGlobal(
 		"fetch",
-		zaiFetchStub([], () => new Response(JSON.stringify(noCodingPlan), { status: 200 })),
+		zaiFetchStub([], () => new Response(JSON.stringify(failure), { status: 200 })),
 	);
 	try {
 		const mock = createMockPi();
@@ -789,22 +827,21 @@ test("a Z.AI credential with no coding plan leaves the statusline empty", async 
 			await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 		});
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
-		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
-
-		assert.equal(statuses.get("usage"), undefined);
+		await vi.waitFor(() =>
+			assert.equal(statuses.get("usage"), "usage err: Z.AI 500: API request failed."),
+		);
 	} finally {
 		vi.unstubAllGlobals();
 	}
 });
 
-// The verdict does not change on retry, so it is throttled like a failure instead of re-querying
-// the quota and plan endpoints on every turn.
-test("an unsupported Z.AI credential is throttled instead of re-queried each turn", async (t) => {
-	const noCodingPlan = { code: 500, msg: "当前用户不存在coding plan", success: false };
+test("a coded Z.AI error is throttled instead of re-queried each turn", async (t) => {
+	const failure = { error: { code: "1302" } };
+	const chip = "usage err: Z.AI 1302: Request rate limit reached. Try again l";
 	const requests: Array<{ url: string; authorization: string | undefined }> = [];
 	vi.stubGlobal(
 		"fetch",
-		zaiFetchStub(requests, () => new Response(JSON.stringify(noCodingPlan), { status: 200 })),
+		zaiFetchStub(requests, () => new Response(JSON.stringify(failure), { status: 429 })),
 	);
 	try {
 		const mock = createMockPi();
@@ -824,19 +861,14 @@ test("an unsupported Z.AI credential is throttled instead of re-queried each tur
 			await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
 		});
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
-		await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
+		await vi.waitFor(() => assert.equal(statuses.get("usage"), chip));
 		for (let turn = 0; turn < 3; turn += 1) {
 			await mock.events.get("turn_start")?.[0]?.({}, ctx);
-			await vi.waitFor(() => assert.equal(statuses.get("usage"), undefined));
+			await vi.waitFor(() => assert.equal(statuses.get("usage"), chip));
 		}
-
-		assert.equal(statuses.get("usage"), undefined);
 		assert.deepEqual(
 			requests.map((request) => request.url),
-			[
-				"https://api.z.ai/api/monitor/usage/quota/limit",
-				"https://api.z.ai/api/biz/subscription/list",
-			],
+			["https://api.z.ai/api/monitor/usage/quota/limit"],
 		);
 	} finally {
 		vi.unstubAllGlobals();

--- a/packages/pi-usage/test/zai.test.ts
+++ b/packages/pi-usage/test/zai.test.ts
@@ -736,70 +736,157 @@ test("malformed Z.AI quota responses keep the error chip and scheduled recovery"
 	}
 });
 
-test("a coded Z.AI refresh failure shows its reason and recovers on the scheduled retry", async () => {
+test.each(
+	ZAI_ORIGINS.flatMap(([provider, baseUrl]) => [
+		{
+			provider,
+			baseUrl,
+			failure: { error: { code: "1003" } },
+			message: "Z.AI 1003: Authentication token expired. Obtain a new token.",
+		},
+		{
+			provider,
+			baseUrl,
+			failure: { code: 500, success: false },
+			message: "Z.AI 500: API request failed.",
+		},
+	]),
+)(
+	"$provider failed refresh retries after backoff: $message",
+	async ({ provider, baseUrl, failure, message }) => {
+		vi.useFakeTimers();
+		const model = { ...ZAI_MODEL, provider, baseUrl };
+		const mock = createMockPi();
+		usageExtension(mock.pi);
+		const actions = ["Refresh current usage", "Close"];
+		const titles: string[] = [];
+		const { ctx, statuses } = createMockContext({
+			hasUI: true,
+			mode: "rpc",
+			model,
+			select: async (title: string) => {
+				titles.push(title);
+				return actions.shift() ?? "Close";
+			},
+			modelRegistry: {
+				getProviderAuth: async () => ({ auth: { apiKey: "zai-secret-key" } }),
+				getAvailable: () => [model],
+				getAll: () => [model],
+				getProviderAuthStatus: () => ({ configured: true }),
+				getProviderDisplayName: () => "Z.AI",
+			},
+		});
+		let quotaPayload: object = ZAI_QUOTA_PAYLOAD;
+		const requests: Array<{ url: string; authorization: string | undefined }> = [];
+		vi.stubGlobal(
+			"fetch",
+			zaiFetchStub(
+				requests,
+				(url) =>
+					new Response(
+						JSON.stringify(
+							url.endsWith("/subscription/list") ? ZAI_SUBSCRIPTION_PAYLOAD : quotaPayload,
+						),
+						{ status: 200 },
+					),
+			),
+		);
+		try {
+			await mock.events.get("session_start")?.[0]?.({}, ctx);
+			await vi.advanceTimersByTimeAsync(0);
+			assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk");
+			assert.equal(requests.length, 2);
+			quotaPayload = failure;
+			await mock.commands.get("usage")?.handler("", ctx);
+			assert.ok(titles.some((title) => title.includes(message)));
+			const chip = `usage err: ${message.slice(0, 50)}`;
+			assert.equal(statuses.get("usage"), chip);
+			assert.equal(requests.length, 3);
+			await mock.events.get("turn_start")?.[0]?.({}, ctx);
+			await vi.advanceTimersByTimeAsync(0);
+			assert.equal(statuses.get("usage"), chip);
+			assert.equal(requests.length, 3);
+			await vi.advanceTimersByTimeAsync(30_001);
+			await mock.events.get("turn_start")?.[0]?.({}, ctx);
+			await vi.advanceTimersByTimeAsync(0);
+			assert.equal(statuses.get("usage"), chip);
+			assert.equal(requests.length, 4, "expired backoff retries instead of returning cached usage");
+			quotaPayload = ZAI_QUOTA_PAYLOAD;
+			await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+			assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk");
+			assert.equal(requests.length, 6);
+		} finally {
+			await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+			vi.useRealTimers();
+			vi.unstubAllGlobals();
+		}
+	},
+);
+
+test("only Z.AI adapters opt into failed-query cache invalidation", () => {
+	assert.deepEqual(
+		SUPPORTED_ADAPTERS.filter((adapter) => adapter.invalidateCacheOnFailure).map(
+			(adapter) => adapter.id,
+		),
+		["zai", "zai-coding-cn"],
+	);
+});
+
+test("a superseded Z.AI failure cannot evict a newer successful refresh", async () => {
 	vi.useFakeTimers();
 	const mock = createMockPi();
 	usageExtension(mock.pi);
-	const actions = ["Refresh current usage", "Close"];
-	const titles: string[] = [];
+	const actions = ["Refresh current usage", "Refresh current usage", "Close"];
 	const { ctx, statuses } = createMockContext({
 		hasUI: true,
 		mode: "rpc",
 		model: ZAI_MODEL,
-		select: async (title: string) => {
-			titles.push(title);
-			return actions.shift() ?? "Close";
-		},
+		select: async () => actions.shift() ?? "Close",
 		modelRegistry: {
-			getProviderAuth: async () => ({ auth: { apiKey: "zai-secret-key" } }),
+			getProviderAuth: async () => ({ auth: { apiKey: "zai-key" } }),
 			getAvailable: () => [ZAI_MODEL],
 			getAll: () => [ZAI_MODEL],
 			getProviderAuthStatus: () => ({ configured: true }),
 			getProviderDisplayName: () => "Z.AI",
 		},
 	});
-	let quotaPayload: object = ZAI_QUOTA_PAYLOAD;
-	const requests: Array<{ url: string; authorization: string | undefined }> = [];
-	vi.stubGlobal(
-		"fetch",
-		zaiFetchStub(
-			requests,
-			(url) =>
-				new Response(
-					JSON.stringify(
-						url.endsWith("/subscription/list") ? ZAI_SUBSCRIPTION_PAYLOAD : quotaPayload,
-					),
-					{ status: 200 },
-				),
-		),
-	);
+	let releaseOld: (response: Response) => void = () => {};
+	const oldResponse = new Promise<Response>((resolve) => {
+		releaseOld = resolve;
+	});
+	let fetches = 0;
+	vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+		fetches += 1;
+		if (fetches === 3) return oldResponse;
+		return new Response(
+			JSON.stringify(
+				String(input).endsWith("/subscription/list") ? ZAI_SUBSCRIPTION_PAYLOAD : ZAI_QUOTA_PAYLOAD,
+			),
+		);
+	});
+	let older: Promise<unknown> | undefined;
 	try {
 		await mock.events.get("session_start")?.[0]?.({}, ctx);
 		await vi.advanceTimersByTimeAsync(0);
-		assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk");
-		assert.equal(requests.length, 2);
-		quotaPayload = { error: { code: "1003", message: "ignored" } };
-		await mock.commands.get("usage")?.handler("", ctx);
-		assert.ok(
-			titles.some((title) =>
-				title.includes("Z.AI 1003: Authentication token expired. Obtain a new token."),
-			),
-		);
-		const chip = "usage err: Z.AI 1003: Authentication token expired. Obtain a ";
-		assert.equal(statuses.get("usage"), chip);
-		assert.equal(requests.length, 3);
+		assert.equal(fetches, 2);
+		const command = mock.commands.get("usage");
+		assert.ok(command);
+		older = Promise.resolve(command.handler("", ctx));
+		await vi.waitFor(() => assert.equal(fetches, 3));
+		await command.handler("", ctx);
+		assert.equal(fetches, 5);
+		releaseOld(new Response(JSON.stringify({ code: 500, success: false })));
+		await older;
 		await mock.events.get("turn_start")?.[0]?.({}, ctx);
 		await vi.advanceTimersByTimeAsync(0);
-		assert.equal(statuses.get("usage"), chip);
-		assert.equal(requests.length, 3);
-		quotaPayload = ZAI_QUOTA_PAYLOAD;
-		await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
 		assert.equal(statuses.get("usage"), "zai 87% 5h 76% wk");
-		assert.equal(requests.length, 5);
+		assert.equal(fetches, 5, "the newer ready report remains cached");
 	} finally {
+		releaseOld(new Response("{}"));
 		await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
-		vi.useRealTimers();
+		await older;
 		vi.unstubAllGlobals();
+		vi.useRealTimers();
 	}
 });
 


### PR DESCRIPTION
## Summary

Follow-up to merged #1239, implementing the requested switch from provider-message matching to https://docs.z.ai/api-reference/api-code.

- Map all 34 documented business codes to fixed English hints, accepting nested error.code and monitor top-level code as numbers or strings.
- Use HTTP-status fallbacks when a failed response has no business error, and a generic failure for unknown business codes. The monitor business code 500 is not treated as HTTP 500 or proof of a missing Coding Plan.
- Never match or echo provider messages, status text, error bodies, or JSON parser excerpts. Test truncated bodies and credential-bearing responses on both official origins.
- Keep quota failures visible through the normal query-failed status/menu, 30-second request backoff, and scheduled recovery. Remove the obsolete unsupported-error and cache-invalidation machinery. Optional plan failures still preserve valid quota usage.
- Update provider documentation and add a patch Changeset.

## Verification

- npm run check passed: builds, Biome, package boundaries, workspace typechecks.
- npm test passed: 380 files, 4,193 tests.
- Regression coverage includes every documented code, both payload shapes, numeric/string/unknown/malformed/conflicting codes, HTTP fallbacks, credential non-exposure, full menu hints, statusline hints, request backoff, scheduled recovery, and optional subscription failures.
- git diff --check and staged precommit checks passed. Signed commit: 157e6f8f.

## Audit and limitations

Audited against docs/extension-conventions.md for status ownership, error safety, lifecycle and cancellation, verification, and release scope. The response hook runs after bounded body reading and cancellation checks; existing timeout/controller cleanup and stale-publication guards are retained. Other providers retain the default HTTP error path. No settings changes or guide deviations; docs/extension-settings.md is not applicable. No metadata or runtime-loading changes, so pack and interactive load smokes are not required. Generated-entry and lifecycle tests passed in the full suite. No live-provider or interactive smoke was run.

Intentional behavior change: a provider failure no longer clears the statusline merely because its message claims there is no Coding Plan. Hints explain documented codes without inferring subscription state from text.