### PR TITLE
fix(plan-mode): release implementation preference revert

### DIFF
--- a/.changeset/revert-plan-implementation-preferences.md
+++ b/.changeset/revert-plan-implementation-preferences.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Remove the implementation model and thinking selectors, restoring Plan implementation handoffs to the current model and normal thinking behavior.


### PR DESCRIPTION
## Summary

- Add the missing patch Changeset for the Plan mode behavior reverted in #1253.
- Ensure the Changesets release workflow versions `@narumitw/pi-plan-mode` so npm users receive the revert.

## Review outcome

Addresses the unresolved release Changeset feedback on #1253. The original pull request was already merged and its source branch was deleted, so this follow-up carries the minimal release fix.

## Verification

- `npm run changeset:status` — selects `@narumitw/pi-plan-mode` 0.57.1.
- `npm run check` — passed.
- `npm test` — passed: 389 files, 4,499 tests.
- `npm run package:pack -- plan-mode` — passed; 41 expected package files.
- Actual tarball inspection — manifest and declared entrypoint present; no reverted implementation preference files or symbols.
