### PR TITLE
fix(btw): honor auth-resolved API base URLs

### DIFF
--- a/.changeset/tidy-copilot-routing.md
+++ b/.changeset/tidy-copilot-routing.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-btw": patch
+---
+
+Honor the API base URL returned by Pi's authentication resolver for both inherited and explicitly configured side-thread models. This fixes misdirected requests for GitHub Copilot accounts that use a different endpoint from the provider default, without changing the main session's model.

--- a/packages/pi-btw/src/btw.ts
+++ b/packages/pi-btw/src/btw.ts
@@ -146,7 +146,12 @@ export async function resolveBtwModel({
 				: `falling back to ${fallback}`;
 			try {
 				const auth = await modelRegistry.getApiKeyAndHeaders(configuredModel);
-				if (auth.ok && hasRequestAuth(auth)) return { model: configuredModel, auth };
+				if (auth.ok && hasRequestAuth(auth)) {
+					return {
+						model: auth.baseUrl ? { ...configuredModel, baseUrl: auth.baseUrl } : configuredModel,
+						auth,
+					};
+				}
 				const reason = auth.ok ? "has no request credentials" : auth.error;
 				reportWarning(
 					`pi-btw model ${settings.model} is unavailable (${reason}); ${fallbackAction}.`,
@@ -163,7 +168,13 @@ export async function resolveBtwModel({
 	if (!currentModel) return undefined;
 	try {
 		const auth = await modelRegistry.getApiKeyAndHeaders(currentModel);
-		if (auth.ok && hasRequestAuth(auth)) return { model: currentModel, auth };
+		if (auth.ok && hasRequestAuth(auth)) {
+			// Direct provider streams bypass Pi's request preparation, including OAuth routing.
+			return {
+				model: auth.baseUrl ? { ...currentModel, baseUrl: auth.baseUrl } : currentModel,
+				auth,
+			};
+		}
 	} catch {
 		// The caller reports the final lack of an available model.
 	}

--- a/packages/pi-btw/test/btw.test.ts
+++ b/packages/pi-btw/test/btw.test.ts
@@ -163,6 +163,45 @@ test("resolveBtwModel inherits current model when no model is configured", async
 	assert.equal(result?.auth.apiKey, "current-key");
 });
 
+for (const selection of ["current", "configured", "fallback"] as const) {
+	for (const baseUrl of [undefined, "", "https://api.business.githubcopilot.com"]) {
+		test(`resolveBtwModel preserves auth routing for ${selection} model (${baseUrl || "default endpoint"})`, async () => {
+			const model = Object.freeze({
+				provider: "github-copilot",
+				id: "test-model",
+				baseUrl: "https://api.individual.githubcopilot.com",
+			}) as Model<Api>;
+			const unavailableModel = { provider: "other", id: "side" } as Model<Api>;
+			const auth = {
+				ok: true as const,
+				apiKey: "test-key",
+				headers: { "X-Test": "preserved", Authorization: null },
+				env: { TEST_PROVIDER_TOKEN: "test" },
+				baseUrl,
+			};
+			const result = await resolveBtwModel({
+				settings:
+					selection === "current"
+						? {}
+						: { model: selection === "configured" ? "github-copilot/test-model" : "other/side" },
+				currentModel: selection === "configured" ? unavailableModel : model,
+				modelRegistry: {
+					find: () => (selection === "configured" ? model : unavailableModel),
+					getApiKeyAndHeaders: async (selectedModel: Model<Api>) =>
+						selectedModel === model ? auth : { ok: false as const, error: "unavailable" },
+				},
+			});
+
+			assert.ok(result);
+			assert.deepEqual(result.model, { ...model, baseUrl: baseUrl || model.baseUrl });
+			assert.equal(result.auth, auth);
+			assert.equal(model.baseUrl, "https://api.individual.githubcopilot.com");
+			if (baseUrl) assert.notEqual(result.model, model);
+			else assert.equal(result.model, model);
+		});
+	}
+}
+
 test("resolveBtwModel warns and falls back for unavailable configured models", async () => {
 	const currentModel = { provider: "current", id: "main" } as Model<Api>;
 	for (const configuredAuth of [


### PR DESCRIPTION
## Summary

Honor `baseUrl` returned by `ModelRegistry.getApiKeyAndHeaders()` when resolving a side-thread model, for both inherited and explicitly configured models. Clone only when an override is present; do not mutate the registry/main-session model. Include a patch Changeset.

## Problem

`pi-btw` resolves credentials and then calls the provider's `streamSimple()` directly. This bypasses `ModelRuntime.prepareRequest()`, which normally applies `resolution.auth.baseUrl` to the request model.

For example, GitHub Copilot OAuth can resolve to `api.business.githubcopilot.com` while the model's default URL is `api.individual.githubcopilot.com`. BTW was retaining the latter, causing `OpenAI API error (421): 421 Misdirected Request` even though the same model worked in the main session.

## Fix and coverage

- Match Pi's request-preparation behavior: a truthy auth URL overrides the model URL; an omitted/empty override preserves the original model and identity.
- Apply this to inherited, explicitly configured, and fallback-to-current paths.
- Preserve provider/model identity and the complete auth result, including header deletion markers and environment values.
- Add nine table-driven regression cases and freeze source models to catch accidental mutation.
- Before the fix, all three endpoint-override cases fail; after the fix, all nine pass.

## Verification

- `npm run check` — passed (build, Biome, boundaries, and workspace typechecks).
- `PI_EXTENSIONS_TEST_BASE=origin/main PI_EXTENSIONS_BUILD_READY=1 VITEST_MAX_WORKERS=2 npm test` — passed: **24 files / 380 tests**, using the repository's affected-test workflow.
- Focused pi-btw suite — passed: **14 files / 330 tests**.
- `npm run package:pack -- btw` — passed; inspected tarball contents, including the generated runtime.
- Packed local package loaded through Pi 0.85.1's `DefaultResourceLoader`/Jiti and registered `/btw` without errors; local source/runtime hashes match the tested build.
- Live smoke through the patched resolver and side-question completion path, using Pi 0.85.1's model registry/provider: Copilot request used the OAuth-resolved Business endpoint and returned `OK`; the registry model was unchanged. No main-conversation context was sent.

### Full-suite caveat

The full `npm test` gate was also attempted. After satisfying local OpenTelemetry peer resolution and reducing worker concurrency, it reported **4506 passed / 3 failed**. All three failures reproduce with this patch temporarily stashed on the unchanged upstream baseline:

- `pi-subagents/test/process.test.ts`: asynchronous RPC stdin write-error case hits the existing 5-second timeout.
- `pi-github-pr/test/github-pr.test.ts`: in-flight periodic refresh abort assertion.
- `pi-tui-kit/test/lazy-syntax-highlighting.test.ts`: highlighter-module loading assertion.

No dependency, lockfile, timeout, or unrelated test changes are included in this PR.

## Scope / audit

Reviewed `AGENTS.md` and `docs/extension-conventions.md`, and compared against installed Pi `ModelRuntime.prepareRequest()` and `ModelRegistry` behavior. This change adds no settings, UI flows, lifecycle resources, extra awaits, or model-visible prompt changes. Existing cancellation/resume behavior and credential ownership are unchanged. The interactive `/btw` UI after `/reload` remains a manual user check; the live request path and package loading were independently verified.
