### PR TITLE
feat(stamp): Add opt-in cost since user message tracking

### DIFF
--- a/.changeset/calm-stamps-count.md
+++ b/.changeset/calm-stamps-count.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-stamp": minor
+---
+
+Add an optional since-user cost total to final assistant stamps.

--- a/packages/pi-stamp/README.md
+++ b/packages/pi-stamp/README.md
@@ -9,7 +9,7 @@ Optionally show response timing, assistant provenance and usage, or tool duratio
 
 - Shows each message's recorded creation time on a dim, right-aligned row.
 - Supports 12/24-hour clocks, seconds, automatic date context, locales, and time zones.
-- Optionally shows response latency, model and provider identity, effective Pi Thinking level, stop reason, tokens, and estimated cost.
+- Optionally shows response latency, model and provider identity, effective Pi Thinking level, stop reason, tokens, call cost, and cost since user.
 - Optionally records tool duration and success or error after each complete tool block.
 - Shows exact UTC ISO 8601 and Unix millisecond observation times only during transcript expansion.
 - Keeps sensitive response IDs and bounded diagnostics behind explicit opt-in and transcript expansion.
@@ -57,7 +57,7 @@ Run `/stamp` to open the presentation menu:
 
 ```text
 Stamp
-24-hour · seconds · Day changes · Invariant · Local · Timing off · Timeline shown · Metadata off · Thinking shown · Abnormal shown · Tool stamps hidden
+24-hour · seconds · Day changes · Invariant · Local · Timing off · Timeline shown · Metadata off · Thinking shown · Abnormal shown · Cost since user hidden · Tool stamps hidden
 
 Settings
 Status
@@ -89,6 +89,7 @@ The `/stamp` Settings screen provides these controls:
 | `assistantMetadata` | `"off"`, `"compact"`, `"expanded"` | `"off"` | Captures and shows no assistant metadata, a compact model/Thinking-level/total/cost summary, or all supported provenance and usage fields. |
 | `showThinkingLevel` | boolean | `true` | Captures and shows Pi's effective turn Thinking level when assistant metadata is enabled. |
 | `showCompactAbnormalOutcome` | boolean | `true` | Shows `length`, `error`, and `aborted` stop reasons in compact assistant metadata. |
+| `showCostSinceUser` | boolean | `false` | Shows the cost since user and final call cost on a non-`toolUse` assistant response. |
 | `toolStamps` | boolean | `false` | Records and shows duration plus success/error for newly observed tools. |
 
 The compatibility defaults produce local `HH:mm:ss` for ordinary same-day messages.
@@ -115,6 +116,7 @@ This example shows 12-hour Taipei time without seconds, compact assistant metada
   "assistantMetadata": "compact",
   "showThinkingLevel": false,
   "showCompactAbnormalOutcome": false,
+  "showCostSinceUser": true,
   "toolStamps": true
 }
 ```
@@ -205,6 +207,23 @@ Provider support varies.
 Every optional field is shown only when present and valid on that finalized assistant message.
 The cost label says `est` because Pi's message value is an estimate based on the provider/model usage data available to Pi; the extension performs no price lookup.
 
+### Cost since user
+
+Cost since user is the cumulative estimated cost from the latest user message through the final response.
+With `showCostSinceUser: true`, each finalized assistant call and tool result contributes its separately reported `usage.cost.total` to that running total.
+A user message resets it, including a steering or queued follow-up user message.
+Tool-use calls, model-backed or paid tools that report usage, retries, automatic continuations, and model runs started by extensions all keep accumulating until another user message arrives.
+The next assistant response whose stop reason is not `toolUse` records and displays both its call cost and that total:
+
+```text
+claude-sonnet-4-6 · thinking high · 842 tok · est $0.009 · since user $0.039
+```
+
+Cost since user reads only the reported cost field and does not require `assistantMetadata` capture.
+When assistant metadata is off, the final stamp uses a separate cost-only row.
+Intermediate `toolUse` stamps continue to show their call cost only when assistant metadata is enabled.
+Missing or invalid reported costs are omitted rather than estimated, while valid reported zero costs still count toward the total.
+
 ## 🛠️ Tool timing
 
 With `toolStamps: true`, the extension observes `tool_execution_start` and `tool_execution_end`, pairs them by exact `toolCallId`, and appends entries in `turn_end.toolResults` source order:
@@ -239,6 +258,8 @@ Message entry compatibility is cumulative:
 - Version 4 assistant entries add a sanitized metadata snapshot when metadata capture is enabled.
   Timing remains optional so a valid metadata stamp survives a backwards timing clock.
 - Version 5 assistant entries add Pi's validated effective turn Thinking level when metadata capture is enabled and the runtime exposes it.
+- Version 6 assistant entries add the optional call cost and cost since user.
+  Full assistant metadata and Thinking level remain optional in this version.
 - Version 1 tool entries store only bounded association/timing/outcome data.
 
 Existing versions remain readable.
@@ -250,7 +271,7 @@ Messages and tools created before `pi-stamp` observed them are not backfilled be
 
 - Pi does not currently expose a public decorator for built-in message or tool rows, so stamps appear as separate transcript rows rather than inside the original bubble/block.
 - Another extension can append transcript entries at the same lifecycle boundary, so strict visual adjacency between independently loaded extensions is not guaranteed.
-- There are no arbitrary format strings, relative labels, provider-server latency, aggregates, raw diagnostics, or analytics dashboard.
+- There are no arbitrary format strings, relative labels, provider-server latency, token aggregates, raw diagnostics, or analytics dashboard.
 - Thinking level is Pi's effective turn setting and does not claim that a provider honored or reported the same reasoning behavior.
 - Token and cost values come only from Pi's message fields.
 

--- a/packages/pi-stamp/src/format.ts
+++ b/packages/pi-stamp/src/format.ts
@@ -26,6 +26,7 @@ export interface StampSettings {
 	showExactTimeline: boolean;
 	showThinkingLevel: boolean;
 	showCompactAbnormalOutcome: boolean;
+	showCostSinceUser: boolean;
 	toolStamps: boolean;
 }
 
@@ -40,6 +41,7 @@ export const DEFAULT_STAMP_SETTINGS: Readonly<StampSettings> = Object.freeze({
 	showExactTimeline: true,
 	showThinkingLevel: true,
 	showCompactAbnormalOutcome: true,
+	showCostSinceUser: false,
 	toolStamps: false,
 });
 

--- a/packages/pi-stamp/src/menu.ts
+++ b/packages/pi-stamp/src/menu.ts
@@ -21,6 +21,7 @@ type StampAction =
 	| "set-exact-timeline"
 	| "set-thinking-level"
 	| "set-compact-abnormal-outcome"
+	| "set-cost-since-user"
 	| "set-tool-stamps"
 	| "open-locale"
 	| "choose-invariant-locale"
