### PR TITLE
feat(plan-mode): select implementation model and thinking

### DIFF
--- a/.changeset/plan-implementation-model.md
+++ b/.changeset/plan-implementation-model.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Add optional implementation model and thinking defaults plus per-menu implementation options for same-session and fresh-session handoffs. Apply choices only at implementation start without changing Pi defaults or automatically restoring the planner's model after a run ends.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -11,6 +11,7 @@ Use a Codex-like `/plan` mode to explore a codebase, resolve important questions
 - Uses structured questions for important ambiguity and explicit completion for a decision-ready plan.
 - Reviews the complete plan before implementation, export, save, further planning, or discard.
 - Implements in the planning session or a fresh linked session with the approved plan.
+- Selects an implementation model and thinking level through saved defaults or one-menu overrides, without switching back automatically.
 - Restores Plan state and one saved plan across resume and compaction.
 - Configures the Plan tool allowlist, reviewed shell commands, user-trusted subcommands, export path, plan reinjection, shortcut, and thinking level.
 - Publishes statusline state and cooperates anonymously with Workflow Mutex Protocol v1 participants.
@@ -150,6 +151,14 @@ Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and 
 
 After completion, `/plan` opens the ready actions when interactive UI is available.
 The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews the selected **Plan reinjection** policy.
+**Implementation options…** stages model and thinking choices for either action in that menu; `/plan implement` uses saved defaults.
+Choices take effect only when implementation starts and do not change Pi's global defaults.
+After kickoff, run settlement, user abort, and active-plan clearing do not restore the previous model or thinking; subsequent manual choices remain yours.
+Implementation preferences are characterized on Pi 0.85.0; use that release or newer for this feature.
+See [implementation preferences](./docs/settings.md#implementation-model-and-thinking) for inheritance and failure behavior.
+
+Selecting another provider with **Implement here** sends the retained planning conversation to that provider.
+Fresh implementation transfers only the approved plan plus the destination's normal resources.
 **Implement here**—and the compatibility route `/plan implement`—appends the Normal contract, lifts the Plan runtime policy, captures the reinjection setting, and starts implementation in the current session with its complete planning conversation and tool calls.
 **Start fresh and implement** waits for the source session to become idle, verifies the selected model and authentication, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
 The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions.
@@ -242,6 +251,10 @@ Only the latest active Plan contract authorizes the helpers; inactive or stale c
 Plan mode does not widen a restrictive active-tool policy; start or restore fails when a required helper is unavailable.
 Stable schemas preserve a cache-eligible prefix but cannot guarantee a hit because provider serialization, cache lifetime, minimum prefix size, implementation details, and session affinity remain external.
 
+An explicit implementation model or thinking change is an intentional provider/cache boundary at handoff, not an ordinary-turn context rewrite.
+Preferences and fresh-session acknowledgements are non-model state; they do not add tool schemas or leading prompt instructions.
+Subsequent turns retain the existing append-only context behavior.
+
 The default `thinkingLevel: "inherit"` avoids a Plan-specific reasoning-parameter change.
 A fixed Plan thinking level remains supported, but changing reasoning parameters can prevent provider-side state reuse even when prompts and tool schemas stay stable.
 
@@ -294,6 +307,7 @@ The optional file is read at session start and watched for changes; only an expl
 ```
 
 By default, Plan mode inherits thinking, allows active safe built-ins, exports to `PLAN.md`, and relies on ordinary conversation history after implementation starts.
+Implementation model and thinking defaults are optional Settings rows; unset values keep existing behavior, including normal restoration of Plan-specific thinking.
 The shortcut is disabled unless configured.
 Settings saves apply to later workflows; an active implementation keeps its captured reinjection policy.
 The export destination affects the next export immediately.

--- a/packages/pi-plan-mode/docs/command-workflows.md
+++ b/packages/pi-plan-mode/docs/command-workflows.md
@@ -17,7 +17,8 @@ Persistent defaults belong in [Settings](./settings.md).
 The TUI selector supports fuzzy search and paging; RPC shows the unfiltered list.
 Blocked, inactive, or not-yet-registered tools remain distinguishable, and selected names awaiting metadata stay selected for first-request resolution.
 Reopen the selector to refresh newly registered tools.
-Active and ready workflows lock tools and settings; exit and start a new workflow to change the allowlist.
+Active and ready workflows lock planning tools and persistent settings; exit and start a new workflow to change the allowlist.
+Ready and saved plans expose **Implementation options…**, which stages model/thinking for that menu's implementation actions without changing the planner or saved defaults.
 See [Planning and implementation](../README.md#-planning-and-implementation) for the first-request policy boundary, completion, and same-session versus fresh-session handoff.
 
 ## Busy transitions and recovery
@@ -28,6 +29,9 @@ An ordinary follow-up or `/plan finalize` can still run while Plan mode is activ
 
 `show`, `save`, `export`, and `implement` require an applicable stored plan; `finalize` requires active Plan mode.
 Cancellation and failed implementation preflight leave the stored plan intact.
+`/plan implement` applies saved implementation preferences; menu actions additionally accept the current menu's draft overrides.
+After kickoff, settlement, abort, and clearing an active plan do not restore model/thinking.
+See [implementation preferences](./settings.md#implementation-model-and-thinking) for inheritance, provider-transfer effects, and partial fresh-session recovery.
 For finalization retries, fresh-session recovery, and non-interactive limitations, see [Planning and implementation](../README.md#-planning-and-implementation).
 
 ## Export Markdown

--- a/packages/pi-plan-mode/docs/settings.md
+++ b/packages/pi-plan-mode/docs/settings.md
@@ -2,6 +2,7 @@
 
 [Back to README](../README.md)
 
+- [Implementation model and thinking](#implementation-model-and-thinking)
 - [Default Plan policy tools](#default-plan-policy-tools)
 - [Plan reinjection](#plan-reinjection)
 - [Export destination](#export-destination)
@@ -11,7 +12,7 @@
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit **Plan thinking**, **Plan policy tools**, **Plan reinjection**, **Export destination**, and **Plan mode shortcut**.
+Open **Settings** from an inactive `/plan` menu to edit planning defaults, implementation model/thinking, reinjection, export destination, and the shortcut.
 You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
 `safeSubcommands` is JSON-only.
 The optional file is read at session start, watched for changes, and created only by an explicit Settings save or manual edit.
@@ -31,6 +32,27 @@ The shortcut is disabled when `toggleShortcut` is omitted.
   "toggleShortcut": "<your_key>"
 }
 ```
+
+### Implementation model and thinking
+
+`implementationModel` is an optional object with exact, case-sensitive `provider` and `id` strings. Both must be non-blank and at most 4,096 characters; IDs are opaque, so slashes and colons are not parsed. Omit this field or choose **Use current** to make no model change. For fresh implementation, that means the destination's normal startup model, not a forced copy of the source model.
+
+`implementationThinkingLevel` accepts `inherit` (the default), `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. `inherit` preserves normal behavior: same-session handoff restores a temporary Plan thinking override when appropriate, a model switch uses Pi's model/default thinking policy, and a fresh session uses its normal startup thinking. It does not promise to retain the planner's temporary thinking level. Explicit implementation thinking applies after model selection; Pi clamps it to the target's supported levels, and Plan mode reports an adjustment.
+
+```json
+{
+  "implementationModel": { "provider": "openai", "id": "your-registered-model-id" },
+  "implementationThinkingLevel": "high"
+}
+```
+
+Settings saves immediately but does not switch the running session. Each implementation menu snapshots those defaults when opened. **Implementation options…** edits a draft shared by both implementation actions in that menu; backing out of a nested picker leaves its previous choice, while closing the owning menu discards all its overrides. Reopen `/plan` to use updated defaults. `/plan implement` uses current saved defaults without a selector. Precedence is built-in behavior, user defaults, then the current menu's override; **Use current** and `inherit` can explicitly override fixed defaults.
+
+The model picker uses Pi's scoped models when configured, otherwise its available catalogue. It does not refresh providers or resolve auth merely to display choices; close and reopen the owning menu after refreshing Pi's catalogue. Display labels are sanitized without changing raw model identity. No registered match or failed authentication blocks an explicit target rather than silently selecting a fallback.
+
+Before kickoff, failed or cancelled preparation retains the ready/saved plan. Same-session recovery restores only still-owned runtime changes and does not overwrite a later manual choice. Pi owns authentication and model-selection operations, which have no public cancellation signal; the extension waits for them to settle and rejects stale continuations. After a fresh replacement commits, a preference failure leaves the request in the destination editor instead of starting with a fallback. If kickoff then fails, the destination retains its selected model/thinking and existing editor or active-plan recovery; the source remains resumable. Reload/resume never replays a pending preference request.
+
+After successful kickoff there is **no automatic restoration** on `agent_end`, `agent_settled`, user abort, or active-plan clearing. A settled run is not proof that the implementation task is complete. Later manual model/thinking changes are preserved. These preferences never write Pi's global model or thinking defaults, and existing plan-retention cleanup is unchanged.
 
 ### Plan helper tools
 

--- a/packages/pi-plan-mode/scripts/build-runtime.mjs
+++ b/packages/pi-plan-mode/scripts/build-runtime.mjs
@@ -30,6 +30,7 @@ const FORBIDDEN_EAGER_INPUTS = [
 	"src/plan-launch-menu.ts",
 	"src/saved-plan-menu.ts",
 	"src/settings-menu.ts",
+	"src/implementation-options.ts",
 ];
 const FORBIDDEN_EAGER_EXTERNALS = ["@narumitw/pi-tui-kit"];
 

--- a/packages/pi-plan-mode/src/fresh-implementation-preferences.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation-preferences.ts
@@ -1,0 +1,102 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	createImplementationPreferenceChange,
+	hasImplementationPreferences,
+	type ImplementationSnapshot,
+	preferenceError,
+	preflightImplementationPreferences,
+	sameModel,
+} from "./implementation-preferences.js";
+import { type ImplementationPreferences, normalizePlanModeSettings } from "./settings.js";
+
+export const FRESH_PREFERENCES_ENTRY = "plan-mode:fresh-preferences:v1";
+
+export interface FreshPreferencesRequest {
+	id: string;
+	status: "pending";
+	preferences: ImplementationPreferences;
+}
+
+/** Called only for reason=new, with the destination instance's own API. */
+export async function applyFreshImplementationPreferences(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	isCurrent: () => boolean,
+	selectionSnapshot?: () => ImplementationSnapshot | undefined,
+) {
+	if (!isCurrent() || !ctx.isIdle()) return;
+	const entry = latestPreferenceEntry(ctx);
+	if (entry?.type !== "custom" || !entry.data || typeof entry.data !== "object") return;
+	const request = entry.data as Partial<FreshPreferencesRequest>;
+	if (request.status !== "pending" || typeof request.id !== "string") return;
+	const preferences = normalizePlanModeSettings(request.preferences);
+	// Consume before any await. Reload/resume never replays a handoff selection.
+	pi.appendEntry(FRESH_PREFERENCES_ENTRY, { id: request.id, status: "failed" });
+	if (!preferences || !hasImplementationPreferences(preferences)) return;
+	const change = createImplementationPreferenceChange(
+		pi,
+		ctx,
+		isCurrent,
+		undefined,
+		selectionSnapshot,
+	);
+	try {
+		const originalModel = ctx.model;
+		const originalThinking = pi.getThinkingLevel();
+		const current = () => isCurrent() && ctx.isIdle();
+		const model = await preflightImplementationPreferences(
+			ctx,
+			preferences,
+			() =>
+				current() &&
+				sameModel(ctx.model, originalModel) &&
+				pi.getThinkingLevel() === originalThinking,
+		);
+		if (!model || !current()) return;
+		if (!(await change.apply(model, preferences, current)) || !current()) {
+			await change.rollback();
+			return;
+		}
+		pi.appendEntry(FRESH_PREFERENCES_ENTRY, {
+			id: request.id,
+			status: "applied",
+			model: { provider: ctx.model?.provider, id: ctx.model?.id },
+			thinking: pi.getThinkingLevel(),
+		});
+	} catch (error) {
+		if (!isCurrent()) return;
+		await change.rollback().catch(() => undefined);
+		if (!isCurrent()) return;
+		pi.appendEntry(FRESH_PREFERENCES_ENTRY, {
+			id: request.id,
+			status: "failed",
+			error: preferenceError(error),
+		});
+	}
+}
+
+/** No captured source API is usable here; inspect only the replacement context. */
+function latestPreferenceEntry(ctx: ExtensionContext) {
+	return ctx.sessionManager
+		.getBranch()
+		.slice()
+		.reverse()
+		.find((entry) => entry.type === "custom" && entry.customType === FRESH_PREFERENCES_ENTRY);
+}
+
+export function freshPreferencesApplied(ctx: ExtensionContext, id: string) {
+	const entry = latestPreferenceEntry(ctx);
+	if (entry?.type !== "custom" || !entry.data || typeof entry.data !== "object") return false;
+	const result = entry.data as {
+		id?: string;
+		status?: string;
+		model?: { provider: string; id: string };
+		thinking?: string;
+	};
+	return (
+		result.id === id &&
+		result.status === "applied" &&
+		sameModel(ctx.model, result.model) &&
+		ctx.thinkingLevel === result.thinking
+	);
+}

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -1,14 +1,24 @@
 import { randomUUID } from "node:crypto";
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	FRESH_PREFERENCES_ENTRY,
+	freshPreferencesApplied,
+} from "./fresh-implementation-preferences.js";
+import {
+	hasImplementationPreferences,
+	preflightImplementationPreferences,
+	sameModel,
+} from "./implementation-preferences.js";
 import { PLAN_HISTORY_IMPLEMENTATION_PROMPT } from "./message-transform.js";
 import { createModeContractMessage } from "./mode-contract.js";
-import type { ImplementationPlanRetention } from "./settings.js";
+import type { ImplementationPlanRetention, ImplementationPreferences } from "./settings.js";
 import type { PlanCompletionSource, PlanModeState } from "./state.js";
 
 type NewSessionOptions = Exclude<Parameters<ExtensionCommandContext["newSession"]>[0], undefined>;
 type ReplacementContext = Parameters<NonNullable<NewSessionOptions["withSession"]>>[0];
 
 export interface FreshImplementationRequest {
+	preferences?: ImplementationPreferences;
 	plan: string;
 	source: PlanCompletionSource;
 	retention: ImplementationPlanRetention;
@@ -17,6 +27,7 @@ export interface FreshImplementationRequest {
 }
 
 interface FreshImplementationFromStateOptions {
+	preferences?: ImplementationPreferences;
 	getState(): PlanModeState;
 	menuIsCurrent(): boolean;
 	retention: ImplementationPlanRetention;
@@ -76,6 +87,7 @@ export async function startFreshImplementationFromState(
 	return startFreshImplementationSession(ctx, {
 		plan,
 		source,
+		preferences: options.preferences,
 		retention: options.retention,
 		stateEntryType: options.stateEntryType,
 		isCurrent,
@@ -92,8 +104,25 @@ export async function startFreshImplementationSession(
 
 	await ctx.waitForIdle();
 	if (!request.isCurrent()) return { kind: "stale" };
-	if (!(await preflightModel(ctx, request.isCurrent))) return { kind: "rejected" };
-	if (!request.isCurrent()) return { kind: "stale" };
+	const preferences = request.preferences ?? {};
+	const originalModel = ctx.model;
+	const originalThinking = ctx.thinkingLevel;
+	const preflightCurrent = () =>
+		request.isCurrent() &&
+		sameModel(ctx.model, originalModel) &&
+		ctx.thinkingLevel === originalThinking;
+	const preferencesId = hasImplementationPreferences(preferences) ? randomUUID() : undefined;
+	if (preferencesId) {
+		try {
+			if (!(await preflightImplementationPreferences(ctx, preferences, preflightCurrent)))
+				return { kind: "stale" };
+		} catch (error) {
+			if (preflightCurrent())
+				safeNotify(ctx, `Unable to implement the plan: ${safeErrorDetail(error)}`, "error");
+			return { kind: "rejected" };
+		}
+	} else if (!(await preflightModel(ctx, preflightCurrent))) return { kind: "rejected" };
+	if (!preflightCurrent() || !ctx.isIdle()) return { kind: "stale" };
 
 	const usesConversationHistory = request.retention === "clear-on-start";
 	const destinationState: PlanModeState | undefined = usesConversationHistory
@@ -124,6 +153,12 @@ export async function startFreshImplementationSession(
 			...(parentSession ? { parentSession } : {}),
 			setup: async (sessionManager) => {
 				try {
+					if (preferencesId)
+						sessionManager.appendCustomEntry(FRESH_PREFERENCES_ENTRY, {
+							id: preferencesId,
+							status: "pending",
+							preferences,
+						});
 					const contract = createModeContractMessage("normal");
 					sessionManager.appendCustomMessageEntry(
 						contract.customType,
@@ -139,6 +174,14 @@ export async function startFreshImplementationSession(
 				}
 			},
 			withSession: async (replacementCtx) => {
+				if (
+					!setupError &&
+					preferencesId &&
+					!freshPreferencesApplied(replacementCtx, preferencesId)
+				) {
+					setupError =
+						"Implementation model/thinking could not be applied or changed before kickoff";
+				}
 				if (setupError) {
 					recoverSetupFailure(replacementCtx, handoff, setupError);
 					return;

--- a/packages/pi-plan-mode/src/implementation-options.ts
+++ b/packages/pi-plan-mode/src/implementation-options.ts
@@ -1,0 +1,127 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ChoiceScreen, SettingsScreen } from "@narumitw/pi-tui-kit";
+import { safeImplementationText as terminalText } from "./implementation-preferences.js";
+import { type ImplementationPreferences, PLAN_MODE_THINKING_LEVELS } from "./settings.js";
+
+export function implementationModelLabel(model: ImplementationPreferences["implementationModel"]) {
+	return model ? terminalText(`${model.provider} / ${model.id}`) : "Use current";
+}
+
+export function implementationSummary(preferences: ImplementationPreferences) {
+	return `Model: ${implementationModelLabel(preferences.implementationModel)} · Thinking: ${preferences.implementationThinkingLevel && preferences.implementationThinkingLevel !== "inherit" ? preferences.implementationThinkingLevel : "Use normal behavior"}`;
+}
+
+export type ImplementationOptionAction =
+	| "open-implementation-model"
+	| "set-implementation-model"
+	| "set-implementation-thinking";
+
+export function implementationSettingItems(
+	preferences: ImplementationPreferences,
+): SettingsScreen<ImplementationOptionAction>["items"] {
+	return [
+		{
+			id: "implementationModel",
+			label: "Implementation model",
+			currentValue: implementationModelLabel(preferences.implementationModel),
+			description:
+				"Select the model only when implementation starts; never switch back automatically.",
+			action: "open-implementation-model",
+		},
+		{
+			id: "implementationThinkingLevel",
+			label: "Implementation thinking",
+			currentValue: preferences.implementationThinkingLevel ?? "inherit",
+			values: PLAN_MODE_THINKING_LEVELS,
+			description:
+				"inherit preserves normal behavior, including restoration of Plan thinking. Explicit levels apply after model selection and are clamped by Pi.",
+			action: "set-implementation-thinking",
+		},
+	];
+}
+
+export function createImplementationModelPicker(ctx: ExtensionContext) {
+	// Snapshot Pi's scoped catalogue without network refresh or auth execution.
+	// Unlike /model, this picker stages a preference and never persists Pi defaults.
+	const models = ctx.scopedModels?.length
+		? ctx.scopedModels.map(({ model }) => model)
+		: ctx.modelRegistry.getAvailable();
+	const byId = new Map(
+		models.map((model, index) => [
+			`implementation-model:${index}`,
+			{ provider: model.provider, id: model.id },
+		]),
+	);
+	return {
+		selection(itemId: string) {
+			return itemId === "implementation-current" ? null : byId.get(itemId);
+		},
+		screen(preferences: ImplementationPreferences): ChoiceScreen<"set-implementation-model"> {
+			return {
+				kind: "choice",
+				title: "Implementation model",
+				enableSearch: true,
+				viewportSize: 10,
+				hint: "back",
+				action: "set-implementation-model",
+				lines: [
+					"Use current makes no model change. Reopen this menu to refresh the catalogue.",
+					"Implement here sends the planning conversation to the selected provider; fresh transfers only the approved plan and normal destination resources.",
+					`Selected: ${implementationModelLabel(preferences.implementationModel)}`,
+				],
+				items: [
+					{ id: "implementation-current", label: "Use current" },
+					...[...byId].map(([id, model]) => ({ id, label: implementationModelLabel(model) })),
+				],
+			};
+		},
+	};
+}
+
+/** Local draft lives only as long as the owning action menu. */
+export function createImplementationOptions(
+	ctx: ExtensionContext,
+	initial: ImplementationPreferences = {},
+) {
+	let preferences = { ...initial };
+	let picker: ReturnType<typeof createImplementationModelPicker> | undefined;
+	return {
+		get: () => preferences,
+		summary: () => implementationSummary(preferences),
+		screens: {
+			"implementation-options": (): SettingsScreen<ImplementationOptionAction> => ({
+				kind: "settings",
+				title: "Implementation options",
+				lines: [
+					"Applies to both implementation actions in this menu only.",
+					"Changes take effect only when implementation starts. No automatic restoration afterwards.",
+					`Current model: ${implementationModelLabel(ctx.model)}`,
+					"inherit keeps normal thinking behavior, not necessarily the temporary Plan thinking level.",
+				],
+				items: implementationSettingItems(preferences),
+			}),
+			"implementation-model": () => {
+				picker ??= createImplementationModelPicker(ctx);
+				return picker.screen(preferences);
+			},
+		},
+		actions: {
+			"open-implementation-model": async () => ({
+				kind: "to" as const,
+				screen: "implementation-model" as const,
+			}),
+			"set-implementation-model": async ({ itemId }: { itemId: string }) => {
+				const selected = picker?.selection(itemId);
+				if (selected === undefined) return { kind: "rejected" as const };
+				preferences = { ...preferences, implementationModel: selected ?? undefined };
+				return { kind: "back" as const };
+			},
+			"set-implementation-thinking": async ({ value }: { value?: string }) => {
+				const level = PLAN_MODE_THINKING_LEVELS.find((level) => level === value);
+				if (!level) return { kind: "rejected" as const };
+				preferences = { ...preferences, implementationThinkingLevel: level };
+				return { kind: "stay" as const };
+			},
+		},
+	};
+}

--- a/packages/pi-plan-mode/src/implementation-preferences.ts
+++ b/packages/pi-plan-mode/src/implementation-preferences.ts
@@ -1,0 +1,145 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ImplementationPreferences } from "./settings.js";
+
+type Model = NonNullable<ExtensionContext["model"]>;
+type Thinking = ReturnType<ExtensionAPI["getThinkingLevel"]>;
+export interface ImplementationSnapshot {
+	model: Model | undefined;
+	thinking: Thinking;
+}
+
+export function observeImplementationModelSelections(pi: ExtensionAPI) {
+	let latest: ImplementationSnapshot | undefined;
+	pi.on("model_select", (_event, ctx) => {
+		latest = { model: ctx.model, thinking: pi.getThinkingLevel() };
+	});
+	return () => latest;
+}
+
+export function hasImplementationPreferences(preferences: ImplementationPreferences) {
+	return (
+		preferences.implementationModel !== undefined ||
+		(preferences.implementationThinkingLevel !== undefined &&
+			preferences.implementationThinkingLevel !== "inherit")
+	);
+}
+
+export function sameModel(
+	left: { provider: string; id: string } | undefined,
+	right: { provider: string; id: string } | undefined,
+) {
+	return left?.provider === right?.provider && left?.id === right?.id;
+}
+
+export function safeImplementationText(value: string) {
+	return [...value]
+		.map((character) => {
+			const code = character.codePointAt(0) ?? 0;
+			return code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? " " : character;
+		})
+		.join("")
+		.trim();
+}
+
+export function preferenceError(error: unknown) {
+	return safeImplementationText(error instanceof Error ? error.message : String(error)).slice(
+		0,
+		500,
+	);
+}
+
+export async function preflightImplementationPreferences(
+	ctx: ExtensionContext,
+	preferences: ImplementationPreferences,
+	isCurrent: () => boolean,
+): Promise<Model | undefined> {
+	if (!isCurrent()) return undefined;
+	const identity = preferences.implementationModel;
+	const model = identity ? ctx.modelRegistry.find(identity.provider, identity.id) : ctx.model;
+	if (!model)
+		throw new Error(
+			"Implementation model is unavailable. Select a registered model or use current.",
+		);
+	// Pi's auth facade has no AbortSignal. Pi owns this operation; drain it and
+	// revalidate rather than claiming that cancellation stops provider auth work.
+	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	if (!isCurrent()) return undefined;
+	// Composed registries may materialize a new definition on every lookup.
+	const currentModel = identity ? ctx.modelRegistry.find(identity.provider, identity.id) : model;
+	if (!currentModel) {
+		throw new Error(
+			"Implementation model catalogue changed during preflight. Reopen the menu and retry.",
+		);
+	}
+	if (!auth.ok) throw new Error(auth.error);
+	return currentModel;
+}
+
+/** A one-shot handoff transaction, never an implementation-run restoration hook. */
+export function createImplementationPreferenceChange(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	isSessionCurrent: () => boolean,
+	original: ImplementationSnapshot = { model: ctx.model, thinking: pi.getThinkingLevel() },
+	selectionSnapshot?: () => ImplementationSnapshot | undefined,
+) {
+	let applied: ImplementationSnapshot | undefined;
+	const snapshot = (): ImplementationSnapshot => ({
+		model: ctx.model,
+		thinking: pi.getThinkingLevel(),
+	});
+	const matches = (value: ImplementationSnapshot) =>
+		sameModel(ctx.model, value.model) && pi.getThinkingLevel() === value.thinking;
+	return {
+		async apply(model: Model, preferences: ImplementationPreferences, isCurrent: () => boolean) {
+			if (!isCurrent()) return false;
+			// Includes any Plan-thinking restoration performed immediately before apply.
+			applied = snapshot();
+			if (preferences.implementationModel && !sameModel(ctx.model, model)) {
+				const beforeSelection = selectionSnapshot?.();
+				if (!(await pi.setModel(model)))
+					throw new Error("Implementation model authentication is unavailable.");
+				if (!isSessionCurrent()) return false;
+				if (!sameModel(ctx.model, model)) return false;
+				const selected = selectionSnapshot?.();
+				applied = selected && selected !== beforeSelection ? selected : snapshot();
+				if (!matches(applied)) {
+					if (ctx.hasUI)
+						ctx.ui.notify(
+							"Model or thinking changed during implementation preparation. The plan remains available; retry when ready.",
+							"warning",
+						);
+					return false;
+				}
+				if (!isCurrent()) return false;
+			}
+			const level = preferences.implementationThinkingLevel;
+			if (level && level !== "inherit") {
+				pi.setThinkingLevel(level);
+				applied = snapshot();
+				if (applied.thinking !== level && ctx.hasUI)
+					ctx.ui.notify(
+						`Implementation thinking: ${applied.thinking} (requested ${level}; adjusted by Pi for this model).`,
+						"info",
+					);
+			}
+			return isCurrent();
+		},
+		async rollback() {
+			if (!applied || !isSessionCurrent() || !ctx.isIdle() || !matches(applied)) return;
+			if (!sameModel(ctx.model, original.model)) {
+				const beforeSelection = selectionSnapshot?.();
+				if (!original.model || !(await pi.setModel(original.model))) {
+					throw new Error(
+						"Could not restore the previous model. The plan remains available; select a model before retrying.",
+					);
+				}
+				if (!isSessionCurrent() || !ctx.isIdle() || !sameModel(ctx.model, original.model)) return;
+				const selected = selectionSnapshot?.();
+				if (selected && selected !== beforeSelection && !matches(selected)) return;
+			}
+			pi.setThinkingLevel(original.thinking);
+			applied = undefined;
+		},
+	};
+}

--- a/packages/pi-plan-mode/src/plan-action-controller.ts
+++ b/packages/pi-plan-mode/src/plan-action-controller.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { PlanExportDestination } from "./plan-export.js";
+import type { ImplementationPreferences } from "./settings.js";
 import type { PlanModeState } from "./state.js";
 
 type InteractiveUi = typeof import("./interactive-ui.js");
@@ -18,8 +19,17 @@ interface PlanActionControllerOptions {
 	getExportDestination(ctx: ExtensionContext): PlanExportDestination;
 	show(ctx: ExtensionContext): void;
 	finalize(ctx: ExtensionContext): void;
-	implementHere(ctx: ExtensionContext): void | Promise<void>;
-	implementFresh(ctx: ExtensionContext, isCurrent: () => boolean): void | Promise<void>;
+	getImplementationPreferences?(): ImplementationPreferences;
+	implementHere(
+		ctx: ExtensionContext,
+		preferences?: ImplementationPreferences,
+		isCurrent?: () => boolean,
+	): void | Promise<void>;
+	implementFresh(
+		ctx: ExtensionContext,
+		isCurrent: () => boolean,
+		preferences?: ImplementationPreferences,
+	): void | Promise<void>;
 	exportPlan(
 		ctx: ExtensionContext,
 		path: string,
@@ -34,8 +44,17 @@ interface PlanActionControllerOptions {
 }
 
 export function createPlanActionController(options: PlanActionControllerOptions) {
-	const freshAction = (ctx: ExtensionContext, lifecycle: MenuLifecycle, signal: AbortSignal) =>
-		options.implementFresh(ctx, () => lifecycle.isCurrent() && !signal.aborted);
+	const implementationActions = (ctx: ExtensionContext, lifecycle: MenuLifecycle) => ({
+		implementationPreferences: options.getImplementationPreferences?.(),
+		implementHere: (preferences?: ImplementationPreferences, signal?: AbortSignal) =>
+			options.implementHere(
+				ctx,
+				preferences,
+				() => lifecycle.isCurrent() && !lifecycle.signal.aborted && !signal?.aborted,
+			),
+		implementFresh: (signal: AbortSignal, preferences?: ImplementationPreferences) =>
+			options.implementFresh(ctx, () => lifecycle.isCurrent() && !signal.aborted, preferences),
+	});
 
 	return {
 		async showSaved(ctx: ExtensionContext) {
@@ -50,8 +69,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				signal: lifecycle.signal,
 				isCurrent: lifecycle.isCurrent,
 				show: () => options.show(ctx),
-				implementHere: () => options.implementHere(ctx),
-				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
+				...implementationActions(ctx, lifecycle),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				settings: (signal) => options.settings(ctx, signal, lifecycle.isCurrent),
 				clear: () => options.clearSaved(ctx),
@@ -74,8 +92,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				...lifecycle,
 				show: () => options.show(ctx),
 				finalize: () => options.finalize(ctx),
-				implementHere: () => options.implementHere(ctx),
-				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
+				...implementationActions(ctx, lifecycle),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),
 				stay: () => options.stay(ctx),
@@ -91,8 +108,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				...lifecycle,
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
-				implementHere: () => options.implementHere(ctx),
-				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
+				...implementationActions(ctx, lifecycle),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),
 				stay: () => undefined,

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -1,35 +1,57 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import {
+	createImplementationOptions,
+	type ImplementationOptionAction,
+} from "./implementation-options.js";
 import { type PlanExportDestinationProvider, planExportInputScreen } from "./plan-export-screen.js";
+import type { ImplementationPreferences } from "./settings.js";
 
-interface MenuLifecycle {
+interface ReadyPlanMenuOptions {
 	signal: AbortSignal;
 	isCurrent(): boolean;
-}
-
-const IMPLEMENTATION_CONTEXT_LINES = [
-	"Implement here keeps this planning conversation.",
-	"Start fresh transfers only the approved plan to a new session.",
-] as const;
-
-interface PlanMenuOptions extends MenuLifecycle {
-	statusText: string;
-	hasReadyPlan: boolean;
+	implementationPreferences?: ImplementationPreferences;
 	implementationOutcome(): string;
 	getExportDestination: PlanExportDestinationProvider;
-	show(): void;
-	finalize(): void;
-	implementHere(): void | Promise<void>;
-	implementFresh(signal: AbortSignal): void | Promise<void>;
+	implementHere(
+		preferences?: ImplementationPreferences,
+		signal?: AbortSignal,
+	): void | Promise<void>;
+	implementFresh(
+		signal: AbortSignal,
+		preferences?: ImplementationPreferences,
+	): void | Promise<void>;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
 	stay(): void;
 	exit(): void;
 }
 
-export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuOptions) {
-	type Screen = "main" | "export";
+interface PlanMenuOptions extends ReadyPlanMenuOptions {
+	statusText: string;
+	hasReadyPlan: boolean;
+	show(): void;
+	finalize(): void;
+}
+
+export function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuOptions) {
+	return showActions(ctx, options, options);
+}
+
+export function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPlanMenuOptions) {
+	return showActions(ctx, options);
+}
+
+async function showActions(
+	ctx: ExtensionContext,
+	options: ReadyPlanMenuOptions,
+	current?: PlanMenuOptions,
+) {
+	const implementation = createImplementationOptions(ctx, options.implementationPreferences);
+	const ready = current?.hasReadyPlan ?? true;
+	type Screen = "main" | "export" | "implementation-options" | "implementation-model";
 	type Action =
+		| ImplementationOptionAction
 		| "show"
 		| "finalize"
 		| "implement-here"
@@ -41,23 +63,32 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "main",
 		screens: {
+			...implementation.screens,
 			main: () => ({
 				kind: "actions",
-				title: "Plan mode",
+				title: current ? "Plan mode" : "Proposed plan ready. What next?",
 				lines: [
-					options.statusText,
-					...(options.hasReadyPlan
-						? [...IMPLEMENTATION_CONTEXT_LINES, options.implementationOutcome()]
+					...(current ? [current.statusText] : []),
+					...(ready
+						? [
+								"Implement here keeps this planning conversation.",
+								"Start fresh transfers only the approved plan to a new session.",
+								options.implementationOutcome(),
+								implementation.summary(),
+							]
 						: []),
 				],
-				items: options.hasReadyPlan
+				items: ready
 					? [
-							{ id: "show", label: "Show latest proposed plan", action: "show" },
+							...(current
+								? [{ id: "show", label: "Show latest proposed plan", action: "show" as const }]
+								: []),
 							{
 								id: "implement-here",
 								label: "Implement here",
 								description: "Continue in this session with the planning conversation.",
 								action: "implement-here",
+								busyLabel: "Preparing implementation…",
 							},
 							{
 								id: "implement-fresh",
@@ -65,6 +96,11 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 								description: "Open a new linked session; transfer only the approved plan.",
 								action: "implement-fresh",
 								busyLabel: "Starting fresh implementation session…",
+							},
+							{
+								id: "implementation-options",
+								label: "Implementation options…",
+								to: "implementation-options",
 							},
 							{ id: "export", label: "Export plan…", to: "export" },
 							{ id: "save", label: "Save for later", action: "save" },
@@ -81,96 +117,21 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
+			...implementation.actions,
 			show: async () => {
-				options.show();
+				current?.show();
 				return { kind: "close" };
 			},
 			finalize: async () => {
-				options.finalize();
+				current?.finalize();
 				return { kind: "close" };
 			},
-			"implement-here": async () => {
-				await options.implementHere();
-				return { kind: "close" };
-			},
-			"implement-fresh": async ({ signal }) => {
-				await options.implementFresh(signal);
-				return { kind: "close" };
-			},
-			export: async ({ value, signal }) =>
-				(await options.exportPlan(value ?? "", signal)) ? { kind: "close" } : { kind: "rejected" },
-			save: async () => {
-				options.save();
-				return { kind: "close" };
-			},
-			stay: async () => {
-				options.stay();
-				return { kind: "close" };
-			},
-			exit: async () => {
-				options.exit();
-				return { kind: "close" };
-			},
-		},
-	});
-	await runMenu(ctx, menu, {
-		getState: () => undefined,
-		signal: options.signal,
-		isCurrent: options.isCurrent,
-	});
-}
-
-interface ReadyPlanMenuOptions extends MenuLifecycle {
-	implementationOutcome(): string;
-	getExportDestination: PlanExportDestinationProvider;
-	implementHere(): void | Promise<void>;
-	implementFresh(signal: AbortSignal): void | Promise<void>;
-	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
-	save(): void;
-	stay(): void;
-	exit(): void;
-}
-
-export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPlanMenuOptions) {
-	type Screen = "ready" | "export";
-	type Action = "implement-here" | "implement-fresh" | "export" | "save" | "stay" | "exit";
-	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
-		start: "ready",
-		screens: {
-			ready: () => ({
-				kind: "actions",
-				title: "Proposed plan ready. What next?",
-				lines: [...IMPLEMENTATION_CONTEXT_LINES, options.implementationOutcome()],
-				items: [
-					{
-						id: "implement-here",
-						label: "Implement here",
-						description: "Continue in this session with the planning conversation.",
-						action: "implement-here",
-					},
-					{
-						id: "implement-fresh",
-						label: "Start fresh and implement",
-						description: "Open a new linked session; transfer only the approved plan.",
-						action: "implement-fresh",
-						busyLabel: "Starting fresh implementation session…",
-					},
-					{ id: "export", label: "Export plan…", to: "export" },
-					{ id: "save", label: "Save for later", action: "save" },
-					{ id: "stay", label: "Stay in Plan mode", action: "stay" },
-					{ id: "exit", label: "Discard plan and exit", action: "exit" },
-				],
-				hint: "close",
-			}),
-			export: () => planExportInputScreen(options.getExportDestination),
-		},
-		actions: {
-			"implement-here": async () => {
-				await options.implementHere();
+			"implement-here": async ({ signal }) => {
+				await options.implementHere(implementation.get(), signal);
 				return { kind: "close" };
 			},
 			"implement-fresh": async ({ signal }) => {
-				await options.implementFresh(signal);
+				await options.implementFresh(signal, implementation.get());
 				return { kind: "close" };
 			},
 			export: async ({ value, signal }) =>

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -27,6 +27,15 @@ import {
 	formatTransferredPlanPrompt,
 	startFreshImplementationFromState,
 } from "./fresh-implementation.js";
+import { applyFreshImplementationPreferences } from "./fresh-implementation-preferences.js";
+import {
+	createImplementationPreferenceChange,
+	hasImplementationPreferences,
+	observeImplementationModelSelections,
+	preferenceError,
+	preflightImplementationPreferences,
+	sameModel,
+} from "./implementation-preferences.js";
 import {
 	createImplementationRetentionCoordinator,
 	implementationRetentionPreview,
@@ -74,6 +83,7 @@ import {
 	configuredImplementationPlanRetention,
 	configuredPlanModeToggleShortcut,
 	configuredThinkingLevel,
+	type ImplementationPreferences,
 	type PlanModeSettings,
 	type PlanModeSettingsPatch,
 	planModeSettingsPath,
@@ -125,6 +135,7 @@ interface PlanModeDependencies {
 // Keep session state, persistence, tool, thinking, and mutex commits in this one closure so an
 // activation path cannot bypass the same atomic transition by crossing module-owned state.
 export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDependencies = {}) {
+	const selectionSnapshot = observeImplementationModelSelections(pi);
 	const workflowMutex = new WorkflowMutex(pi);
 	let workflowOwner: WorkflowMutexOwner | undefined;
 	let currentSession: object | undefined;
@@ -153,6 +164,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let latestCommandContext: ExtensionCommandContext | undefined;
 	let nextReadyPresentationNonce = 0;
 	let menuGeneration = 0;
+	let implementationInFlight = false;
+	let applyingImplementationPreferences = false;
 	let workflowGeneration = 0;
 	let refreshStateBeforeFirstAgentStart = false;
 	let menuController = new AbortController();
@@ -177,6 +190,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		getExportDestination: (ctx) => planExports.getDestination(ctx),
 		show: (ctx) => showStoredPlan(pi, ctx, state),
 		finalize: requestFinalPlan,
+		getImplementationPreferences: () => ({
+			implementationModel: settings.implementationModel,
+			implementationThinkingLevel: settings.implementationThinkingLevel,
+		}),
 		implementHere: startImplementation,
 		implementFresh: startFreshImplementation,
 		exportPlan: exportPlan,
@@ -467,6 +484,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!installRestoredState(restoredState, ctx)) return;
 		implementationRetention.restore(state.activeImplementation);
 		updateUi(ctx);
+		if (event.reason === "new")
+			await applyFreshImplementationPreferences(
+				pi,
+				ctx,
+				() => generation === menuGeneration && !menuController.signal.aborted,
+				selectionSnapshot,
+			);
 	});
 
 	pi.on("session_before_tree", (event, ctx) => {
@@ -501,7 +525,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("thinking_level_select", (event) => {
-		if (!state.enabled || !state.appliedThinkingLevel) return;
+		if (applyingImplementationPreferences || !state.enabled || !state.appliedThinkingLevel) return;
 		if (event.level !== state.appliedThinkingLevel) {
 			state = {
 				...state,
@@ -982,8 +1006,13 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		ctx.ui.notify("Plan saved for later. Plan mode disabled.", "info");
 	}
 
-	async function startFreshImplementation(ctx: ExtensionContext, menuIsCurrent: () => boolean) {
+	async function startFreshImplementation(
+		ctx: ExtensionContext,
+		menuIsCurrent: () => boolean,
+		preferences: ImplementationPreferences = settings,
+	) {
 		await startFreshImplementationFromState(ctx, {
+			preferences,
 			getState: () => state,
 			menuIsCurrent,
 			retention: configuredImplementationPlanRetention(settings),
@@ -991,7 +1020,77 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		});
 	}
 
-	async function startImplementation(ctx: ExtensionContext) {
+	async function startImplementation(
+		ctx: ExtensionContext,
+		preferences: ImplementationPreferences = settings,
+		menuIsCurrent: () => boolean = () => true,
+	) {
+		if (implementationInFlight || !menuIsCurrent()) return;
+		if (!hasImplementationPreferences(preferences)) {
+			await startImplementationCore(ctx);
+			return;
+		}
+		if (!allowModeTransition(ctx, "start plan implementation")) return;
+		if (ctx.mode === "print" || ctx.mode === "json")
+			throw new Error("Implementation model options require TUI or RPC mode.");
+		const previousState = state;
+		if (!(state.enabled ? state.latestPlan : state.savedPlan?.plan)) return;
+		const generation = menuGeneration;
+		const workflow = workflowGeneration;
+		const original = { model: ctx.model, thinking: pi.getThinkingLevel() };
+		const sessionCurrent = () => generation === menuGeneration && !menuController.signal.aborted;
+		let expectedState = state;
+		const current = () =>
+			sessionCurrent() &&
+			workflow === workflowGeneration &&
+			state === expectedState &&
+			menuIsCurrent() &&
+			ctx.isIdle();
+		const change = createImplementationPreferenceChange(
+			pi,
+			ctx,
+			sessionCurrent,
+			original,
+			selectionSnapshot,
+		);
+		implementationInFlight = true;
+		let started = false;
+		try {
+			const model = await preflightImplementationPreferences(
+				ctx,
+				preferences,
+				() =>
+					current() &&
+					sameModel(ctx.model, original.model) &&
+					pi.getThinkingLevel() === original.thinking,
+			);
+			if (!model || !current()) return;
+			applyingImplementationPreferences = true;
+			if (state.enabled) restoreThinkingLevel();
+			expectedState = state;
+			if (!(await change.apply(model, preferences, current)) || !current()) return;
+			started = (await startImplementationCore(ctx, true)) === true;
+		} catch (error) {
+			if (sessionCurrent())
+				ctx.ui.notify(`Unable to start implementation: ${preferenceError(error)}`, "error");
+		} finally {
+			if (!started && sessionCurrent()) {
+				await change.rollback().catch((error) => {
+					if (sessionCurrent()) ctx.ui.notify(preferenceError(error), "error");
+				});
+				if (sessionCurrent() && state === expectedState) {
+					state = previousState;
+					captureManualThinkingLevel();
+					persistState();
+					updateUi(ctx);
+				}
+			}
+			applyingImplementationPreferences = false;
+			implementationInFlight = false;
+		}
+	}
+
+	async function startImplementationCore(ctx: ExtensionContext, preferencesApplied = false) {
 		const savedPlan = state.enabled ? undefined : state.savedPlan;
 		const initialPlan = (state.enabled ? state.latestPlan : savedPlan?.plan)?.trim();
 		if (!initialPlan) {
@@ -999,7 +1098,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			return;
 		}
 		if (!allowModeTransition(ctx, "start plan implementation")) return;
-		if (savedPlan) {
+		if (savedPlan && !preferencesApplied) {
 			const sessionGeneration = menuGeneration;
 			const planWorkflowGeneration = workflowGeneration;
 			const isCurrent = () =>
@@ -1044,7 +1143,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			workflowToolPolicy: undefined,
 			manualThinkingLevel: undefined,
 		};
-		if (wasEnabled) {
+		if (wasEnabled && !preferencesApplied) {
 			restoreThinkingLevel();
 			state = { ...state, manualThinkingLevel: undefined };
 		}
@@ -1063,13 +1162,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			if (wasEnabled) {
 				restoreWorkflowToolPolicy(state.workflowToolPolicy);
 				publishModeContract("plan", ctx);
-				applyPlanThinkingLevel();
+				if (!preferencesApplied) applyPlanThinkingLevel();
 			}
 			persistState();
 			updateUi(ctx);
 			return;
 		}
 		if (wasEnabled) releaseWorkflowOwner();
+		return true;
 	}
 
 	function clearActiveImplementation(id: string, ctx: ExtensionContext) {

--- a/packages/pi-plan-mode/src/saved-plan-menu.ts
+++ b/packages/pi-plan-mode/src/saved-plan-menu.ts
@@ -1,6 +1,11 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import {
+	createImplementationOptions,
+	type ImplementationOptionAction,
+} from "./implementation-options.js";
 import { type PlanExportDestinationProvider, planExportInputScreen } from "./plan-export-screen.js";
+import type { ImplementationPreferences } from "./settings.js";
 
 interface SavedPlanMenuOptions {
 	statusText: string;
@@ -9,8 +14,15 @@ interface SavedPlanMenuOptions {
 	signal: AbortSignal;
 	isCurrent(): boolean;
 	show(): void;
-	implementHere(): void | Promise<void>;
-	implementFresh(signal: AbortSignal): void | Promise<void>;
+	implementationPreferences?: ImplementationPreferences;
+	implementHere(
+		preferences?: ImplementationPreferences,
+		signal?: AbortSignal,
+	): void | Promise<void>;
+	implementFresh(
+		signal: AbortSignal,
+		preferences?: ImplementationPreferences,
+	): void | Promise<void>;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	settings(signal: AbortSignal): Promise<boolean>;
 	clear(): void;
@@ -22,11 +34,20 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 			`${options.statusText} Use /plan show, /plan implement, /plan export, or /plan exit.`,
 		);
 	}
-	type Screen = "saved" | "export";
-	type Action = "show" | "implement-here" | "implement-fresh" | "export" | "settings" | "clear";
+	const implementation = createImplementationOptions(ctx, options.implementationPreferences);
+	type Screen = "saved" | "export" | "implementation-options" | "implementation-model";
+	type Action =
+		| ImplementationOptionAction
+		| "show"
+		| "implement-here"
+		| "implement-fresh"
+		| "export"
+		| "settings"
+		| "clear";
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "saved",
 		screens: {
+			...implementation.screens,
 			saved: () => ({
 				kind: "actions",
 				title: "Saved plan",
@@ -35,6 +56,7 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 					"Implement here keeps this planning conversation.",
 					"Start fresh transfers only the approved plan to a new session.",
 					options.implementationOutcome(),
+					implementation.summary(),
 				],
 				items: [
 					{ id: "show", label: "Show saved plan", action: "show" },
@@ -51,6 +73,11 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 						action: "implement-fresh",
 						busyLabel: "Starting fresh implementation session…",
 					},
+					{
+						id: "implementation-options",
+						label: "Implementation options…",
+						to: "implementation-options",
+					},
 					{ id: "export", label: "Export plan…", to: "export" },
 					{ id: "settings", label: "Settings", action: "settings" },
 					{ id: "clear", label: "Clear saved plan", action: "clear" },
@@ -60,16 +87,17 @@ export async function showSavedPlanMenu(ctx: ExtensionContext, options: SavedPla
 			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
+			...implementation.actions,
 			show: async () => {
 				options.show();
 				return { kind: "close" };
 			},
-			"implement-here": async () => {
-				await options.implementHere();
+			"implement-here": async ({ signal }) => {
+				await options.implementHere(implementation.get(), signal);
 				return { kind: "close" };
 			},
 			"implement-fresh": async ({ signal }) => {
-				await options.implementFresh(signal);
+				await options.implementFresh(signal, implementation.get());
 				return { kind: "close" };
 			},
 			export: async ({ value, signal }) =>

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -1,6 +1,11 @@
 import type { ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
 import { defineMenu, type RunMenuResult, runMenu } from "@narumitw/pi-tui-kit";
 import { PLAN_MODE_COMPLETE_TOOL_NAME } from "./completion-tool.js";
+import {
+	createImplementationModelPicker,
+	type ImplementationOptionAction,
+	implementationSettingItems,
+} from "./implementation-options.js";
 import { retentionLabel } from "./implementation-retention.js";
 import { planExportDestination } from "./plan-export.js";
 import { PLAN_MODE_QUESTION_TOOL_NAME } from "./question-tool.js";
@@ -44,8 +49,9 @@ export interface PlanModeSettingsMenuOptions {
 	onSaved(settings: PlanModeSettings): void;
 }
 
-type Screen = "settings" | "tools" | "export" | "shortcut";
+type Screen = "settings" | "tools" | "export" | "shortcut" | "implementation-model";
 type Action =
+	| ImplementationOptionAction
 	| "set-thinking"
 	| "open-tools"
 	| "toggle-tool"
@@ -92,6 +98,7 @@ export async function showPlanModeSettings(
 		};
 	};
 
+	let implementationPicker: ReturnType<typeof createImplementationModelPicker> | undefined;
 	const menu = defineMenu<SettingsMenuState, Screen, Action, ExtensionContext>({
 		start: "settings",
 		screens: {
@@ -144,8 +151,13 @@ export async function showPlanModeSettings(
 									currentValue: configuredPlanModeToggleShortcut(state.settings) ?? "none",
 									action: "open-shortcut",
 								},
+								...implementationSettingItems(state.settings),
 							],
 						},
+			"implementation-model": ({ state }) => {
+				implementationPicker ??= createImplementationModelPicker(ctx);
+				return implementationPicker.screen(state.settings);
+			},
 			tools: ({ state }) => ({
 				kind: "multiSelect",
 				title: "Default Plan policy allowlist",
@@ -203,6 +215,28 @@ export async function showPlanModeSettings(
 			}),
 		},
 		actions: {
+			"open-implementation-model": async () => ({ kind: "to", screen: "implementation-model" }),
+			"set-implementation-model": async ({ ctx: actionCtx, itemId, signal }) => {
+				const model = implementationPicker?.selection(itemId);
+				if (model === undefined) return { kind: "rejected" };
+				const result = await savePatch(
+					actionCtx,
+					{ implementationModel: model },
+					signal,
+					"Implementation model saved. Applies when implementation starts.",
+				);
+				return result.kind === "stay" ? { kind: "back" } : result;
+			},
+			"set-implementation-thinking": async ({ ctx: actionCtx, value, signal }) => {
+				const level = PLAN_MODE_THINKING_LEVELS.find((level) => level === value);
+				if (!level) return { kind: "rejected" };
+				return savePatch(
+					actionCtx,
+					{ implementationThinkingLevel: level },
+					signal,
+					"Implementation thinking saved. Applies when implementation starts.",
+				);
+			},
 			"set-thinking": async ({ ctx: actionCtx, value, signal }) => {
 				if (
 					!PLAN_MODE_THINKING_LEVELS.includes(value as (typeof PLAN_MODE_THINKING_LEVELS)[number])

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -84,7 +84,11 @@ const MAX_PLAN_EXPORT_PATH_LENGTH = 4096;
 export type PlanModeThinkingLevel = (typeof PLAN_MODE_THINKING_LEVELS)[number];
 export type ImplementationPlanRetention = (typeof IMPLEMENTATION_PLAN_RETENTIONS)[number];
 export type PlanModeFixedThinkingLevel = Exclude<PlanModeThinkingLevel, "inherit">;
-export interface PlanModeSettings {
+export interface ImplementationPreferences {
+	implementationModel?: { provider: string; id: string };
+	implementationThinkingLevel?: PlanModeThinkingLevel;
+}
+export interface PlanModeSettings extends ImplementationPreferences {
 	thinkingLevel: PlanModeThinkingLevel;
 	defaultPlanTools?: string[];
 	implementationPlanRetention?: ImplementationPlanRetention;
@@ -93,6 +97,8 @@ export interface PlanModeSettings {
 	toggleShortcut?: KeyId;
 }
 export interface PlanModeSettingsPatch {
+	implementationModel?: ImplementationPreferences["implementationModel"] | null;
+	implementationThinkingLevel?: PlanModeThinkingLevel;
 	thinkingLevel?: PlanModeThinkingLevel;
 	defaultPlanTools?: readonly string[] | null;
 	implementationPlanRetention?: ImplementationPlanRetention;
@@ -137,6 +143,21 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 	const settings: PlanModeSettings = {
 		thinkingLevel: thinkingLevel as PlanModeThinkingLevel,
 	};
+	if (Object.hasOwn(value, "implementationModel")) {
+		const model = Reflect.get(value, "implementationModel");
+		if (
+			!isSettingsDocument(model) ||
+			!validModelIdentity(model.provider) ||
+			!validModelIdentity(model.id)
+		)
+			return undefined;
+		settings.implementationModel = { provider: model.provider, id: model.id };
+	}
+	if (Object.hasOwn(value, "implementationThinkingLevel")) {
+		const level = Reflect.get(value, "implementationThinkingLevel");
+		if (!PLAN_MODE_THINKING_LEVELS.includes(level as PlanModeThinkingLevel)) return undefined;
+		settings.implementationThinkingLevel = level as PlanModeThinkingLevel;
+	}
 	if (Object.hasOwn(value, "defaultPlanTools")) {
 		const defaultPlanTools = normalizeToolNames(Reflect.get(value, "defaultPlanTools"));
 		if (!defaultPlanTools) return undefined;
@@ -172,6 +193,10 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 		settings.safeSubcommands = safeSubcommands;
 	}
 	return settings;
+}
+
+function validModelIdentity(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0 && value.length <= 4096;
 }
 
 function normalizeToolNames(value: unknown) {
@@ -289,6 +314,15 @@ export function updatePlanModeSettings(
 		const current = await readSettingsDocumentForUpdate(settingsPath, legacySettingsPath);
 		const updated: SettingsDocument = { ...current };
 		if (patch.thinkingLevel !== undefined) updated.thinkingLevel = patch.thinkingLevel;
+		if (patch.implementationModel === null) delete updated.implementationModel;
+		else if (patch.implementationModel !== undefined) {
+			const previous = isSettingsDocument(updated.implementationModel)
+				? updated.implementationModel
+				: {};
+			updated.implementationModel = { ...previous, ...patch.implementationModel };
+		}
+		if (patch.implementationThinkingLevel !== undefined)
+			updated.implementationThinkingLevel = patch.implementationThinkingLevel;
 		if (patch.defaultPlanTools === null) delete updated.defaultPlanTools;
 		else if (patch.defaultPlanTools !== undefined) {
 			updated.defaultPlanTools = [...patch.defaultPlanTools];

--- a/packages/pi-plan-mode/test/build-runtime.test.ts
+++ b/packages/pi-plan-mode/test/build-runtime.test.ts
@@ -30,6 +30,7 @@ const forbiddenEagerInputs: readonly string[] = [
 	"src/plan-launch-menu.ts",
 	"src/saved-plan-menu.ts",
 	"src/settings-menu.ts",
+	"src/implementation-options.ts",
 ];
 
 type BuildMetadata = {

--- a/packages/pi-plan-mode/test/fresh-implementation-model.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-model.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import { startFreshImplementationSession } from "../src/fresh-implementation.js";
+import {
+	applyFreshImplementationPreferences,
+	FRESH_PREFERENCES_ENTRY,
+} from "../src/fresh-implementation-preferences.js";
+import { IMPLEMENTATION_PLAN_RETENTIONS } from "../src/settings.js";
+import { implementationRuntime } from "./implementation-runtime-support.js";
+
+for (const retention of IMPLEMENTATION_PLAN_RETENTIONS) {
+	test(`fresh handoff selects the destination model before kickoff (${retention})`, async () => {
+		const fixture = await implementationRuntime((pi) => {
+			pi.on("session_start", async (event, ctx) => {
+				if (event.reason === "new") await applyFreshImplementationPreferences(pi, ctx, () => true);
+			});
+		});
+		try {
+			const source = fixture.runtime.session.createReplacedSessionContext();
+			const sourceManager = source.sessionManager;
+			const sourceEntries = sourceManager.getBranch();
+			const kickoffs: Array<{ model?: string; thinking?: string; prompt: string }> = [];
+			const ctx = new Proxy(source, {
+				get(target, key) {
+					if (key === "newSession")
+						return (options: Parameters<ExtensionCommandContext["newSession"]>[0]) =>
+							fixture.runtime.newSession({
+								...options,
+								withSession: async (replacement) => {
+									const destination = new Proxy(replacement, {
+										get(target, key) {
+											if (key === "sendUserMessage")
+												return async (prompt: string) => {
+													kickoffs.push({
+														model: target.model?.id,
+														thinking: target.thinkingLevel,
+														prompt,
+													});
+												};
+											return Reflect.get(target, key);
+										},
+									});
+									await options?.withSession?.(destination);
+								},
+							});
+					return Reflect.get(target, key);
+				},
+			});
+			const result = await startFreshImplementationSession(ctx, {
+				plan: "# Approved plan",
+				source: "plan_mode_complete",
+				stateEntryType: "plan-mode-state",
+				retention,
+				isCurrent: () => true,
+				preferences: {
+					implementationModel: { provider: "plan-test", id: "worker" },
+					implementationThinkingLevel: "max",
+				},
+			});
+			assert.deepEqual(result, { kind: "started" });
+			assert.equal(kickoffs.length, 1);
+			assert.equal(kickoffs[0]?.model, "worker");
+			assert.equal(kickoffs[0]?.thinking, "max");
+			assert.match(kickoffs[0]?.prompt ?? "", /# Approved plan/);
+			assert.deepEqual(sourceManager.getBranch(), sourceEntries);
+			fixture.pi.setThinkingLevel("high");
+			await fixture.runtime.session.extensionRunner.emit({
+				type: "session_start",
+				reason: "reload",
+			});
+			assert.equal(fixture.pi.getThinkingLevel(), "high");
+			assert.equal(fixture.settings.getDefaultModel(), "planner");
+		} finally {
+			await fixture.dispose();
+		}
+	});
+}
+
+for (const failure of ["cancelled", "missing-target", "missing-ack", "kickoff"] as const) {
+	test(`fresh preference ${failure} preserves source and does not silently start on a fallback`, async () => {
+		const fixture = await implementationRuntime((pi) => {
+			pi.on("session_start", async (event, ctx) => {
+				if (event.reason === "new" && failure !== "missing-ack")
+					await applyFreshImplementationPreferences(pi, ctx, () => true);
+			});
+		});
+		try {
+			const source = fixture.runtime.session.createReplacedSessionContext();
+			const sourceManager = source.sessionManager;
+			const before = sourceManager.getBranch();
+			let sends = 0;
+			let recovered = "";
+			if (failure === "cancelled") fixture.cancelReplacement();
+			const ctx = new Proxy(source, {
+				get(target, key) {
+					if (key === "newSession")
+						return (options: Parameters<ExtensionCommandContext["newSession"]>[0]) =>
+							fixture.runtime.newSession({
+								...options,
+								withSession: async (replacement) => {
+									const destination = new Proxy(replacement, {
+										get(target, key) {
+											if (key === "sendUserMessage")
+												return async () => {
+													sends++;
+													throw new Error("delivery failed");
+												};
+											if (key === "ui")
+												return {
+													...target.ui,
+													setEditorText: (text: string) => {
+														recovered = text;
+													},
+												};
+											return Reflect.get(target, key);
+										},
+									});
+									await options?.withSession?.(destination);
+								},
+							});
+					return Reflect.get(target, key);
+				},
+			});
+			const result = await startFreshImplementationSession(ctx, {
+				plan: "# Approved plan",
+				source: "plan_mode_complete",
+				stateEntryType: "plan-mode-state",
+				retention: "clear-on-start",
+				isCurrent: () => true,
+				preferences: {
+					implementationModel: {
+						provider: "plan-test",
+						id: failure === "missing-target" ? "missing" : "worker",
+					},
+				},
+			});
+			assert.equal(
+				result.kind,
+				failure === "cancelled"
+					? "cancelled"
+					: failure === "missing-target"
+						? "rejected"
+						: "partial",
+			);
+			assert.equal(sends, failure === "kickoff" ? 1 : 0);
+			assert.deepEqual(sourceManager.getBranch(), before);
+			if (result.kind === "partial") assert.match(recovered, /# Approved plan/);
+			else assert.equal(fixture.ctx.model?.id, "planner");
+		} finally {
+			await fixture.dispose();
+		}
+	});
+}
+
+test("fresh destination consumes failed preference requests without replay", async () => {
+	const fixture = await implementationRuntime();
+	try {
+		fixture.pi.appendEntry(FRESH_PREFERENCES_ENTRY, {
+			id: "bad",
+			status: "pending",
+			preferences: { implementationModel: { provider: "plan-test", id: "missing" } },
+		});
+		await applyFreshImplementationPreferences(fixture.pi, fixture.ctx, () => true);
+		const before = fixture.runtime.session.sessionManager.getBranch();
+		await applyFreshImplementationPreferences(fixture.pi, fixture.ctx, () => true);
+		assert.deepEqual(fixture.runtime.session.sessionManager.getBranch(), before);
+		assert.equal(fixture.ctx.model?.id, "planner");
+	} finally {
+		await fixture.dispose();
+	}
+});

--- a/packages/pi-plan-mode/test/implementation-handoff.test.ts
+++ b/packages/pi-plan-mode/test/implementation-handoff.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import {
+	IMPLEMENTATION_PLAN_RETENTIONS,
+	type ImplementationPreferences,
+	type PlanModeSettings,
+} from "../src/settings.js";
+import { createMockContext, createMockPi } from "./support.js";
+
+const PLANNER = { provider: "test", id: "planner" };
+const WORKER = { provider: "test", id: "worker" };
+const PREFERENCES: ImplementationPreferences = {
+	implementationModel: WORKER,
+	implementationThinkingLevel: "high",
+};
+
+async function readyFixture(
+	settings: PlanModeSettings = { thinkingLevel: "medium", ...PREFERENCES },
+) {
+	const directory = await mkdtemp(join(tmpdir(), "plan-handoff-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = directory;
+	const { default: planMode } = await import("../src/plan-mode.js");
+	const mock = createMockPi({ activeTools: ["read", "edit"], thinkingLevel: "low" });
+	let model = PLANNER;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		cwd: directory,
+		modelRegistry: {
+			find: (provider: string, id: string) =>
+				[PLANNER, WORKER].find((model) => model.provider === provider && model.id === id),
+			getAvailable: () => [PLANNER, WORKER],
+			getApiKeyAndHeaders: async () => ({ ok: true }),
+		},
+	});
+	const ctx: ExtensionContext = context.ctx;
+	Object.defineProperty(ctx, "model", { get: () => model });
+	Object.defineProperty(ctx, "thinkingLevel", { get: () => mock.thinkingLevel });
+	mock.rawPi.setModel = async (next) => {
+		model = next as typeof model;
+		mock.setModels.push(next);
+		for (const handler of mock.events.get("model_select") ?? []) await handler({ model }, ctx);
+		return true;
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "loaded", settings }) });
+	const emit = async (event: string, data: unknown = {}) => {
+		for (const handler of mock.events.get(event) ?? []) await handler(data, ctx);
+	};
+	const registered = mock.commands.get("plan");
+	assert.ok(registered);
+	const command = (text: string) => registered.handler(text, context.ctx);
+	await emit("session_start", { reason: "startup" });
+	await command("start");
+	const tool = mock.tools.find((tool) => tool.name === "plan_mode_complete");
+	assert.ok(tool);
+	const complete = tool.execute as (...args: unknown[]) => Promise<unknown>;
+	await complete(
+		"complete",
+		{ plan: "# Approved\nImplement and test." },
+		undefined,
+		undefined,
+		ctx,
+	);
+	return {
+		mock,
+		context,
+		ctx,
+		command,
+		emit,
+		manualModel: (next: typeof model) => {
+			model = next;
+		},
+		async dispose() {
+			await emit("session_shutdown");
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			await rm(directory, { recursive: true, force: true });
+		},
+	};
+}
+
+for (const { saved, retention } of [false, true].flatMap((saved) =>
+	IMPLEMENTATION_PLAN_RETENTIONS.map((retention) => ({ saved, retention })),
+)) {
+	test(`implementation applies defaults without run-end restoration (saved=${saved}, ${retention})`, async () => {
+		const fixture = await readyFixture({
+			thinkingLevel: "medium",
+			...PREFERENCES,
+			implementationPlanRetention: retention,
+		});
+		try {
+			if (saved) await fixture.command("save");
+			await fixture.command("implement");
+			assert.deepEqual(fixture.ctx.model, WORKER);
+			assert.equal(fixture.mock.thinkingLevel, "high");
+			assert.equal(fixture.mock.sentUserMessages.length, 1);
+			await fixture.emit("agent_end", {
+				messages: [{ role: "assistant", content: [], stopReason: "aborted" }],
+			});
+			await fixture.emit("agent_settled");
+			assert.deepEqual(fixture.ctx.model, WORKER);
+			assert.equal(fixture.mock.thinkingLevel, "high");
+			fixture.manualModel(PLANNER);
+			fixture.mock.rawPi.setThinkingLevel("minimal");
+			await fixture.command("exit");
+			assert.deepEqual(fixture.ctx.model, PLANNER);
+			assert.equal(fixture.mock.thinkingLevel, "minimal");
+		} finally {
+			await fixture.dispose();
+		}
+	});
+}
+
+test("inherit preserves existing Plan thinking restoration without model selection", async () => {
+	const fixture = await readyFixture({
+		thinkingLevel: "medium",
+		implementationThinkingLevel: "inherit",
+	});
+	try {
+		await fixture.command("implement");
+		assert.equal(fixture.mock.thinkingLevel, "low");
+		assert.deepEqual(fixture.mock.setModels, []);
+	} finally {
+		await fixture.dispose();
+	}
+});
+
+test("manual thinking changed by a later model-selection listener is preserved without kickoff", async () => {
+	const fixture = await readyFixture();
+	try {
+		fixture.mock.rawPi.on("model_select", () => {
+			fixture.mock.rawPi.setThinkingLevel("max");
+		});
+		await fixture.command("implement");
+		assert.equal(fixture.mock.sentUserMessages.length, 0);
+		assert.equal(fixture.mock.thinkingLevel, "max");
+		assert.equal(fixture.context.statuses.get("plan-mode"), "plan ready");
+	} finally {
+		await fixture.dispose();
+	}
+});
+
+for (const failure of ["missing-model", "removed-model", "auth", "selection", "kickoff"] as const) {
+	test(`implementation ${failure} failure retains the ready plan and previous runtime`, async () => {
+		const fixture = await readyFixture(
+			failure === "missing-model"
+				? { thinkingLevel: "medium", implementationModel: { provider: "missing", id: "model" } }
+				: undefined,
+		);
+		try {
+			if (failure === "auth")
+				fixture.ctx.modelRegistry.getApiKeyAndHeaders = async () => ({
+					ok: false,
+					error: "No auth",
+				});
+			if (failure === "removed-model")
+				fixture.ctx.modelRegistry.getApiKeyAndHeaders = async () => {
+					fixture.ctx.modelRegistry.find = () => undefined;
+					return { ok: true, apiKey: "test" };
+				};
+			if (failure === "selection") fixture.mock.rawPi.setModel = async () => false;
+			if (failure === "kickoff")
+				fixture.mock.rawPi.sendUserMessage = () => {
+					throw new Error("kickoff failed");
+				};
+			await fixture.command("implement");
+			assert.equal(fixture.mock.sentUserMessages.length, 0);
+			assert.equal(fixture.context.statuses.get("plan-mode"), "plan ready");
+			assert.deepEqual(fixture.ctx.model, PLANNER);
+			assert.equal(fixture.mock.thinkingLevel, "medium");
+			assert.ok(fixture.context.notifications.some(({ level }) => level === "error"));
+		} finally {
+			await fixture.dispose();
+		}
+	});
+}
+
+for (const interruption of [
+	"shutdown",
+	"exit",
+	"manual-model",
+	"manual-thinking",
+	"busy",
+] as const) {
+	test(`pending preference preflight stops on ${interruption}`, async () => {
+		const fixture = await readyFixture();
+		let release!: (value: { ok: true }) => void;
+		let ready!: () => void;
+		const started = new Promise<void>((resolve) => {
+			ready = resolve;
+		});
+		fixture.ctx.modelRegistry.getApiKeyAndHeaders = () =>
+			new Promise((resolve) => {
+				release = resolve;
+				ready();
+			});
+		try {
+			const pending = fixture.command("implement");
+			await started;
+			if (interruption === "shutdown") await fixture.emit("session_shutdown");
+			if (interruption === "exit") await fixture.command("exit");
+			if (interruption === "manual-model") fixture.manualModel(WORKER);
+			if (interruption === "manual-thinking") fixture.mock.rawPi.setThinkingLevel("max");
+			if (interruption === "busy") fixture.ctx.isIdle = () => false;
+			release({ ok: true });
+			await pending;
+			assert.equal(fixture.mock.sentUserMessages.length, 0);
+			assert.equal(fixture.mock.setModels.length, 0);
+		} finally {
+			await fixture.dispose();
+		}
+	});
+}

--- a/packages/pi-plan-mode/test/implementation-options.test.ts
+++ b/packages/pi-plan-mode/test/implementation-options.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type KeyId, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
+import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";
+import { test } from "vitest";
+import { createImplementationModelPicker } from "../src/implementation-options.js";
+import { showReadyPlanMenu } from "../src/plan-action-menus.js";
+import type { ImplementationPreferences } from "../src/settings.js";
+import { showPlanModeSettings } from "../src/settings-menu.js";
+import { createMockContext } from "./support.js";
+
+const MODEL = { provider: "cheap", id: "org/worker" };
+function readyOptions(onImplement: (preferences?: ImplementationPreferences) => void) {
+	return {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+		implementationOutcome: () => "Plan reinjection: Off",
+		getExportDestination: () => ({ configuredPath: "PLAN.md", resolvedPath: "/tmp/PLAN.md" }),
+		implementHere: onImplement,
+		implementFresh: (_signal: AbortSignal, preferences?: ImplementationPreferences) =>
+			onImplement(preferences),
+		exportPlan: async () => false,
+		save: () => {},
+		stay: () => {},
+		exit: () => {},
+	};
+}
+
+for (const destination of ["Implement here", "Start fresh and implement"]) {
+	test(`RPC options stage model/thinking for ${destination} without saving defaults`, async () => {
+		const rpc = createRpcHarness([
+			{ kind: "select", response: "Implementation options…" },
+			{ kind: "select", response: "Implementation model (Use current)" },
+			{ kind: "select", response: "cheap / org/worker" },
+			{ kind: "select", response: "Implementation thinking (inherit)" },
+			{ kind: "select", response: "Back" },
+			{ kind: "select", response: destination },
+		]);
+		const context = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			...rpc.ui,
+			modelRegistry: { getAvailable: () => [MODEL] },
+		});
+		const calls: ImplementationPreferences[] = [];
+		await showReadyPlanMenu(
+			context.ctx,
+			readyOptions((preferences) => {
+				if (preferences) calls.push(preferences);
+			}),
+		);
+		rpc.assertConsumed();
+		assert.deepEqual(calls, [{ implementationModel: MODEL, implementationThinkingLevel: "off" }]);
+		assert.match(rpc.dialogs.at(-1)?.title ?? "", /Model: cheap \/ org\/worker.*Thinking: off/);
+	});
+}
+
+test("TUI options are staged, sanitized, width bounded, and discarded on hard cancellation", async () => {
+	const tui = createTuiHarness({ width: 64, rows: 30 });
+	const hostile = { provider: "provider\u001b[31m", id: "model\n\u0007" };
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: tui.custom,
+		modelRegistry: { getAvailable: () => [hostile] },
+	});
+	const calls: unknown[] = [];
+	try {
+		const running = showReadyPlanMenu(
+			context.ctx,
+			readyOptions((value) => {
+				calls.push(value);
+			}),
+		);
+		await tui.waitForOpen();
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Implementation options/);
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.ok(tui.render(24).every((line) => visibleWidth(line) <= 24));
+		assert.equal(tui.render().join("\n").includes("\u0007"), false);
+		assert.equal(tui.render().join("\n").includes("\u001b[31m"), false);
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render(64).join("\n"), /provider/);
+		tui.press("ctrl+c");
+		await running;
+		assert.equal(calls.length, 0);
+		const reopened = showReadyPlanMenu(
+			context.ctx,
+			readyOptions((value) => {
+				calls.push(value);
+			}),
+		);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Model: Use current/);
+		tui.dispose();
+		await reopened;
+		assert.deepEqual(calls, []);
+	} finally {
+		tui.dispose();
+	}
+});
+
+test("implementation actions use remapped confirmation and keep hard cancellation", async () => {
+	const keys: Record<string, KeyId[]> = {
+		"tui.select.confirm": ["ctrl+x"],
+		"tui.select.cancel": ["alt+q"],
+		"tui.select.down": ["down"],
+		"tui.select.up": ["up"],
+	};
+	const tui = createTuiHarness({
+		keybindings: {
+			getKeys: (binding) => keys[binding] ?? [],
+			matches: (data, binding) => (keys[binding] ?? []).some((key) => matchesKey(data, key)),
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	let calls = 0;
+	try {
+		const running = showReadyPlanMenu(
+			context.ctx,
+			readyOptions(() => {
+				calls++;
+			}),
+		);
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /ctrl\+x/i);
+		tui.send("\u0018");
+		await running;
+		assert.equal(calls, 1);
+		const cancelled = showReadyPlanMenu(
+			context.ctx,
+			readyOptions(() => {
+				calls++;
+			}),
+		);
+		await tui.waitForOpen();
+		tui.press("ctrl+c");
+		await cancelled;
+		assert.equal(calls, 1);
+	} finally {
+		tui.dispose();
+	}
+});
+
+test("model choices use exact opaque identities and respect scoped models", () => {
+	const context = createMockContext({
+		scopedModels: [{ model: MODEL }],
+		modelRegistry: {
+			getAvailable: () => {
+				throw new Error("scope must win");
+			},
+		},
+	});
+	const picker = createImplementationModelPicker(context.ctx);
+	assert.deepEqual(picker.selection("implementation-model:0"), MODEL);
+	assert.equal(picker.selection("cheap/org/worker"), undefined);
+	assert.equal(picker.selection("implementation-current"), null);
+});
+
+test("RPC Settings persists implementation defaults without touching the current runtime", async () => {
+	const root = await mkdtemp(join(tmpdir(), "plan-options-settings-"));
+	const settingsPath = join(root, "settings.json");
+	const rpc = createRpcHarness([
+		{ kind: "select", response: "Implementation model (Use current)" },
+		{ kind: "select", response: "cheap / org/worker" },
+		{ kind: "select", response: "Implementation thinking (inherit)" },
+		{ kind: "select", response: "Back" },
+	]);
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		...rpc.ui,
+		model: { provider: "expensive", id: "planner" },
+		modelRegistry: { getAvailable: () => [MODEL] },
+	});
+	try {
+		await showPlanModeSettings(context.ctx, {
+			settingsPath,
+			tools: [],
+			signal: new AbortController().signal,
+			isCurrent: () => true,
+			onSaved: () => {},
+		});
+		rpc.assertConsumed();
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			implementationModel: MODEL,
+			implementationThinkingLevel: "off",
+		});
+		assert.deepEqual((context.ctx as { model: unknown }).model, {
+			provider: "expensive",
+			id: "planner",
+		});
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-plan-mode/test/implementation-runtime-support.ts
+++ b/packages/pi-plan-mode/test/implementation-runtime-support.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionFromServices,
+	createAgentSessionRuntime,
+	createAgentSessionServices,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type ExtensionFactory,
+	SessionManager,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+export async function implementationRuntime(extension?: ExtensionFactory) {
+	const root = mkdtempSync(join(tmpdir(), "plan-implementation-runtime-"));
+	let pi!: ExtensionAPI;
+	let ctx!: ExtensionContext;
+	let cancelReplacement = false;
+	const events: string[] = [];
+	const settings = SettingsManager.inMemory({
+		defaultProvider: "plan-test",
+		defaultModel: "planner",
+		defaultThinkingLevel: "low",
+		modelThinkingLevels: { "plan-test/worker": "medium" },
+	});
+	const factory: CreateAgentSessionRuntimeFactory = async (options) => {
+		const services = await createAgentSessionServices({
+			cwd: root,
+			agentDir: root,
+			settingsManager: settings,
+			resourceLoaderOptions: {
+				noExtensions: true,
+				noSkills: true,
+				noPromptTemplates: true,
+				noThemes: true,
+				extensionFactories: [
+					{
+						name: "implementation-test",
+						factory: async (api) => {
+							pi = api;
+							await extension?.(api);
+							api.on("session_start", (_event, context) => {
+								ctx = context;
+								events.push("start");
+							});
+							api.on("session_shutdown", () => {
+								events.push("shutdown");
+							});
+							api.on("session_before_switch", () =>
+								cancelReplacement ? { cancel: true } : undefined,
+							);
+							api.on("model_select", () => {
+								events.push("model");
+							});
+							api.on("thinking_level_select", () => {
+								events.push("thinking");
+							});
+						},
+					},
+				],
+			},
+		});
+		services.modelRuntime.registerProvider("plan-test", {
+			api: "openai-completions",
+			baseUrl: "http://127.0.0.1:1",
+			apiKey: "test-only",
+			models: [
+				{
+					id: "planner",
+					name: "planner",
+					reasoning: true,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 100000,
+					maxTokens: 1000,
+				},
+				{
+					id: "worker",
+					name: "worker",
+					reasoning: true,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 100000,
+					maxTokens: 1000,
+					thinkingLevelMap: { low: null, xhigh: null, max: "max" },
+				},
+				{
+					id: "plain",
+					name: "plain",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 100000,
+					maxTokens: 1000,
+				},
+			],
+		});
+		const result = await createAgentSessionFromServices({
+			services,
+			sessionManager: options.sessionManager,
+			sessionStartEvent: options.sessionStartEvent,
+			tools: [],
+		});
+		return { ...result, services, diagnostics: services.diagnostics };
+	};
+	const runtime = await createAgentSessionRuntime(factory, {
+		cwd: root,
+		agentDir: root,
+		sessionManager: SessionManager.inMemory(root),
+	});
+	const bind = async () =>
+		runtime.session.bindExtensions({
+			mode: "rpc",
+			commandContextActions: {
+				waitForIdle: async () => {},
+				newSession: (options) => runtime.newSession(options),
+				fork: (entryId, options) => runtime.fork(entryId, options),
+				switchSession: (path, options) => runtime.switchSession(path, options),
+				navigateTree: (id, options) => runtime.session.navigateTree(id, options),
+				reload: async () => {},
+			},
+		});
+	runtime.setRebindSession(bind);
+	await bind();
+	return {
+		runtime,
+		settings,
+		events,
+		get pi() {
+			return pi;
+		},
+		get ctx() {
+			return ctx;
+		},
+		cancelReplacement() {
+			cancelReplacement = true;
+		},
+		async dispose() {
+			await runtime.dispose();
+			rmSync(root, { recursive: true, force: true });
+		},
+	};
+}

--- a/packages/pi-plan-mode/test/implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/implementation-runtime.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	applyFreshImplementationPreferences,
+	FRESH_PREFERENCES_ENTRY,
+	freshPreferencesApplied,
+} from "../src/fresh-implementation-preferences.js";
+import { implementationRuntime } from "./implementation-runtime-support.js";
+
+test("Pi model selection is session-only and applies per-model defaults and capability clamping", async () => {
+	const fixture = await implementationRuntime();
+	try {
+		const worker = fixture.ctx.modelRegistry.find("plan-test", "worker");
+		assert.ok(worker);
+		// Composed provider definitions are equivalent by identity, not reference.
+		const repeated = fixture.ctx.modelRegistry.find("plan-test", "worker");
+		assert.notEqual(repeated, worker);
+		assert.equal(repeated?.provider, worker.provider);
+		assert.equal(repeated?.id, worker.id);
+		assert.equal(await fixture.pi.setModel(worker), true);
+		assert.equal(fixture.ctx.model?.id, "worker");
+		assert.equal(fixture.pi.getThinkingLevel(), "medium");
+		fixture.pi.setThinkingLevel("low");
+		assert.equal(fixture.pi.getThinkingLevel(), "medium");
+		fixture.pi.setThinkingLevel("max");
+		assert.equal(fixture.pi.getThinkingLevel(), "max");
+		fixture.pi.setThinkingLevel("xhigh");
+		assert.equal(fixture.pi.getThinkingLevel(), "max");
+		const plain = fixture.ctx.modelRegistry.find("plan-test", "plain");
+		assert.ok(plain);
+		await fixture.pi.setModel(plain);
+		fixture.pi.setThinkingLevel("high");
+		assert.equal(fixture.pi.getThinkingLevel(), "off");
+		assert.equal(await fixture.pi.setModel({ ...worker, provider: "missing-auth" }), false);
+		assert.equal(fixture.ctx.model?.id, "plain");
+		assert.equal(fixture.settings.getDefaultModel(), "planner");
+		assert.equal(fixture.settings.getDefaultThinkingLevel(), "low");
+		assert.ok(fixture.events.includes("model"));
+		assert.ok(fixture.events.includes("thinking"));
+	} finally {
+		await fixture.dispose();
+	}
+});
+
+test("fresh setup precedes destination start, which applies preferences without using stale source APIs", async () => {
+	const fixture = await implementationRuntime((pi) => {
+		pi.on("session_start", async (event, ctx) => {
+			if (event.reason === "new") await applyFreshImplementationPreferences(pi, ctx, () => true);
+		});
+	});
+	try {
+		const sourcePi = fixture.pi;
+		let acknowledged = false;
+		await fixture.runtime.newSession({
+			setup: async (sm) => {
+				fixture.events.push("setup");
+				sm.appendCustomEntry(FRESH_PREFERENCES_ENTRY, {
+					id: "handoff",
+					status: "pending",
+					preferences: {
+						implementationModel: { provider: "plan-test", id: "worker" },
+						implementationThinkingLevel: "high",
+					},
+				});
+			},
+			withSession: async (ctx) => {
+				fixture.events.push("kickoff");
+				acknowledged = freshPreferencesApplied(ctx, "handoff");
+				assert.equal(ctx.model?.id, "worker");
+				assert.equal(ctx.thinkingLevel, "high");
+			},
+		});
+		assert.equal(acknowledged, true);
+		assert.ok(fixture.events.indexOf("shutdown") < fixture.events.indexOf("setup"));
+		assert.ok(fixture.events.indexOf("setup") < fixture.events.lastIndexOf("start"));
+		assert.ok(fixture.events.lastIndexOf("start") < fixture.events.indexOf("kickoff"));
+		assert.throws(() => sourcePi.getThinkingLevel(), /stale/);
+		assert.equal(fixture.settings.getDefaultModel(), "planner");
+		const currentPi = fixture.pi;
+		fixture.cancelReplacement();
+		assert.deepEqual(await fixture.runtime.newSession(), { cancelled: true });
+		assert.equal(fixture.pi, currentPi);
+		assert.equal(fixture.ctx.model?.id, "worker");
+	} finally {
+		await fixture.dispose();
+	}
+});

--- a/packages/pi-plan-mode/test/implementation-settings.test.ts
+++ b/packages/pi-plan-mode/test/implementation-settings.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import {
+	normalizePlanModeSettings,
+	readPlanModeSettings,
+	updatePlanModeSettings,
+} from "../src/settings.js";
+
+test("implementation preferences validate exact provider/model identity and thinking without changing defaults", () => {
+	assert.deepEqual(normalizePlanModeSettings({}), { thinkingLevel: "inherit" });
+	for (const implementationModel of [
+		null,
+		"provider/model",
+		{},
+		{ provider: "p" },
+		{ provider: "", id: "m" },
+		{ provider: "p", id: 3 },
+		{ provider: "p", id: " " },
+	]) {
+		assert.equal(normalizePlanModeSettings({ implementationModel }), undefined);
+	}
+	assert.equal(normalizePlanModeSettings({ implementationThinkingLevel: "auto" }), undefined);
+	assert.deepEqual(
+		normalizePlanModeSettings({
+			implementationModel: { provider: "custom", id: "org/model:variant" },
+			implementationThinkingLevel: "max",
+		}),
+		{
+			thinkingLevel: "inherit",
+			implementationModel: { provider: "custom", id: "org/model:variant" },
+			implementationThinkingLevel: "max",
+		},
+	);
+});
+
+test("implementation settings preserve unknown fields, serialize patches, reset, and protect invalid/failed writes", async () => {
+	const root = await mkdtemp(join(tmpdir(), "plan-implementation-settings-"));
+	const settingsPath = join(root, "settings.json");
+	try {
+		assert.deepEqual(await readPlanModeSettings(settingsPath), { kind: "missing" });
+		await assert.rejects(readFile(settingsPath), { code: "ENOENT" });
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				unknown: 42,
+				implementationModel: { provider: "old", id: "old", future: true },
+			}),
+		);
+		const first = updatePlanModeSettings(
+			{ implementationModel: { provider: "p", id: "m" } },
+			{ settingsPath },
+		);
+		const second = updatePlanModeSettings(
+			{ implementationThinkingLevel: "high" },
+			{ settingsPath },
+		);
+		const loaded = await readPlanModeSettings(settingsPath);
+		await Promise.all([first, second]);
+		assert.equal(loaded.kind, "loaded");
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			unknown: 42,
+			implementationModel: { provider: "p", id: "m", future: true },
+			implementationThinkingLevel: "high",
+		});
+		const before = await readFile(settingsPath, "utf8");
+		await assert.rejects(
+			updatePlanModeSettings(
+				{ implementationThinkingLevel: "off" },
+				{
+					settingsPath,
+					beforeRename: async () => {
+						throw new Error("publication failed");
+					},
+				},
+			),
+			/publication failed/,
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), before);
+		await updatePlanModeSettings(
+			{ implementationModel: null, implementationThinkingLevel: "inherit" },
+			{ settingsPath },
+		);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			unknown: 42,
+			implementationThinkingLevel: "inherit",
+		});
+		await writeFile(settingsPath, "{invalid");
+		await assert.rejects(
+			updatePlanModeSettings({ implementationModel: { provider: "p", id: "m" } }, { settingsPath }),
+			/invalid/,
+		);
+		assert.equal(await readFile(settingsPath, "utf8"), "{invalid");
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -179,6 +179,7 @@ test("automatic and manual ready menus expose Save for later", async () => {
 						? [
 								"Implement here",
 								"Start fresh and implement",
+								"Implementation options…",
 								"Export plan…",
 								"Save for later",
 								"Stay in Plan mode",
@@ -188,6 +189,7 @@ test("automatic and manual ready menus expose Save for later", async () => {
 								"Show latest proposed plan",
 								"Implement here",
 								"Start fresh and implement",
+								"Implementation options…",
 								"Export plan…",
 								"Save for later",
 								"Stay in Plan mode",
@@ -237,6 +239,7 @@ test("saved Plan management can show, implement, clear, or cancel", async () => 
 						"Show saved plan",
 						"Implement here",
 						"Start fresh and implement",
+						"Implementation options…",
 						"Export plan…",
 						"Settings",
 						"Clear saved plan",

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -52,7 +52,7 @@ function menuOptions(
 	};
 }
 
-test("Plan settings show five flat workflow rows without materializing a missing file", async () => {
+test("Plan settings show seven flat workflow rows without materializing a missing file", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
@@ -341,6 +341,8 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan reinjection (Off — conversation history only)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
+					"Implementation model (Use current)",
+					"Implementation thinking (inherit)",
 					"Back",
 				],
 				response: "Plan reinjection (Off — conversation history only)",
@@ -353,6 +355,8 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan reinjection (Through first implementation run)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
+					"Implementation model (Use current)",
+					"Implementation thinking (inherit)",
 					"Back",
 				],
 				response: "Export destination (PLAN.md)",
@@ -370,6 +374,8 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan reinjection (Through first implementation run)",
 					"Export destination (rpc/PLAN.md)",
 					"Plan mode shortcut (none)",
+					"Implementation model (Use current)",
+					"Implementation thinking (inherit)",
 					"Back",
 				],
 				response: undefined,
@@ -396,6 +402,8 @@ test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight s
 				"Plan reinjection (Off — conversation history only)",
 				"Export destination (PLAN.md)",
 				"Plan mode shortcut (none)",
+				"Implementation model (Use current)",
+				"Implementation thinking (inherit)",
 				"Back",
 			],
 			response: undefined,


### PR DESCRIPTION
## Summary
- Add saved implementation model/thinking defaults and per-menu overrides for current and fresh handoffs.
- Apply preferences only at kickoff, preserve Pi global defaults, and never automatically restore model/thinking after settlement, abort, or plan clearing.
- Fail closed for unavailable targets/auth and use destination-owned APIs for fresh sessions.

Refs #1232.

## Verification
- `npm run check` passed (build, Biome, boundaries, workspace typechecks).
- `npm test` passed: 387 files, 4,350 tests.
- Runtime/Jiti lazy-boundary tests, isolated offline print-mode package smoke, package build, pack dry-run, and actual tarball inspection passed.
- Disabling preference detection caused nine regression tests to fail; mutation reverted.
- Audited extension-conventions, extension-settings, README conventions, settings persistence, lifecycle cancellation/stale continuations, cache contracts, and lazy runtime boundaries.

## Risks / remaining verification
- Live-provider authentication/network behavior was not exercised. Pi owns uncancellable auth/model-selection promises; continuations are guarded after they settle.
- Fresh-session preference application uses a one-shot destination lifecycle handshake characterized on pinned Pi 0.85.0; package smoke used Pi 0.85.1. A committed destination remains selected after kickoff failure, with existing plan/editor recovery.
- Choosing another provider for same-session implementation transfers the retained planning conversation; this is documented in the picker and README.

Completed plan removed in `30b63407` after user confirmation.