### PR TITLE
feat(tui-kit): expose bounded frames and consolidate presentation helpers

### DIFF
--- a/.changeset/bounded-terminal-frame.md
+++ b/.changeset/bounded-terminal-frame.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Expose a stateless bounded-frame renderer with caller-owned row priorities, and reuse it in standard menus without changing their input or save lifecycle.

--- a/.changeset/shared-stamp-presentation.md
+++ b/.changeset/shared-stamp-presentation.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-stamp": patch
+---
+
+Use the dependency-free Kit terminal-text sanitizer for display labels while retaining the existing persisted metadata normalization and lazy menu boundary.

--- a/.changeset/shared-sync-hints.md
+++ b/.changeset/shared-sync-hints.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-sync": patch
+---
+
+Reuse published Kit interaction hints for secret input and cancellable operations. Deduplicate cancel aliases and omit the submit hint when no submit key is configured.

--- a/.changeset/shared-todo-presentation.md
+++ b/.changeset/shared-todo-presentation.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-todo": patch
+---
+
+Reuse published Kit terminal-document sanitization and editor-status frames for Todo widgets. Preserve control spacing and adaptive row priorities while removing unterminated terminal sequences from display text.

--- a/docs/plans/2026-09-08_tui-kit-shared-ui-plan.md
+++ b/docs/plans/2026-09-08_tui-kit-shared-ui-plan.md
@@ -1,0 +1,109 @@
+# Shared TUI consolidation plan
+
+## Goal
+
+Reduce repeated terminal presentation code by adopting existing pi-tui-kit APIs first, then adding only the shared frame and key-hint capabilities demonstrated necessary by current consumers. Preserve extension-owned behavior and release new Kit APIs before their consumers.
+
+## Context
+
+The review covers `18e29d3c` (pi-tui-kit release from 0.59.0 to 0.60.0) through `5fb65adb`, including 153 non-merge commits. This plan authorizes no implementation or publication by itself.
+
+Evidence:
+
+- `packages/pi-usage/src/usage-settings-ui.ts` duplicates focused-row clipping and frame behavior already implemented internally in `packages/pi-tui-kit/src/components/rendering.ts`; commits `96ab4dbb`, `12274425`, and `e093527c` repaired framing and row budgets.
+- `packages/pi-btw/src/fullscreen-ui.ts` added key identity, matchability, and conflict filtering after `f24a5b00`; `text.ts`, `bring-to-main.ts`, Sync input/task UI, and Kit questionnaire rendering also contain key-label helpers.
+- `packages/pi-todo/src/widget-renderer.ts` and `packages/pi-stamp/src/metadata.ts` own sanitizers while Herdr and Accounts already consume Kit terminal sanitization.
+- Todo draws widget separators itself; Herdr already uses `EditorStatusWidget`, and Sync adopted its shared separator in `0f319d2b`.
+
+## Architecture
+
+Kit owns terminal sanitization primitives, standard presentation, frame bounds, and extension-neutral hint formatting. Consumers own whitespace policy, fallback labels, item priority, settings transactions, session generations, cancellation ownership, and listener precedence.
+
+Prefer Pi core APIs, then existing Kit APIs, before introducing a new public API. A frame API must not require importing private component contracts. A key-availability helper must receive conflicts from the caller rather than encode btw actions or infer another extension's listeners.
+
+## Non-Goals
+
+- Extract the btw fullscreen host or shared-terminal handoff.
+- Add a generic adaptive widget, settings persistence framework, or session coordinator.
+- Publish Sync's masked input without another demonstrated consumer.
+- Generalize Starship's snapshot-based redraw policy.
+- Change settings schemas, command routes, raw payloads, or domain-specific display ordering.
+
+## Execution findings
+
+Implementation is authorized on `narumi/refactor/shared-tui-primitives`, based on `origin/main` at `5fb65adb`. The initial worktree contained only this untracked plan. Initial root `npm install` completed without lockfile changes or audit vulnerabilities; the later lockfile change only records Todo's new dependency.
+
+Authorized implementation and verification are complete; the overall plan is not complete. Publication and the first usage frame migration remain blocked by the user's explicit no-publication instruction. Keep this plan until that follow-up release and migration are authorized and verified.
+
+Focused signed implementation commits: `3d4054bf` (Todo), `5372f87b` (Stamp), `7ec32e42` (Sync), `317f7bd4` (Kit frame API), and `536e2eaa` (btw characterization). Signatures verified against the already-configured signing public key using a temporary, command-scoped allowed-signers file; no Git identity or persistent signing configuration changed.
+
+Touched-area MUST rules and verification:
+
+- TUI presentation: preserve width bounds, callback themes, editing semantics and effective bindings; verify with rendering/input tests and Review against installed Pi controls.
+- Widgets: preserve the full-width `borderMuted` separator and exact lifecycle key ownership; verify with Todo rendering and lifecycle Tests.
+- Async settings: preserve mode guards, owned-task cancellation, disposal, post-await freshness and persistence semantics; verify with usage characterization Tests and settings/lifecycle Review.
+- Package APIs: keep public boundaries, independent dependencies and published files aligned; verify with boundaries/typecheck Validators and pack/loader Smokes. New APIs must be published before consumer adoption; publication is explicitly prohibited in this execution.
+- Verification: run `npm run check` and `npm test`, add Changesets for published behavior, and report semantic audits separately.
+
+Decision evidence from source inspection (tests still pending):
+
+- Usage's non-searchable SettingsList aborts its local save signal immediately on cancellation. Kit SettingsScreen always enables search and waits for pending saves before Back/Close. Do not migrate the interaction; share only stateless frame layout, leaving consumer adoption pending publication.
+- Stamp's metadata sanitizer participates in persisted snapshot validation. Keep its historical control-to-space codec unchanged; consolidate only the exported display sanitizer onto Kit.
+- Todo's control-to-space policy matches published `sanitizeTerminalDocument()` followed by local whitespace collapse. Added dependency floor `^0.60.0`; `npm view @narumitw/pi-tui-kit@0.60.0 version --json` confirmed publication, and root install plus `npm ls` confirmed Todo resolves 0.60.0. Unterminated sequences are now removed instead of leaving escape fragments; regression tests explicitly cover this safety improvement.
+- Stamp's eager-graph guard initially rejected the new import. Its exact `/terminal-text` leaf is dependency-free in the installed package; the builder now admits only that leaf, with regression tests rejecting other subpaths and verifying the leaf has no imports. Root Kit and first-use menus remain forbidden eagerly.
+- Btw uses title-case labels and specialized PgUp/PgDn aliases; questionnaire uses platform-specific Option labels and separately themed key/description spans. Existing `formatInteractionHints()` has neither contract. Keep these formatters local rather than changing public presentation or adding an unproven key API. Sync's lower-case hints match the existing API.
+- A public usable-key helper is deferred: current Pi matching includes multiple overlapping raw encodings, while callers have different dispatch precedence. Keep btw's tested compatibility filter local; do not publish a partial matcher mirror.
+
+## Plan
+
+### 1. Establish contracts and decision gates
+
+- [x] Re-read `docs/extension-conventions.md` and `docs/extension-settings.md` before implementation; touched MUST rules and named verification methods are recorded above.
+- [x] Inspect installed Pi SettingsList, Input, `matchesKey`, TUI listener dispatch and alternate-screen routing, plus complete TUI/keybindings/terminal-setup documentation and the settings example. Reviewed branches: searchable versus fixed lists, empty lists, cycling versus submenus, selection restoration; paste buffering before cancel/submit/editing; escape/return aliases, case and modifier order, special/function/printable keys, raw Ctrl and Alt collisions, Kitty versus legacy input, release filtering; listener consumption before focused components, overlay focus, search and ordered viewport actions. No matcher or dispatch implementation changed.
+- [x] Compare usage's settings flow against Kit SettingsScreen. No-go for whole-screen migration: usage has no search and immediate abort-on-cancel, unlike Kit's search and drain-before-Back contract. Existing passing `pi-usage/test/usage.test.ts` settings tests cover compact rows, selection, save failures, cancellation/disposal and durability races; Kit `screen-components.test.ts` characterizes serialized changes and drain-before-Back. Non-TUI usage remains guarded before custom UI.
+- [x] Inventory key-label and sanitization differences. Added table-driven `pi-btw/test/key-label-contract.test.ts`, `pi-todo/test/widget-presentation.test.ts`, and `pi-stamp/test/terminal-presentation.test.ts`; existing questionnaire tests preserve separate styling, navigation, platform labels and remapped bindings. Final full passing run: 386 files / 4398 tests.
+
+### 2. Adopt existing Kit primitives in focused changes
+
+- [x] Consolidate Todo presentation onto Kit document sanitization and Stamp display onto Kit text sanitization. Keep Todo whitespace/fallbacks and Stamp's persisted codec local. New characterization tables and existing lifecycle/metadata tests passed.
+- [x] Replace Todo heading/separator drawing with EditorStatusWidget inside its existing row budget. The focused published subpath avoids eagerly loading the Kit menu root. Zero/narrow-width and completion tests plus existing adaptive-priority/lifecycle tests passed after the final import-boundary refinement.
+- [x] Consolidate Sync's compatible hints onto existing formatInteractionHints. Preserve control-bearing binding rejection and omit unbound submit hints. Retain btw and questionnaire formatters under the recorded no-go decision because their casing, aliases, platform labels and theme spans differ; do not add a formatter API merely to rename code. Remapped cancellation, hard cancel, alias-deduplication and control-bearing binding regression tests passed in the final full run.
+- [x] Retain usage SettingsList. Its cancellation test explicitly proves the whole-screen migration gap; `renderBoundedFrame` supplies stateless bounds without adopting Kit's save/search lifecycle. Consumer migration remains gated on publication.
+
+### 3. Add only demonstrated Kit API gaps
+
+- [x] Extract public renderBoundedFrame/BoundedFrameOptions and reuse it in Kit's existing standard frame adapter. It accepts preformatted rows and explicit original-index priorities, with no selection-glyph inference or lifecycle ownership. New bounded-frame tests cover budgets, resize, descriptions, styling, tiny terminals, invalid dimensions/indexes and read-only rows; all existing Kit screen tests passed. This low-level layout API serves the shared row-retention need without admitting a new screen/lifecycle API.
+- [x] Evaluate usable-key extraction; defer it under the recorded no-go decision. Keep Pi matching and btw's caller-specific conflict filter unchanged.
+- [x] Not applicable: no usable-key helper added. Existing btw fullscreen regression tests for aliases, modifier order, legacy/Kitty collisions, invalid strings, earlier handlers, hard cancel and fallbacks passed unchanged.
+- [x] Document the bounded-frame API and caller responsibilities in Kit `docs/api.md`; add independent Kit/Todo/Stamp/Sync Changesets. Public export/typecheck tests and actual tarball inspection verified `bounded-frame.js`, `bounded-frame.d.ts`, root declarations and API version 16 without consumer private imports. Changesets status reports one Kit minor and three consumer patches.
+
+### 4. Release before adopting new APIs
+
+- [ ] BLOCKED: publish the new bounded-frame API through the repository release workflow before consumer adoption. The current user explicitly prohibits publication, tags and workflow dispatch; do not request or perform a release in this execution.
+- [ ] BLOCKED: migrate usage's custom frame after the bounded-frame API is published, raise its Kit floor, run root npm install and npm ls before typechecking. Do not reference the unpublished helper from usage. Btw has no new-API migration after its no-go decision.
+- [ ] BLOCKED: add the usage frame consumer Changeset and migration regressions after publication. Todo/Stamp/Sync adoption Changesets use already-published APIs and do not depend on API version 16.
+
+### 5. Validate each implementation change
+
+- [x] Audit asynchronous UI paths: Sync changes only hint construction; its masked-input clearing, paste-first input handling, hard cancellation, operation signal/draining and commit-aware cancellation remain unchanged. `secret-input.test.ts` and `custom-lifecycle.test.ts` passed. Kit changes are stateless rendering only; menu runtime and event handling are unchanged. Todo widget ownership and Stamp session/metadata reconstruction remain unchanged and their lifecycle tests passed.
+- [x] Audit usage `settings.ts` and `usage-settings-ui.ts` together: runtime serializes reload/update/flush, reads latest valid documents, preserves unknown fields, stages private same-directory writes and publishes by rename; UI serializes saves, rolls back rejected displays, immediately aborts on cancellation, and applies already-durable updates even if disposal wins the await. Existing settings/usage tests passed. No usage code or persistence contract changed; cross-process locking is not claimed.
+- [x] Run final `npm run check` and then `npm test` on 2026-09-08. Build, Biome, boundaries and all workspace typechecks passed without warnings; 386 test files / 4398 tests passed in 23.14 seconds. Kit rebuilt before consumer tests; no timeout overrides or concurrent Kit/root checks. An initial import-only package-export test used CommonJS resolution incorrectly; it was corrected to inspect the declared import target, then the complete suite passed.
+- [x] Run `npm run package:pack -- tui-kit`, `-- todo`, and `-- stamp`, then create and inspect actual tarballs under `/tmp/shared-tui-packs-iVMW26`. Verified Kit public JS/declarations, README/license, generated consumer entries, and Todo's published Kit dependency plus focused imports. Repacked Todo after the final EditorStatusWidget refinement.
+- [x] Exercise short-terminal and remapped-binding flows through the public TUI harness in deterministic tests, including usage's retained frame, Kit screens, Sync cancellation/paste, and Todo adaptive rendering. Manual visual/IME checks in a real interactive terminal were not run because this harness prohibits interactive commands; no claim of manual terminal validation is made.
+- [x] Build and smoke Stamp, Todo and Sync package directories in isolated Pi RPC subprocesses (`--no-extensions -e <package>` with temporary agent dirs). All completed get_state/get_commands handshakes without load errors or model requests; post-readiness deadlines were used. Stamp's existing Jiti tests also exercised its generated lazy menu boundary; Todo/Sync generated-runtime tests passed. Real interactive terminal startup remains unverified.
+
+## Risks
+
+Sanitizers differ in control-to-space behavior; replacing them mechanically can concatenate words. Key labels are not proof that input is matchable or reachable. Frame clipping can hide the focused row or save feedback. Changing UI wrappers can change cancellation and persistence timing even when the screen looks identical. Characterization tests and the decision gates above must resolve these risks before migration.
+
+## Rollback / Recovery
+
+Keep adoption, new Kit APIs, and first-consumer migrations in separate focused commits or pull requests. Use Git reverts for source and dependency recovery; do not add runtime rollback machinery. Do not unpublish or retag a released API without explicit approval. If a new API is defective, fix forward through Changesets or revert the consumer to its last compatible implementation and dependency floor.
+
+## Completion Checklist
+
+- [ ] Every plan task has acceptance evidence or a checked not-applicable decision; no material unknown or external release dependency remains unresolved.
+- [x] The final code diff preserves extension boundaries, command/mode behavior, settings ownership and raw payloads. Conventions/settings semantic audits are recorded above; frame selection inference stays adapter-owned, sanitization stays presentation-only, and the Stamp persisted codec remains unchanged.
+- [ ] Required checks, tests, pack inspections, publication evidence, smokes, deviations, and explicitly accepted unverified paths are named in the handoff.
+- [x] No consumer depends on API version 16. Todo uses registry-confirmed existing APIs; Stamp/Sync retain their existing dependency floors. No publication, version tag or release workflow was run.
+- [ ] Delete this plan only after execution and all completion evidence are complete; report its deleted path in the final handoff.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7749,6 +7749,9 @@
 			"name": "@narumitw/pi-todo",
 			"version": "0.3.0",
 			"license": "MIT",