@@ -146,6 +147,15 @@ export function createStampMenu(
 						currentValue: visibilityLabel(state.settings.showCompactAbnormalOutcome),
 						values: ["Show", "Hide"],
 						action: "set-compact-abnormal-outcome",
+					},
+					{
+						id: "showCostSinceUser",
+						label: "Cost since user message",
+						description:
+							"Show the final call cost and the running total since the last user message.",
+						currentValue: visibilityLabel(state.settings.showCostSinceUser),
+						values: ["Show", "Hide"],
+						action: "set-cost-since-user",
 					},
 					{
 						id: "toolStamps",
@@ -279,6 +289,12 @@ export function createStampMenu(
 						"showCompactAbnormalOutcome",
 					),
 					settingStatus(
+						"Cost since user message",
+						visibilityLabel(state.settings.showCostSinceUser),
+						state,
+						"showCostSinceUser",
+					),
+					settingStatus(
 						"Tool stamps",
 						toolStampsLabel(state.settings.toolStamps),
 						state,
@@ -298,6 +314,7 @@ export function createStampMenu(
 					"First n/a means no meaningful update was observed; no other boundary is substituted.",
 					"Thinking level capture requires both assistant metadata and its own setting to be enabled.",
 					"Compact abnormal labels require their setting; normal stops always stay quiet there.",
+					"Cost since user message resets at every user message and appears on non-tool-use responses.",
 					"Expanded exact UTC/Unix rows require Exact timeline; debug metadata remains separate.",
 					"Tool stamps pair start/end by ID, exclude tool data, and appear after the complete block.",
 					"Assistant timing excludes tool execution and is unavailable on legacy stamp entries.",
@@ -373,6 +390,14 @@ export function createStampMenu(
 					signal,
 					{ showCompactAbnormalOutcome: value === "Show" },
 					`Compact abnormal outcome: ${value}.`,
+				),
+			"set-cost-since-user": ({ ctx, value, signal }) =>
+				savePatch(
+					runtime,
+					ctx,
+					signal,
+					{ showCostSinceUser: value === "Show" },
+					`Cost since user message: ${value}.`,
 				),
 			"set-tool-stamps": ({ ctx, value, signal }) =>
 				savePatch(runtime, ctx, signal, { toolStamps: value === "Show" }, `Tool stamps: ${value}.`),
@@ -506,6 +531,7 @@ function formatCompactStatus(state: StampSettingsState): string {
 		`Metadata ${assistantMetadataLabel(state.settings.assistantMetadata).toLowerCase()}`,
 		`Thinking ${state.settings.showThinkingLevel ? "shown" : "hidden"}`,
 		`Abnormal ${state.settings.showCompactAbnormalOutcome ? "shown" : "hidden"}`,
+		`Cost since user ${state.settings.showCostSinceUser ? "shown" : "hidden"}`,
 		`Tool stamps ${state.settings.toolStamps ? "shown" : "hidden"}`,
 	].join(" · ");
 }

--- a/packages/pi-stamp/src/metadata.ts
+++ b/packages/pi-stamp/src/metadata.ts
@@ -31,6 +31,11 @@ export interface AssistantStampDiagnosticSummary {
 	errorCode?: string;
 }
 
+export interface AssistantCostSinceUserData {
+	estimatedCost?: number;
+	costSinceUser: number;
+}
+
 export interface AssistantMetadataData {
 	api: string;
 	provider: string;
@@ -55,6 +60,13 @@ const USAGE_FIELDS = [
 	"totalTokens",
 	"estimatedCost",
 ] as const satisfies readonly (keyof AssistantStampUsageData)[];
+
+export function captureReportedCost(value: unknown): number | undefined {
+	if (!isRecord(value) || !isRecord(value.usage) || !isRecord(value.usage.cost)) {
+		return undefined;
+	}
+	return isAssistantEstimatedCost(value.usage.cost.total) ? value.usage.cost.total : undefined;
+}
 
 export function captureAssistantMetadata(value: unknown): AssistantMetadataData | undefined {
 	if (!isRecord(value)) return undefined;
@@ -128,23 +140,37 @@ export function isAssistantMetadataData(value: unknown): value is AssistantMetad
 }
 
 export function formatAssistantMetadataLines(
-	metadata: Readonly<AssistantMetadataData>,
+	metadata: Readonly<AssistantMetadataData> | undefined,
 	mode: StampAssistantMetadataMode,
 	debug: boolean,
 	thinkingLevel?: StampThinkingLevel,
 	showCompactAbnormalOutcome = true,
+	costSinceUserData?: Readonly<AssistantCostSinceUserData>,
 ): string[] {
 	if (
-		mode === "off" ||
-		!isAssistantMetadataData(metadata) ||
-		(thinkingLevel !== undefined && !isStampThinkingLevel(thinkingLevel))
+		(thinkingLevel !== undefined && !isStampThinkingLevel(thinkingLevel)) ||
+		(costSinceUserData !== undefined && !isAssistantCostSinceUserData(costSinceUserData))
 	) {
 		return [];
 	}
+	const costSinceUserLine =
+		costSinceUserData === undefined
+			? undefined
+			: formatAssistantCostSinceUserLine(costSinceUserData);
+	if (mode === "off" || !isAssistantMetadataData(metadata)) {
+		return costSinceUserLine === undefined ? [] : [costSinceUserLine];
+	}
 	const lines =
 		mode === "compact"
-			? [formatCompactMetadata(metadata, thinkingLevel, showCompactAbnormalOutcome)]
-			: formatExpandedMetadata(metadata, thinkingLevel);
+			? [
+					formatCompactMetadata(
+						metadata,
+						thinkingLevel,
+						showCompactAbnormalOutcome,
+						costSinceUserData,
+					),
+				]
+			: formatExpandedMetadata(metadata, thinkingLevel, costSinceUserData);
 	if (!debug) return lines;
 	if (metadata.responseId) lines.push(`debug · response id ${metadata.responseId}`);
 	if (metadata.diagnosticCount !== undefined) {
@@ -220,7 +246,7 @@ function captureUsage(value: unknown): AssistantStampUsageData | undefined {
 		const amount = value[field];
 		if (isReportedTokenCount(amount)) assignUsage(usage, field, amount);
 	}
-	if (isRecord(value.cost) && isReportedCost(value.cost.total)) {
+	if (isRecord(value.cost) && isAssistantEstimatedCost(value.cost.total)) {
 		usage.estimatedCost = value.cost.total;
 	}
 	return Object.keys(usage).length > 0 ? usage : undefined;
@@ -260,13 +286,14 @@ function formatCompactMetadata(
 	metadata: Readonly<AssistantMetadataData>,
 	thinkingLevel: StampThinkingLevel | undefined,
 	showCompactAbnormalOutcome: boolean,
+	costSinceUserData: Readonly<AssistantCostSinceUserData> | undefined,
 ): string {
 	const model =
 		metadata.responseModel && metadata.responseModel !== metadata.model
 			? `${metadata.model} → ${metadata.responseModel}`
 			: metadata.model;
 	const tokens = metadata.usage?.totalTokens;
-	const cost = metadata.usage?.estimatedCost;
+	const cost = costSinceUserData?.estimatedCost ?? metadata.usage?.estimatedCost;
 	const abnormalStopReason =
 		showCompactAbnormalOutcome &&
 		(metadata.stopReason === "length" ||
@@ -280,6 +307,9 @@ function formatCompactMetadata(
 		abnormalStopReason === undefined ? undefined : `stop ${abnormalStopReason}`,
 		tokens === undefined ? undefined : `${formatInteger(tokens)} tok`,
 		cost === undefined ? undefined : `est ${formatCost(cost)}`,
+		costSinceUserData === undefined
+			? undefined
+			: `since user ${formatCost(costSinceUserData.costSinceUser)}`,
 	]
 		.filter((part): part is string => part !== undefined)
 		.join(" · ");
@@ -288,6 +318,7 @@ function formatCompactMetadata(
 function formatExpandedMetadata(
 	metadata: Readonly<AssistantMetadataData>,
 	thinkingLevel: StampThinkingLevel | undefined,
+	costSinceUserData: Readonly<AssistantCostSinceUserData> | undefined,
 ): string[] {
 	const provenance = [
 		`api ${metadata.api}`,
@@ -300,7 +331,12 @@ function formatExpandedMetadata(
 		.filter((part): part is string => part !== undefined)
 		.join(" · ");
 	const usage = metadata.usage;
-	if (!usage) return [provenance];
+	if (!usage) {
+		return costSinceUserData === undefined
+			? [provenance]
+			: [provenance, formatAssistantCostSinceUserLine(costSinceUserData)];
+	}
+	const estimatedCost = costSinceUserData?.estimatedCost ?? usage.estimatedCost;
 	const usageLine = [
 		usage.input === undefined ? undefined : `tokens in ${formatInteger(usage.input)}`,
 		usage.output === undefined ? undefined : `out ${formatInteger(usage.output)}`,
@@ -308,7 +344,10 @@ function formatExpandedMetadata(
 		usage.cacheRead === undefined ? undefined : `cache read ${formatInteger(usage.cacheRead)}`,
 		usage.cacheWrite === undefined ? undefined : `cache write ${formatInteger(usage.cacheWrite)}`,
 		usage.totalTokens === undefined ? undefined : `total ${formatInteger(usage.totalTokens)}`,
-		usage.estimatedCost === undefined ? undefined : `est cost ${formatCost(usage.estimatedCost)}`,
+		estimatedCost === undefined ? undefined : `est cost ${formatCost(estimatedCost)}`,
+		costSinceUserData === undefined
+			? undefined
+			: `since user ${formatCost(costSinceUserData.costSinceUser)}`,
 	]
 		.filter((part): part is string => part !== undefined)
 		.join(" · ");
@@ -336,7 +375,7 @@ function isUsageData(value: unknown): value is AssistantStampUsageData {
 		if (!Object.hasOwn(value, field)) continue;
 		const amount = value[field];
 		if (field === "estimatedCost") {
-			if (!isReportedCost(amount)) return false;
+			if (!isAssistantEstimatedCost(amount)) return false;
 		} else if (!isReportedTokenCount(amount)) {
 			return false;
 		}
@@ -382,8 +421,30 @@ function isReportedTokenCount(value: unknown): value is number {
 	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
-function isReportedCost(value: unknown): value is number {
+export function isAssistantEstimatedCost(value: unknown): value is number {
 	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isAssistantCostSinceUserData(value: unknown): value is AssistantCostSinceUserData {
+	return (
+		isRecord(value) &&
+		hasOnlyKeys(value, ["estimatedCost", "costSinceUser"]) &&
+		(!Object.hasOwn(value, "estimatedCost") || isAssistantEstimatedCost(value.estimatedCost)) &&
+		isAssistantEstimatedCost(value.costSinceUser)
+	);
+}
+
+function formatAssistantCostSinceUserLine(
+	costSinceUserData: Readonly<AssistantCostSinceUserData>,
+): string {
+	return [
+		costSinceUserData.estimatedCost === undefined
+			? undefined
+			: `est ${formatCost(costSinceUserData.estimatedCost)}`,
+		`since user ${formatCost(costSinceUserData.costSinceUser)}`,
+	]
+		.filter((part): part is string => part !== undefined)
+		.join(" · ");
 }
 
 function assignUsage<K extends keyof AssistantStampUsageData>(

--- a/packages/pi-stamp/src/settings.ts
+++ b/packages/pi-stamp/src/settings.ts
@@ -82,6 +82,7 @@ const SETTING_FIELDS = [
 	"showExactTimeline",
 	"showThinkingLevel",
 	"showCompactAbnormalOutcome",
+	"showCostSinceUser",
 	"toolStamps",
 ] as const satisfies readonly StampSettingsField[];
 const SETTING_FIELD_SET = new Set<string>(SETTING_FIELDS);
@@ -160,6 +161,11 @@ export function normalizeStampSettingsDocument(
 		if (typeof value.showCompactAbnormalOutcome !== "boolean") return undefined;
 		settings.showCompactAbnormalOutcome = value.showCompactAbnormalOutcome;
 		sources.showCompactAbnormalOutcome = "user";
+	}
+	if (Object.hasOwn(value, "showCostSinceUser")) {
+		if (typeof value.showCostSinceUser !== "boolean") return undefined;
+		settings.showCostSinceUser = value.showCostSinceUser;
+		sources.showCostSinceUser = "user";
 	}
 	if (Object.hasOwn(value, "toolStamps")) {
 		if (typeof value.toolStamps !== "boolean") return undefined;
@@ -404,6 +410,7 @@ function builtInSources(): Record<StampSettingsField, StampSettingsSource> {
 		showExactTimeline: "built-in",
 		showThinkingLevel: "built-in",
 		showCompactAbnormalOutcome: "built-in",
+		showCostSinceUser: "built-in",
 		toolStamps: "built-in",
 	};
 }

--- a/packages/pi-stamp/src/stamp.ts
+++ b/packages/pi-stamp/src/stamp.ts
@@ -9,10 +9,13 @@ import {
 	type StampTimelineBoundary,
 } from "./format.js";
 import {
+	type AssistantCostSinceUserData,
 	type AssistantMetadataData,
 	captureAssistantMetadata,
+	captureReportedCost,
 	formatAssistantMetadataLines,
 	formatToolStampLabel,
+	isAssistantEstimatedCost,
 	isAssistantMetadataData,
 	isStampThinkingLevel,
 	type StampThinkingLevel,
@@ -68,6 +71,19 @@ export interface AssistantMessageStampDataV5 {
 	thinkingLevel: StampThinkingLevel;
 }
 
+export interface AssistantMessageStampDataV6 {
+	version: 6;
+	role: "assistant";
+	timestamp: number;
+	previousTimestamp?: number;
+	completedAt?: number;
+	firstContentAt?: number;
+	metadata?: AssistantMetadataData;
+	thinkingLevel?: StampThinkingLevel;
+	estimatedCost?: number;
+	costSinceUser: number;
+}
+
 export interface ToolStampDataV1 {
 	version: 1;
 	kind: "tool";
@@ -83,7 +99,8 @@ export type MessageStampData =
 	| MessageStampDataV2
 	| AssistantMessageStampDataV3
 	| AssistantMessageStampDataV4
-	| AssistantMessageStampDataV5;
+	| AssistantMessageStampDataV5
+	| AssistantMessageStampDataV6;
 export type StampEntryData = MessageStampData | ToolStampDataV1;
 
 export interface StampExtensionOptions {
@@ -98,6 +115,12 @@ interface AssistantTimingObservation {
 
 interface FinalizedAssistantTiming extends AssistantTimingObservation {
 	completedAt: number;
+}
+
+interface CostSinceUserAccumulator {
+	total: number;
+	hasReportedCost: boolean;
+	valid: boolean;
 }
 
 interface ToolTimingObservation {
@@ -148,6 +171,30 @@ export function isMessageStampData(value: unknown): value is MessageStampData {
 					value.firstContentAt <= value.completedAt))
 		);
 	}
+	if (value.version === 6) {
+		return (
+			value.role === "assistant" &&
+			hasOnlyKeys(value, [
+				"version",
+				"role",
+				"timestamp",
+				"previousTimestamp",
+				"completedAt",
+				"firstContentAt",
+				"metadata",
+				"thinkingLevel",
+				"estimatedCost",
+				"costSinceUser",
+			]) &&
+			(!Object.hasOwn(value, "metadata") || isAssistantMetadataData(value.metadata)) &&
+			(!Object.hasOwn(value, "thinkingLevel") || isStampThinkingLevel(value.thinkingLevel)) &&
+			isAssistantEstimatedCost(value.costSinceUser) &&
+			(!Object.hasOwn(value, "estimatedCost") ||
+				(isAssistantEstimatedCost(value.estimatedCost) &&
+					value.estimatedCost <= value.costSinceUser)) &&
+			hasValidOptionalAssistantTiming(value, value.timestamp)
+		);
+	}
 	if ((value.version !== 4 && value.version !== 5) || value.role !== "assistant") return false;
 	const allowedKeys = [
 		"version",
@@ -159,22 +206,11 @@ export function isMessageStampData(value: unknown): value is MessageStampData {
 		"metadata",
 		...(value.version === 5 ? ["thinkingLevel"] : []),
 	];
-	if (
-		!hasOnlyKeys(value, allowedKeys) ||
-		(Object.hasOwn(value, "previousTimestamp") && !isValidTimestamp(value.previousTimestamp)) ||
-		!isAssistantMetadataData(value.metadata) ||
-		(value.version === 5 && !isStampThinkingLevel(value.thinkingLevel))
-	) {
-		return false;
-	}
-	if (!Object.hasOwn(value, "completedAt")) return !Object.hasOwn(value, "firstContentAt");
 	return (
-		isValidTimestamp(value.completedAt) &&
-		value.completedAt >= value.timestamp &&
-		(!Object.hasOwn(value, "firstContentAt") ||
-			(isValidTimestamp(value.firstContentAt) &&
-				value.firstContentAt >= value.timestamp &&
-				value.firstContentAt <= value.completedAt))
+		hasOnlyKeys(value, allowedKeys) &&
+		isAssistantMetadataData(value.metadata) &&
+		(value.version !== 5 || isStampThinkingLevel(value.thinkingLevel)) &&
+		hasValidOptionalAssistantTiming(value, value.timestamp)
 	);
 }
 
@@ -241,7 +277,8 @@ export function createStampEntryRenderer(
 		return dynamicRightAlignedText(
 			() => {
 				const settings = getSettings();
-				const hasAssistantTiming = data.version === 3 || data.version === 4 || data.version === 5;
+				const hasAssistantTiming =
+					data.version === 3 || data.version === 4 || data.version === 5 || data.version === 6;
 				const label = formatMessageStampLabel(
 					{
 						timestamp: data.timestamp,
@@ -270,13 +307,23 @@ export function createStampEntryRenderer(
 						? exactTimelineLines(timelineObservations)
 						: [];
 				const metadataLines =
-					data.version === 4 || data.version === 5
+					data.version === 4 || data.version === 5 || data.version === 6
 						? formatAssistantMetadataLines(
 								data.metadata,
 								settings.assistantMetadata,
 								options.expanded,
-								data.version === 5 && settings.showThinkingLevel ? data.thinkingLevel : undefined,
+								(data.version === 5 || data.version === 6) && settings.showThinkingLevel
+									? data.thinkingLevel
+									: undefined,
 								settings.showCompactAbnormalOutcome,
+								data.version === 6 && settings.showCostSinceUser
+									? {
+											...(data.estimatedCost === undefined
+												? {}
+												: { estimatedCost: data.estimatedCost }),
+											costSinceUser: data.costSinceUser,
+										}
+									: undefined,
 							)
 						: [];
 				return [regularLine(label), ...timelineLines, ...metadataLines.map(regularLine)];
@@ -359,6 +406,7 @@ export default function stampExtension(
 	let activeAssistantTiming: AssistantTimingObservation | undefined;
 	let finalizedAssistantTiming: FinalizedAssistantTiming | undefined;
 	let activeThinkingLevel: StampThinkingLevel | undefined;
+	let costSinceUser = emptyCostSinceUserAccumulator();
 	const activeToolTimings = new Map<string, ToolTimingObservation>();
 	const pendingUserStamps: Array<{ role: "user"; timestamp: number }> = [];
 
@@ -406,12 +454,40 @@ export default function stampExtension(
 		timing: FinalizedAssistantTiming | undefined,
 		message: unknown,
 		thinkingLevel: StampThinkingLevel | undefined,
+		costSinceUserData: AssistantCostSinceUserData | undefined,
 	): void => {
 		const matchingTiming = timing?.timestamp === timestamp ? timing : undefined;
 		const metadata =
 			settingsRuntime.get().settings.assistantMetadata === "off"
 				? undefined
 				: captureAssistantMetadata(message);
+		if (costSinceUserData) {
+			const stamp: AssistantMessageStampDataV6 = {
+				version: 6,
+				role: "assistant",
+				timestamp,
+				...(lastStampTimestamp === undefined ? {} : { previousTimestamp: lastStampTimestamp }),
+				...(matchingTiming
+					? {
+							completedAt: matchingTiming.completedAt,
+							...(matchingTiming.firstContentAt === undefined
+								? {}
+								: { firstContentAt: matchingTiming.firstContentAt }),
+						}
+					: {}),
+				...(metadata === undefined ? {} : { metadata }),
+				...(thinkingLevel === undefined ? {} : { thinkingLevel }),
+				...(costSinceUserData.estimatedCost === undefined
+					? {}
+					: { estimatedCost: costSinceUserData.estimatedCost }),
+				costSinceUser: costSinceUserData.costSinceUser,
+			};
+			if (isMessageStampData(stamp)) {
+				pi.appendEntry<AssistantMessageStampDataV6>(STAMP_ENTRY_TYPE, stamp);
+				lastStampTimestamp = timestamp;
+				return;
+			}
+		}
 		if (metadata && thinkingLevel !== undefined) {
 			const stamp: AssistantMessageStampDataV5 = {
 				version: 5,
@@ -529,7 +605,9 @@ export default function stampExtension(
 		activeThinkingLevel = undefined;
 		activeToolTimings.clear();
 		tuiSessionActive = ctx.mode === "tui";
-		lastStampTimestamp = lastStampTimestampFromBranch(ctx.sessionManager.getBranch());
+		const branch = ctx.sessionManager.getBranch();
+		lastStampTimestamp = lastStampTimestampFromBranch(branch);
+		costSinceUser = costSinceUserFromBranch(branch);
 		try {
 			const state = await settingsRuntime.reload(controller.signal);
 			if (
@@ -629,12 +707,15 @@ export default function stampExtension(
 	});
 
 	pi.on("message_end", (event) => {
-		if (!tuiSessionActive || !isValidTimestamp(event.message.timestamp)) return;
+		if (!tuiSessionActive) return;
 		if (event.message.role === "user") {
-			pendingUserStamps.push({ role: "user", timestamp: event.message.timestamp });
+			costSinceUser = emptyCostSinceUserAccumulator();
+			if (isValidTimestamp(event.message.timestamp)) {
+				pendingUserStamps.push({ role: "user", timestamp: event.message.timestamp });
+			}
 			return;
 		}
-		if (event.message.role !== "assistant") return;
+		if (event.message.role !== "assistant" || !isValidTimestamp(event.message.timestamp)) return;
 		const completedAt = now();
 		if (!isValidTimestamp(completedAt) || completedAt < event.message.timestamp) {
 			activeAssistantTiming = undefined;
@@ -663,7 +744,29 @@ export default function stampExtension(
 		finalizedAssistantTiming = undefined;
 		activeThinkingLevel = undefined;
 		if (tuiSessionActive && event.message.role === "assistant") {
-			appendAssistantStamp(event.message.timestamp, timing, event.message, thinkingLevel);
+			const estimatedCost = captureReportedCost(event.message);
+			addReportedCostSinceUser(costSinceUser, estimatedCost);
+			for (const toolResult of event.toolResults) {
+				addReportedCostSinceUser(costSinceUser, captureReportedCost(toolResult));
+			}
+			const settings = settingsRuntime.get().settings;
+			const costSinceUserData =
+				settings.showCostSinceUser &&
+				event.message.stopReason !== "toolUse" &&
+				costSinceUser.valid &&
+				costSinceUser.hasReportedCost
+					? {
+							...(estimatedCost === undefined ? {} : { estimatedCost }),
+							costSinceUser: costSinceUser.total,
+						}
+					: undefined;
+			appendAssistantStamp(
+				event.message.timestamp,
+				timing,
+				event.message,
+				thinkingLevel,
+				costSinceUserData,
+			);
 		}
 		flushToolStamps(event.toolResults);
 	});
@@ -687,8 +790,53 @@ export default function stampExtension(
 		activeToolTimings.clear();
 		tuiSessionActive = false;
 		lastStampTimestamp = undefined;
+		costSinceUser = emptyCostSinceUserAccumulator();
 		await settingsRuntime.flush();
 	});
+}
+
+function emptyCostSinceUserAccumulator(): CostSinceUserAccumulator {
+	return { total: 0, hasReportedCost: false, valid: true };
+}
+
+function addReportedCostSinceUser(
+	accumulator: CostSinceUserAccumulator,
+	estimatedCost: number | undefined,
+): void {
+	if (estimatedCost === undefined || !accumulator.valid) return;
+	const total = accumulator.total + estimatedCost;
+	if (!isAssistantEstimatedCost(total)) {
+		accumulator.valid = false;
+		return;
+	}
+	accumulator.total = total;
+	accumulator.hasReportedCost = true;
+}
+
+function costSinceUserFromBranch(entries: readonly unknown[]): CostSinceUserAccumulator {
+	let costSinceUserStart = 0;
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (
+			isRecord(entry) &&
+			entry.type === "message" &&
+			isRecord(entry.message) &&
+			entry.message.role === "user"
+		) {
+			costSinceUserStart = index + 1;
+			break;
+		}
+	}
+
+	const accumulator = emptyCostSinceUserAccumulator();
+	for (let index = costSinceUserStart; index < entries.length; index += 1) {
+		const entry = entries[index];
+		if (!isRecord(entry) || entry.type !== "message" || !isRecord(entry.message)) continue;
+		if (entry.message.role === "assistant" || entry.message.role === "toolResult") {
+			addReportedCostSinceUser(accumulator, captureReportedCost(entry.message));
+		}
+	}
+	return accumulator;
 }
 
 function lastStampTimestampFromBranch(entries: readonly unknown[]): number | undefined {
@@ -704,6 +852,24 @@ function lastStampTimestampFromBranch(entries: readonly unknown[]): number | und
 		}
 	}
 	return undefined;
+}
+
+function hasValidOptionalAssistantTiming(
+	value: Record<string, unknown>,
+	timestamp: number,
+): boolean {
+	if (Object.hasOwn(value, "previousTimestamp") && !isValidTimestamp(value.previousTimestamp)) {
+		return false;
+	}
+	if (!Object.hasOwn(value, "completedAt")) return !Object.hasOwn(value, "firstContentAt");
+	return (
+		isValidTimestamp(value.completedAt) &&
+		value.completedAt >= timestamp &&
+		(!Object.hasOwn(value, "firstContentAt") ||
+			(isValidTimestamp(value.firstContentAt) &&
+				value.firstContentAt >= timestamp &&
+				value.firstContentAt <= value.completedAt))
+	);
 }
 
 function isMeaningfulAssistantUpdate(value: unknown): boolean {

--- a/packages/pi-stamp/test/menu.test.ts
+++ b/packages/pi-stamp/test/menu.test.ts
@@ -39,6 +39,7 @@ test("stamp menu exposes Main, Settings, Status, Help, and read-only invalid sta
 			["assistantMetadata", "Off"],
 			["showThinkingLevel", "Show"],
 			["showCompactAbnormalOutcome", "Show"],
+			["showCostSinceUser", "Hide"],
 			["toolStamps", "Hide"],
 		],
 	);
@@ -47,6 +48,7 @@ test("stamp menu exposes Main, Settings, Status, Help, and read-only invalid sta
 	assert.match((main.lines ?? []).join("\n"), /Metadata off/u);
 	assert.match((main.lines ?? []).join("\n"), /Thinking shown/u);
 	assert.match((main.lines ?? []).join("\n"), /Abnormal shown/u);
+	assert.match((main.lines ?? []).join("\n"), /Cost since user hidden/u);
 	assert.match((main.lines ?? []).join("\n"), /Tool stamps hidden/u);
 
 	const status = resolveMenuScreen(menu, "status", state);
@@ -58,6 +60,7 @@ test("stamp menu exposes Main, Settings, Status, Help, and read-only invalid sta
 	assert.match(status.lines.join("\n"), /Assistant metadata: Off · Built-in/u);
 	assert.match(status.lines.join("\n"), /Thinking level: Show · Built-in/u);
 	assert.match(status.lines.join("\n"), /Compact abnormal outcome: Show · Built-in/u);
+	assert.match(status.lines.join("\n"), /Cost since user message: Hide · Built-in/u);
 	assert.match(status.lines.join("\n"), /Tool stamps: Hide · Built-in/u);
 	assert.match(status.lines.join("\n"), /\/tmp\/pi-stamp\.json/u);
 
@@ -165,6 +168,15 @@ test("bounded setting actions persist exact patches", async () => {
 		});
 	}
 	for (const value of ["Show", "Hide"] as const) {
+		await menu.actions["set-cost-since-user"]({
+			ctx,
+			state: runtime.get(),
+			signal: new AbortController().signal,
+			itemId: "showCostSinceUser",
+			value,
+		});
+	}
+	for (const value of ["Show", "Hide"] as const) {
 		await menu.actions["set-tool-stamps"]({
 			ctx,
 			state: runtime.get(),
@@ -189,6 +201,8 @@ test("bounded setting actions persist exact patches", async () => {
 		{ showThinkingLevel: false },
 		{ showCompactAbnormalOutcome: true },
 		{ showCompactAbnormalOutcome: false },
+		{ showCostSinceUser: true },
+		{ showCostSinceUser: false },
 		{ toolStamps: true },
 		{ toolStamps: false },
 	]);
@@ -289,7 +303,7 @@ test("RPC custom input retries a rejected value before saving", async () => {
 		{
 			kind: "select",
 			title:
-				"Stamp\n24-hour · seconds · Day changes · Invariant · Local · Timing off · Timeline shown · Metadata off · Thinking shown · Abnormal shown · Tool stamps hidden",
+				"Stamp\n24-hour · seconds · Day changes · Invariant · Local · Timing off · Timeline shown · Metadata off · Thinking shown · Abnormal shown · Cost since user hidden · Tool stamps hidden",
 			options: ["Settings", "Status", "Help", "Close"],
 			response: "Settings",
 		},
@@ -307,6 +321,7 @@ test("RPC custom input retries a rejected value before saving", async () => {
 				"Assistant metadata (Off)",
 				"Thinking level (Show)",
 				"Compact abnormal outcome (Show)",
+				"Cost since user message (Hide)",
 				"Tool stamps (Hide)",
 				"Back",
 			],
@@ -344,6 +359,7 @@ test("RPC custom input retries a rejected value before saving", async () => {
 				"Assistant metadata (Off)",
 				"Thinking level (Show)",
 				"Compact abnormal outcome (Show)",
+				"Cost since user message (Hide)",
 				"Tool stamps (Hide)",
 				"Back",
 			],
@@ -352,7 +368,7 @@ test("RPC custom input retries a rejected value before saving", async () => {
 		{
 			kind: "select",
 			title:
-				"Stamp\n24-hour · seconds · Day changes · en-US · Local · Timing off · Timeline shown · Metadata off · Thinking shown · Abnormal shown · Tool stamps hidden",
+				"Stamp\n24-hour · seconds · Day changes · en-US · Local · Timing off · Timeline shown · Metadata off · Thinking shown · Abnormal shown · Cost since user hidden · Tool stamps hidden",
 			options: ["Settings", "Status", "Help", "Close"],
 			response: "Close",
 		},
@@ -440,6 +456,7 @@ function memorySettingsRuntime(
 			showExactTimeline: "built-in",
 			showThinkingLevel: "built-in",
 			showCompactAbnormalOutcome: "built-in",
+			showCostSinceUser: "built-in",
 			toolStamps: "built-in",
 		},
 		canSave: true,

--- a/packages/pi-stamp/test/metadata.test.ts
+++ b/packages/pi-stamp/test/metadata.test.ts
@@ -157,6 +157,40 @@ test("assistant metadata formatting distinguishes compact, expanded, and explici
 	]);
 });
 
+test("assistant cost-since-user formatting works with or without full metadata", () => {
+	const metadata = captureAssistantMetadata(COMPLETE_MESSAGE);
+	assert.ok(metadata);
+	const costSinceUserData = { estimatedCost: 0.018, costSinceUser: 0.039 };
+	assert.deepEqual(
+		formatAssistantMetadataLines(metadata, "compact", false, undefined, true, costSinceUserData),
+		["requested-model → actual-model · 1,234 tok · est $0.018 · since user $0.039"],
+	);
+	assert.deepEqual(
+		formatAssistantMetadataLines(metadata, "expanded", false, undefined, true, costSinceUserData),
+		[
+			"api anthropic-messages · provider anthropic · requested requested-model · response actual-model · stop toolUse",
+			"tokens in 100 · out 200 · reasoning 50 · cache read 300 · cache write 400 · total 1,234 · est cost $0.018 · since user $0.039",
+		],
+	);
+	assert.deepEqual(
+		formatAssistantMetadataLines(undefined, "off", false, undefined, true, costSinceUserData),
+		["est $0.018 · since user $0.039"],
+	);
+	assert.deepEqual(
+		formatAssistantMetadataLines(undefined, "off", false, undefined, true, {
+			costSinceUser: 0.03,
+		}),
+		["since user $0.03"],
+	);
+	assert.deepEqual(
+		formatAssistantMetadataLines(metadata, "compact", false, undefined, true, {
+			estimatedCost: -1,
+			costSinceUser: 0.039,
+		}),
+		[],
+	);
+});
+
 test("assistant metadata formats effective Thinking level and only abnormal compact outcomes", () => {
 	for (const thinkingLevel of [
 		"off",

--- a/packages/pi-stamp/test/settings.test.ts
+++ b/packages/pi-stamp/test/settings.test.ts
@@ -45,6 +45,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 			showExactTimeline: false,
 			showThinkingLevel: false,
 			showCompactAbnormalOutcome: false,
+			showCostSinceUser: true,
 			toolStamps: true,
 			future: { retained: true },
 		}),
@@ -59,6 +60,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 				showExactTimeline: false,
 				showThinkingLevel: false,
 				showCompactAbnormalOutcome: false,
+				showCostSinceUser: true,
 				toolStamps: true,
 			},
 			sources: {
@@ -72,6 +74,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 				showExactTimeline: "user",
 				showThinkingLevel: "user",
 				showCompactAbnormalOutcome: "user",
+				showCostSinceUser: "user",
 				toolStamps: "user",
 			},
 		},
@@ -91,6 +94,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 		{ showExactTimeline: "yes" },
 		{ showThinkingLevel: "yes" },
 		{ showCompactAbnormalOutcome: "yes" },
+		{ showCostSinceUser: "yes" },
 		{ toolStamps: "yes" },
 	]) {
 		assert.equal(normalizeStampSettingsDocument(value), undefined);
@@ -111,6 +115,7 @@ test("normalization accepts partial settings, canonicalizes locale and zone, and
 		"showExactTimeline",
 		"showThinkingLevel",
 		"showCompactAbnormalOutcome",
+		"showCostSinceUser",
 		"toolStamps",
 	] as const) {
 		for (const value of [false, true]) {
@@ -134,6 +139,7 @@ test("updates preserve unknown and omitted fields and publish private JSON atomi
 	await runtime.update({ showExactTimeline: false });
 	await runtime.update({ showThinkingLevel: false });
 	await runtime.update({ showCompactAbnormalOutcome: false });
+	await runtime.update({ showCostSinceUser: true });
 	await runtime.update({ toolStamps: true });
 
 	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
@@ -145,6 +151,7 @@ test("updates preserve unknown and omitted fields and publish private JSON atomi
 		showExactTimeline: false,
 		showThinkingLevel: false,
 		showCompactAbnormalOutcome: false,
+		showCostSinceUser: true,
 		toolStamps: true,
 	});
 	assert.deepEqual(runtime.get().settings, {
@@ -156,6 +163,7 @@ test("updates preserve unknown and omitted fields and publish private JSON atomi
 		showExactTimeline: false,
 		showThinkingLevel: false,
 		showCompactAbnormalOutcome: false,
+		showCostSinceUser: true,
 		toolStamps: true,
 	});
 	assert.equal(runtime.get().sources.responseTiming, "user");
@@ -163,6 +171,7 @@ test("updates preserve unknown and omitted fields and publish private JSON atomi
 	assert.equal(runtime.get().sources.showExactTimeline, "user");
 	assert.equal(runtime.get().sources.showThinkingLevel, "user");
 	assert.equal(runtime.get().sources.showCompactAbnormalOutcome, "user");
+	assert.equal(runtime.get().sources.showCostSinceUser, "user");
 	assert.equal(runtime.get().sources.toolStamps, "user");
 	if (process.platform !== "win32") {
 		assert.equal(statSync(settingsPath).mode & 0o777, 0o600);

--- a/packages/pi-stamp/test/stamp-renderer.test.ts
+++ b/packages/pi-stamp/test/stamp-renderer.test.ts
@@ -16,7 +16,7 @@ import {
 const USER_TIMESTAMP = new Date(2026, 0, 2, 5, 6, 7, 123).getTime();
 const ASSISTANT_TIMESTAMP = new Date(2026, 0, 2, 5, 6, 9, 456).getTime();
 
-test("isMessageStampData accepts exact message versions 1 through 5", () => {
+test("isMessageStampData accepts exact message versions 1 through 6", () => {
 	assert.equal(isMessageStampData({ version: 1, role: "user", timestamp: USER_TIMESTAMP }), true);
 	assert.equal(
 		isMessageStampData({ version: 2, role: "assistant", timestamp: ASSISTANT_TIMESTAMP }),
@@ -100,6 +100,27 @@ test("isMessageStampData accepts exact message versions 1 through 5", () => {
 		}),
 		true,
 	);
+	assert.equal(
+		isMessageStampData({
+			version: 6,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			metadata,
+			thinkingLevel: "high",
+			estimatedCost: 0.009,
+			costSinceUser: 0.039,
+		}),
+		true,
+	);
+	assert.equal(
+		isMessageStampData({
+			version: 6,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			costSinceUser: 0.03,
+		}),
+		true,
+	);
 	for (const value of [
 		{
 			version: 3,
@@ -165,6 +186,34 @@ test("isMessageStampData accepts exact message versions 1 through 5", () => {
 			timestamp: USER_TIMESTAMP,
 			metadata,
 			thinkingLevel: "high",
+			future: true,
+		},
+		{ version: 6, role: "assistant", timestamp: USER_TIMESTAMP },
+		{
+			version: 6,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			costSinceUser: -1,
+		},
+		{
+			version: 6,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			costSinceUser: 0.03,
+			estimatedCost: Number.NaN,
+		},
+		{
+			version: 6,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			costSinceUser: 0.01,
+			estimatedCost: 0.02,
+		},
+		{
+			version: 6,
+			role: "assistant",
+			timestamp: USER_TIMESTAMP,
+			costSinceUser: 0.03,
 			future: true,
 		},
 	]) {
@@ -322,6 +371,49 @@ test("entry renderer expands exact timelines from only the observations each ver
 			for (const line of renderedComponent.render(width)) {
 				assert.ok(visibleWidth(line) <= width, `${JSON.stringify(line)} exceeded width ${width}`);
 			}
+		}
+	}
+});
+
+test("version-6 rendering gates cost since user without requiring assistant metadata", () => {
+	let settings: StampSettings = {
+		...DEFAULT_STAMP_SETTINGS,
+		timeZone: "UTC",
+		showCostSinceUser: true,
+	};
+	const renderer = createStampEntryRenderer(() => settings);
+	const assistant = assistantMessage(Date.UTC(2026, 6, 30, 0, 1, 2));
+	const metadata = captureAssistantMetadata(assistant);
+	assert.ok(metadata);
+	const data = {
+		version: 6,
+		role: "assistant",
+		timestamp: assistant.timestamp,
+		metadata,
+		estimatedCost: 0.009,
+		costSinceUser: 0.039,
+	} as const;
+	const theme = { fg: (_color: string, text: string) => text } as never;
+	const component = renderer({ data } as never, { expanded: false }, theme);
+	assert.ok(component);
+	assert.deepEqual(
+		component.render(80).map((line) => line.trim()),
+		["00:01:02", "est $0.009 · since user $0.039"],
+	);
+
+	settings = { ...settings, assistantMetadata: "compact" };
+	assert.deepEqual(
+		component.render(80).map((line) => line.trim()),
+		["00:01:02", "test-model · 2 tok · est $0.009 · since user $0.039"],
+	);
+	settings = { ...settings, showCostSinceUser: false };
+	assert.deepEqual(
+		component.render(80).map((line) => line.trim()),
+		["00:01:02", "test-model · 2 tok · est $0"],
+	);
+	for (const width of [1, 4, 8, 12]) {
+		for (const line of component.render(width)) {
+			assert.ok(visibleWidth(line) <= width, `${JSON.stringify(line)} exceeded width ${width}`);
 		}
 	}
 });
@@ -486,14 +578,14 @@ test("entry renderer composes opt-in assistant metadata, explicit debug details,
 	}
 });
 
-test("Pi persists version-5 stamp entries across reopen without adding them to model context", (t) => {
+test("Pi persists version-6 stamp entries across reopen without adding them to model context", (t) => {
 	const sessionDir = mkdtempSync(`${os.tmpdir()}/pi-stamp-session-`);
 	t.onTestFinished(() => rmSync(sessionDir, { recursive: true, force: true }));
 	const session = SessionManager.create(process.cwd(), sessionDir);
 	const metadata = captureAssistantMetadata(assistantMessage(ASSISTANT_TIMESTAMP));
 	assert.ok(metadata);
 	const stampData = {
-		version: 5,
+		version: 6,
 		role: "assistant",
 		timestamp: USER_TIMESTAMP,
 		previousTimestamp: USER_TIMESTAMP - 1_000,
@@ -501,6 +593,8 @@ test("Pi persists version-5 stamp entries across reopen without adding them to m
 		firstContentAt: USER_TIMESTAMP + 800,
 		metadata,
 		thinkingLevel: "high",
+		estimatedCost: 0.009,
+		costSinceUser: 0.039,
 	} as const;
 
 	session.appendMessage(userMessage(USER_TIMESTAMP));

--- a/packages/pi-stamp/test/stamp-tool.test.ts
+++ b/packages/pi-stamp/test/stamp-tool.test.ts
@@ -272,6 +272,7 @@ function settingsRuntimeWithToolStamps(toolStamps = true): StampSettingsRuntime 
 			showExactTimeline: "built-in",
 			showThinkingLevel: "built-in",
 			showCompactAbnormalOutcome: "built-in",
+			showCostSinceUser: "built-in",
 			toolStamps: "user",
 		},
 		canSave: true,

--- a/packages/pi-stamp/test/stamp.test.ts
+++ b/packages/pi-stamp/test/stamp.test.ts
@@ -456,6 +456,93 @@ test("session replacement clears finalized timing owned by the prior session", a
 	assert.deepEqual(mock.entries, [stampEntry("assistant", ASSISTANT_TIMESTAMP)]);
 });
 
+test("cost since user accumulates assistant and tool-result costs and resets on user messages", async () => {
+	const mock = createMockPi();
+	stamp(mock.pi, { settingsRuntime: settingsRuntimeWith({ showCostSinceUser: true }) });
+	const { ctx } = createMockContext({ mode: "tui" });
+	const firstUser = userMessage(USER_TIMESTAMP);
+	const firstToolUse = assistantMessage(ASSISTANT_TIMESTAMP, "toolUse", 0.012);
+	const firstToolResult = toolResultMessage(ASSISTANT_TIMESTAMP + 500, 0.006);
+	const secondToolUse = assistantMessage(ASSISTANT_TIMESTAMP + 1_000, "toolUse", 0.018);
+	const final = assistantMessage(ASSISTANT_TIMESTAMP + 2_000, "stop", 0.009);
+
+	await emit(mock, "session_start", { reason: "startup" }, ctx);
+	await emit(mock, "message_end", { message: firstUser }, ctx);
+	await emit(mock, "message_start", { message: firstToolUse }, ctx);
+	await emit(
+		mock,
+		"turn_end",
+		{ message: firstToolUse, toolResults: [firstToolResult], turnIndex: 0 },
+		ctx,
+	);
+	await emit(mock, "message_start", { message: secondToolUse }, ctx);
+	await emit(mock, "turn_end", { message: secondToolUse, toolResults: [], turnIndex: 1 }, ctx);
+	await emit(mock, "message_start", { message: final }, ctx);
+	await emit(mock, "turn_end", { message: final, toolResults: [], turnIndex: 2 }, ctx);
+
+	assert.deepEqual(
+		[0, 1, 2].map((index) => messageStampDataAt(mock, index).version),
+		[2, 2, 2],
+	);
+	const finalStamp = messageStampDataAt(mock, 3);
+	assert.equal(finalStamp.version, 6);
+	if (finalStamp.version !== 6) assert.fail("Expected a version-6 cost stamp");
+	assert.equal(finalStamp.estimatedCost, 0.009);
+	assert.ok(Math.abs(finalStamp.costSinceUser - 0.045) < 1e-12);
+	assert.equal(finalStamp.metadata, undefined);
+
+	await emit(mock, "agent_end", { messages: [firstToolUse, secondToolUse, final] }, ctx);
+	const autonomous = assistantMessage(ASSISTANT_TIMESTAMP + 3_000, "stop", 0.001);
+	await emit(mock, "message_start", { message: autonomous }, ctx);
+	await emit(mock, "turn_end", { message: autonomous, toolResults: [], turnIndex: 3 }, ctx);
+	const autonomousStamp = messageStampDataAt(mock, 4);
+	assert.equal(autonomousStamp.version, 6);
+	if (autonomousStamp.version !== 6) assert.fail("Expected a version-6 cost stamp");
+	assert.ok(Math.abs(autonomousStamp.costSinceUser - 0.046) < 1e-12);
+
+	const secondUser = userMessage(USER_TIMESTAMP + 10_000);
+	const secondFinal = assistantMessage(ASSISTANT_TIMESTAMP + 11_000, "stop", 0.004);
+	await emit(mock, "message_end", { message: secondUser }, ctx);
+	await emit(mock, "message_start", { message: secondFinal }, ctx);
+	await emit(mock, "turn_end", { message: secondFinal, toolResults: [], turnIndex: 4 }, ctx);
+	const resetStamp = messageStampDataAt(mock, 6);
+	assert.equal(resetStamp.version, 6);
+	if (resetStamp.version !== 6) assert.fail("Expected a version-6 cost stamp");
+	assert.equal(resetStamp.costSinceUser, 0.004);
+});
+
+test("session resume rebuilds cost since user from assistant and tool-result usage", async () => {
+	const mock = createMockPi();
+	stamp(mock.pi, { settingsRuntime: settingsRuntimeWith({ showCostSinceUser: true }) });
+	const resumedUser = userMessage(USER_TIMESTAMP);
+	const firstToolUse = assistantMessage(ASSISTANT_TIMESTAMP, "toolUse", 0.012);
+	const firstToolResult = toolResultMessage(ASSISTANT_TIMESTAMP + 500, 0.006);
+	const secondToolUse = assistantMessage(ASSISTANT_TIMESTAMP + 1_000, "toolUse", 0.018);
+	const { ctx } = createMockContext({
+		mode: "tui",
+		sessionManager: {
+			getSessionId: () => "test-session",
+			getSessionName: () => undefined,
+			getEntries: () => [],
+			getBranch: () => [
+				{ type: "message", message: assistantMessage(USER_TIMESTAMP - 1_000, "stop", 1) },
+				{ type: "message", message: resumedUser },
+				{ type: "message", message: firstToolUse },
+				{ type: "message", message: firstToolResult },
+				{ type: "message", message: secondToolUse },
+			],
+		},
+	});
+
+	await emit(mock, "session_start", { reason: "resume" }, ctx);
+	const final = assistantMessage(ASSISTANT_TIMESTAMP + 2_000, "stop", 0.009);
+	await emit(mock, "turn_end", { message: final, toolResults: [], turnIndex: 2 }, ctx);
+	const finalStamp = messageStampDataAt(mock);
+	assert.equal(finalStamp.version, 6);
+	if (finalStamp.version !== 6) assert.fail("Expected a version-6 cost stamp");
+	assert.ok(Math.abs(finalStamp.costSinceUser - 0.045) < 1e-12);
+});
+
 test("assistant tool and error turns receive one stamp without stamping tool results", async () => {
 	const mock = createMockPi();
 	stamp(mock.pi, { settingsRuntime: testSettingsRuntime() });
@@ -672,9 +759,29 @@ function userMessage(timestamp: number) {
 	return { role: "user" as const, content: "hello", timestamp };
 }
 
+function toolResultMessage(timestamp: number, estimatedCost: number) {
+	return {
+		role: "toolResult" as const,
+		toolCallId: "call-1",
+		toolName: "model-backed-tool",
+		content: [],
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: estimatedCost },
+		},
+		isError: false,
+		timestamp,
+	};
+}
+
 function assistantMessage(
 	timestamp: number,
 	stopReason: "stop" | "toolUse" | "error" | "aborted" = "stop",
+	estimatedCost = 0,
 ) {
 	return {
 		role: "assistant" as const,
@@ -688,7 +795,7 @@ function assistantMessage(
 			cacheRead: 0,
 			cacheWrite: 0,
 			totalTokens: 2,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: estimatedCost },
 		},
 		stopReason,
 		timestamp,
@@ -720,6 +827,7 @@ function defaultSettingsState(): Readonly<StampSettingsState> {
 			showExactTimeline: "built-in",
 			showThinkingLevel: "built-in",
 			showCompactAbnormalOutcome: "built-in",
+			showCostSinceUser: "built-in",
 			toolStamps: "built-in",
 		},
 		canSave: true,


### PR DESCRIPTION
Add an opt-in `showTurnCost` setting that reports the cumulative estimated cost of work associated with the current turn. The feature is disabled by default so existing transcript output and metadata behavior remain unchanged unless explicitly enabled.

- Reset the turn-cost accumulator on every literal user message, including steering and queued follow-up messages.
- Accumulate valid reported costs from assistant model calls and tool-result messages, covering tool-use calls, retries, continuations, paid or model-backed tools that expose usage, and autonomous extension-started runs.
- Show the final assistant call cost together with the cumulative turn cost only on the first assistant response whose stop reason is not `toolUse`.
- Keep turn-cost rendering independent from full assistant metadata capture so the feature also works when `assistantMetadata` is `off`.
- Persist the new values in strict version-6 assistant stamp entries while keeping assistant metadata and Thinking level optional and preserving compatibility with earlier stamp versions.
- Reconstruct the active turn balance from the latest user-message boundary on session resume, scanning backward for the boundary and accumulating the retained suffix in chronological order.
- Preserve existing timing, rendering, settings persistence, menu, status, help, and lifecycle behavior while adding focused coverage for settings, formatting, schema validation, rendering, live accumulation, tool-result usage, and resume reconstruction.
- Document the setting, cost semantics, limitations, and version-6 compatibility behavior, and record the published package change in a changeset.