### PR TITLE
fix(plan-mode): preserve failed handoff state

### DIFF
--- a/.changeset/plan-implementation-lifecycle.md
+++ b/.changeset/plan-implementation-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Preserve in-memory planning branches before fresh handoffs and roll back implementation model preferences before session replacement.

--- a/packages/pi-plan-mode/src/fresh-implementation-preferences.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation-preferences.ts
@@ -23,6 +23,7 @@ export async function applyFreshImplementationPreferences(
 	ctx: ExtensionContext,
 	isCurrent: () => boolean,
 	selectionSnapshot?: () => ImplementationSnapshot | undefined,
+	isSessionCurrent: () => boolean = isCurrent,
 ) {
 	if (!isCurrent() || !ctx.isIdle()) return;
 	const entry = latestPreferenceEntry(ctx);
@@ -36,7 +37,7 @@ export async function applyFreshImplementationPreferences(
 	const change = createImplementationPreferenceChange(
 		pi,
 		ctx,
-		isCurrent,
+		isSessionCurrent,
 		undefined,
 		selectionSnapshot,
 	);
@@ -64,7 +65,6 @@ export async function applyFreshImplementationPreferences(
 			thinking: pi.getThinkingLevel(),
 		});
 	} catch (error) {
-		if (!isCurrent()) return;
 		await change.rollback().catch(() => undefined);
 		if (!isCurrent()) return;
 		pi.appendEntry(FRESH_PREFERENCES_ENTRY, {

--- a/packages/pi-plan-mode/src/fresh-implementation-preferences.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation-preferences.ts
@@ -24,6 +24,7 @@ export async function applyFreshImplementationPreferences(
 	isCurrent: () => boolean,
 	selectionSnapshot?: () => ImplementationSnapshot | undefined,
 	isSessionCurrent: () => boolean = isCurrent,
+	beginPreferenceApplication?: () => () => void,
 ) {
 	if (!isCurrent() || !ctx.isIdle()) return;
 	const entry = latestPreferenceEntry(ctx);
@@ -41,6 +42,7 @@ export async function applyFreshImplementationPreferences(
 		undefined,
 		selectionSnapshot,
 	);
+	let finishPreferenceApplication: (() => void) | undefined;
 	try {
 		const originalModel = ctx.model;
 		const originalThinking = pi.getThinkingLevel();
@@ -54,6 +56,7 @@ export async function applyFreshImplementationPreferences(
 				pi.getThinkingLevel() === originalThinking,
 		);
 		if (!model || !current()) return;
+		finishPreferenceApplication = beginPreferenceApplication?.();
 		if (!(await change.apply(model, preferences, current)) || !current()) {
 			await change.rollback();
 			return;
@@ -72,6 +75,8 @@ export async function applyFreshImplementationPreferences(
 			status: "failed",
 			error: preferenceError(error),
 		});
+	} finally {
+		finishPreferenceApplication?.();
 	}
 }
 

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import {
 	type ExtensionCommandContext,
 	type ExtensionContext,
@@ -37,6 +37,11 @@ interface FreshImplementationFromStateOptions {
 	menuIsCurrent(): boolean;
 	retention: ImplementationPlanRetention;
 	stateEntryType: string;
+}
+
+interface ResumableParentSession {
+	path: string;
+	created: boolean;
 }
 
 export type FreshImplementationResult =
@@ -146,7 +151,7 @@ export async function startFreshImplementationSession(
 	const handoff = usesConversationHistory
 		? formatTransferredPlanPrompt(request.plan, true)
 		: formatImplementationHandoff(request.plan);
-	let parentSession: string;
+	let parentSession: ResumableParentSession;
 	try {
 		parentSession = resumableParentSession(ctx);
 	} catch (error) {
@@ -165,7 +170,7 @@ export async function startFreshImplementationSession(
 	let result: Awaited<ReturnType<ExtensionCommandContext["newSession"]>>;
 	try {
 		result = await ctx.newSession({
-			parentSession,
+			parentSession: parentSession.path,
 			setup: async (sessionManager) => {
 				try {
 					if (preferencesId)
@@ -235,15 +240,16 @@ export async function startFreshImplementationSession(
 	}
 
 	if (result.cancelled) {
+		if (parentSession.created) removeCreatedParentSession(ctx, parentSession.path);
 		safeNotify(ctx, "Fresh implementation cancelled. The plan remains available.", "info");
 		return { kind: "cancelled" };
 	}
 	return setupError || kickoffError ? { kind: "partial" } : { kind: "started" };
 }
 
-function resumableParentSession(ctx: ExtensionCommandContext) {
+function resumableParentSession(ctx: ExtensionCommandContext): ResumableParentSession {
 	const existing = ctx.sessionManager.getSessionFile();
-	if (existing) return existing;
+	if (existing) return { path: existing, created: false };
 
 	const sourceCopy = SessionManager.create(ctx.cwd, undefined, {
 		parentSession: ctx.sessionManager.getHeader()?.parentSession,
@@ -253,9 +259,23 @@ function resumableParentSession(ctx: ExtensionCommandContext) {
 	if (!path || !header) throw new Error("Pi did not provide a destination for the source copy");
 	const entries = [header, ...ctx.sessionManager.getBranch()];
 	writeFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+		encoding: "utf8",
 		flag: "wx",
+		mode: 0o600,
 	});
-	return path;
+	return { path, created: true };
+}
+
+function removeCreatedParentSession(ctx: ExtensionCommandContext, path: string) {
+	try {
+		rmSync(path, { force: true });
+	} catch (error) {
+		safeNotify(
+			ctx,
+			`Fresh implementation was cancelled, but its temporary source copy could not be removed: ${safeErrorDetail(error)}`,
+			"warning",
+		);
+	}
 }
 
 async function preflightModel(ctx: ExtensionCommandContext, isCurrent: () => boolean) {

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { writeFileSync } from "node:fs";
+import {
+	type ExtensionCommandContext,
+	type ExtensionContext,
+	SessionManager,
+} from "@earendil-works/pi-coding-agent";
 import {
 	FRESH_PREFERENCES_ENTRY,
 	freshPreferencesApplied,
@@ -141,7 +146,17 @@ export async function startFreshImplementationSession(
 	const handoff = usesConversationHistory
 		? formatTransferredPlanPrompt(request.plan, true)
 		: formatImplementationHandoff(request.plan);
-	const parentSession = ctx.sessionManager.getSessionFile();
+	let parentSession: string;
+	try {
+		parentSession = resumableParentSession(ctx);
+	} catch (error) {
+		safeNotify(
+			ctx,
+			`Unable to preserve the source planning session: ${safeErrorDetail(error)}. The source plan remains available; retry before starting a fresh implementation session.`,
+			"error",
+		);
+		return { kind: "rejected" };
+	}
 	let setupError: string | undefined;
 	let kickoffError: string | undefined;
 
@@ -150,7 +165,7 @@ export async function startFreshImplementationSession(
 	let result: Awaited<ReturnType<ExtensionCommandContext["newSession"]>>;
 	try {
 		result = await ctx.newSession({
-			...(parentSession ? { parentSession } : {}),
+			parentSession,
 			setup: async (sessionManager) => {
 				try {
 					if (preferencesId)
@@ -224,6 +239,23 @@ export async function startFreshImplementationSession(
 		return { kind: "cancelled" };
 	}
 	return setupError || kickoffError ? { kind: "partial" } : { kind: "started" };
+}
+
+function resumableParentSession(ctx: ExtensionCommandContext) {
+	const existing = ctx.sessionManager.getSessionFile();
+	if (existing) return existing;
+
+	const sourceCopy = SessionManager.create(ctx.cwd, undefined, {
+		parentSession: ctx.sessionManager.getHeader()?.parentSession,
+	});
+	const path = sourceCopy.getSessionFile();
+	const header = sourceCopy.getHeader();
+	if (!path || !header) throw new Error("Pi did not provide a destination for the source copy");
+	const entries = [header, ...ctx.sessionManager.getBranch()];
+	writeFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+		flag: "wx",
+	});
+	return path;
 }
 
 async function preflightModel(ctx: ExtensionCommandContext, isCurrent: () => boolean) {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -120,6 +120,11 @@ interface PendingWorkflowToolPolicy {
 	generation: number;
 	mode: "resolve" | "revalidate";
 }
+interface ActiveImplementationPreferencePreparation {
+	sessionManager: ExtensionContext["sessionManager"];
+	completion: Promise<void>;
+	finish(): void;
+}
 type InteractiveUi = typeof import("./interactive-ui.js");
 
 interface PlanModeDependencies {
@@ -166,6 +171,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let menuGeneration = 0;
 	let implementationInFlight = false;
 	let applyingImplementationPreferences = false;
+	let activeImplementationPreferencePreparation:
+		| ActiveImplementationPreferencePreparation
+		| undefined;
 	let workflowGeneration = 0;
 	let refreshStateBeforeFirstAgentStart = false;
 	let menuController = new AbortController();
@@ -174,6 +182,24 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	const implementationRetention = createImplementationRetentionCoordinator();
 	const finalizationRequest = createFinalizationRequestCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
+	const beginImplementationPreferencePreparation = (
+		sessionManager: ExtensionContext["sessionManager"],
+	) => {
+		let resolveCompletion!: () => void;
+		const preparation: ActiveImplementationPreferencePreparation = {
+			sessionManager,
+			completion: new Promise<void>((resolve) => {
+				resolveCompletion = resolve;
+			}),
+			finish() {
+				if (activeImplementationPreferencePreparation === preparation)
+					activeImplementationPreferencePreparation = undefined;
+				resolveCompletion();
+			},
+		};
+		activeImplementationPreferencePreparation = preparation;
+		return preparation.finish;
+	};
 	const planExports = createPlanExportController({
 		getState: () => state,
 		getSettings: () => settings,
@@ -484,13 +510,21 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!installRestoredState(restoredState, ctx)) return;
 		implementationRetention.restore(state.activeImplementation);
 		updateUi(ctx);
-		if (event.reason === "new")
-			await applyFreshImplementationPreferences(
-				pi,
-				ctx,
-				() => generation === menuGeneration && !menuController.signal.aborted,
-				selectionSnapshot,
-			);
+		if (event.reason === "new") {
+			const sessionManager = ctx.sessionManager;
+			const finishPreparation = beginImplementationPreferencePreparation(sessionManager);
+			try {
+				await applyFreshImplementationPreferences(
+					pi,
+					ctx,
+					() => generation === menuGeneration && !menuController.signal.aborted,
+					selectionSnapshot,
+					() => currentSession === sessionManager,
+				);
+			} finally {
+				finishPreparation();
+			}
+		}
 	});
 
 	pi.on("session_before_tree", (event, ctx) => {
@@ -539,6 +573,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		const shutdownSession = ctx.sessionManager;
+		const preferencePreparation =
+			activeImplementationPreferencePreparation?.sessionManager === shutdownSession
+				? activeImplementationPreferencePreparation
+				: undefined;
 		finalizationRequest.reset();
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode session shut down", "AbortError"));
@@ -548,6 +586,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		workflowAllowedToolNames = undefined;
 		pendingWorkflowToolPolicy = undefined;
 		implementationRetention.reset();
+		if (preferencePreparation) await preferencePreparation.completion;
+		if (currentSession !== undefined && currentSession !== shutdownSession) {
+			workflowMutex.unbindSession(shutdownSession);
+			return;
+		}
 		await awaitPlanModeSettingsWrites(dependencies.settingsPath);
 		if (currentSession !== undefined && currentSession !== shutdownSession) {
 			workflowMutex.unbindSession(shutdownSession);
@@ -1037,11 +1080,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!(state.enabled ? state.latestPlan : state.savedPlan?.plan)) return;
 		const generation = menuGeneration;
 		const workflow = workflowGeneration;
+		const sessionManager = ctx.sessionManager;
 		const original = { model: ctx.model, thinking: pi.getThinkingLevel() };
-		const sessionCurrent = () => generation === menuGeneration && !menuController.signal.aborted;
+		const sessionActive = () => currentSession === sessionManager;
+		const flowCurrent = () =>
+			sessionActive() && generation === menuGeneration && !menuController.signal.aborted;
 		let expectedState = state;
 		const current = () =>
-			sessionCurrent() &&
+			flowCurrent() &&
 			workflow === workflowGeneration &&
 			state === expectedState &&
 			menuIsCurrent() &&
@@ -1049,10 +1095,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const change = createImplementationPreferenceChange(
 			pi,
 			ctx,
-			sessionCurrent,
+			sessionActive,
 			original,
 			selectionSnapshot,
 		);
+		const finishPreparation = beginImplementationPreferencePreparation(sessionManager);
 		implementationInFlight = true;
 		let started = false;
 		try {
@@ -1071,22 +1118,26 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			if (!(await change.apply(model, preferences, current)) || !current()) return;
 			started = (await startImplementationCore(ctx, true)) === true;
 		} catch (error) {
-			if (sessionCurrent())
+			if (flowCurrent())
 				ctx.ui.notify(`Unable to start implementation: ${preferenceError(error)}`, "error");
 		} finally {
-			if (!started && sessionCurrent()) {
-				await change.rollback().catch((error) => {
-					if (sessionCurrent()) ctx.ui.notify(preferenceError(error), "error");
-				});
-				if (sessionCurrent() && state === expectedState) {
-					state = previousState;
-					captureManualThinkingLevel();
-					persistState();
-					updateUi(ctx);
+			try {
+				if (!started && sessionActive()) {
+					await change.rollback().catch((error) => {
+						if (flowCurrent()) ctx.ui.notify(preferenceError(error), "error");
+					});
+					if (sessionActive() && state === expectedState) {
+						state = previousState;
+						captureManualThinkingLevel();
+						persistState();
+						updateUi(ctx);
+					}
 				}
+			} finally {
+				applyingImplementationPreferences = false;
+				implementationInFlight = false;
+				finishPreparation();
 			}
-			applyingImplementationPreferences = false;
-			implementationInFlight = false;
 		}
 	}
 

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -512,18 +512,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		updateUi(ctx);
 		if (event.reason === "new") {
 			const sessionManager = ctx.sessionManager;
-			const finishPreparation = beginImplementationPreferencePreparation(sessionManager);
-			try {
-				await applyFreshImplementationPreferences(
-					pi,
-					ctx,
-					() => generation === menuGeneration && !menuController.signal.aborted,
-					selectionSnapshot,
-					() => currentSession === sessionManager,
-				);
-			} finally {
-				finishPreparation();
-			}
+			await applyFreshImplementationPreferences(
+				pi,
+				ctx,
+				() => generation === menuGeneration && !menuController.signal.aborted,
+				selectionSnapshot,
+				() => currentSession === sessionManager,
+				() => beginImplementationPreferencePreparation(sessionManager),
+			);
 		}
 	});
 
@@ -1099,7 +1095,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			original,
 			selectionSnapshot,
 		);
-		const finishPreparation = beginImplementationPreferencePreparation(sessionManager);
+		let finishPreparation: (() => void) | undefined;
 		implementationInFlight = true;
 		let started = false;
 		try {
@@ -1112,6 +1108,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 					pi.getThinkingLevel() === original.thinking,
 			);
 			if (!model || !current()) return;
+			finishPreparation = beginImplementationPreferencePreparation(sessionManager);
 			applyingImplementationPreferences = true;
 			if (state.enabled) restoreThinkingLevel();
 			expectedState = state;
@@ -1136,7 +1133,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			} finally {
 				applyingImplementationPreferences = false;
 				implementationInFlight = false;
-				finishPreparation();
+				finishPreparation?.();
 			}
 		}
 	}

--- a/packages/pi-plan-mode/test/fresh-implementation-model.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-model.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { type ExtensionCommandContext, SessionManager } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import { startFreshImplementationSession } from "../src/fresh-implementation.js";
 import {
@@ -17,10 +17,12 @@ for (const retention of IMPLEMENTATION_PLAN_RETENTIONS) {
 			});
 		});
 		try {
+			const sourceManager = fixture.runtime.session.sessionManager;
+			sourceManager.appendCustomEntry("planning-marker", { plan: "# Approved plan" });
 			const source = fixture.runtime.session.createReplacedSessionContext();
-			const sourceManager = source.sessionManager;
 			const sourceEntries = sourceManager.getBranch();
 			const kickoffs: Array<{ model?: string; thinking?: string; prompt: string }> = [];
+			let parentSession: string | undefined;
 			const ctx = new Proxy(source, {
 				get(target, key) {
 					if (key === "newSession")
@@ -28,6 +30,7 @@ for (const retention of IMPLEMENTATION_PLAN_RETENTIONS) {
 							fixture.runtime.newSession({
 								...options,
 								withSession: async (replacement) => {
+									parentSession = replacement.sessionManager.getHeader()?.parentSession;
 									const destination = new Proxy(replacement, {
 										get(target, key) {
 											if (key === "sendUserMessage")
@@ -64,6 +67,8 @@ for (const retention of IMPLEMENTATION_PLAN_RETENTIONS) {
 			assert.equal(kickoffs[0]?.thinking, "max");
 			assert.match(kickoffs[0]?.prompt ?? "", /# Approved plan/);
 			assert.deepEqual(sourceManager.getBranch(), sourceEntries);
+			assert.ok(parentSession);
+			assert.deepEqual(SessionManager.open(parentSession).getBranch(), sourceEntries);
 			fixture.pi.setThinkingLevel("high");
 			await fixture.runtime.session.extensionRunner.emit({
 				type: "session_start",

--- a/packages/pi-plan-mode/test/fresh-implementation-model.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-model.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { existsSync, statSync } from "node:fs";
 import { type ExtensionCommandContext, SessionManager } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import { startFreshImplementationSession } from "../src/fresh-implementation.js";
@@ -69,6 +70,7 @@ for (const retention of IMPLEMENTATION_PLAN_RETENTIONS) {
 			assert.deepEqual(sourceManager.getBranch(), sourceEntries);
 			assert.ok(parentSession);
 			assert.deepEqual(SessionManager.open(parentSession).getBranch(), sourceEntries);
+			if (process.platform !== "win32") assert.equal(statSync(parentSession).mode & 0o777, 0o600);
 			fixture.pi.setThinkingLevel("high");
 			await fixture.runtime.session.extensionRunner.emit({
 				type: "session_start",
@@ -96,12 +98,14 @@ for (const failure of ["cancelled", "missing-target", "missing-ack", "kickoff"] 
 			const before = sourceManager.getBranch();
 			let sends = 0;
 			let recovered = "";
+			let attemptedParentSession: string | undefined;
 			if (failure === "cancelled") fixture.cancelReplacement();
 			const ctx = new Proxy(source, {
 				get(target, key) {
 					if (key === "newSession")
-						return (options: Parameters<ExtensionCommandContext["newSession"]>[0]) =>
-							fixture.runtime.newSession({
+						return (options: Parameters<ExtensionCommandContext["newSession"]>[0]) => {
+							attemptedParentSession = options?.parentSession;
+							return fixture.runtime.newSession({
 								...options,
 								withSession: async (replacement) => {
 									const destination = new Proxy(replacement, {
@@ -124,6 +128,7 @@ for (const failure of ["cancelled", "missing-target", "missing-ack", "kickoff"] 
 									await options?.withSession?.(destination);
 								},
 							});
+						};
 					return Reflect.get(target, key);
 				},
 			});
@@ -150,6 +155,10 @@ for (const failure of ["cancelled", "missing-target", "missing-ack", "kickoff"] 
 			);
 			assert.equal(sends, failure === "kickoff" ? 1 : 0);
 			assert.deepEqual(sourceManager.getBranch(), before);
+			if (failure === "cancelled") {
+				assert.ok(attemptedParentSession);
+				assert.equal(existsSync(attemptedParentSession), false);
+			}
 			if (result.kind === "partial") assert.match(recovered, /# Approved plan/);
 			else assert.equal(fixture.ctx.model?.id, "planner");
 		} finally {
@@ -157,6 +166,50 @@ for (const failure of ["cancelled", "missing-target", "missing-ack", "kickoff"] 
 		}
 	});
 }
+
+test("fresh preference preflight starts lifecycle draining only when mutation begins", async () => {
+	const fixture = await implementationRuntime();
+	let releaseAuth!: (value: { ok: true }) => void;
+	let markAuthStarted!: () => void;
+	const authStarted = new Promise<void>((resolve) => {
+		markAuthStarted = resolve;
+	});
+	fixture.ctx.modelRegistry.getApiKeyAndHeaders = () =>
+		new Promise((resolve) => {
+			releaseAuth = resolve;
+			markAuthStarted();
+		});
+	try {
+		fixture.pi.appendEntry(FRESH_PREFERENCES_ENTRY, {
+			id: "preflight-boundary",
+			status: "pending",
+			preferences: { implementationThinkingLevel: "high" },
+		});
+		let applications = 0;
+		let completions = 0;
+		const pending = applyFreshImplementationPreferences(
+			fixture.pi,
+			fixture.ctx,
+			() => true,
+			undefined,
+			() => true,
+			() => {
+				applications += 1;
+				return () => {
+					completions += 1;
+				};
+			},
+		);
+		await authStarted;
+		assert.equal(applications, 0);
+		releaseAuth({ ok: true });
+		await pending;
+		assert.equal(applications, 1);
+		assert.equal(completions, 1);
+	} finally {
+		await fixture.dispose();
+	}
+});
 
 test("fresh destination consumes failed preference requests without replay", async () => {
 	const fixture = await implementationRuntime();

--- a/packages/pi-plan-mode/test/implementation-handoff.test.ts
+++ b/packages/pi-plan-mode/test/implementation-handoff.test.ts
@@ -145,6 +145,40 @@ test("manual thinking changed by a later model-selection listener is preserved w
 	}
 });
 
+test("session shutdown waits for pending model selection and rolls back before replacement", async () => {
+	const fixture = await readyFixture();
+	let releaseSelection!: () => void;
+	let selectionStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		selectionStarted = resolve;
+	});
+	fixture.mock.rawPi.on("model_select", async (event) => {
+		if ((event as { model?: { id?: string } }).model?.id !== "worker") return;
+		selectionStarted();
+		await new Promise<void>((resolve) => {
+			releaseSelection = resolve;
+		});
+	});
+	try {
+		const pending = fixture.command("implement");
+		await started;
+		let shutdownSettled = false;
+		const shutdown = fixture.emit("session_shutdown").then(() => {
+			shutdownSettled = true;
+		});
+		await Promise.resolve();
+		assert.equal(shutdownSettled, false);
+		releaseSelection();
+		await Promise.all([pending, shutdown]);
+		assert.equal(fixture.mock.sentUserMessages.length, 0);
+		assert.deepEqual(fixture.mock.setModels, [WORKER, PLANNER]);
+		assert.deepEqual(fixture.ctx.model, PLANNER);
+		assert.equal(fixture.mock.thinkingLevel, "low");
+	} finally {
+		await fixture.dispose();
+	}
+});
+
 for (const failure of ["missing-model", "removed-model", "auth", "selection", "kickoff"] as const) {
 	test(`implementation ${failure} failure retains the ready plan and previous runtime`, async () => {
 		const fixture = await readyFixture(
@@ -202,13 +236,13 @@ for (const interruption of [
 		try {
 			const pending = fixture.command("implement");
 			await started;
-			if (interruption === "shutdown") await fixture.emit("session_shutdown");
+			const shutdown = interruption === "shutdown" ? fixture.emit("session_shutdown") : undefined;
 			if (interruption === "exit") await fixture.command("exit");
 			if (interruption === "manual-model") fixture.manualModel(WORKER);
 			if (interruption === "manual-thinking") fixture.mock.rawPi.setThinkingLevel("max");
 			if (interruption === "busy") fixture.ctx.isIdle = () => false;
 			release({ ok: true });
-			await pending;
+			await Promise.all([pending, shutdown]);
 			assert.equal(fixture.mock.sentUserMessages.length, 0);
 			assert.equal(fixture.mock.setModels.length, 0);
 		} finally {

--- a/packages/pi-plan-mode/test/implementation-handoff.test.ts
+++ b/packages/pi-plan-mode/test/implementation-handoff.test.ts
@@ -237,6 +237,7 @@ for (const interruption of [
 			const pending = fixture.command("implement");
 			await started;
 			const shutdown = interruption === "shutdown" ? fixture.emit("session_shutdown") : undefined;
+			if (shutdown) await shutdown;
 			if (interruption === "exit") await fixture.command("exit");
 			if (interruption === "manual-model") fixture.manualModel(WORKER);
 			if (interruption === "manual-thinking") fixture.mock.rawPi.setThinkingLevel("max");

--- a/packages/pi-plan-mode/test/implementation-runtime-support.ts
+++ b/packages/pi-plan-mode/test/implementation-runtime-support.ts
@@ -13,10 +13,18 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 
-export async function implementationRuntime(extension?: ExtensionFactory) {
+export async function implementationRuntime(extension?: ExtensionFactory, beforeBind?: () => void) {
 	const root = mkdtempSync(join(tmpdir(), "plan-implementation-runtime-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	process.env.PI_CODING_AGENT_DIR = root;
+	let cleaned = false;
+	const cleanup = () => {
+		if (cleaned) return;
+		cleaned = true;
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(root, { recursive: true, force: true });
+	};
 	let pi!: ExtensionAPI;
 	let ctx!: ExtensionContext;
 	let cancelReplacement = false;
@@ -107,47 +115,54 @@ export async function implementationRuntime(extension?: ExtensionFactory) {
 		});
 		return { ...result, services, diagnostics: services.diagnostics };
 	};
-	const runtime = await createAgentSessionRuntime(factory, {
-		cwd: root,
-		agentDir: root,
-		sessionManager: SessionManager.inMemory(root),
-	});
-	const bind = async () =>
-		runtime.session.bindExtensions({
-			mode: "rpc",
-			commandContextActions: {
-				waitForIdle: async () => {},
-				newSession: (options) => runtime.newSession(options),
-				fork: (entryId, options) => runtime.fork(entryId, options),
-				switchSession: (path, options) => runtime.switchSession(path, options),
-				navigateTree: (id, options) => runtime.session.navigateTree(id, options),
-				reload: async () => {},
-			},
+	let runtime: Awaited<ReturnType<typeof createAgentSessionRuntime>> | undefined;
+	try {
+		runtime = await createAgentSessionRuntime(factory, {
+			cwd: root,
+			agentDir: root,
+			sessionManager: SessionManager.inMemory(root),
 		});
-	runtime.setRebindSession(bind);
-	await bind();
-	return {
-		root,
-		runtime,
-		settings,
-		events,
-		get pi() {
-			return pi;
-		},
-		get ctx() {
-			return ctx;
-		},
-		cancelReplacement() {
-			cancelReplacement = true;
-		},
-		async dispose() {
-			try {
-				await runtime.dispose();
-			} finally {
-				if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-				else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-				rmSync(root, { recursive: true, force: true });
-			}
-		},
-	};
+		const activeRuntime = runtime;
+		const bind = async () =>
+			activeRuntime.session.bindExtensions({
+				mode: "rpc",
+				commandContextActions: {
+					waitForIdle: async () => {},
+					newSession: (options) => activeRuntime.newSession(options),
+					fork: (entryId, options) => activeRuntime.fork(entryId, options),
+					switchSession: (path, options) => activeRuntime.switchSession(path, options),
+					navigateTree: (id, options) => activeRuntime.session.navigateTree(id, options),
+					reload: async () => {},
+				},
+			});
+		activeRuntime.setRebindSession(bind);
+		beforeBind?.();
+		await bind();
+		return {
+			root,
+			runtime: activeRuntime,
+			settings,
+			events,
+			get pi() {
+				return pi;
+			},
+			get ctx() {
+				return ctx;
+			},
+			cancelReplacement() {
+				cancelReplacement = true;
+			},
+			async dispose() {
+				try {
+					await activeRuntime.dispose();
+				} finally {
+					cleanup();
+				}
+			},
+		};
+	} catch (error) {
+		await runtime?.dispose().catch(() => undefined);
+		cleanup();
+		throw error;
+	}
 }

--- a/packages/pi-plan-mode/test/implementation-runtime-support.ts
+++ b/packages/pi-plan-mode/test/implementation-runtime-support.ts
@@ -15,6 +15,8 @@ import {
 
 export async function implementationRuntime(extension?: ExtensionFactory) {
 	const root = mkdtempSync(join(tmpdir(), "plan-implementation-runtime-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
 	let pi!: ExtensionAPI;
 	let ctx!: ExtensionContext;
 	let cancelReplacement = false;
@@ -125,6 +127,7 @@ export async function implementationRuntime(extension?: ExtensionFactory) {
 	runtime.setRebindSession(bind);
 	await bind();
 	return {
+		root,
 		runtime,
 		settings,
 		events,
@@ -138,8 +141,13 @@ export async function implementationRuntime(extension?: ExtensionFactory) {
 			cancelReplacement = true;
 		},
 		async dispose() {
-			await runtime.dispose();
-			rmSync(root, { recursive: true, force: true });
+			try {
+				await runtime.dispose();
+			} finally {
+				if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+				else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+				rmSync(root, { recursive: true, force: true });
+			}
 		},
 	};
 }

--- a/packages/pi-plan-mode/test/implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/implementation-runtime.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import type { SessionManager } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import {
@@ -6,8 +8,28 @@ import {
 	FRESH_PREFERENCES_ENTRY,
 	freshPreferencesApplied,
 } from "../src/fresh-implementation-preferences.js";
-import planMode from "../src/plan-mode.js";
 import { implementationRuntime } from "./implementation-runtime-support.js";
+
+test("runtime setup failure restores the agent directory and removes its fixture", async () => {
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = "previous-agent-directory";
+	let isolatedRoot: string | undefined;
+	try {
+		await assert.rejects(
+			implementationRuntime(undefined, () => {
+				isolatedRoot = process.env.PI_CODING_AGENT_DIR;
+				throw new Error("injected bind setup failure");
+			}),
+			/injected bind setup failure/,
+		);
+		assert.equal(process.env.PI_CODING_AGENT_DIR, "previous-agent-directory");
+		assert.ok(isolatedRoot);
+		assert.equal(existsSync(isolatedRoot), false);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
+});
 
 test("Pi model selection is session-only and applies per-model defaults and capability clamping", async () => {
 	const fixture = await implementationRuntime();
@@ -50,7 +72,11 @@ test("fresh preference application rolls back before a concurrent replacement", 
 	const started = new Promise<void>((resolve) => {
 		selectionStarted = resolve;
 	});
-	const fixture = await implementationRuntime((pi) => {
+	const fixture = await implementationRuntime(async (pi) => {
+		const planModeUrl = new URL("../src/plan-mode.js", import.meta.url);
+		const { default: planMode } = (await import(
+			`${planModeUrl.href}?test=${randomUUID()}`
+		)) as typeof import("../src/plan-mode.js");
 		planMode(pi, {
 			readSettings: async () => ({
 				kind: "loaded" as const,

--- a/packages/pi-plan-mode/test/implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/implementation-runtime.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import type { SessionManager } from "@earendil-works/pi-coding-agent";
 import { test } from "vitest";
 import {
 	applyFreshImplementationPreferences,
 	FRESH_PREFERENCES_ENTRY,
 	freshPreferencesApplied,
 } from "../src/fresh-implementation-preferences.js";
+import planMode from "../src/plan-mode.js";
 import { implementationRuntime } from "./implementation-runtime-support.js";
 
 test("Pi model selection is session-only and applies per-model defaults and capability clamping", async () => {
@@ -37,6 +39,71 @@ test("Pi model selection is session-only and applies per-model defaults and capa
 		assert.equal(fixture.settings.getDefaultThinkingLevel(), "low");
 		assert.ok(fixture.events.includes("model"));
 		assert.ok(fixture.events.includes("thinking"));
+	} finally {
+		await fixture.dispose();
+	}
+});
+
+test("fresh preference application rolls back before a concurrent replacement", async () => {
+	let releaseSelection!: () => void;
+	let selectionStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		selectionStarted = resolve;
+	});
+	const fixture = await implementationRuntime((pi) => {
+		planMode(pi, {
+			readSettings: async () => ({
+				kind: "loaded" as const,
+				settings: { thinkingLevel: "inherit" },
+			}),
+		});
+		pi.on("model_select", async (event) => {
+			if (event.model.id !== "worker") return;
+			selectionStarted();
+			await new Promise<void>((resolve) => {
+				releaseSelection = resolve;
+			});
+		});
+	});
+	try {
+		let preferenceSession: SessionManager | undefined;
+		const firstReplacement = fixture.runtime.newSession({
+			setup: async (sessionManager) => {
+				preferenceSession = sessionManager;
+				sessionManager.appendCustomEntry(FRESH_PREFERENCES_ENTRY, {
+					id: "replace-pending",
+					status: "pending",
+					preferences: {
+						implementationModel: { provider: "plan-test", id: "worker" },
+						implementationThinkingLevel: "high",
+					},
+				});
+			},
+		});
+		await started;
+		let replacementSettled = false;
+		const secondReplacement = fixture.runtime.newSession().then((result) => {
+			replacementSettled = true;
+			return result;
+		});
+		await Promise.resolve();
+		assert.equal(replacementSettled, false);
+		releaseSelection();
+		await Promise.all([firstReplacement, secondReplacement]);
+		assert.ok(preferenceSession);
+		assert.deepEqual(preferenceSession.buildSessionContext().model, {
+			provider: "plan-test",
+			modelId: "planner",
+		});
+		assert.equal(preferenceSession.buildSessionContext().thinkingLevel, "low");
+		assert.deepEqual(
+			preferenceSession
+				.getBranch()
+				.filter((entry) => entry.type === "model_change")
+				.map((entry) => entry.modelId)
+				.slice(-2),
+			["worker", "planner"],
+		);
 	} finally {
 		await fixture.dispose();
 	}


### PR DESCRIPTION
## Summary
- Persist an exact parent copy of an in-memory planning branch before a fresh implementation session replaces it.
- Drain pending implementation-preference work during shutdown so same-session and fresh-session model changes roll back before invalidation.
- Add regression coverage for `--no-session` parent recovery and concurrent RPC replacement.

Follow-up to #1245 because its review completed after that pull request merged.

## Verification
- `npx vitest run packages/pi-plan-mode/test/fresh-implementation-model.test.ts packages/pi-plan-mode/test/implementation-handoff.test.ts packages/pi-plan-mode/test/implementation-runtime.test.ts` — 30 tests passed.
- `npm run check` passed.
- `npm test` passed: 391 files, 4,437 tests.
- `npm run package:pack -- plan-mode` passed and included the changed source and generated runtime.
- Isolated offline `--no-session` package load smoke passed.