+			"dependencies": {
+				"@narumitw/pi-tui-kit": "^0.60.0"
+			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.11",
 				"@earendil-works/pi-ai": "0.85.0",

--- a/packages/pi-btw/test/key-label-contract.test.ts
+++ b/packages/pi-btw/test/key-label-contract.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { formatKeyLabel } from "../src/text.js";
+
+// These display-only contracts intentionally differ from Kit's lower-case hint groups.
+// Fullscreen key reachability remains covered by fullscreen-ui.test.ts, not this formatter.
+for (const [raw, label] of [
+	["ctrl+c", "Ctrl+C"],
+	["shift+ctrl+p", "Shift+Ctrl+P"],
+	["alt+super+k", "Alt+Super+K"],
+	["pageUp", "PageUp"],
+	["pageDown", "PageDown"],
+	["return", "Return"],
+	["escape", "Escape"],
+	["", ""],
+] as const) {
+	test(`btw retains its specialized label for ${raw || "empty input"}`, () => {
+		assert.equal(formatKeyLabel(raw), label);
+	});
+}

--- a/packages/pi-stamp/scripts/build-runtime.mjs
+++ b/packages/pi-stamp/scripts/build-runtime.mjs
@@ -14,6 +14,8 @@ const GENERATED_BANNER = [
 ].join("\n");
 const FORBIDDEN_EAGER_INPUTS = ["src/menu.ts"];
 const FORBIDDEN_EAGER_EXTERNALS = ["@narumitw/pi-tui-kit"];
+// This pure, dependency-free presentation leaf does not load the Kit menu runtime.
+const EAGER_PRESENTATION_LEAF = "@narumitw/pi-tui-kit/terminal-text";
 
 export async function buildRuntime({
 	outputDirectory = distDirectory,
@@ -82,6 +84,7 @@ export function validateEagerGraph(metadata) {
 			if (
 				imported.external &&
 				imported.kind !== "dynamic-import" &&
+				imported.path !== EAGER_PRESENTATION_LEAF &&
 				FORBIDDEN_EAGER_EXTERNALS.some(
 					(dependency) =>
 						imported.path === dependency || imported.path.startsWith(`${dependency}/`),

--- a/packages/pi-stamp/src/metadata.ts
+++ b/packages/pi-stamp/src/metadata.ts
@@ -192,7 +192,10 @@ export function isStampThinkingLevel(value: unknown): value is StampThinkingLeve
 	return STAMP_THINKING_LEVELS.includes(value as StampThinkingLevel);
 }
 
-export function sanitizeTerminalText(value: string): string {
+// Display parsing is shared; persisted snapshots retain their historical normalization below.
+export { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
+
+function normalizePersistedMetadataText(value: string): string {
 	return [...value]
 		.map((character) =>
 			isUnsafeTerminalCodePoint(character.codePointAt(0) ?? 0) ? " " : character,
@@ -205,7 +208,7 @@ export function sanitizeMetadataText(
 	maximumLength = MAX_METADATA_TEXT_LENGTH,
 ): string | undefined {
 	if (typeof value !== "string" || maximumLength < 1) return undefined;
-	const safe = sanitizeTerminalText(value).replace(/\s+/gu, " ").trim();
+	const safe = normalizePersistedMetadataText(value).replace(/\s+/gu, " ").trim();
 	if (!safe) return undefined;
 	return [...safe].slice(0, maximumLength).join("");
 }

--- a/packages/pi-stamp/test/build-runtime.test.ts
+++ b/packages/pi-stamp/test/build-runtime.test.ts
@@ -116,6 +116,30 @@ test("eager graph validation preserves first-use boundaries and external package
 	);
 });
 
+test("only the dependency-free Kit terminal-text leaf may load eagerly", async () => {
+	const builder = await loadBuilder();
+	for (const [specifier, allowed] of [
+		["@narumitw/pi-tui-kit/terminal-text", true],
+		["@narumitw/pi-tui-kit/terminal-document", false],
+		["@narumitw/pi-tui-kit/testing", false],
+		["@narumitw/pi-tui-kit/terminal-text/other", false],
+	] as const) {
+		const metadata = validMetadata();
+		requireOutput(metadata, "dist/index.ts").imports?.push({
+			path: specifier,
+			kind: "import-statement",
+			external: true,
+		});
+		if (allowed) assert.doesNotThrow(() => builder.validateEagerGraph(metadata));
+		else assert.throws(() => builder.validateEagerGraph(metadata), /Eager external dependency/u);
+	}
+	const manifest = JSON.parse(await readFile(join(resolvedKitRoot, "package.json"), "utf8"));
+	const leaf = manifest.exports["./terminal-text"].import;
+	assert.equal(leaf, "./dist/terminal-text.js");
+	const source = await readFile(join(resolvedKitRoot, leaf), "utf8");
+	assert.doesNotMatch(source, /\b(?:import\s|import\(|require\(|from\s+["'])/u);
+});
+
 test("runtime build rejects destructive output paths and symlink escapes", async () => {
 	const builder = await loadBuilder();
 	const outside = await mkdtemp(join(tmpdir(), "pi-stamp-build-outside-"));

--- a/packages/pi-stamp/test/terminal-presentation.test.ts
+++ b/packages/pi-stamp/test/terminal-presentation.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { sanitizeMetadataText, sanitizeTerminalText } from "../src/metadata.js";
+
+for (const [name, raw, expected] of [
+	["Unicode", "界 e\u0301 👩‍💻", "界 e\u0301 👩‍💻"],
+	["line separators", "one\ntwo\tthree", "one two three"],
+	["control removal", "one\u0000two", "onetwo"],
+	["Bidi removal", "one\u202etwo", "onetwo"],
+	["ANSI styles", "\u001b[31mred\u001b[0m", "red"],
+	["OSC link", "\u001b]8;;https://example.com\u0007label\u001b]8;;\u001b\\", "label"],
+	["unterminated OSC", "safe\u001b]hidden", "safe"],
+	["unterminated CSI", "safe\u001b[31", "safe"],
+] as const) {
+	test(`Stamp display sanitizer: ${name}`, () => {
+		assert.equal(sanitizeTerminalText(raw), expected);
+	});
+}
+
+test("Stamp persisted metadata keeps its historical normalization", () => {
+	const raw = { modelId: "one\u0000two\u202ethree", label: "\u001b[31mred" };
+	const before = structuredClone(raw);
+	assert.equal(sanitizeMetadataText(raw.modelId), "one two three");
+	assert.equal(sanitizeMetadataText(raw.label), "[31mred");
+	assert.deepEqual(raw, before);
+});

--- a/packages/pi-sync/src/ui/cancellable-operation.ts
+++ b/packages/pi-sync/src/ui/cancellable-operation.ts
@@ -1,14 +1,9 @@
-import {
-	BorderedLoader,
-	type ExtensionContext,
-	type KeybindingsManager,
-} from "@earendil-works/pi-coding-agent";
+import { BorderedLoader, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
-import { runCustomInteraction } from "@narumitw/pi-tui-kit";
+import { formatInteractionHints, runCustomInteraction } from "@narumitw/pi-tui-kit";
 import type { SetupPullOutcome } from "../sync/setup-switch.js";
 import type { SyncDecision } from "../sync/sync-decision.js";
 import type { RemoteSelectionDecision } from "../sync/sync-policy.js";
-import { safeTerminalText } from "./terminal-text.js";
 
 export type RunRouteResult =
 	| { kind: "completed"; outcome?: SetupPullOutcome }
@@ -61,7 +56,9 @@ export async function runCancellableOperation(
 		isCurrent: () => !signal?.aborted,
 		create: ({ tui, theme, keybindings, signal: interactionSignal, complete }) => {
 			const loader = new BorderedLoader(tui, theme, message, { cancellable: false });
-			const cancelHint = `${keybindingText(keybindings, "tui.select.cancel", "esc")} cancel`;
+			const cancelHint = formatInteractionHints(keybindings, [
+				{ bindings: ["tui.select.cancel"], keys: ["ctrl+c"], label: "cancel" },
+			]);
 			const operation = runRoute(
 				route,
 				interactionSignal,
@@ -112,20 +109,4 @@ export async function runCancellableOperation(
 	}
 	if (interaction.value.error) throw interaction.value.error;
 	return routeResult ?? { kind: "failed" };
-}
-
-function keybindingText(
-	keybindings: Pick<KeybindingsManager, "getKeys">,
-	binding: Parameters<KeybindingsManager["getKeys"]>[0],
-	fallback: string,
-) {
-	const keys = [...new Set([...keybindings.getKeys(binding), "ctrl+c"])]
-		.map(String)
-		.map((key) => {
-			if (key === "return") return "enter";
-			if (key === "escape") return "esc";
-			return safeTerminalText(key);
-		})
-		.filter(Boolean);
-	return keys.join("/") || fallback;
 }

--- a/packages/pi-sync/src/ui/cancellable-operation.ts
+++ b/packages/pi-sync/src/ui/cancellable-operation.ts
@@ -57,7 +57,13 @@ export async function runCancellableOperation(
 		create: ({ tui, theme, keybindings, signal: interactionSignal, complete }) => {
 			const loader = new BorderedLoader(tui, theme, message, { cancellable: false });
 			const cancelHint = formatInteractionHints(keybindings, [
-				{ bindings: ["tui.select.cancel"], keys: ["ctrl+c"], label: "cancel" },
+				{
+					keys: [
+						...keybindings.getKeys("tui.select.cancel").filter((key) => !hasControlCharacter(key)),
+						"ctrl+c",
+					],
+					label: "cancel",
+				},
 			]);
 			const operation = runRoute(
 				route,
@@ -109,4 +115,9 @@ export async function runCancellableOperation(
 	}
 	if (interaction.value.error) throw interaction.value.error;
 	return routeResult ?? { kind: "failed" };
+}
+
+function hasControlCharacter(value: string) {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: Unsafe key labels must be omitted.
+	return /[\u0000-\u001f\u007f-\u009f]/u.test(value);
 }

--- a/packages/pi-sync/src/ui/secret-input.ts
+++ b/packages/pi-sync/src/ui/secret-input.ts
@@ -9,7 +9,7 @@ import {
 	Text,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
-import { runCustomInteraction } from "@narumitw/pi-tui-kit";
+import { formatInteractionHints, runCustomInteraction } from "@narumitw/pi-tui-kit";
 
 const MASK = "•";
 
@@ -25,13 +25,22 @@ export async function promptSecret(
 		create: ({ tui, theme, keybindings, complete }) => {
 			const heading = new Text("", 0, 0);
 			const hint = new Text("", 0, 0);
-			const submitKey = keybindingText(keybindings, "tui.input.submit", "enter");
-			const cancelKey = keybindingText(keybindings, "tui.select.cancel", "esc", ["ctrl+c"]);
+			const interactionHint = formatInteractionHints(keybindings, [
+				{
+					keys: keybindings.getKeys("tui.input.submit").filter((key) => !hasControlCharacter(key)),
+					label: "continue",
+				},
+				{
+					keys: [
+						...keybindings.getKeys("tui.select.cancel").filter((key) => !hasControlCharacter(key)),
+						"ctrl+c",
+					],
+					label: "cancel",
+				},
+			]);
 			const applyTheme = () => {
 				heading.setText(theme.fg("accent", theme.bold(title)));
-				hint.setText(
-					theme.fg("dim", `${submitKey} continue • ${cancelKey} cancel • Input is hidden`),
-				);
+				hint.setText(theme.fg("dim", `${interactionHint} • Input is hidden`));
 			};
 			applyTheme();
 			const input = new MaskedInput(keybindings);
@@ -210,23 +219,6 @@ class MaskedInput implements Focusable {
 		this.value.splice(this.cursor, 0, ...characters);
 		this.cursor += characters.length;
 	}
-}
-
-function keybindingText(
-	keybindings: Pick<KeybindingsManager, "getKeys">,
-	binding: Parameters<KeybindingsManager["getKeys"]>[0],
-	fallback: string,
-	additionalKeys: readonly string[] = [],
-) {
-	const keys = [...new Set([...keybindings.getKeys(binding), ...additionalKeys])]
-		.map(String)
-		.map((key) => {
-			if (key === "return") return "enter";
-			if (key === "escape") return "esc";
-			return hasControlCharacter(key) ? "" : key;
-		})
-		.filter(Boolean);
-	return keys.join("/") || fallback;
 }
 
 function hasControlCharacter(value: string) {

--- a/packages/pi-sync/test/custom-lifecycle.test.ts
+++ b/packages/pi-sync/test/custom-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { createTuiHarness } from "@narumitw/pi-tui-kit/testing";
 import { test } from "vitest";
 import { createMockContext } from "../../../test/support.js";
 import { localConfigPath } from "../src/settings/config-file.js";
+import { runCancellableOperation } from "../src/ui/cancellable-operation.js";
 import { showSyncManager } from "../src/ui/manager-ui.js";
 import { withTempHome } from "./helpers.js";
 
@@ -166,6 +167,47 @@ test.each([
 		});
 	},
 );
+
+test("cancellable operation omits control-bearing key labels", async () => {
+	const tui = createTuiHarness({
+		width: 48,
+		rows: 16,
+		keybindings: {
+			matches: () => false,
+			getKeys: (binding) => (binding === "tui.select.cancel" ? ["\u0000enter" as never] : []),
+		},
+	});
+	const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+	let routeSignal: AbortSignal | undefined;
+	let releaseRoute: () => void = () => undefined;
+	const routeGate = new Promise<void>((resolve) => {
+		releaseRoute = resolve;
+	});
+	const running = runCancellableOperation(ctx, "Working", "sync", async (_route, signal) => {
+		routeSignal = signal;
+		await routeGate;
+		return undefined;
+	});
+
+	await tui.waitForOpen();
+	let result: Awaited<typeof running>;
+	try {
+		const frame = tui.render().join("\n");
+		assert.doesNotMatch(frame, /enter/u);
+		assert.match(frame, /ctrl\+c cancel/u);
+		tui.send("\r");
+		await flushAsync();
+		assert.equal(routeSignal?.aborted, false);
+		tui.press("ctrl+c");
+		await flushAsync();
+		assert.equal(routeSignal?.aborted, true);
+	} finally {
+		releaseRoute();
+		result = await running;
+		if (tui.isOpen) tui.dispose();
+	}
+	assert.deepEqual(result, { kind: "cancelled" });
+});
 
 test("commit-aware hard cancellation stays open until the active operation settles", async () => {
 	await withTempHome(async (agentDir) => {

--- a/packages/pi-sync/test/secret-input.test.ts
+++ b/packages/pi-sync/test/secret-input.test.ts
@@ -186,6 +186,42 @@ test("a stale secret prompt never creates its masked component", async () => {
 	assert.equal(await pending, undefined);
 });
 
+test("masked input omits unbound submit hints and deduplicates cancel aliases", async () => {
+	const tui = createTuiHarness({
+		width: 80,
+		keybindings: {
+			matches: (data, binding) => binding === "tui.select.cancel" && data === "\u001b",
+			getKeys: (binding) => (binding === "tui.select.cancel" ? ["escape", "esc", "ctrl+c"] : []),
+		},
+	});
+	const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+	const pending = promptSecret(ctx, "Password");
+	await tui.waitForOpen();
+	const frame = tui.render().join("\n");
+	assert.match(frame, /esc\/ctrl\+c cancel/u);
+	assert.doesNotMatch(frame, /continue|enter/u);
+	tui.send("\u001b");
+	assert.equal(await pending, undefined);
+});
+
+test("masked input does not advertise a binding reconstructed from control characters", async () => {
+	const tui = createTuiHarness({
+		width: 80,
+		keybindings: {
+			matches: () => false,
+			getKeys: () => ["\u0000enter" as never],
+		},
+	});
+	const { ctx } = createMockContext({ hasUI: true, mode: "tui", custom: tui.custom });
+	const pending = promptSecret(ctx, "Password");
+	await tui.waitForOpen();
+	const frame = tui.render().join("\n");
+	tui.press("ctrl+c");
+	assert.equal(await pending, undefined);
+	assert.doesNotMatch(frame, /enter|continue/u);
+	assert.match(frame, /ctrl\+c cancel/u);
+});
+
 async function flushAsync() {
 	await Promise.resolve();
 	await new Promise<void>((resolve) => setImmediate(resolve));

--- a/packages/pi-todo/package.json
+++ b/packages/pi-todo/package.json
@@ -31,6 +31,9 @@
 		"prepack": "npm run build",
 		"typecheck": "tsc --noEmit"
 	},
+	"dependencies": {
+		"@narumitw/pi-tui-kit": "^0.60.0"
+	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*",

--- a/packages/pi-todo/src/widget-renderer.ts
+++ b/packages/pi-todo/src/widget-renderer.ts
@@ -1,9 +1,9 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { stripTerminalSequences, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { EditorStatusWidget } from "@narumitw/pi-tui-kit/editor-status-widget";
+import { sanitizeTerminalDocument } from "@narumitw/pi-tui-kit/terminal-document";
 import { DEFAULT_TODO_SETTINGS, type TodoWidgetSettings } from "./settings.js";
 import type { Todo } from "./todo-widget.js";
-
-const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
 
 export interface RenderTodoWidgetOptions {
 	settings?: Readonly<TodoWidgetSettings>;
@@ -61,21 +61,15 @@ export function renderTodoWidget(
 }
 
 export function renderCompletionSummary(total: number, theme: Theme, width: number): string[] {
-	const renderWidth = Math.max(0, width);
-	return [
-		theme.fg("borderMuted", "─".repeat(renderWidth)),
-		theme.fg("success", `✓ ${total}/${total} tasks completed`),
-	].map((line) => truncateToWidth(line, renderWidth, ""));
+	return new EditorStatusWidget({
+		theme,
+		renderBody: () => [theme.fg("success", `✓ ${total}/${total} tasks completed`)],
+	}).render(width);
 }
 
 export function sanitizeTodoText(value: string): string {
-	let text = "";
-	for (const character of stripTerminalSequences(value).replace(BIDI_CONTROLS, "")) {
-		const codePoint = character.codePointAt(0) ?? 0;
-		const isControl = codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
-		text += isControl ? " " : character;
-	}
-	return text.replace(/\s+/gu, " ").trim();
+	// Document sanitization preserves Todo's control-to-space policy; whitespace is local.
+	return sanitizeTerminalDocument(value).replace(/\s+/gu, " ").trim();
 }
 
 export function widgetRowBudget(terminalRows?: number): number {
@@ -93,10 +87,13 @@ function renderHeader(
 	showProgress: boolean,
 ): string[] {
 	const completed = todos.filter((todo) => todo.status === "completed").length;
-	return [
-		theme.fg("borderMuted", "─".repeat(width)),
-		theme.fg("muted", showProgress ? `Todo · ${completed}/${todos.length} complete` : "Todo"),
-	];
+	// Keep both heading rows inside Todo's existing adaptive budget.
+	return new EditorStatusWidget({
+		theme,
+		renderBody: () => [
+			theme.fg("muted", showProgress ? `Todo · ${completed}/${todos.length} complete` : "Todo"),
+		],
+	}).render(width);
 }
 
 function renderTodo(todo: Todo, theme: Theme, width: number): string[] {

--- a/packages/pi-todo/test/widget-presentation.test.ts
+++ b/packages/pi-todo/test/widget-presentation.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import {
+	renderCompletionSummary,
+	renderTodoWidget,
+	sanitizeTodoText,
+} from "../src/widget-renderer.js";
+import { identityTheme } from "./todo-harness.js";
+
+for (const [name, raw, expected] of [
+	["plain Unicode", "  界 e\u0301 👩‍💻  ", "界 e\u0301 👩‍💻"],
+	["control spacing", "one\u0000two\u0007three\u007ffour", "one two three four"],
+	["line spacing", "one\r\ntwo\tthree\u2028four", "one two three four"],
+	["Bidi removal", "one\u202etwo\u2066three", "onetwothree"],
+	["ANSI styles", "one\u001b[31mtwo\u001b[0m", "onetwo"],
+	["hyperlink", "\u001b]8;;https://example.com\u0007label\u001b]8;;\u001b\\", "label"],
+	["unterminated OSC", "safe\u001b]8;;hidden", "safe"],
+	["unterminated CSI", "safe\u001b[31", "safe"],
+	["C1 string", "safe\u009dhidden\u009cvisible", "safevisible"],
+] as const) {
+	test(`Todo shared sanitizer: ${name}`, () => {
+		assert.equal(sanitizeTodoText(raw), expected);
+		const todos = [{ step: raw, status: "pending" as const }];
+		const before = structuredClone(todos);
+		renderTodoWidget(todos, identityTheme().theme, 80);
+		assert.deepEqual(todos, before);
+	});
+}
+
+for (const width of [0, 1, 2, 10, 80]) {
+	test(`Todo separators preserve row ownership at width ${width}`, () => {
+		const { theme, calls } = identityTheme();
+		for (const lines of [
+			renderCompletionSummary(2, theme, width),
+			renderTodoWidget([{ step: "pending", status: "pending" }], theme, width),
+		]) {
+			assert.equal(lines[0], "─".repeat(width));
+			assert.equal(
+				lines.filter((line) => width > 0 && line === "─".repeat(width)).length,
+				width > 0 ? 1 : 0,
+			);
+			for (const line of lines) assert.ok(visibleWidth(line) <= width);
+		}
+		assert.ok(calls.some(([kind, role]) => kind === "fg" && role === "borderMuted") || width === 0);
+	});
+}

--- a/packages/pi-tui-kit/docs/api.md
+++ b/packages/pi-tui-kit/docs/api.md
@@ -4,6 +4,7 @@
 
 - [Horizontal rules](#-horizontal-rules)
 - [Editor status widgets](#-editor-status-widgets)
+- [Bounded frames](#bounded-frames)
 - [Complete menu example](#-complete-menu-example)
 - [Standalone interactions](#standalone-tasks)
 - [Standard screens](#-standard-screens)
@@ -67,6 +68,33 @@ export function publishProgress(ctx: ExtensionContext, lines: readonly string[])
 `EditorStatusWidget` treats body rows as terminal-formatted display text and does not sanitize or wrap them.
 Sanitize untrusted values before styling or width-sensitive formatting, and perform product-specific wrapping in `renderBody()`.
 Publish plain string arrays separately when an extension supports Pi RPC widgets because RPC ignores component factories.
+
+## Bounded frames
+
+Use `renderBoundedFrame()` to share the standard menu's height-bounded presentation without adopting its input or save lifecycle. It accepts already sanitized, styled, wrapped single-line rows and a rendered horizontal rule. The caller owns terminal row reservations, themes, input, persistence, and which content must survive clipping. This is a stateless layout primitive, not another screen or lifecycle API.
+
+```ts
+import { HorizontalRule, renderBoundedFrame } from "@narumitw/pi-tui-kit";
+
+const width = 40;
+const rows = renderBoundedFrame({
+  width,
+  maxRows: 8,
+  rule: new HorizontalRule().render(width)[0] ?? "",
+  title: ["Settings"],
+  content: ["First setting", "Selected setting", "Saving…"],
+  hints: ["enter change • esc cancel"], // Supply effective, reachable bindings in real UI.
+  compactHint: "esc cancel",
+  priorityRows: [1, 2],
+  focusedRow: 1,
+});
+```
+
+A full frame contains the rule, title, context, a blank separator before nonempty content, hints, and the closing rule. On overflow, blank content rows are removed. `priorityRows` refers to indexes in the original content array, in retention order; invalid, duplicate, and blank-row indexes are ignored. `focusedRow` determines proximity when filling remaining space, not selection styling. Explicitly include the focused row in `priorityRows` when it must survive. The function never infers selection from cursor glyphs.
+
+Compact layout reserves a hint row when `compactHint` is nonempty and at least two body rows remain, then retains priority content, one title row, full hints when they fit, neighboring content, and context. `compactHints` can replace full hints during compact rendering, for example to include an overflow count. Rules remain when at least five total rows are available. Static frames prioritize context at one row. Output retains original row order.
+
+Width and row budgets are floored and clamped to zero; non-finite values normalize to zero. A zero row budget returns no rows. Every line is truncated by terminal cells, without an ellipsis. The helper preserves ANSI styling, does not sanitize or wrap rows, and holds no cached theme or dimension state. Sanitize raw values before wrapping or styling, and rebuild rows after resize or theme changes.
 
 ## 🧭 Complete menu example
 
@@ -805,12 +833,14 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `sanitizeTerminalText()` — removes terminal and bidirectional controls from untrusted single-line display text without changing raw payloads; `@narumitw/pi-tui-kit/terminal-text` also exports it.
 - `EditorStatusWidget` — frames passive editor status rows with a muted top rule and terminal-width guard; `@narumitw/pi-tui-kit/editor-status-widget` exports it and its options.
 - `HorizontalRule` — renders a full-width or inset horizontal divider with an optional sanitized and aligned label plus render-time style callbacks.
+- `renderBoundedFrame()` and `BoundedFrameOptions` — frame preformatted rows within explicit width and height budgets, with caller-owned content priorities and no input or lifecycle ownership.
 - `runCustomInteraction()` — owns cancellation, stale checks, exactly-once disposal, optional pending-work draining, and typed results for one custom TUI component.
 - `resolveMenuScreen()` — resolves and validates a dynamic screen for tests or adapters.
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, `BrowseDetailDocument`, `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — test-only subpath for `createTuiHarness()`, `createRpcHarness()`, strict scripts, and their types; the production root does not re-export it.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`15`).
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`16`).
+Version 16 adds the stateless bounded-frame helper while version-15 menu definitions remain valid.
 Version 15 adds opt-in review and browse-detail search plus public multiline terminal-document helpers while version-14 menu definitions remain valid.
 Version 14 adds the standalone `runQuestionnaire()` interaction while version-13 menu definitions remain valid.
 Version 13 adds opt-in Markdown, LaTeX, and Mermaid document formatting while version-12 menu definitions remain valid.

--- a/packages/pi-tui-kit/src/bounded-frame.ts
+++ b/packages/pi-tui-kit/src/bounded-frame.ts
@@ -1,0 +1,124 @@
+import { stripVTControlCharacters } from "node:util";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+
+/** Already formatted single-line rows. Sanitize untrusted values before styling or wrapping. */
+export interface BoundedFrameOptions {
+	width: number;
+	maxRows: number;
+	rule: string;
+	title: readonly string[];
+	context?: readonly string[];
+	content: readonly string[];
+	hints?: readonly string[];
+	/** Full hints for compact mode, optionally including an overflow indicator. */
+	compactHints?: readonly string[];
+	compactHint?: string;
+	/** Content row indexes in retention priority order; blank rows are ignored when compacting. */
+	priorityRows?: readonly number[];
+	/** Content row whose neighbors fill the remaining compact budget. */
+	focusedRow?: number;
+}
+
+/** Frame terminal-formatted rows without owning input, persistence, or terminal reservations. */
+export function renderBoundedFrame(options: BoundedFrameOptions): string[] {
+	const width = dimension(options.width);
+	const maxRows = dimension(options.maxRows);
+	if (maxRows === 0) return [];
+	const { rule, title, content, hints = [], context = [], compactHint = "" } = options;
+	const full = [
+		rule,
+		...title,
+		...context,
+		...(content.length ? ["", ...content] : []),
+		...hints,
+		rule,
+	];
+	if (full.length <= maxRows) return full.map((line) => truncateToWidth(line, width, ""));
+
+	const framed = maxRows >= 5;
+	const available = maxRows - (framed ? 2 : 0);
+	const rows = content
+		.map((line, index) => ({ line, index }))
+		.filter(({ line }) => stripVTControlCharacters(line).trim().length > 0);
+	const priorities = [...new Set(options.priorityRows ?? [])]
+		.map((index) => rows.findIndex((row) => row.index === index))
+		.filter((index) => index >= 0);
+	const focused = rows.findIndex((row) => row.index === options.focusedRow);
+	const body = rows.length
+		? compactContent(
+				title,
+				context,
+				rows.map(({ line }) => line),
+				options.compactHints ?? hints,
+				compactHint,
+				available,
+				priorities,
+				focused,
+			)
+		: compactStatic(title, context, compactHint, available);
+	return (framed ? [rule, ...body, rule] : body).map((line) => truncateToWidth(line, width, ""));
+}
+
+function dimension(value: number): number {
+	return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function compactContent(
+	title: readonly string[],
+	context: readonly string[],
+	content: readonly string[],
+	hints: readonly string[],
+	compactHint: string,
+	available: number,
+	priorities: readonly number[],
+	focused: number,
+): string[] {
+	const hintBudget = compactHint && available > 1 ? 1 : 0;
+	const minimumContent = Math.min(available - hintBudget, Math.max(1, priorities.length));
+	let remaining = Math.max(0, available - hintBudget - minimumContent);
+	const titleBudget = title.length > 0 && remaining > 0 ? 1 : 0;
+	remaining -= titleBudget;
+	const extraHints = Math.max(0, hints.length - hintBudget);
+	const fullHints = hintBudget > 0 && hints.length > 0 && extraHints <= remaining;
+	if (fullHints) remaining -= extraHints;
+	const contentBudget = Math.min(content.length, minimumContent + remaining);
+	remaining -= contentBudget - minimumContent;
+	const contextBudget = Math.min(context.length, remaining);
+	const indexes = new Set(priorities.slice(0, contentBudget));
+	const fillOrder = content
+		.map((_, index) => index)
+		.sort((left, right) =>
+			focused < 0
+				? left - right
+				: Math.abs(left - focused) - Math.abs(right - focused) || left - right,
+		);
+	for (const index of fillOrder) {
+		if (indexes.size >= contentBudget) break;
+		indexes.add(index);
+	}
+	return [
+		...title.slice(0, titleBudget),
+		...context.slice(0, contextBudget),
+		...[...indexes].sort((left, right) => left - right).map((index) => content[index] ?? ""),
+		...(hintBudget ? (fullHints ? hints : [compactHint]) : []),
+	];
+}
+
+function compactStatic(
+	title: readonly string[],
+	context: readonly string[],
+	compactHint: string,
+	available: number,
+): string[] {
+	if (available === 1) return [context[0] || compactHint || title[0] || ""];
+	const hintBudget = compactHint ? 1 : 0;
+	const minimumContext = context.length > 0 ? 1 : 0;
+	let remaining = Math.max(0, available - hintBudget - minimumContext);
+	const titleBudget = title.length > 0 && remaining > 0 ? 1 : 0;
+	remaining -= titleBudget;
+	return [
+		...title.slice(0, titleBudget),
+		...context.slice(0, Math.min(context.length, minimumContext + remaining)),
+		...(hintBudget ? [compactHint] : []),
+	];
+}

--- a/packages/pi-tui-kit/src/components/rendering.ts
+++ b/packages/pi-tui-kit/src/components/rendering.ts
@@ -1,10 +1,6 @@
 import { stripVTControlCharacters } from "node:util";
-import {
-	type Input,
-	truncateToWidth,
-	visibleWidth,
-	wrapTextWithAnsi,
-} from "@earendil-works/pi-tui";
+import { type Input, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { renderBoundedFrame } from "../bounded-frame.js";
 import { HorizontalRule } from "../horizontal-rule.js";
 import { formatInteractionHints } from "../interaction-hints.js";
 import { replaceTerminalControls, safeMenuText } from "../text.js";
@@ -92,152 +88,29 @@ export function renderFrame<ScreenId extends string, ActionId extends string>(
 			safeWidth,
 		),
 	);
-	const fullFrame = [
+	// Selection affordances belong to the menu adapter, not the public frame primitive.
+	const compactContent = content
+		.map((line, index) => ({ line, index }))
+		.filter(({ line }) => stripVTControlCharacters(line).trim().length > 0);
+	const compactRows = compactContent.map(({ line }) => line);
+	const priorities = priorityRowIndexes(
+		compactRows,
+		layout.pinnedContentRows ?? 0,
+		layout.priorityTailRows ?? 0,
+	);
+	return renderBoundedFrame({
+		width: safeWidth,
+		maxRows: componentRows(options.tui.terminal.rows),
 		rule,
-		...titleRows,
-		...contextRows,
-		...(content.length > 0 ? ["", ...content] : []),
-		...hintRows,
-		rule,
-	];
-	const maxRows = componentRows(options.tui.terminal.rows);
-	const result =
-		fullFrame.length <= maxRows
-			? fullFrame
-			: compactFrame(
-					rule,
-					titleRows,
-					contextRows,
-					content,
-					compactFullHintRows,
-					compactHintRow,
-					maxRows,
-					layout.pinnedContentRows ?? 0,
-					layout.priorityTailRows ?? 0,
-				);
-	return result.map((line) => truncateToWidth(line, safeWidth, ""));
-}
-
-function compactFrame(
-	rule: string,
-	titleRows: readonly string[],
-	contextRows: readonly string[],
-	contentRows: readonly string[],
-	hintRows: readonly string[],
-	compactHintRow: string,
-	maxRows: number,
-	pinnedContentRows: number,
-	priorityTailRows: number,
-): string[] {
-	const framed = maxRows >= 5;
-	const availableRows = framed ? maxRows - 2 : maxRows;
-	const compactContentRows = contentRows.filter(
-		(line) => stripVTControlCharacters(line).trim().length > 0,
-	);
-	const body =
-		compactContentRows.length > 0
-			? compactInteractiveRows(
-					titleRows,
-					contextRows,
-					compactContentRows,
-					hintRows,
-					compactHintRow,
-					availableRows,
-					pinnedContentRows,
-					priorityTailRows,
-				)
-			: compactStaticRows(titleRows, contextRows, compactHintRow, availableRows);
-	return framed ? [rule, ...body, rule] : body;
-}
-
-function compactInteractiveRows(
-	titleRows: readonly string[],
-	contextRows: readonly string[],
-	contentRows: readonly string[],
-	hintRows: readonly string[],
-	compactHintRow: string,
-	availableRows: number,
-	pinnedContentRows: number,
-	priorityTailRows: number,
-): string[] {
-	const hintBudget = compactHintRow && availableRows > 1 ? 1 : 0;
-	const minimumContentRows = Math.min(
-		availableRows - hintBudget,
-		minimumFocusedRows(contentRows, pinnedContentRows, priorityTailRows),
-	);
-	let remainingRows = Math.max(0, availableRows - hintBudget - minimumContentRows);
-	const titleBudget = titleRows.length > 0 && remainingRows > 0 ? 1 : 0;
-	remainingRows -= titleBudget;
-	const extraHintRows = Math.max(0, hintRows.length - hintBudget);
-	const useFullHints = hintBudget > 0 && extraHintRows <= remainingRows;
-	if (useFullHints) remainingRows -= extraHintRows;
-	const contentBudget = Math.min(contentRows.length, minimumContentRows + remainingRows);
-	remainingRows -= contentBudget - minimumContentRows;
-	const contextBudget = Math.min(contextRows.length, remainingRows);
-	const boundedContent = focusedRows(
-		contentRows,
-		contentBudget,
-		pinnedContentRows,
-		priorityTailRows,
-	);
-	return [
-		...titleRows.slice(0, titleBudget),
-		...contextRows.slice(0, contextBudget),
-		...boundedContent,
-		...(hintBudget > 0 ? (useFullHints ? hintRows : [compactHintRow]) : []),
-	];
-}
-
-function compactStaticRows(
-	titleRows: readonly string[],
-	contextRows: readonly string[],
-	compactHintRow: string,
-	availableRows: number,
-): string[] {
-	if (availableRows <= 0) return [];
-	if (availableRows === 1) {
-		return [contextRows[0] || compactHintRow || titleRows[0] || ""];
-	}
-	const hintBudget = compactHintRow ? 1 : 0;
-	const minimumContextRows = contextRows.length > 0 ? 1 : 0;
-	let remainingRows = Math.max(0, availableRows - hintBudget - minimumContextRows);
-	const titleBudget = titleRows.length > 0 && remainingRows > 0 ? 1 : 0;
-	remainingRows -= titleBudget;
-	const contextBudget = Math.min(contextRows.length, minimumContextRows + remainingRows);
-	return [
-		...titleRows.slice(0, titleBudget),
-		...contextRows.slice(0, contextBudget),
-		...(hintBudget > 0 ? [compactHintRow] : []),
-	];
-}
-
-function minimumFocusedRows(rows: readonly string[], pinnedRows: number, priorityTailRows: number) {
-	const priorities = priorityRowIndexes(rows, pinnedRows, priorityTailRows);
-	return Math.max(1, priorities.size);
-}
-
-function focusedRows(
-	rows: readonly string[],
-	budget: number,
-	pinnedRows = 0,
-	priorityTailRows = 0,
-): readonly string[] {
-	if (budget <= 0) return [];
-	if (rows.length <= budget) return rows;
-	const indexes = priorityRowIndexes(rows, pinnedRows, priorityTailRows, budget);
-	const selectedIndex = selectedRowIndex(rows);
-	const fillOrder = Array.from({ length: rows.length }, (_, index) => index).sort((left, right) => {
-		if (selectedIndex < 0) return left - right;
-		return Math.abs(left - selectedIndex) - Math.abs(right - selectedIndex) || left - right;
+		title: titleRows,
+		context: contextRows,
+		content,
+		hints: hintRows,
+		compactHints: compactFullHintRows,
+		compactHint: compactHintRow,
+		priorityRows: [...priorities].map((index) => compactContent[index]?.index ?? -1),
+		focusedRow: compactContent[selectedRowIndex(compactRows)]?.index,
 	});
-	for (const index of fillOrder) {
-		if (indexes.size >= budget) break;
-		indexes.add(index);
-	}
-	return [...indexes]
-		.sort((left, right) => left - right)
-		.map((index) => rows[index])
-		.filter((line): line is string => line !== undefined);
 }
 
 function priorityRowIndexes(

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -1,3 +1,4 @@
+export { type BoundedFrameOptions, renderBoundedFrame } from "./bounded-frame.js";
 export {
 	type RunConfirmationOptions,
 	type RunConfirmationResult,
@@ -80,4 +81,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 15;
+export const PI_EXTENSION_MENU_API_VERSION = 16;

--- a/packages/pi-tui-kit/test/bounded-frame.test.ts
+++ b/packages/pi-tui-kit/test/bounded-frame.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { type BoundedFrameOptions, renderBoundedFrame } from "../src/index.js";
+
+const options: BoundedFrameOptions = {
+	width: 80,
+	maxRows: 24,
+	rule: "─".repeat(80),
+	title: ["Settings"],
+	context: ["Current session"],
+	content: ["", "Search", "", "First", "Focused", "Other", "", "Description", "Saving…"],
+	hints: ["enter change • esc back • ctrl+c close"],
+	compactHint: "esc back",
+	priorityRows: [1, 4, 8],
+	focusedRow: 4,
+};
+
+test("bounded frame preserves the full presentation and caller state", () => {
+	const before = structuredClone(options);
+	assert.deepEqual(renderBoundedFrame(options), [
+		options.rule,
+		"Settings",
+		"Current session",
+		"",
+		...options.content,
+		...(options.hints ?? []),
+		options.rule,
+	]);
+	assert.deepEqual(options, before);
+});
+
+for (const width of [0, 1, 2, 12, 80]) {
+	for (const maxRows of [0, 1, 2, 3, 4, 5, 8, 24]) {
+		test(`bounded frame fits ${width} columns and ${maxRows} rows`, () => {
+			const lines = renderBoundedFrame({ ...options, width, maxRows });
+			assert.ok(lines.length <= maxRows);
+			for (const line of lines) assert.ok(visibleWidth(line) <= width);
+		});
+	}
+}
+
+test("compact priorities refer to original indexes, not cursor glyphs or compact indexes", () => {
+	const result = renderBoundedFrame({
+		...options,
+		maxRows: 4,
+		content: ["", "Selected without cursor", "→ Not selected", "", "Saving"],
+		priorityRows: [4, 1, 4, 0, -1, 1.5, Number.NaN, 99],
+		focusedRow: 1,
+	});
+	assert.deepEqual(result, [
+		"Settings",
+		"Selected without cursor",
+		"Saving",
+		"enter change • esc back • ctrl+c close",
+	]);
+});
+
+test("a one-row viewport preserves the first caller priority", () => {
+	assert.deepEqual(renderBoundedFrame({ ...options, maxRows: 1, priorityRows: [8, 4] }), [
+		"Saving…",
+	]);
+});
+
+test("focus proximity fills rows without reordering output", () => {
+	assert.deepEqual(
+		renderBoundedFrame({
+			width: 20,
+			maxRows: 3,
+			rule: "─",
+			title: [],
+			content: ["zero", "one", "two", "three", "four"],
+			priorityRows: [3],
+			focusedRow: 3,
+		}),
+		["two", "three", "four"],
+	);
+});
+
+test("compact mode retains a standalone compact hint and ignores blank priorities", () => {
+	assert.deepEqual(
+		renderBoundedFrame({
+			width: 20,
+			maxRows: 2,
+			rule: "─",
+			title: [],
+			content: ["", "item", "other"],
+			priorityRows: [0, 1],
+			compactHint: "ctrl+c close",
+		}),
+		["item", "ctrl+c close"],
+	);
+});
+
+test("static and empty frames remain readable at tiny heights", () => {
+	assert.deepEqual(renderBoundedFrame({ ...options, content: [], maxRows: 1 }), [
+		"Current session",
+	]);
+	assert.deepEqual(
+		renderBoundedFrame({ ...options, title: [], context: [], content: [], maxRows: 1 }),
+		["esc back"],
+	);
+});
+
+test("resizing restores descriptions, styling, and frame without cached dimensions", () => {
+	const styled = {
+		...options,
+		content: options.content.map((line) => `\u001b[31m${line}\u001b[0m`),
+	};
+	const full = renderBoundedFrame(styled);
+	assert.ok(full.some((line) => stripVTControlCharacters(line) === "Description"));
+	const tiny = renderBoundedFrame({ ...styled, maxRows: 1 });
+	assert.equal(stripVTControlCharacters(tiny[0] ?? ""), "Search");
+	assert.deepEqual(renderBoundedFrame(styled), full);
+});
+
+for (const dimension of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+	test(`invalid dimensions normalize to zero: ${dimension}`, () => {
+		assert.deepEqual(renderBoundedFrame({ ...options, maxRows: dimension }), []);
+		for (const line of renderBoundedFrame({ ...options, width: dimension })) {
+			assert.equal(visibleWidth(line), 0);
+		}
+	});
+}

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -41,7 +41,7 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes API version 15 and Markdown document types", () => {
+test("package exposes API version 16 and Markdown document types", () => {
 	const markdown: ReviewFormat = {
 		kind: "markdown",
 		renderLatex: false,
@@ -56,9 +56,9 @@ test("package exposes API version 15 and Markdown document types", () => {
 		label: "Schema",
 		detailDocument: document,
 	};
-	const apiVersion: 15 = PI_EXTENSION_MENU_API_VERSION;
+	const apiVersion: 16 = PI_EXTENSION_MENU_API_VERSION;
 	assert.equal(item.detailDocument, document);
-	assert.equal(apiVersion, 15);
+	assert.equal(apiVersion, 16);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/package-exports.test.ts
+++ b/packages/pi-tui-kit/test/package-exports.test.ts
@@ -19,7 +19,8 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 	const terminalDocument = await import(terminalDocumentSpecifier);
 	const terminalText = await import(terminalTextSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 15);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 16);
+	assert.equal(typeof production.renderBoundedFrame, "function");
 	assert.equal(typeof production.sanitizeTerminalDocument, "function");
 	assert.equal(typeof production.hardWrapTerminalDocument, "function");
 	assert.equal(typeof production.sanitizeTerminalText, "function");
@@ -54,7 +55,9 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 			`import { hardWrapTerminalDocument, sanitizeTerminalDocument } from "@narumitw/pi-tui-kit/terminal-document";\n` +
 			`import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 15 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 16 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const frame: import("@narumitw/pi-tui-kit").BoundedFrameOptions = { width: 20, maxRows: 3, rule: "─", title: [], content: ["row"] };\n` +
+			`void (await import("@narumitw/pi-tui-kit")).renderBoundedFrame(frame);\n` +
 			`const keybindings: InteractionKeybindings<"confirm"> = { getKeys: () => ["return"] };\n` +
 			`const hints: InteractionHint<"confirm">[] = [{ bindings: ["confirm"], label: sanitizeTerminalText("apply") }];\n` +
 			`const hintOptions: FormatInteractionHintsOptions = { separator: "·" };\n` +


### PR DESCRIPTION
## Summary

Reduce repeated TUI presentation code without moving extension-owned state or lifecycle policy into Kit.

- Expose `renderBoundedFrame()` with explicit row priorities and reuse it in existing Kit menus (API version 16).
- Adopt already-published Kit widget/sanitization helpers in Todo, display sanitization in Stamp, and interaction hints in Sync.
- Preserve Stamp's persisted metadata codec, Todo's adaptive priorities, and Sync's cancellation/paste behavior. Retain specialized btw/questionnaire key formatting after compatibility review.
- Add independent Changesets and regression tests; all six commits are signed.

## Verification

- `npm run check`: build, Biome, boundaries, and all workspace typechecks passed.
- `npm test`: **386 files / 4,398 tests passed**; Kit rebuilt first, no increased timeouts.
- `npm run package:pack -- tui-kit`, `-- todo`, and `-- stamp` passed; actual tarballs inspected for public JS/declarations, dependencies, generated entries, README, and license.
- Isolated package-directory Pi RPC load smokes passed for Stamp, Todo, and Sync without model requests. Generated-runtime/Jiti lazy-boundary tests passed.
- Registry confirmed Todo's required existing Kit release; root install and `npm ls @narumitw/pi-tui-kit` verified resolution.
- Reviewed `docs/extension-conventions.md` and `docs/extension-settings.md`: presentation bounds/themes, raw payload preservation, asynchronous cancellation/disposal, session freshness, save ordering/recovery, invalid-file protection, and atomic publication. No usage persistence or interaction code changed.

## Risks and remaining plan work

The plan is **not complete** and remains at `docs/plans/2026-09-08_tui-kit-shared-ui-plan.md`. The new Kit API must be published before usage can adopt it; publishing, version tags, and release workflow dispatch were explicitly prohibited and were not performed. No consumer in this PR uses the unpublished API.

Usage keeps its custom SettingsList because it aborts pending saves immediately on cancel, unlike Kit SettingsScreen's drain-before-close behavior. Its frame migration and Changeset remain a release-dependent follow-up.

Stamp now admits only Kit's dependency-free `/terminal-text` leaf eagerly; tests continue rejecting the Kit root and other subpaths. Manual visual/IME checks in a real interactive terminal were not run; short-terminal, remapped-key, paste, and lifecycle paths were tested through non-interactive harnesses.
