### PR TITLE
feat(plan-mode): choose fresh implementation runtime

### DIFF
--- a/.changeset/fresh-runtime-choice.md
+++ b/.changeset/fresh-runtime-choice.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Add one-shot model and thinking selection before fresh ready-plan implementation.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -154,13 +154,15 @@ The same flat menu shows **Implement here** and **Start fresh and implement**, e
 **Implement here**—and the compatibility route `/plan implement`—appends the Normal contract, lifts the Plan runtime policy, captures the reinjection setting, and starts implementation in the current session with its complete planning conversation and tool calls.
 **Start fresh and implement** opens a settings page before replacement.
 Its searchable model list snapshots the session's scoped models when configured, otherwise Pi's currently available models, and shows each provider, model ID, and friendly name.
-The model and thinking rows default independently to **Destination default**; the fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+Pi 0.80.6–0.82.1 does not expose session model scopes to extensions, so the list uses all currently available models on those releases.
+One-shot provider and model identifiers are limited to 512 characters each; longer custom identifiers are rejected before the source session is replaced.
+The model and thinking rows default independently to **Same as plan**, which carries the planning session's current model and thinking level into the fresh session; the fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
 Back navigation preserves this menu-local draft, while closing and reopening the menu resets both rows.
 The saved-plan menu keeps its direct fresh-session action without these optional rows.
 
 Starting from that settings page waits for the source session to become idle, re-resolves and authenticates an explicit model, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
 The destination consumes the one-shot choices before its first provider request, applies an explicit model first, and then applies explicit thinking.
-A model-only choice uses Pi's normal thinking default for that model; a thinking-only choice applies to the destination's normal model.
+Changing only the model keeps the planning thinking level; changing only the thinking level keeps the planning model.
 If Pi clamps an unsupported thinking level, the extension reports the effective level.
 If the chosen model disappears or loses authentication after source preflight, the destination reports the race, consumes the intent without retrying it later, and continues with its default model.
 The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -153,7 +153,7 @@ After completion, `/plan` opens the ready actions when interactive UI is availab
 The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews the selected **Plan reinjection** policy.
 **Implement here**—and the compatibility route `/plan implement`—appends the Normal contract, lifts the Plan runtime policy, captures the reinjection setting, and starts implementation in the current session with its complete planning conversation and tool calls.
 **Start fresh and implement** opens a settings page before replacement.
-Its searchable model list is a snapshot of Pi's currently available models and shows each provider, model ID, and friendly name.
+Its searchable model list snapshots the session's scoped models when configured, otherwise Pi's currently available models, and shows each provider, model ID, and friendly name.
 The model and thinking rows default independently to **Destination default**; the fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
 Back navigation preserves this menu-local draft, while closing and reopening the menu resets both rows.
 The saved-plan menu keeps its direct fresh-session action without these optional rows.
@@ -174,6 +174,7 @@ In-memory sessions create an unlinked fresh session because no parent file exist
 Escape, Ctrl+C, menu disposal, source replacement/shutdown, model/auth failure, or cancellation by another extension before replacement leaves the source plan unchanged.
 Under **Off — conversation history only**, the destination receives the complete plan in its initial user prompt and does not persist active-plan state.
 When a one-shot runtime choice exists, only that temporary non-model state is persisted and it is removed before the first request.
+If that removal cannot be persisted, the request is not sent and can be retried after session persistence is available.
 If that kickoff fails, the complete request remains in the destination editor and the source remains resumable.
 Under either guaranteed-plan policy, the destination persists active-plan state before kickoff.
 If guaranteed-plan persistence fails, the complete request is placed in the destination editor and the source remains resumable.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -156,7 +156,7 @@ The same flat menu shows **Implement here** and **Start fresh and implement**, e
 Its searchable model list snapshots the session's scoped models when configured, otherwise Pi's currently available models, and shows each provider, model ID, and friendly name.
 Pi 0.80.6–0.82.1 does not expose session model scopes to extensions, so the list uses all currently available models on those releases.
 One-shot provider and model identifiers are limited to 512 characters each; longer custom identifiers are rejected before the source session is replaced.
-The model and thinking rows default independently to **Same as plan**, which carries the planning session's current model and thinking level into the fresh session; the fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+The model and thinking rows show the planning session's current values with **same as plan** by default and carry those values into the fresh session independently; the fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
 Back navigation preserves this menu-local draft, while closing and reopening the menu resets both rows.
 The saved-plan menu keeps its direct fresh-session action without these optional rows.
 

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -162,6 +162,8 @@ The saved-plan menu keeps its direct fresh-session action without these optional
 
 Starting from that settings page waits for the source session to become idle, re-resolves and authenticates an explicit model, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
 The destination consumes the one-shot choices before its first provider request, applies an explicit model first, and then applies explicit thinking.
+Concurrent prompts that arrive while those choices are being applied are queued as follow-ups behind the kickoff prompt.
+If durable consumption blocks the kickoff, the handoff reports a partial start and restores a conversation-history prompt to the editor instead of reporting success.
 Changing only the model keeps the planning thinking level; changing only the thinking level keeps the planning model.
 If Pi clamps an unsupported thinking level, the extension reports the effective level.
 If the chosen model disappears or loses authentication after source preflight, the destination reports the race, consumes the intent without retrying it later, and continues with its default model.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -11,6 +11,7 @@ Use a Codex-like `/plan` mode to explore a codebase, resolve important questions
 - Uses structured questions for important ambiguity and explicit completion for a decision-ready plan.
 - Reviews the complete plan before implementation, export, save, further planning, or discard.
 - Implements in the planning session or a fresh linked session with the approved plan.
+- Optionally selects a one-shot destination model and thinking level before a fresh ready-plan handoff.
 - Restores Plan state and one saved plan across resume and compaction.
 - Configures the Plan tool allowlist, reviewed shell commands, user-trusted subcommands, export path, plan reinjection, shortcut, and thinking level.
 - Publishes statusline state and cooperates anonymously with Workflow Mutex Protocol v1 participants.
@@ -151,7 +152,17 @@ Empty, malformed, unclosed, or multiple legacy blocks keep Plan mode active and 
 After completion, `/plan` opens the ready actions when interactive UI is available.
 The same flat menu shows **Implement here** and **Start fresh and implement**, explains which conversation context each choice uses, and previews the selected **Plan reinjection** policy.
 **Implement here**—and the compatibility route `/plan implement`—appends the Normal contract, lifts the Plan runtime policy, captures the reinjection setting, and starts implementation in the current session with its complete planning conversation and tool calls.
-**Start fresh and implement** waits for the source session to become idle, verifies the selected model and authentication, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
+**Start fresh and implement** opens a settings page before replacement.
+Its searchable model list is a snapshot of Pi's currently available models and shows each provider, model ID, and friendly name.
+The model and thinking rows default independently to **Destination default**; the fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+Back navigation preserves this menu-local draft, while closing and reopening the menu resets both rows.
+The saved-plan menu keeps its direct fresh-session action without these optional rows.
+
+Starting from that settings page waits for the source session to become idle, re-resolves and authenticates an explicit model, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
+The destination consumes the one-shot choices before its first provider request, applies an explicit model first, and then applies explicit thinking.
+A model-only choice uses Pi's normal thinking default for that model; a thinking-only choice applies to the destination's normal model.
+If Pi clamps an unsupported thinking level, the extension reports the effective level.
+If the chosen model disappears or loses authentication after source preflight, the destination reports the race, consumes the intent without retrying it later, and continues with its default model.
 The destination still loads its normal `AGENTS.md`, skills, project resources, and extensions.
 Choosing **Export plan…** asks for a destination, writes the plan, appends the Normal contract, restores inherited thinking, and leaves Plan mode without starting a model turn or changing active tools.
 Choosing **Save for later**—or running `/plan save`—instead stores one plan in the current Pi session before leaving Plan mode.
@@ -162,6 +173,7 @@ Resume it later to inspect or hand off the ready/saved plan again; this delibera
 In-memory sessions create an unlinked fresh session because no parent file exists.
 Escape, Ctrl+C, menu disposal, source replacement/shutdown, model/auth failure, or cancellation by another extension before replacement leaves the source plan unchanged.
 Under **Off — conversation history only**, the destination receives the complete plan in its initial user prompt and does not persist active-plan state.
+When a one-shot runtime choice exists, only that temporary non-model state is persisted and it is removed before the first request.
 If that kickoff fails, the complete request remains in the destination editor and the source remains resumable.
 Under either guaranteed-plan policy, the destination persists active-plan state before kickoff.
 If guaranteed-plan persistence fails, the complete request is placed in the destination editor and the source remains resumable.

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -181,12 +181,19 @@ export async function startFreshImplementationSession(
 					reportKickoffFailure(safeErrorDetail(error));
 					return;
 				}
-				if (
-					pendingImplementationRuntime &&
-					destinationRuntimeIsStillPending(replacementCtx, request.stateEntryType)
-				) {
-					reportKickoffFailure("fresh implementation settings could not be consumed");
-					return;
+				if (pendingImplementationRuntime) {
+					const runtimeStatus = destinationRuntimeConsumptionStatus(
+						replacementCtx,
+						request.stateEntryType,
+					);
+					if (runtimeStatus !== "consumed") {
+						reportKickoffFailure(
+							runtimeStatus === "pending"
+								? "fresh implementation settings could not be consumed"
+								: "fresh implementation settings could not be verified as consumed",
+						);
+						return;
+					}
 				}
 				safeNotify(
 					replacementCtx,
@@ -304,14 +311,17 @@ function safeModelReference(model: { provider: string; id?: string; modelId?: st
 	return safeErrorDetail(`${model.provider}/${model.modelId ?? model.id ?? "unknown"}`);
 }
 
-function destinationRuntimeIsStillPending(ctx: ReplacementContext, stateEntryType: string) {
+function destinationRuntimeConsumptionStatus(
+	ctx: ReplacementContext,
+	stateEntryType: string,
+): "consumed" | "pending" | "unavailable" {
 	try {
-		return (
-			restorePlanModeState(ctx.sessionManager.getBranch(), stateEntryType)
-				.pendingImplementationRuntime !== undefined
-		);
+		return restorePlanModeState(ctx.sessionManager.getBranch(), stateEntryType)
+			.pendingImplementationRuntime
+			? "pending"
+			: "consumed";
 	} catch {
-		return false;
+		return "unavailable";
 	}
 }
 

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -1,9 +1,15 @@
 import { randomUUID } from "node:crypto";
+import { stripVTControlCharacters } from "node:util";
 import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { PLAN_HISTORY_IMPLEMENTATION_PROMPT } from "./message-transform.js";
 import { createModeContractMessage } from "./mode-contract.js";
 import type { ImplementationPlanRetention } from "./settings.js";
-import type { PlanCompletionSource, PlanModeState } from "./state.js";
+import type {
+	ImplementationRuntimeSelection,
+	PendingImplementationRuntime,
+	PlanCompletionSource,
+	PlanModeState,
+} from "./state.js";
 
 type NewSessionOptions = Exclude<Parameters<ExtensionCommandContext["newSession"]>[0], undefined>;
 type ReplacementContext = Parameters<NonNullable<NewSessionOptions["withSession"]>>[0];
@@ -13,6 +19,7 @@ export interface FreshImplementationRequest {
 	source: PlanCompletionSource;
 	retention: ImplementationPlanRetention;
 	stateEntryType: string;
+	runtime?: ImplementationRuntimeSelection;
 	isCurrent(): boolean;
 }
 
@@ -21,6 +28,7 @@ interface FreshImplementationFromStateOptions {
 	menuIsCurrent(): boolean;
 	retention: ImplementationPlanRetention;
 	stateEntryType: string;
+	runtime?: ImplementationRuntimeSelection;
 }
 
 export type FreshImplementationResult =
@@ -78,6 +86,7 @@ export async function startFreshImplementationFromState(
 		source,
 		retention: options.retention,
 		stateEntryType: options.stateEntryType,
+		runtime: options.runtime,
 		isCurrent,
 	});
 }
@@ -92,23 +101,29 @@ export async function startFreshImplementationSession(
 
 	await ctx.waitForIdle();
 	if (!request.isCurrent()) return { kind: "stale" };
-	if (!(await preflightModel(ctx, request.isCurrent))) return { kind: "rejected" };
+	if (!(await preflightModel(ctx, request))) return { kind: "rejected" };
 	if (!request.isCurrent()) return { kind: "stale" };
 
 	const usesConversationHistory = request.retention === "clear-on-start";
-	const destinationState: PlanModeState | undefined = usesConversationHistory
+	const pendingImplementationRuntime = pendingRuntimeIntent(request.runtime);
+	const activeImplementation = usesConversationHistory
 		? undefined
 		: {
-				enabled: false,
-				awaitingAction: false,
-				activeImplementation: {
-					id: randomUUID(),
-					plan: request.plan,
-					source: request.source,
-					startedAt: Date.now(),
-					retention: request.retention,
-				},
+				id: randomUUID(),
+				plan: request.plan,
+				source: request.source,
+				startedAt: Date.now(),
+				retention: request.retention,
 			};
+	const destinationState: PlanModeState | undefined =
+		activeImplementation || pendingImplementationRuntime
+			? {
+					enabled: false,
+					awaitingAction: false,
+					...(activeImplementation ? { activeImplementation } : {}),
+					...(pendingImplementationRuntime ? { pendingImplementationRuntime } : {}),
+				}
+			: undefined;
 	const handoff = usesConversationHistory
 		? formatTransferredPlanPrompt(request.plan, true)
 		: formatImplementationHandoff(request.plan);
@@ -183,8 +198,26 @@ export async function startFreshImplementationSession(
 	return setupError || kickoffError ? { kind: "partial" } : { kind: "started" };
 }
 
-async function preflightModel(ctx: ExtensionCommandContext, isCurrent: () => boolean) {
-	const model = ctx.model;
+async function preflightModel(ctx: ExtensionCommandContext, request: FreshImplementationRequest) {
+	const requestedModel = request.runtime?.model;
+	let model = ctx.model;
+	if (requestedModel) {
+		try {
+			model = ctx.modelRegistry.find(requestedModel.provider, requestedModel.modelId);
+		} catch (error: unknown) {
+			if (request.isCurrent()) {
+				ctx.ui.notify(`Unable to implement the plan: ${safeErrorDetail(error)}`, "error");
+			}
+			return false;
+		}
+		if (!model) {
+			ctx.ui.notify(
+				`Unable to implement the plan: implementation model ${safeModelReference(requestedModel)} is no longer available. Choose another model and retry.`,
+				"warning",
+			);
+			return false;
+		}
+	}
 	if (!model) {
 		ctx.ui.notify("Unable to implement the plan: no model is selected.", "warning");
 		return false;
@@ -193,17 +226,37 @@ async function preflightModel(ctx: ExtensionCommandContext, isCurrent: () => boo
 	try {
 		auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	} catch (error: unknown) {
-		if (isCurrent()) {
+		if (request.isCurrent()) {
 			ctx.ui.notify(`Unable to implement the plan: ${safeErrorDetail(error)}`, "error");
 		}
 		return false;
 	}
-	if (!isCurrent()) return false;
+	if (!request.isCurrent()) return false;
 	if (!auth.ok) {
-		ctx.ui.notify(`Unable to implement the plan: ${safeErrorDetail(auth.error)}`, "warning");
+		ctx.ui.notify(
+			requestedModel
+				? `Unable to implement the plan with ${safeModelReference(model)}: ${safeErrorDetail(auth.error)}. Choose another model or configure authentication, then retry.`
+				: `Unable to implement the plan: ${safeErrorDetail(auth.error)}`,
+			"warning",
+		);
 		return false;
 	}
 	return true;
+}
+
+function pendingRuntimeIntent(
+	selection: ImplementationRuntimeSelection | undefined,
+): PendingImplementationRuntime | undefined {
+	if (!selection?.model && !selection?.thinkingLevel) return undefined;
+	return {
+		version: 1,
+		...(selection.model ? { model: { ...selection.model } } : {}),
+		...(selection.thinkingLevel ? { thinkingLevel: selection.thinkingLevel } : {}),
+	};
+}
+
+function safeModelReference(model: { provider: string; id?: string; modelId?: string }) {
+	return safeErrorDetail(`${model.provider}/${model.modelId ?? model.id ?? "unknown"}`);
 }
 
 function recoverSetupFailure(ctx: ReplacementContext, handoff: string, setupError: string) {
@@ -246,10 +299,15 @@ function isCommandContext(ctx: ExtensionContext): ctx is ExtensionCommandContext
 function safeErrorDetail(error: unknown) {
 	const detail = error instanceof Error ? error.message : String(error);
 	const normalized =
-		[...detail]
+		[...stripVTControlCharacters(detail)]
 			.map((character) => {
 				const codePoint = character.codePointAt(0) ?? 0;
-				return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+				return codePoint <= 0x1f ||
+					(codePoint >= 0x7f && codePoint <= 0x9f) ||
+					(codePoint >= 0x202a && codePoint <= 0x202e) ||
+					(codePoint >= 0x2066 && codePoint <= 0x2069)
+					? " "
+					: character;
 			})
 			.join("")
 			.replace(/\s+/gu, " ")

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -11,6 +11,7 @@ import {
 	type PendingImplementationRuntime,
 	type PlanCompletionSource,
 	type PlanModeState,
+	restorePlanModeState,
 } from "./state.js";
 
 type NewSessionOptions = Exclude<Parameters<ExtensionCommandContext["newSession"]>[0], undefined>;
@@ -160,21 +161,31 @@ export async function startFreshImplementationSession(
 					recoverSetupFailure(replacementCtx, handoff, setupError);
 					return;
 				}
-				try {
-					await replacementCtx.sendUserMessage(handoff);
-				} catch (error: unknown) {
-					kickoffError = safeErrorDetail(error);
+				const reportKickoffFailure = (detail: string) => {
+					kickoffError = detail;
 					const recoveredInEditor =
 						usesConversationHistory && safeSetEditorText(replacementCtx, handoff);
 					safeNotify(
 						replacementCtx,
 						usesConversationHistory
 							? recoveredInEditor
-								? `Fresh session created, but implementation did not start: ${kickoffError}. The implementation request is in the editor; submit it or resume the parent planning session.`
-								: `Fresh session created, but implementation did not start: ${kickoffError}. The implementation request could not be restored to the editor; resume the parent planning session.`
-							: `Fresh session created, but implementation did not start: ${kickoffError}. Send a message to continue, use /plan exit to clear the active plan, or resume the parent planning session.`,
+								? `Fresh session created, but implementation did not start: ${detail}. The implementation request is in the editor; submit it or resume the parent planning session.`
+								: `Fresh session created, but implementation did not start: ${detail}. The implementation request could not be restored to the editor; resume the parent planning session.`
+							: `Fresh session created, but implementation did not start: ${detail}. Send a message to continue, use /plan exit to clear the active plan, or resume the parent planning session.`,
 						"error",
 					);
+				};
+				try {
+					await replacementCtx.sendUserMessage(handoff);
+				} catch (error: unknown) {
+					reportKickoffFailure(safeErrorDetail(error));
+					return;
+				}
+				if (
+					pendingImplementationRuntime &&
+					destinationRuntimeIsStillPending(replacementCtx, request.stateEntryType)
+				) {
+					reportKickoffFailure("fresh implementation settings could not be consumed");
 					return;
 				}
 				safeNotify(
@@ -291,6 +302,17 @@ function pendingRuntimeIntent(
 
 function safeModelReference(model: { provider: string; id?: string; modelId?: string }) {
 	return safeErrorDetail(`${model.provider}/${model.modelId ?? model.id ?? "unknown"}`);
+}
+
+function destinationRuntimeIsStillPending(ctx: ReplacementContext, stateEntryType: string) {
+	try {
+		return (
+			restorePlanModeState(ctx.sessionManager.getBranch(), stateEntryType)
+				.pendingImplementationRuntime !== undefined
+		);
+	} catch {
+		return false;
+	}
 }
 
 function recoverSetupFailure(ctx: ReplacementContext, handoff: string, setupError: string) {

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -4,11 +4,13 @@ import type { ExtensionCommandContext, ExtensionContext } from "@earendil-works/
 import { PLAN_HISTORY_IMPLEMENTATION_PROMPT } from "./message-transform.js";
 import { createModeContractMessage } from "./mode-contract.js";
 import type { ImplementationPlanRetention } from "./settings.js";
-import type {
-	ImplementationRuntimeSelection,
-	PendingImplementationRuntime,
-	PlanCompletionSource,
-	PlanModeState,
+import {
+	type ImplementationRuntimeSelection,
+	isPendingImplementationModelIdentifier,
+	MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH,
+	type PendingImplementationRuntime,
+	type PlanCompletionSource,
+	type PlanModeState,
 } from "./state.js";
 
 type NewSessionOptions = Exclude<Parameters<ExtensionCommandContext["newSession"]>[0], undefined>;
@@ -202,16 +204,32 @@ async function preflightModel(ctx: ExtensionCommandContext, request: FreshImplem
 	const requestedModel = request.runtime?.model;
 	let model = ctx.model;
 	if (requestedModel) {
-		try {
-			model = ctx.modelRegistry.find(requestedModel.provider, requestedModel.modelId);
-		} catch (error: unknown) {
+		if (
+			!isPendingImplementationModelIdentifier(requestedModel.provider) ||
+			!isPendingImplementationModelIdentifier(requestedModel.modelId)
+		) {
 			notifyCurrent(
 				ctx,
 				request,
-				`Unable to implement the plan: ${safeErrorDetail(error)}`,
-				"error",
+				`Unable to implement the plan: implementation model provider and ID must each contain 1-${MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH} characters. Choose another model and retry.`,
+				"warning",
 			);
 			return false;
+		}
+		const isCurrentModel =
+			ctx.model?.provider === requestedModel.provider && ctx.model.id === requestedModel.modelId;
+		if (!isCurrentModel) {
+			try {
+				model = ctx.modelRegistry.find(requestedModel.provider, requestedModel.modelId);
+			} catch (error: unknown) {
+				notifyCurrent(
+					ctx,
+					request,
+					`Unable to implement the plan: ${safeErrorDetail(error)}`,
+					"error",
+				);
+				return false;
+			}
 		}
 		if (!model) {
 			notifyCurrent(
@@ -264,7 +282,9 @@ function pendingRuntimeIntent(
 	if (!selection?.model && !selection?.thinkingLevel) return undefined;
 	return {
 		version: 1,
-		...(selection.model ? { model: { ...selection.model } } : {}),
+		...(selection.model
+			? { model: { provider: selection.model.provider, modelId: selection.model.modelId } }
+			: {}),
 		...(selection.thinkingLevel ? { thinkingLevel: selection.thinkingLevel } : {}),
 	};
 }

--- a/packages/pi-plan-mode/src/fresh-implementation.ts
+++ b/packages/pi-plan-mode/src/fresh-implementation.ts
@@ -205,13 +205,18 @@ async function preflightModel(ctx: ExtensionCommandContext, request: FreshImplem
 		try {
 			model = ctx.modelRegistry.find(requestedModel.provider, requestedModel.modelId);
 		} catch (error: unknown) {
-			if (request.isCurrent()) {
-				ctx.ui.notify(`Unable to implement the plan: ${safeErrorDetail(error)}`, "error");
-			}
+			notifyCurrent(
+				ctx,
+				request,
+				`Unable to implement the plan: ${safeErrorDetail(error)}`,
+				"error",
+			);
 			return false;
 		}
 		if (!model) {
-			ctx.ui.notify(
+			notifyCurrent(
+				ctx,
+				request,
 				`Unable to implement the plan: implementation model ${safeModelReference(requestedModel)} is no longer available. Choose another model and retry.`,
 				"warning",
 			);
@@ -219,21 +224,21 @@ async function preflightModel(ctx: ExtensionCommandContext, request: FreshImplem
 		}
 	}
 	if (!model) {
-		ctx.ui.notify("Unable to implement the plan: no model is selected.", "warning");
+		notifyCurrent(ctx, request, "Unable to implement the plan: no model is selected.", "warning");
 		return false;
 	}
 	let auth: Awaited<ReturnType<ExtensionCommandContext["modelRegistry"]["getApiKeyAndHeaders"]>>;
 	try {
 		auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	} catch (error: unknown) {
-		if (request.isCurrent()) {
-			ctx.ui.notify(`Unable to implement the plan: ${safeErrorDetail(error)}`, "error");
-		}
+		notifyCurrent(ctx, request, `Unable to implement the plan: ${safeErrorDetail(error)}`, "error");
 		return false;
 	}
 	if (!request.isCurrent()) return false;
 	if (!auth.ok) {
-		ctx.ui.notify(
+		notifyCurrent(
+			ctx,
+			request,
 			requestedModel
 				? `Unable to implement the plan with ${safeModelReference(model)}: ${safeErrorDetail(auth.error)}. Choose another model or configure authentication, then retry.`
 				: `Unable to implement the plan: ${safeErrorDetail(auth.error)}`,
@@ -242,6 +247,15 @@ async function preflightModel(ctx: ExtensionCommandContext, request: FreshImplem
 		return false;
 	}
 	return true;
+}
+
+function notifyCurrent(
+	ctx: Pick<ExtensionContext, "ui">,
+	request: FreshImplementationRequest,
+	message: string,
+	level: "info" | "warning" | "error",
+) {
+	if (request.isCurrent()) safeNotify(ctx, message, level);
 }
 
 function pendingRuntimeIntent(

--- a/packages/pi-plan-mode/src/plan-action-controller.ts
+++ b/packages/pi-plan-mode/src/plan-action-controller.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { PlanExportDestination } from "./plan-export.js";
+import type { PlanModeFixedThinkingLevel } from "./settings.js";
 import type { ImplementationRuntimeSelection, PlanModeState } from "./state.js";
 
 type InteractiveUi = typeof import("./interactive-ui.js");
@@ -14,6 +15,7 @@ interface PlanActionControllerOptions {
 	getState(): PlanModeState;
 	captureLifecycle(): MenuLifecycle;
 	statusText(): string;
+	getThinkingLevel(): PlanModeFixedThinkingLevel | undefined;
 	implementationOutcome(): string;
 	getExportDestination(ctx: ExtensionContext): PlanExportDestination;
 	show(ctx: ExtensionContext): void;
@@ -76,6 +78,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			await ui.showPlanModeMenu(ctx, {
 				statusText: options.statusText(),
+				planThinkingLevel: options.getThinkingLevel(),
 				hasReadyPlan: options.getState().latestPlan !== undefined,
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
@@ -97,6 +100,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 			if (!lifecycle.isCurrent() || lifecycle.signal.aborted) return;
 			await ui.showReadyPlanMenu(ctx, {
 				...lifecycle,
+				planThinkingLevel: options.getThinkingLevel(),
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
 				implementHere: () => options.implementHere(ctx),

--- a/packages/pi-plan-mode/src/plan-action-controller.ts
+++ b/packages/pi-plan-mode/src/plan-action-controller.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { PlanExportDestination } from "./plan-export.js";
-import type { PlanModeState } from "./state.js";
+import type { ImplementationRuntimeSelection, PlanModeState } from "./state.js";
 
 type InteractiveUi = typeof import("./interactive-ui.js");
 
@@ -19,7 +19,11 @@ interface PlanActionControllerOptions {
 	show(ctx: ExtensionContext): void;
 	finalize(ctx: ExtensionContext): void;
 	implementHere(ctx: ExtensionContext): void | Promise<void>;
-	implementFresh(ctx: ExtensionContext, isCurrent: () => boolean): void | Promise<void>;
+	implementFresh(
+		ctx: ExtensionContext,
+		isCurrent: () => boolean,
+		runtime?: ImplementationRuntimeSelection,
+	): void | Promise<void>;
 	exportPlan(
 		ctx: ExtensionContext,
 		path: string,
@@ -34,8 +38,12 @@ interface PlanActionControllerOptions {
 }
 
 export function createPlanActionController(options: PlanActionControllerOptions) {
-	const freshAction = (ctx: ExtensionContext, lifecycle: MenuLifecycle, signal: AbortSignal) =>
-		options.implementFresh(ctx, () => lifecycle.isCurrent() && !signal.aborted);
+	const freshAction = (
+		ctx: ExtensionContext,
+		lifecycle: MenuLifecycle,
+		signal: AbortSignal,
+		runtime?: ImplementationRuntimeSelection,
+	) => options.implementFresh(ctx, () => lifecycle.isCurrent() && !signal.aborted, runtime);
 
 	return {
 		async showSaved(ctx: ExtensionContext) {
@@ -75,7 +83,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				show: () => options.show(ctx),
 				finalize: () => options.finalize(ctx),
 				implementHere: () => options.implementHere(ctx),
-				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
+				implementFresh: (runtime, signal) => freshAction(ctx, lifecycle, signal, runtime),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),
 				stay: () => options.stay(ctx),
@@ -92,7 +100,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
 				implementHere: () => options.implementHere(ctx),
-				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
+				implementFresh: (runtime, signal) => freshAction(ctx, lifecycle, signal, runtime),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),
 				stay: () => undefined,

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -275,6 +275,9 @@ function createFreshImplementationFlow(
 ) {
 	const models = snapshotAvailableModels(ctx);
 	const planModel = ctx.model ? { provider: ctx.model.provider, modelId: ctx.model.id } : undefined;
+	const planModelSummary = ctx.model
+		? `${safeModelMetadata(ctx.model.id, "unknown model")} [${safeModelMetadata(ctx.model.provider, "unknown provider")}]`
+		: undefined;
 	const planThinkingLevel = FIXED_THINKING_LEVELS.find((level) => level === ctx.thinkingLevel);
 	let selectedModel: ModelChoice | undefined;
 	let selectedThinkingLevel: PlanModeFixedThinkingLevel | undefined;
@@ -294,13 +297,17 @@ function createFreshImplementationFlow(
 				{
 					id: "implementation-model",
 					label: "Model",
-					description: selectedModel?.summary ?? "Same as plan",
+					description:
+						selectedModel?.summary ??
+						(planModelSummary ? `${planModelSummary} · same as plan` : "Same as plan"),
 					to: "models" as const,
 				},
 				{
 					id: "implementation-thinking",
 					label: "Thinking level",
-					description: selectedThinkingLevel ?? "Same as plan",
+					description:
+						selectedThinkingLevel ??
+						(planThinkingLevel ? `${planThinkingLevel} · same as plan` : "Same as plan"),
 					to: "thinking" as const,
 				},
 			],

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -1,6 +1,8 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { defineMenu, runMenu } from "@narumitw/pi-tui-kit";
+import { defineMenu, runMenu, sanitizeTerminalText } from "@narumitw/pi-tui-kit";
 import { type PlanExportDestinationProvider, planExportInputScreen } from "./plan-export-screen.js";
+import type { PlanModeFixedThinkingLevel } from "./settings.js";
+import type { ImplementationModelOverride, ImplementationRuntimeSelection } from "./state.js";
 
 interface MenuLifecycle {
 	signal: AbortSignal;
@@ -12,6 +14,16 @@ const IMPLEMENTATION_CONTEXT_LINES = [
 	"Start fresh transfers only the approved plan to a new session.",
 ] as const;
 
+const FIXED_THINKING_LEVELS: readonly PlanModeFixedThinkingLevel[] = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+];
+
 interface PlanMenuOptions extends MenuLifecycle {
 	statusText: string;
 	hasReadyPlan: boolean;
@@ -20,7 +32,10 @@ interface PlanMenuOptions extends MenuLifecycle {
 	show(): void;
 	finalize(): void;
 	implementHere(): void | Promise<void>;
-	implementFresh(signal: AbortSignal): void | Promise<void>;
+	implementFresh(
+		runtime: ImplementationRuntimeSelection,
+		signal: AbortSignal,
+	): void | Promise<void>;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
 	stay(): void;
@@ -28,16 +43,19 @@ interface PlanMenuOptions extends MenuLifecycle {
 }
 
 export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuOptions) {
-	type Screen = "main" | "export";
+	type Screen = "main" | "fresh" | "models" | "thinking" | "export";
 	type Action =
 		| "show"
 		| "finalize"
 		| "implement-here"
-		| "implement-fresh"
+		| "select-model"
+		| "select-thinking"
+		| "start-fresh"
 		| "export"
 		| "save"
 		| "stay"
 		| "exit";
+	const freshFlow = createFreshImplementationFlow(ctx, options.implementFresh);
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "main",
 		screens: {
@@ -62,9 +80,8 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 							{
 								id: "implement-fresh",
 								label: "Start fresh and implement",
-								description: "Open a new linked session; transfer only the approved plan.",
-								action: "implement-fresh",
-								busyLabel: "Starting fresh implementation session…",
+								description: "Configure one-shot model and thinking choices first.",
+								to: "fresh",
 							},
 							{ id: "export", label: "Export plan…", to: "export" },
 							{ id: "save", label: "Save for later", action: "save" },
@@ -78,6 +95,9 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 						],
 				hint: "close",
 			}),
+			fresh: freshFlow.settingsScreen,
+			models: freshFlow.modelScreen,
+			thinking: freshFlow.thinkingScreen,
 			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
@@ -93,8 +113,16 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 				await options.implementHere();
 				return { kind: "close" };
 			},
-			"implement-fresh": async ({ signal }) => {
-				await options.implementFresh(signal);
+			"select-model": async ({ itemId }) => {
+				freshFlow.selectModel(itemId);
+				return { kind: "back" };
+			},
+			"select-thinking": async ({ itemId }) => {
+				freshFlow.selectThinking(itemId);
+				return { kind: "back" };
+			},
+			"start-fresh": async ({ signal }) => {
+				await freshFlow.start(signal);
 				return { kind: "close" };
 			},
 			export: async ({ value, signal }) =>
@@ -124,7 +152,10 @@ interface ReadyPlanMenuOptions extends MenuLifecycle {
 	implementationOutcome(): string;
 	getExportDestination: PlanExportDestinationProvider;
 	implementHere(): void | Promise<void>;
-	implementFresh(signal: AbortSignal): void | Promise<void>;
+	implementFresh(
+		runtime: ImplementationRuntimeSelection,
+		signal: AbortSignal,
+	): void | Promise<void>;
 	exportPlan(path: string, signal: AbortSignal): Promise<boolean>;
 	save(): void;
 	stay(): void;
@@ -132,8 +163,17 @@ interface ReadyPlanMenuOptions extends MenuLifecycle {
 }
 
 export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPlanMenuOptions) {
-	type Screen = "ready" | "export";
-	type Action = "implement-here" | "implement-fresh" | "export" | "save" | "stay" | "exit";
+	type Screen = "ready" | "fresh" | "models" | "thinking" | "export";
+	type Action =
+		| "implement-here"
+		| "select-model"
+		| "select-thinking"
+		| "start-fresh"
+		| "export"
+		| "save"
+		| "stay"
+		| "exit";
+	const freshFlow = createFreshImplementationFlow(ctx, options.implementFresh);
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "ready",
 		screens: {
@@ -151,9 +191,8 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 					{
 						id: "implement-fresh",
 						label: "Start fresh and implement",
-						description: "Open a new linked session; transfer only the approved plan.",
-						action: "implement-fresh",
-						busyLabel: "Starting fresh implementation session…",
+						description: "Configure one-shot model and thinking choices first.",
+						to: "fresh",
 					},
 					{ id: "export", label: "Export plan…", to: "export" },
 					{ id: "save", label: "Save for later", action: "save" },
@@ -162,6 +201,9 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 				],
 				hint: "close",
 			}),
+			fresh: freshFlow.settingsScreen,
+			models: freshFlow.modelScreen,
+			thinking: freshFlow.thinkingScreen,
 			export: () => planExportInputScreen(options.getExportDestination),
 		},
 		actions: {
@@ -169,8 +211,16 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 				await options.implementHere();
 				return { kind: "close" };
 			},
-			"implement-fresh": async ({ signal }) => {
-				await options.implementFresh(signal);
+			"select-model": async ({ itemId }) => {
+				freshFlow.selectModel(itemId);
+				return { kind: "back" };
+			},
+			"select-thinking": async ({ itemId }) => {
+				freshFlow.selectThinking(itemId);
+				return { kind: "back" };
+			},
+			"start-fresh": async ({ signal }) => {
+				await freshFlow.start(signal);
 				return { kind: "close" };
 			},
 			export: async ({ value, signal }) =>
@@ -194,4 +244,128 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 		signal: options.signal,
 		isCurrent: options.isCurrent,
 	});
+}
+
+interface ModelChoice {
+	itemId: string;
+	model: ImplementationModelOverride;
+	label: string;
+	description?: string;
+	searchText: string;
+}
+
+function createFreshImplementationFlow(
+	ctx: ExtensionContext,
+	implementFresh: (
+		runtime: ImplementationRuntimeSelection,
+		signal: AbortSignal,
+	) => void | Promise<void>,
+) {
+	const models = snapshotAvailableModels(ctx);
+	let selectedModel: ModelChoice | undefined;
+	let selectedThinkingLevel: PlanModeFixedThinkingLevel | undefined;
+	return {
+		settingsScreen: () => ({
+			kind: "actions" as const,
+			title: "Fresh implementation settings",
+			lines: ["These choices apply once to the new implementation session."],
+			items: [
+				{
+					id: "implementation-model",
+					label: `Implementation model: ${selectedModel?.label ?? "Destination default"}`,
+					to: "models" as const,
+				},
+				{
+					id: "implementation-thinking",
+					label: `Implementation thinking: ${selectedThinkingLevel ?? "Destination default"}`,
+					to: "thinking" as const,
+				},
+				{
+					id: "start-fresh",
+					label: "Start fresh implementation",
+					description: "Create the linked session and begin implementation.",
+					action: "start-fresh" as const,
+					busyLabel: "Starting fresh implementation session…",
+				},
+			],
+		}),
+		modelScreen: () => ({
+			kind: "choice" as const,
+			title: "Implementation model",
+			lines: ["Choose a one-shot model override for the destination session."],
+			items: [
+				{
+					id: "destination-default",
+					label: "Destination default",
+					description: "Use Pi's normal model selection for the new session.",
+				},
+				...models.map((choice) => ({
+					id: choice.itemId,
+					label: choice.label,
+					description: choice.description,
+					searchText: choice.searchText,
+				})),
+			],
+			action: "select-model" as const,
+			currentItemId: selectedModel?.itemId ?? "destination-default",
+			initialItemId: selectedModel?.itemId ?? "destination-default",
+			enableSearch: true,
+			viewportSize: 10,
+		}),
+		thinkingScreen: () => ({
+			kind: "choice" as const,
+			title: "Implementation thinking",
+			lines: ["Choose a one-shot thinking override for the destination session."],
+			items: [
+				{
+					id: "destination-default",
+					label: "Destination default",
+					description: "Use the destination model's normal thinking level.",
+				},
+				...FIXED_THINKING_LEVELS.map((level) => ({ id: level, label: level })),
+			],
+			action: "select-thinking" as const,
+			currentItemId: selectedThinkingLevel ?? "destination-default",
+			initialItemId: selectedThinkingLevel ?? "destination-default",
+			viewportSize: FIXED_THINKING_LEVELS.length + 1,
+		}),
+		selectModel(itemId: string) {
+			selectedModel = models.find((choice) => choice.itemId === itemId);
+		},
+		selectThinking(itemId: string) {
+			selectedThinkingLevel = FIXED_THINKING_LEVELS.find((level) => level === itemId);
+		},
+		start(signal: AbortSignal) {
+			return implementFresh(
+				{
+					...(selectedModel ? { model: { ...selectedModel.model } } : {}),
+					...(selectedThinkingLevel ? { thinkingLevel: selectedThinkingLevel } : {}),
+				},
+				signal,
+			);
+		},
+	};
+}
+
+function snapshotAvailableModels(ctx: ExtensionContext): ModelChoice[] {
+	const getAvailable = ctx.modelRegistry.getAvailable;
+	const available = typeof getAvailable === "function" ? getAvailable.call(ctx.modelRegistry) : [];
+	return available.map((model, index) => {
+		const provider = safeModelMetadata(model.provider, "unknown provider");
+		const modelId = safeModelMetadata(model.id, "unknown model");
+		const name = safeModelMetadata(model.name, "");
+		return {
+			itemId: `model-${index}`,
+			model: { provider: model.provider, modelId: model.id },
+			label: `${provider}/${modelId}${name ? ` — ${name}` : ""}`,
+			...(name ? { description: name } : {}),
+			searchText: [provider, modelId, name].filter(Boolean).join(" "),
+		};
+	});
+}
+
+function safeModelMetadata(value: unknown, fallback: string) {
+	if (typeof value !== "string") return fallback;
+	const safe = sanitizeTerminalText(value).trim() || fallback;
+	return [...safe].slice(0, 512).join("");
 }

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -24,6 +24,16 @@ const FIXED_THINKING_LEVELS: readonly PlanModeFixedThinkingLevel[] = [
 	"max",
 ];
 
+const THINKING_LEVEL_DESCRIPTIONS: Record<PlanModeFixedThinkingLevel, string> = {
+	off: "No reasoning",
+	minimal: "Very brief reasoning (~1k tokens)",
+	low: "Light reasoning (~2k tokens)",
+	medium: "Moderate reasoning (~8k tokens)",
+	high: "Deep reasoning (~16k tokens)",
+	xhigh: "Extra-high reasoning (~32k tokens)",
+	max: "Maximum reasoning",
+};
+
 interface PlanMenuOptions extends MenuLifecycle {
 	statusText: string;
 	hasReadyPlan: boolean;
@@ -250,8 +260,10 @@ interface ModelChoice {
 	itemId: string;
 	model: ImplementationModelOverride;
 	label: string;
-	description?: string;
+	summary: string;
+	details?: readonly string[];
 	searchText: string;
+	isPlanModel: boolean;
 }
 
 function createFreshImplementationFlow(
@@ -262,6 +274,8 @@ function createFreshImplementationFlow(
 	) => void | Promise<void>,
 ) {
 	const models = snapshotAvailableModels(ctx);
+	const planModel = ctx.model ? { provider: ctx.model.provider, modelId: ctx.model.id } : undefined;
+	const planThinkingLevel = FIXED_THINKING_LEVELS.find((level) => level === ctx.thinkingLevel);
 	let selectedModel: ModelChoice | undefined;
 	let selectedThinkingLevel: PlanModeFixedThinkingLevel | undefined;
 	return {
@@ -271,75 +285,72 @@ function createFreshImplementationFlow(
 			lines: ["These choices apply once to the new implementation session."],
 			items: [
 				{
-					id: "implementation-model",
-					label: `Implementation model: ${selectedModel?.label ?? "Destination default"}`,
-					to: "models" as const,
-				},
-				{
-					id: "implementation-thinking",
-					label: `Implementation thinking: ${selectedThinkingLevel ?? "Destination default"}`,
-					to: "thinking" as const,
-				},
-				{
 					id: "start-fresh",
 					label: "Start fresh implementation",
 					description: "Create the linked session and begin implementation.",
 					action: "start-fresh" as const,
 					busyLabel: "Starting fresh implementation session…",
 				},
+				{
+					id: "implementation-model",
+					label: "Model",
+					description: selectedModel?.summary ?? "Same as plan",
+					to: "models" as const,
+				},
+				{
+					id: "implementation-thinking",
+					label: "Thinking level",
+					description: selectedThinkingLevel ?? "Same as plan",
+					to: "thinking" as const,
+				},
 			],
 		}),
 		modelScreen: () => ({
 			kind: "choice" as const,
 			title: "Implementation model",
-			lines: ["Choose a one-shot model override for the destination session."],
-			items: [
-				{
-					id: "destination-default",
-					label: "Destination default",
-					description: "Use Pi's normal model selection for the new session.",
-				},
-				...models.map((choice) => ({
-					id: choice.itemId,
-					label: choice.label,
-					description: choice.description,
-					searchText: choice.searchText,
-				})),
-			],
+			items: models.map((choice) => ({
+				id: choice.itemId,
+				label: choice.label,
+				details: choice.details,
+				searchText: choice.searchText,
+			})),
 			action: "select-model" as const,
-			currentItemId: selectedModel?.itemId ?? "destination-default",
-			initialItemId: selectedModel?.itemId ?? "destination-default",
+			initialItemId: selectedModel?.itemId ?? models.find((choice) => choice.isPlanModel)?.itemId,
 			enableSearch: true,
 			viewportSize: 10,
 		}),
 		thinkingScreen: () => ({
 			kind: "choice" as const,
-			title: "Implementation thinking",
-			lines: ["Choose a one-shot thinking override for the destination session."],
+			title: "Implementation thinking level",
 			items: [
 				{
-					id: "destination-default",
-					label: "Destination default",
-					description: "Use the destination model's normal thinking level.",
+					id: "same-as-plan",
+					label: "Same as plan",
 				},
-				...FIXED_THINKING_LEVELS.map((level) => ({ id: level, label: level })),
+				...FIXED_THINKING_LEVELS.map((level) => ({
+					id: level,
+					label: `${level === planThinkingLevel ? "✓ " : ""}${level}`,
+					description: THINKING_LEVEL_DESCRIPTIONS[level],
+				})),
 			],
 			action: "select-thinking" as const,
-			currentItemId: selectedThinkingLevel ?? "destination-default",
-			initialItemId: selectedThinkingLevel ?? "destination-default",
+			initialItemId: selectedThinkingLevel ?? "same-as-plan",
 			viewportSize: FIXED_THINKING_LEVELS.length + 1,
 		}),
 		selectModel(itemId: string) {
-			selectedModel = models.find((choice) => choice.itemId === itemId);
+			const choice = models.find((candidate) => candidate.itemId === itemId);
+			selectedModel = choice?.isPlanModel ? undefined : choice;
 		},
 		selectThinking(itemId: string) {
 			selectedThinkingLevel = FIXED_THINKING_LEVELS.find((level) => level === itemId);
 		},
 		start(signal: AbortSignal) {
+			const model = selectedModel?.model ?? planModel;
+			const thinkingLevel = selectedThinkingLevel ?? planThinkingLevel;
 			return implementFresh(
 				{
-					...(selectedModel ? { model: { ...selectedModel.model } } : {}),
-					...(selectedThinkingLevel ? { thinkingLevel: selectedThinkingLevel } : {}),
+					...(model ? { model: { ...model } } : {}),
+					...(thinkingLevel ? { thinkingLevel } : {}),
 				},
 				signal,
 			);
@@ -349,24 +360,31 @@ function createFreshImplementationFlow(
 
 function snapshotAvailableModels(ctx: ExtensionContext): ModelChoice[] {
 	const getAvailable = ctx.modelRegistry.getAvailable;
+	const scopedModels = ctx.scopedModels ?? [];
 	const models =
-		ctx.scopedModels.length > 0
-			? ctx.scopedModels.map((entry) => entry.model)
+		scopedModels.length > 0
+			? scopedModels.map((entry) => entry.model)
 			: typeof getAvailable === "function"
 				? getAvailable.call(ctx.modelRegistry)
 				: [];
-	return models.map((model, index) => {
-		const provider = safeModelMetadata(model.provider, "unknown provider");
-		const modelId = safeModelMetadata(model.id, "unknown model");
-		const name = safeModelMetadata(model.name, "");
-		return {
-			itemId: `model-${index}`,
-			model: { provider: model.provider, modelId: model.id },
-			label: `${provider}/${modelId}${name ? ` — ${name}` : ""}`,
-			...(name ? { description: name } : {}),
-			searchText: [provider, modelId, name].filter(Boolean).join(" "),
-		};
-	});
+	return models
+		.map((model, index) => {
+			const provider = safeModelMetadata(model.provider, "unknown provider");
+			const modelId = safeModelMetadata(model.id, "unknown model");
+			const name = safeModelMetadata(model.name, "");
+			const isPlanModel = ctx.model?.provider === model.provider && ctx.model.id === model.id;
+			const summary = `${modelId} [${provider}]`;
+			return {
+				itemId: `model-${index}`,
+				model: { provider: model.provider, modelId: model.id },
+				label: `${isPlanModel ? "✓ " : ""}${summary}${isPlanModel ? " · default" : ""}`,
+				summary,
+				...(name ? { details: [`Model Name: ${name}`] } : {}),
+				searchText: [provider, modelId, name].filter(Boolean).join(" "),
+				isPlanModel,
+			};
+		})
+		.sort((left, right) => Number(right.isPlanModel) - Number(left.isPlanModel));
 }
 
 function safeModelMetadata(value: unknown, fallback: string) {

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -349,8 +349,13 @@ function createFreshImplementationFlow(
 
 function snapshotAvailableModels(ctx: ExtensionContext): ModelChoice[] {
 	const getAvailable = ctx.modelRegistry.getAvailable;
-	const available = typeof getAvailable === "function" ? getAvailable.call(ctx.modelRegistry) : [];
-	return available.map((model, index) => {
+	const models =
+		ctx.scopedModels.length > 0
+			? ctx.scopedModels.map((entry) => entry.model)
+			: typeof getAvailable === "function"
+				? getAvailable.call(ctx.modelRegistry)
+				: [];
+	return models.map((model, index) => {
 		const provider = safeModelMetadata(model.provider, "unknown provider");
 		const modelId = safeModelMetadata(model.id, "unknown model");
 		const name = safeModelMetadata(model.name, "");

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -36,6 +36,7 @@ const THINKING_LEVEL_DESCRIPTIONS: Record<PlanModeFixedThinkingLevel, string> = 
 
 interface PlanMenuOptions extends MenuLifecycle {
 	statusText: string;
+	planThinkingLevel: PlanModeFixedThinkingLevel | undefined;
 	hasReadyPlan: boolean;
 	implementationOutcome(): string;
 	getExportDestination: PlanExportDestinationProvider;
@@ -65,7 +66,11 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 		| "save"
 		| "stay"
 		| "exit";
-	const freshFlow = createFreshImplementationFlow(ctx, options.implementFresh);
+	const freshFlow = createFreshImplementationFlow(
+		ctx,
+		options.planThinkingLevel,
+		options.implementFresh,
+	);
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "main",
 		screens: {
@@ -159,6 +164,7 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 }
 
 interface ReadyPlanMenuOptions extends MenuLifecycle {
+	planThinkingLevel: PlanModeFixedThinkingLevel | undefined;
 	implementationOutcome(): string;
 	getExportDestination: PlanExportDestinationProvider;
 	implementHere(): void | Promise<void>;
@@ -183,7 +189,11 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 		| "save"
 		| "stay"
 		| "exit";
-	const freshFlow = createFreshImplementationFlow(ctx, options.implementFresh);
+	const freshFlow = createFreshImplementationFlow(
+		ctx,
+		options.planThinkingLevel,
+		options.implementFresh,
+	);
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
 		start: "ready",
 		screens: {
@@ -268,6 +278,7 @@ interface ModelChoice {
 
 function createFreshImplementationFlow(
 	ctx: ExtensionContext,
+	planThinkingLevel: PlanModeFixedThinkingLevel | undefined,
 	implementFresh: (
 		runtime: ImplementationRuntimeSelection,
 		signal: AbortSignal,
@@ -278,7 +289,6 @@ function createFreshImplementationFlow(
 	const planModelSummary = ctx.model
 		? `${safeModelMetadata(ctx.model.id, "unknown model")} [${safeModelMetadata(ctx.model.provider, "unknown provider")}]`
 		: undefined;
-	const planThinkingLevel = FIXED_THINKING_LEVELS.find((level) => level === ctx.thinkingLevel);
 	let selectedModel: ModelChoice | undefined;
 	let selectedThinkingLevel: PlanModeFixedThinkingLevel | undefined;
 	return {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -190,6 +190,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		getState: () => state,
 		captureLifecycle: captureMenuLifecycle,
 		statusText: planStatusText,
+		// ExtensionContext.thinkingLevel was added after the supported Pi 0.80.6 floor.
+		// ExtensionAPI has exposed the same runtime value throughout that compatibility range.
+		getThinkingLevel: () => pi.getThinkingLevel(),
 		implementationOutcome,
 		getExportDestination: (ctx) => planExports.getDestination(ctx),
 		show: (ctx) => showStoredPlan(pi, ctx, state),
@@ -1585,23 +1588,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			.then(async (): Promise<ImplementationRuntimeApplicationResult> => {
 				if (!isCurrent()) return "stale";
 				const pendingState = state;
-				state = { ...state, pendingImplementationRuntime: undefined };
-				try {
-					persistState();
-				} catch (error: unknown) {
-					state = pendingState;
-					try {
-						persistState();
-					} catch {
-						// SessionManager mutates its in-memory branch before a disk append can fail.
-						// A best-effort rollback entry keeps that branch aligned with durable pending state.
-					}
-					notifyCurrent(
-						`Unable to apply fresh implementation settings because their one-shot state could not be consumed: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The implementation request was not sent; retry after session persistence is available.`,
-					);
-					return "blocked";
-				}
-				if (!isCurrent()) return "stale";
+				const previousThinkingLevel = pi.getThinkingLevel();
 
 				const applyThinking = () => {
 					if (!intent.thinkingLevel) return;
@@ -1681,7 +1668,32 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				}
 				if (!isCurrent()) return "stale";
 				applyThinking();
-				return isCurrent() ? "ready" : "stale";
+				if (!isCurrent()) return "stale";
+
+				state = { ...state, pendingImplementationRuntime: undefined };
+				try {
+					persistState();
+				} catch (error: unknown) {
+					state = pendingState;
+					try {
+						if (pi.getThinkingLevel() !== previousThinkingLevel) {
+							pi.setThinkingLevel(previousThinkingLevel);
+						}
+					} catch {
+						// Keep the durable intent pending even if a runtime rollback is unavailable.
+					}
+					try {
+						persistState();
+					} catch {
+						// SessionManager mutates its in-memory branch before a disk append can fail.
+						// A best-effort rollback entry keeps that branch aligned with durable pending state.
+					}
+					notifyCurrent(
+						`Unable to apply fresh implementation settings because their one-shot state could not be consumed: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The implementation request was not sent; retry after session persistence is available.`,
+					);
+					return "blocked";
+				}
+				return "ready";
 			})
 			.finally(() => {
 				if (activeImplementationRuntimeApplication === application) {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -103,6 +103,7 @@ import { WorkflowMutex, type WorkflowMutexOwner } from "./workflow-mutex.js";
 
 const STATE_ENTRY_TYPE = "plan-mode-state";
 const PROPOSED_PLAN_MESSAGE_TYPE = "proposed-plan";
+const RECOVERED_RUNTIME_ADMISSION_INPUT_MESSAGE_TYPE = "plan-mode-recovered-input";
 const BLOCKED_MUTATING_TOOLS = new Set(["edit", "write", "update_plan"]);
 const DEFAULT_TOOLS = ["read", "bash", "edit", "write"];
 interface ReadyPresentationIntent {
@@ -122,6 +123,7 @@ interface ActiveImplementationRuntimeApplication {
 	holdForAdmission: boolean;
 }
 interface QueuedRuntimeAdmissionInput {
+	sessionManager: ExtensionContext["sessionManager"];
 	text: string;
 	images?: NonNullable<InputEvent["images"]>;
 	source: InputSource;
@@ -498,6 +500,15 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("session_before_tree", (event, ctx) => {
+		if (hasQueuedRuntimeAdmissionInputs(ctx.sessionManager)) {
+			if (ctx.hasUI) {
+				ctx.ui.notify(
+					"Wait for fresh implementation startup to admit the queued prompts before changing branches.",
+					"warning",
+				);
+			}
+			return { cancel: true };
+		}
 		const target = ctx.sessionManager.getEntry(event.preparation.targetId);
 		if (target?.type !== "custom_message" || target.customType !== MODE_CONTRACT_MESSAGE_TYPE) {
 			return;
@@ -551,6 +562,18 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			activeImplementationRuntimeApplication.drainOnShutdown
 				? activeImplementationRuntimeApplication
 				: undefined;
+		const queuedInputs = takeQueuedRuntimeAdmissionInputs(shutdownSession);
+		for (const queued of queuedInputs) {
+			pi.sendMessage(
+				{
+					customType: RECOVERED_RUNTIME_ADMISSION_INPUT_MESSAGE_TYPE,
+					content: runtimeAdmissionInputContent(queued),
+					display: true,
+					details: { source: queued.source },
+				},
+				{ triggerTurn: false },
+			);
+		}
 		finalizationRequest.reset();
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode session shut down", "AbortError"));
@@ -702,16 +725,21 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		const waitsForRuntimeAdmission =
 			activeImplementationRuntimeApplication?.sessionManager === ctx.sessionManager ||
 			pendingRuntimeAdmissionSession === ctx.sessionManager;
+		const queuedInput = waitsForRuntimeAdmission
+			? {
+					sessionManager: ctx.sessionManager,
+					text: event.text,
+					...(event.images ? { images: [...event.images] } : {}),
+					source: event.source,
+				}
+			: undefined;
+		if (queuedInput) queuedRuntimeAdmissionInputs.push(queuedInput);
 		const result = await applyPendingImplementationRuntime(ctx, true);
-		if (result !== "ready") return { action: "handled" };
-		if (waitsForRuntimeAdmission) {
-			queuedRuntimeAdmissionInputs.push({
-				text: event.text,
-				...(event.images ? { images: [...event.images] } : {}),
-				source: event.source,
-			});
+		if (result !== "ready") {
+			if (queuedInput) removeQueuedRuntimeAdmissionInput(queuedInput);
 			return { action: "handled" };
 		}
+		if (queuedInput) return { action: "handled" };
 	});
 
 	pi.on("agent_start", (_event, ctx) => {
@@ -719,14 +747,9 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (pendingRuntimeAdmissionSession === ctx.sessionManager) {
 			pendingRuntimeAdmissionSession = undefined;
 		}
-		if (queuedRuntimeAdmissionInputs.length === 0) return;
-		const queuedInputs = queuedRuntimeAdmissionInputs;
-		queuedRuntimeAdmissionInputs = [];
+		const queuedInputs = takeQueuedRuntimeAdmissionInputs(ctx.sessionManager);
 		for (const queued of queuedInputs) {
-			const content = queued.images?.length
-				? [{ type: "text" as const, text: queued.text }, ...queued.images]
-				: queued.text;
-			pi.sendUserMessage(content, {
+			pi.sendUserMessage(runtimeAdmissionInputContent(queued), {
 				deliverAs: "followUp",
 				expandPromptTemplates: queued.source !== "extension",
 			});
@@ -1560,6 +1583,32 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		} catch {
 			return [];
 		}
+	}
+
+	function hasQueuedRuntimeAdmissionInputs(sessionManager: ExtensionContext["sessionManager"]) {
+		return queuedRuntimeAdmissionInputs.some((queued) => queued.sessionManager === sessionManager);
+	}
+
+	function takeQueuedRuntimeAdmissionInputs(sessionManager: ExtensionContext["sessionManager"]) {
+		const matching: QueuedRuntimeAdmissionInput[] = [];
+		const remaining: QueuedRuntimeAdmissionInput[] = [];
+		for (const queued of queuedRuntimeAdmissionInputs) {
+			if (queued.sessionManager === sessionManager) matching.push(queued);
+			else remaining.push(queued);
+		}
+		queuedRuntimeAdmissionInputs = remaining;
+		return matching;
+	}
+
+	function removeQueuedRuntimeAdmissionInput(queuedInput: QueuedRuntimeAdmissionInput) {
+		const index = queuedRuntimeAdmissionInputs.indexOf(queuedInput);
+		if (index >= 0) queuedRuntimeAdmissionInputs.splice(index, 1);
+	}
+
+	function runtimeAdmissionInputContent(queued: QueuedRuntimeAdmissionInput) {
+		return queued.images?.length
+			? [{ type: "text" as const, text: queued.text }, ...queued.images]
+			: queued.text;
 	}
 
 	function refreshStateForFirstPrompt(ctx: ExtensionContext) {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -476,6 +476,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!installRestoredState(restoredState, ctx)) return;
 		implementationRetention.restore(state.activeImplementation);
 		updateUi(ctx);
+		// A new session receives its setup entries after session_start, so its input gate refreshes
+		// them. Resumed and forked sessions already have the intent and must apply it here because
+		// extension-triggered custom-message turns bypass both input and before_agent_start.
+		if (event.reason !== "new") await applyPendingImplementationRuntime(ctx);
 	});
 
 	pi.on("session_before_tree", (event, ctx) => {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -6,6 +6,8 @@ import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
 	ExtensionContext,
+	InputEvent,
+	InputSource,
 } from "@earendil-works/pi-coding-agent";
 import { completePlanArguments } from "./command.js";
 import {
@@ -118,6 +120,11 @@ interface ActiveImplementationRuntimeApplication {
 	completion: Promise<ImplementationRuntimeApplicationResult>;
 	drainOnShutdown: boolean;
 }
+interface QueuedRuntimeAdmissionInput {
+	text: string;
+	images?: NonNullable<InputEvent["images"]>;
+	source: InputSource;
+}
 type InteractiveUi = typeof import("./interactive-ui.js");
 
 interface PlanModeDependencies {
@@ -164,6 +171,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let workflowGeneration = 0;
 	let refreshStateBeforeFirstAgentStart = false;
 	let activeImplementationRuntimeApplication: ActiveImplementationRuntimeApplication | undefined;
+	let queuedRuntimeAdmissionInputs: QueuedRuntimeAdmissionInput[] = [];
 	let menuController = new AbortController();
 	let settingsWatch: ReturnType<typeof watch> | undefined;
 	let settingsReloadTimer: ReturnType<typeof setTimeout> | undefined;
@@ -458,6 +466,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		workflowOwner = undefined;
 		workflowMutex.bindSession(ctx.sessionManager);
 		refreshStateBeforeFirstAgentStart = event.reason === "new";
+		queuedRuntimeAdmissionInputs = [];
 		menuController.abort(new DOMException("Plan-mode session replaced", "AbortError"));
 		menuController = new AbortController();
 		readyPresentationIntent = undefined;
@@ -503,6 +512,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		menuController = new AbortController();
 		readyPresentationIntent = undefined;
 		latestCommandContext = undefined;
+		queuedRuntimeAdmissionInputs = [];
 		implementationRetention.reset();
 		const branch = ctx.sessionManager.getBranch();
 		const restoredState = restorePlanModeState(branch, STATE_ENTRY_TYPE);
@@ -539,6 +549,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		readyPresentationIntent = undefined;
 		latestCommandContext = undefined;
 		refreshStateBeforeFirstAgentStart = false;
+		queuedRuntimeAdmissionInputs = [];
 		workflowAllowedToolNames = undefined;
 		pendingWorkflowToolPolicy = undefined;
 		implementationRetention.reset();
@@ -677,10 +688,35 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		return { messages: messages as typeof event.messages };
 	});
 
-	pi.on("input", async (_event, ctx) => {
+	pi.on("input", async (event, ctx) => {
 		refreshStateForFirstPrompt(ctx);
+		const waitsForRuntimeApplication =
+			activeImplementationRuntimeApplication?.sessionManager === ctx.sessionManager;
 		const result = await applyPendingImplementationRuntime(ctx);
 		if (result !== "ready") return { action: "handled" };
+		if (waitsForRuntimeApplication) {
+			queuedRuntimeAdmissionInputs.push({
+				text: event.text,
+				...(event.images ? { images: [...event.images] } : {}),
+				source: event.source,
+			});
+			return { action: "handled" };
+		}
+	});
+
+	pi.on("agent_start", (_event, ctx) => {
+		if (currentSession !== ctx.sessionManager || queuedRuntimeAdmissionInputs.length === 0) return;
+		const queuedInputs = queuedRuntimeAdmissionInputs;
+		queuedRuntimeAdmissionInputs = [];
+		for (const queued of queuedInputs) {
+			const content = queued.images?.length
+				? [{ type: "text" as const, text: queued.text }, ...queued.images]
+				: queued.text;
+			pi.sendUserMessage(content, {
+				deliverAs: "followUp",
+				expandPromptTemplates: queued.source !== "extension",
+			});
+		}
 	});
 
 	pi.on("before_agent_start", (_event, ctx) => {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { watch } from "node:fs";
 import { basename, dirname } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
@@ -82,6 +83,7 @@ import {
 	updatePlanModeSettings,
 } from "./settings.js";
 import {
+	type ImplementationRuntimeSelection,
 	type PlanCompletionSource,
 	type PlanModeState,
 	type PlanModeWorkflowToolPolicy,
@@ -109,6 +111,11 @@ interface ReadyPresentationIntent {
 interface PendingWorkflowToolPolicy {
 	generation: number;
 	mode: "resolve" | "revalidate";
+}
+interface ActiveImplementationRuntimeApplication {
+	sessionManager: ExtensionContext["sessionManager"];
+	completion: Promise<void>;
+	finish(): void;
 }
 type InteractiveUi = typeof import("./interactive-ui.js");
 
@@ -155,12 +162,32 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let menuGeneration = 0;
 	let workflowGeneration = 0;
 	let refreshStateBeforeFirstAgentStart = false;
+	let activeImplementationRuntimeApplication: ActiveImplementationRuntimeApplication | undefined;
 	let menuController = new AbortController();
 	let settingsWatch: ReturnType<typeof watch> | undefined;
 	let settingsReloadTimer: ReturnType<typeof setTimeout> | undefined;
 	const implementationRetention = createImplementationRetentionCoordinator();
 	const finalizationRequest = createFinalizationRequestCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
+	const beginImplementationRuntimeApplication = (
+		sessionManager: ExtensionContext["sessionManager"],
+	) => {
+		let resolveCompletion!: () => void;
+		const application: ActiveImplementationRuntimeApplication = {
+			sessionManager,
+			completion: new Promise<void>((resolve) => {
+				resolveCompletion = resolve;
+			}),
+			finish() {
+				if (activeImplementationRuntimeApplication === application) {
+					activeImplementationRuntimeApplication = undefined;
+				}
+				resolveCompletion();
+			},
+		};
+		activeImplementationRuntimeApplication = application;
+		return application.finish;
+	};
 	const planExports = createPlanExportController({
 		getState: () => state,
 		getSettings: () => settings,
@@ -515,6 +542,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		const shutdownSession = ctx.sessionManager;
+		const runtimeApplication =
+			activeImplementationRuntimeApplication?.sessionManager === shutdownSession
+				? activeImplementationRuntimeApplication
+				: undefined;
 		finalizationRequest.reset();
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode session shut down", "AbortError"));
@@ -524,6 +555,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		workflowAllowedToolNames = undefined;
 		pendingWorkflowToolPolicy = undefined;
 		implementationRetention.reset();
+		if (runtimeApplication) await runtimeApplication.completion;
+		if (currentSession !== undefined && currentSession !== shutdownSession) {
+			workflowMutex.unbindSession(shutdownSession);
+			return;
+		}
 		await awaitPlanModeSettingsWrites(dependencies.settingsPath);
 		if (currentSession !== undefined && currentSession !== shutdownSession) {
 			workflowMutex.unbindSession(shutdownSession);
@@ -654,7 +690,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		return { messages: messages as typeof event.messages };
 	});
 
-	pi.on("before_agent_start", (_event, ctx) => {
+	pi.on("before_agent_start", async (_event, ctx) => {
 		if (refreshStateBeforeFirstAgentStart) {
 			refreshStateBeforeFirstAgentStart = false;
 			implementationRetention.reset();
@@ -665,6 +701,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			implementationRetention.restore(state.activeImplementation);
 			updateUi(ctx);
 		}
+		if (!(await applyPendingImplementationRuntime(ctx))) return;
 		if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) return;
 		if (state.latestPlan || state.awaitingAction) {
 			readyPresentationIntent = undefined;
@@ -776,6 +813,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 				awaitingAction: false,
 				savedPlan: undefined,
 				activeImplementation: undefined,
+				pendingImplementationRuntime: undefined,
 				selectedToolNames: candidate.selectedToolNames,
 				selectedToolKeys: candidate.selectedToolKeys,
 			};
@@ -820,6 +858,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			awaitingAction: false,
 			savedPlan: undefined,
 			activeImplementation: undefined,
+			pendingImplementationRuntime: undefined,
 			workflowToolPolicy: undefined,
 			manualThinkingLevel: undefined,
 		};
@@ -839,7 +878,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			hasModeContractArtifact(branch) ||
 			restoredState.enabled ||
 			restoredState.savedPlan !== undefined ||
-			restoredState.activeImplementation !== undefined;
+			restoredState.activeImplementation !== undefined ||
+			restoredState.pendingImplementationRuntime !== undefined;
 	}
 
 	function publishModeContract(mode: PlanModeContract, ctx: ExtensionContext) {
@@ -971,6 +1011,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			awaitingAction: false,
 			savedPlan: { plan, source },
 			activeImplementation: undefined,
+			pendingImplementationRuntime: undefined,
 			workflowToolPolicy: undefined,
 			manualThinkingLevel: undefined,
 		};
@@ -982,12 +1023,17 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		ctx.ui.notify("Plan saved for later. Plan mode disabled.", "info");
 	}
 
-	async function startFreshImplementation(ctx: ExtensionContext, menuIsCurrent: () => boolean) {
+	async function startFreshImplementation(
+		ctx: ExtensionContext,
+		menuIsCurrent: () => boolean,
+		runtime?: ImplementationRuntimeSelection,
+	) {
 		await startFreshImplementationFromState(ctx, {
 			getState: () => state,
 			menuIsCurrent,
 			retention: configuredImplementationPlanRetention(settings),
 			stateEntryType: STATE_ENTRY_TYPE,
+			runtime,
 		});
 	}
 
@@ -1032,6 +1078,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			latestPlanSource: undefined,
 			awaitingAction: false,
 			savedPlan: undefined,
+			pendingImplementationRuntime: undefined,
 			activeImplementation: usesConversationHistory
 				? undefined
 				: {
@@ -1482,6 +1529,123 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	}
 
+	async function applyPendingImplementationRuntime(ctx: ExtensionContext) {
+		const intent = state.enabled ? undefined : state.pendingImplementationRuntime;
+		if (!intent) return true;
+		const session = ctx.sessionManager;
+		const generation = menuGeneration;
+		state = { ...state, pendingImplementationRuntime: undefined };
+		try {
+			persistState();
+		} catch (error: unknown) {
+			if (currentSession === session && generation === menuGeneration) {
+				ctx.ui.notify(
+					`Unable to apply fresh implementation settings because their one-shot state could not be consumed: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. Destination defaults will be used.`,
+					"warning",
+				);
+			}
+			return false;
+		}
+		const isCurrent = () =>
+			currentSession === session && generation === menuGeneration && !menuController.signal.aborted;
+		const applyThinking = () => {
+			if (!intent.thinkingLevel) return;
+			try {
+				pi.setThinkingLevel(intent.thinkingLevel);
+				const effectiveLevel = pi.getThinkingLevel();
+				if (isCurrent() && effectiveLevel !== intent.thinkingLevel) {
+					ctx.ui.notify(
+						`Implementation thinking ${intent.thinkingLevel} is unsupported by the destination model; Pi is using ${effectiveLevel}.`,
+						"warning",
+					);
+				}
+			} catch (error: unknown) {
+				if (isCurrent()) {
+					ctx.ui.notify(
+						`Implementation thinking ${intent.thinkingLevel} could not be applied: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default will continue.`,
+						"warning",
+					);
+				}
+			}
+		};
+		if (intent.model) {
+			let model: ReturnType<ExtensionContext["modelRegistry"]["find"]>;
+			let resolutionFailed = false;
+			try {
+				model = ctx.modelRegistry.find(intent.model.provider, intent.model.modelId);
+			} catch (error: unknown) {
+				if (isCurrent()) {
+					ctx.ui.notify(
+						`Implementation model ${terminalModelReference(intent.model)} could not be resolved: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
+						"warning",
+					);
+				}
+				resolutionFailed = true;
+				model = undefined;
+			}
+			if (!model && !resolutionFailed && isCurrent()) {
+				ctx.ui.notify(
+					`Implementation model ${terminalModelReference(intent.model)} is no longer available. The destination default model will continue.`,
+					"warning",
+				);
+			}
+			if (model) {
+				let authenticated = false;
+				try {
+					const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+					if (!isCurrent()) return false;
+					if (auth.ok) authenticated = true;
+					else {
+						ctx.ui.notify(
+							`Implementation model ${terminalModelReference(intent.model)} could not be authenticated: ${safeTerminalText(auth.error)}. The destination default model will continue.`,
+							"warning",
+						);
+					}
+				} catch (error: unknown) {
+					if (isCurrent()) {
+						ctx.ui.notify(
+							`Implementation model ${terminalModelReference(intent.model)} could not be authenticated: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
+							"warning",
+						);
+					}
+				}
+				if (!isCurrent()) return false;
+				if (authenticated) {
+					let applied = false;
+					let applicationFailed = false;
+					const finishApplication = beginImplementationRuntimeApplication(session);
+					try {
+						try {
+							applied = await pi.setModel(model);
+						} catch (error: unknown) {
+							applicationFailed = true;
+							if (isCurrent()) {
+								ctx.ui.notify(
+									`Implementation model ${terminalModelReference(intent.model)} could not be applied: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
+									"warning",
+								);
+							}
+						}
+						if (currentSession !== session) return false;
+						if (isCurrent() && !applied && !applicationFailed) {
+							ctx.ui.notify(
+								`Implementation model ${terminalModelReference(intent.model)} could not be applied after authentication changed. The destination default model will continue.`,
+								"warning",
+							);
+						}
+						applyThinking();
+						return isCurrent();
+					} finally {
+						finishApplication();
+					}
+				}
+			}
+		}
+		if (!isCurrent()) return false;
+		applyThinking();
+		return isCurrent();
+	}
+
 	function applyPlanThinkingLevel() {
 		if (state.manualThinkingLevel) {
 			if (pi.getThinkingLevel() !== state.manualThinkingLevel) {
@@ -1705,11 +1869,21 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		return safe.length > 120 ? `${safe.slice(0, 119)}…` : safe;
 	}
 
+	function terminalModelReference(model: { provider: string; modelId: string }) {
+		const safe = safeTerminalText(`${model.provider}/${model.modelId}`) || "(unnamed model)";
+		return safe.length > 160 ? `${safe.slice(0, 159)}…` : safe;
+	}
+
 	function safeTerminalText(value: string) {
-		return [...value]
+		return [...stripVTControlCharacters(value)]
 			.map((character) => {
 				const codePoint = character.codePointAt(0) ?? 0;
-				return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+				return codePoint <= 0x1f ||
+					(codePoint >= 0x7f && codePoint <= 0x9f) ||
+					(codePoint >= 0x202a && codePoint <= 0x202e) ||
+					(codePoint >= 0x2066 && codePoint <= 0x2069)
+					? " "
+					: character;
 			})
 			.join("")
 			.trim();

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -500,10 +500,10 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("session_before_tree", (event, ctx) => {
-		if (hasQueuedRuntimeAdmissionInputs(ctx.sessionManager)) {
+		if (runtimeAdmissionIsPending(ctx.sessionManager)) {
 			if (ctx.hasUI) {
 				ctx.ui.notify(
-					"Wait for fresh implementation startup to admit the queued prompts before changing branches.",
+					"Wait for fresh implementation startup to admit the pending prompts before changing branches.",
 					"warning",
 				);
 			}
@@ -736,7 +736,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (queuedInput) queuedRuntimeAdmissionInputs.push(queuedInput);
 		const result = await applyPendingImplementationRuntime(ctx, true);
 		if (result !== "ready") {
-			if (queuedInput) removeQueuedRuntimeAdmissionInput(queuedInput);
+			if (result === "stale" && queuedInput) removeQueuedRuntimeAdmissionInput(queuedInput);
 			return { action: "handled" };
 		}
 		if (queuedInput) return { action: "handled" };
@@ -1585,8 +1585,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	}
 
-	function hasQueuedRuntimeAdmissionInputs(sessionManager: ExtensionContext["sessionManager"]) {
-		return queuedRuntimeAdmissionInputs.some((queued) => queued.sessionManager === sessionManager);
+	function runtimeAdmissionIsPending(sessionManager: ExtensionContext["sessionManager"]) {
+		return (
+			activeImplementationRuntimeApplication?.sessionManager === sessionManager ||
+			pendingRuntimeAdmissionSession === sessionManager ||
+			queuedRuntimeAdmissionInputs.some((queued) => queued.sessionManager === sessionManager)
+		);
 	}
 
 	function takeQueuedRuntimeAdmissionInputs(sessionManager: ExtensionContext["sessionManager"]) {

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -119,6 +119,7 @@ interface ActiveImplementationRuntimeApplication {
 	sessionManager: ExtensionContext["sessionManager"];
 	completion: Promise<ImplementationRuntimeApplicationResult>;
 	drainOnShutdown: boolean;
+	holdForAdmission: boolean;
 }
 interface QueuedRuntimeAdmissionInput {
 	text: string;
@@ -171,6 +172,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let workflowGeneration = 0;
 	let refreshStateBeforeFirstAgentStart = false;
 	let activeImplementationRuntimeApplication: ActiveImplementationRuntimeApplication | undefined;
+	let pendingRuntimeAdmissionSession: object | undefined;
 	let queuedRuntimeAdmissionInputs: QueuedRuntimeAdmissionInput[] = [];
 	let menuController = new AbortController();
 	let settingsWatch: ReturnType<typeof watch> | undefined;
@@ -469,6 +471,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		workflowOwner = undefined;
 		workflowMutex.bindSession(ctx.sessionManager);
 		refreshStateBeforeFirstAgentStart = event.reason === "new";
+		pendingRuntimeAdmissionSession = undefined;
 		queuedRuntimeAdmissionInputs = [];
 		menuController.abort(new DOMException("Plan-mode session replaced", "AbortError"));
 		menuController = new AbortController();
@@ -508,13 +511,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		return { cancel: true };
 	});
 
-	pi.on("session_tree", (_event, ctx) => {
+	pi.on("session_tree", async (_event, ctx) => {
 		advanceWorkflowGeneration();
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode tree branch changed", "AbortError"));
 		menuController = new AbortController();
 		readyPresentationIntent = undefined;
 		latestCommandContext = undefined;
+		pendingRuntimeAdmissionSession = undefined;
 		queuedRuntimeAdmissionInputs = [];
 		implementationRetention.reset();
 		const branch = ctx.sessionManager.getBranch();
@@ -524,6 +528,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		implementationRetention.restore(state.activeImplementation);
 		startPlanModeSettingsWatch(menuGeneration);
 		updateUi(ctx);
+		await applyPendingImplementationRuntime(ctx);
 	});
 
 	pi.on("thinking_level_select", (event) => {
@@ -552,6 +557,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		readyPresentationIntent = undefined;
 		latestCommandContext = undefined;
 		refreshStateBeforeFirstAgentStart = false;
+		pendingRuntimeAdmissionSession = undefined;
 		queuedRuntimeAdmissionInputs = [];
 		workflowAllowedToolNames = undefined;
 		pendingWorkflowToolPolicy = undefined;
@@ -693,11 +699,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	pi.on("input", async (event, ctx) => {
 		refreshStateForFirstPrompt(ctx);
-		const waitsForRuntimeApplication =
-			activeImplementationRuntimeApplication?.sessionManager === ctx.sessionManager;
-		const result = await applyPendingImplementationRuntime(ctx);
+		const waitsForRuntimeAdmission =
+			activeImplementationRuntimeApplication?.sessionManager === ctx.sessionManager ||
+			pendingRuntimeAdmissionSession === ctx.sessionManager;
+		const result = await applyPendingImplementationRuntime(ctx, true);
 		if (result !== "ready") return { action: "handled" };
-		if (waitsForRuntimeApplication) {
+		if (waitsForRuntimeAdmission) {
 			queuedRuntimeAdmissionInputs.push({
 				text: event.text,
 				...(event.images ? { images: [...event.images] } : {}),
@@ -708,7 +715,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("agent_start", (_event, ctx) => {
-		if (currentSession !== ctx.sessionManager || queuedRuntimeAdmissionInputs.length === 0) return;
+		if (currentSession !== ctx.sessionManager) return;
+		if (pendingRuntimeAdmissionSession === ctx.sessionManager) {
+			pendingRuntimeAdmissionSession = undefined;
+		}
+		if (queuedRuntimeAdmissionInputs.length === 0) return;
 		const queuedInputs = queuedRuntimeAdmissionInputs;
 		queuedRuntimeAdmissionInputs = [];
 		for (const queued of queuedInputs) {
@@ -1565,10 +1576,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 
 	async function applyPendingImplementationRuntime(
 		ctx: ExtensionContext,
+		holdForAdmission = false,
 	): Promise<ImplementationRuntimeApplicationResult> {
 		const session = ctx.sessionManager;
 		const activeApplication = activeImplementationRuntimeApplication;
-		if (activeApplication?.sessionManager === session) return activeApplication.completion;
+		if (activeApplication?.sessionManager === session) {
+			if (holdForAdmission) activeApplication.holdForAdmission = true;
+			return activeApplication.completion;
+		}
 
 		const intent = state.enabled ? undefined : state.pendingImplementationRuntime;
 		if (!intent) return "ready";
@@ -1693,6 +1708,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 					);
 					return "blocked";
 				}
+				if (application.holdForAdmission) pendingRuntimeAdmissionSession = session;
 				return "ready";
 			})
 			.finally(() => {
@@ -1700,7 +1716,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 					activeImplementationRuntimeApplication = undefined;
 				}
 			});
-		application = { sessionManager: session, completion, drainOnShutdown: false };
+		application = {
+			sessionManager: session,
+			completion,
+			drainOnShutdown: false,
+			holdForAdmission,
+		};
 		activeImplementationRuntimeApplication = application;
 		return completion;
 	}

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -112,10 +112,11 @@ interface PendingWorkflowToolPolicy {
 	generation: number;
 	mode: "resolve" | "revalidate";
 }
+type ImplementationRuntimeApplicationResult = "ready" | "blocked" | "stale";
 interface ActiveImplementationRuntimeApplication {
 	sessionManager: ExtensionContext["sessionManager"];
-	completion: Promise<void>;
-	finish(): void;
+	completion: Promise<ImplementationRuntimeApplicationResult>;
+	drainOnShutdown: boolean;
 }
 type InteractiveUi = typeof import("./interactive-ui.js");
 
@@ -169,25 +170,6 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	const implementationRetention = createImplementationRetentionCoordinator();
 	const finalizationRequest = createFinalizationRequestCoordinator();
 	const persistState = () => pi.appendEntry<PlanModeState>(STATE_ENTRY_TYPE, state);
-	const beginImplementationRuntimeApplication = (
-		sessionManager: ExtensionContext["sessionManager"],
-	) => {
-		let resolveCompletion!: () => void;
-		const application: ActiveImplementationRuntimeApplication = {
-			sessionManager,
-			completion: new Promise<void>((resolve) => {
-				resolveCompletion = resolve;
-			}),
-			finish() {
-				if (activeImplementationRuntimeApplication === application) {
-					activeImplementationRuntimeApplication = undefined;
-				}
-				resolveCompletion();
-			},
-		};
-		activeImplementationRuntimeApplication = application;
-		return application.finish;
-	};
 	const planExports = createPlanExportController({
 		getState: () => state,
 		getSettings: () => settings,
@@ -543,7 +525,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	pi.on("session_shutdown", async (_event, ctx) => {
 		const shutdownSession = ctx.sessionManager;
 		const runtimeApplication =
-			activeImplementationRuntimeApplication?.sessionManager === shutdownSession
+			activeImplementationRuntimeApplication?.sessionManager === shutdownSession &&
+			activeImplementationRuntimeApplication.drainOnShutdown
 				? activeImplementationRuntimeApplication
 				: undefined;
 		finalizationRequest.reset();
@@ -690,18 +673,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		return { messages: messages as typeof event.messages };
 	});
 
-	pi.on("before_agent_start", async (_event, ctx) => {
-		if (refreshStateBeforeFirstAgentStart) {
-			refreshStateBeforeFirstAgentStart = false;
-			implementationRetention.reset();
-			const branch = ctx.sessionManager.getBranch();
-			const restoredState = restorePlanModeState(branch, STATE_ENTRY_TYPE);
-			restoreModeContractTracking(branch, restoredState);
-			if (!installRestoredState(restoredState, ctx)) return;
-			implementationRetention.restore(state.activeImplementation);
-			updateUi(ctx);
-		}
-		if (!(await applyPendingImplementationRuntime(ctx))) return;
+	pi.on("input", async (_event, ctx) => {
+		refreshStateForFirstPrompt(ctx);
+		const result = await applyPendingImplementationRuntime(ctx);
+		if (result !== "ready") return { action: "handled" };
+	});
+
+	pi.on("before_agent_start", (_event, ctx) => {
+		refreshStateForFirstPrompt(ctx);
 		if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) return;
 		if (state.latestPlan || state.awaitingAction) {
 			readyPresentationIntent = undefined;
@@ -1529,121 +1508,149 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		}
 	}
 
-	async function applyPendingImplementationRuntime(ctx: ExtensionContext) {
-		const intent = state.enabled ? undefined : state.pendingImplementationRuntime;
-		if (!intent) return true;
+	function refreshStateForFirstPrompt(ctx: ExtensionContext) {
+		if (!refreshStateBeforeFirstAgentStart) return;
+		refreshStateBeforeFirstAgentStart = false;
+		implementationRetention.reset();
+		const branch = ctx.sessionManager.getBranch();
+		const restoredState = restorePlanModeState(branch, STATE_ENTRY_TYPE);
+		restoreModeContractTracking(branch, restoredState);
+		if (!installRestoredState(restoredState, ctx)) return;
+		implementationRetention.restore(state.activeImplementation);
+		updateUi(ctx);
+	}
+
+	async function applyPendingImplementationRuntime(
+		ctx: ExtensionContext,
+	): Promise<ImplementationRuntimeApplicationResult> {
 		const session = ctx.sessionManager;
+		const activeApplication = activeImplementationRuntimeApplication;
+		if (activeApplication?.sessionManager === session) return activeApplication.completion;
+
+		const intent = state.enabled ? undefined : state.pendingImplementationRuntime;
+		if (!intent) return "ready";
 		const generation = menuGeneration;
-		state = { ...state, pendingImplementationRuntime: undefined };
-		try {
-			persistState();
-		} catch (error: unknown) {
-			if (currentSession === session && generation === menuGeneration) {
-				ctx.ui.notify(
-					`Unable to apply fresh implementation settings because their one-shot state could not be consumed: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. Destination defaults will be used.`,
-					"warning",
-				);
-			}
-			return false;
-		}
 		const isCurrent = () =>
 			currentSession === session && generation === menuGeneration && !menuController.signal.aborted;
-		const applyThinking = () => {
-			if (!intent.thinkingLevel) return;
+		const notifyCurrent = (message: string) => {
+			if (!isCurrent()) return;
 			try {
-				pi.setThinkingLevel(intent.thinkingLevel);
-				const effectiveLevel = pi.getThinkingLevel();
-				if (isCurrent() && effectiveLevel !== intent.thinkingLevel) {
-					ctx.ui.notify(
-						`Implementation thinking ${intent.thinkingLevel} is unsupported by the destination model; Pi is using ${effectiveLevel}.`,
-						"warning",
-					);
-				}
-			} catch (error: unknown) {
-				if (isCurrent()) {
-					ctx.ui.notify(
-						`Implementation thinking ${intent.thinkingLevel} could not be applied: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default will continue.`,
-						"warning",
-					);
-				}
+				ctx.ui.notify(message, "warning");
+			} catch {
+				// The session can become stale while an asynchronous runtime application settles.
 			}
 		};
-		if (intent.model) {
-			let model: ReturnType<ExtensionContext["modelRegistry"]["find"]>;
-			let resolutionFailed = false;
-			try {
-				model = ctx.modelRegistry.find(intent.model.provider, intent.model.modelId);
-			} catch (error: unknown) {
-				if (isCurrent()) {
-					ctx.ui.notify(
-						`Implementation model ${terminalModelReference(intent.model)} could not be resolved: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
-						"warning",
-					);
-				}
-				resolutionFailed = true;
-				model = undefined;
-			}
-			if (!model && !resolutionFailed && isCurrent()) {
-				ctx.ui.notify(
-					`Implementation model ${terminalModelReference(intent.model)} is no longer available. The destination default model will continue.`,
-					"warning",
-				);
-			}
-			if (model) {
-				let authenticated = false;
+		let application!: ActiveImplementationRuntimeApplication;
+		const completion = Promise.resolve()
+			.then(async (): Promise<ImplementationRuntimeApplicationResult> => {
+				if (!isCurrent()) return "stale";
+				const pendingState = state;
+				state = { ...state, pendingImplementationRuntime: undefined };
 				try {
-					const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-					if (!isCurrent()) return false;
-					if (auth.ok) authenticated = true;
-					else {
-						ctx.ui.notify(
-							`Implementation model ${terminalModelReference(intent.model)} could not be authenticated: ${safeTerminalText(auth.error)}. The destination default model will continue.`,
-							"warning",
-						);
-					}
+					persistState();
 				} catch (error: unknown) {
-					if (isCurrent()) {
-						ctx.ui.notify(
-							`Implementation model ${terminalModelReference(intent.model)} could not be authenticated: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
-							"warning",
+					state = pendingState;
+					try {
+						persistState();
+					} catch {
+						// SessionManager mutates its in-memory branch before a disk append can fail.
+						// A best-effort rollback entry keeps that branch aligned with durable pending state.
+					}
+					notifyCurrent(
+						`Unable to apply fresh implementation settings because their one-shot state could not be consumed: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The implementation request was not sent; retry after session persistence is available.`,
+					);
+					return "blocked";
+				}
+				if (!isCurrent()) return "stale";
+
+				const applyThinking = () => {
+					if (!intent.thinkingLevel) return;
+					try {
+						pi.setThinkingLevel(intent.thinkingLevel);
+						const effectiveLevel = pi.getThinkingLevel();
+						if (effectiveLevel !== intent.thinkingLevel) {
+							notifyCurrent(
+								`Implementation thinking ${intent.thinkingLevel} is unsupported by the destination model; Pi is using ${effectiveLevel}.`,
+							);
+						}
+					} catch (error: unknown) {
+						notifyCurrent(
+							`Implementation thinking ${intent.thinkingLevel} could not be applied: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default will continue.`,
 						);
 					}
-				}
-				if (!isCurrent()) return false;
-				if (authenticated) {
-					let applied = false;
-					let applicationFailed = false;
-					const finishApplication = beginImplementationRuntimeApplication(session);
+				};
+
+				if (intent.model) {
+					let model: ReturnType<ExtensionContext["modelRegistry"]["find"]>;
+					let resolutionFailed = false;
 					try {
+						model = ctx.modelRegistry.find(intent.model.provider, intent.model.modelId);
+					} catch (error: unknown) {
+						notifyCurrent(
+							`Implementation model ${terminalModelReference(intent.model)} could not be resolved: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
+						);
+						resolutionFailed = true;
+						model = undefined;
+					}
+					if (!model && !resolutionFailed) {
+						notifyCurrent(
+							`Implementation model ${terminalModelReference(intent.model)} is no longer available. The destination default model will continue.`,
+						);
+					}
+					if (model) {
+						let authenticated = false;
 						try {
-							applied = await pi.setModel(model);
+							const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+							if (!isCurrent()) return "stale";
+							if (auth.ok) authenticated = true;
+							else {
+								notifyCurrent(
+									`Implementation model ${terminalModelReference(intent.model)} could not be authenticated: ${safeTerminalText(auth.error)}. The destination default model will continue.`,
+								);
+							}
 						} catch (error: unknown) {
-							applicationFailed = true;
-							if (isCurrent()) {
-								ctx.ui.notify(
-									`Implementation model ${terminalModelReference(intent.model)} could not be applied: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
-									"warning",
+							notifyCurrent(
+								`Implementation model ${terminalModelReference(intent.model)} could not be authenticated: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
+							);
+						}
+						if (!isCurrent()) return "stale";
+						if (authenticated) {
+							let applied = false;
+							let applicationFailed = false;
+							application.drainOnShutdown = true;
+							try {
+								try {
+									applied = await pi.setModel(model);
+								} catch (error: unknown) {
+									applicationFailed = true;
+									notifyCurrent(
+										`Implementation model ${terminalModelReference(intent.model)} could not be applied: ${safeTerminalText(error instanceof Error ? error.message : String(error))}. The destination default model will continue.`,
+									);
+								}
+							} finally {
+								application.drainOnShutdown = false;
+							}
+							if (!isCurrent()) return "stale";
+							if (!applied && !applicationFailed) {
+								notifyCurrent(
+									`Implementation model ${terminalModelReference(intent.model)} could not be applied after authentication changed. The destination default model will continue.`,
 								);
 							}
 						}
-						if (currentSession !== session) return false;
-						if (isCurrent() && !applied && !applicationFailed) {
-							ctx.ui.notify(
-								`Implementation model ${terminalModelReference(intent.model)} could not be applied after authentication changed. The destination default model will continue.`,
-								"warning",
-							);
-						}
-						applyThinking();
-						return isCurrent();
-					} finally {
-						finishApplication();
 					}
 				}
-			}
-		}
-		if (!isCurrent()) return false;
-		applyThinking();
-		return isCurrent();
+				if (!isCurrent()) return "stale";
+				applyThinking();
+				return isCurrent() ? "ready" : "stale";
+			})
+			.finally(() => {
+				if (activeImplementationRuntimeApplication === application) {
+					activeImplementationRuntimeApplication = undefined;
+				}
+			});
+		application = { sessionManager: session, completion, drainOnShutdown: false };
+		activeImplementationRuntimeApplication = application;
+		return completion;
 	}
 
 	function applyPlanThinkingLevel() {

--- a/packages/pi-plan-mode/src/state.ts
+++ b/packages/pi-plan-mode/src/state.ts
@@ -25,6 +25,20 @@ export interface SavedPlan {
 	source: PlanCompletionSource;
 }
 
+export interface ImplementationModelOverride {
+	provider: string;
+	modelId: string;
+}
+
+export interface ImplementationRuntimeSelection {
+	model?: ImplementationModelOverride;
+	thinkingLevel?: PlanModeFixedThinkingLevel;
+}
+
+export interface PendingImplementationRuntime extends ImplementationRuntimeSelection {
+	version: 1;
+}
+
 export interface PlanModeWorkflowToolPolicy {
 	kind: "automatic" | "explicit";
 	desiredNames?: string[];
@@ -39,6 +53,7 @@ export interface PlanModeState {
 	awaitingAction: boolean;
 	savedPlan?: SavedPlan;
 	activeImplementation?: ActiveImplementationPlan;
+	pendingImplementationRuntime?: PendingImplementationRuntime;
 	selectedToolNames?: string[];
 	selectedToolKeys?: string[];
 	workflowToolPolicy?: PlanModeWorkflowToolPolicy;
@@ -82,6 +97,9 @@ export function restorePlanModeState(entries: unknown[], stateEntryType: string)
 		: normalizeActiveImplementation(entry.data.activeImplementation);
 	const savedPlan =
 		enabled || activeImplementation ? undefined : normalizeSavedPlan(entry.data.savedPlan);
+	const pendingImplementationRuntime = enabled
+		? undefined
+		: normalizePendingImplementationRuntime(entry.data.pendingImplementationRuntime);
 	return {
 		enabled,
 		latestPlan,
@@ -92,6 +110,7 @@ export function restorePlanModeState(entries: unknown[], stateEntryType: string)
 		awaitingAction: enabled && latestPlan !== undefined,
 		savedPlan,
 		activeImplementation,
+		pendingImplementationRuntime,
 		selectedToolNames: stringArray(entry.data.selectedToolNames),
 		selectedToolKeys: stringArray(entry.data.selectedToolKeys),
 		workflowToolPolicy: enabled
@@ -130,6 +149,47 @@ function normalizeSavedPlan(value: unknown): SavedPlan | undefined {
 	const normalized = normalizePlanModeCompletion({ plan: value.plan });
 	if (!source || !normalized.ok) return undefined;
 	return { plan: normalized.plan, source };
+}
+
+function normalizePendingImplementationRuntime(
+	value: unknown,
+): PendingImplementationRuntime | undefined {
+	if (!isRecord(value) || value.version !== 1) return undefined;
+	if (
+		Object.keys(value).some(
+			(key) => key !== "version" && key !== "model" && key !== "thinkingLevel",
+		)
+	) {
+		return undefined;
+	}
+	let model: ImplementationModelOverride | undefined;
+	if (value.model !== undefined) {
+		if (
+			!isRecord(value.model) ||
+			Object.keys(value.model).some((key) => key !== "provider" && key !== "modelId")
+		) {
+			return undefined;
+		}
+		const provider = boundedIdentifier(value.model.provider);
+		const modelId = boundedIdentifier(value.model.modelId);
+		if (!provider || !modelId) return undefined;
+		model = { provider, modelId };
+	}
+	const thinkingLevel =
+		value.thinkingLevel === undefined ? undefined : fixedThinkingLevel(value.thinkingLevel);
+	if (value.thinkingLevel !== undefined && !thinkingLevel) return undefined;
+	if (!model && !thinkingLevel) return undefined;
+	return {
+		version: 1,
+		...(model ? { model } : {}),
+		...(thinkingLevel ? { thinkingLevel } : {}),
+	};
+}
+
+function boundedIdentifier(value: unknown) {
+	return typeof value === "string" && value.trim().length > 0 && value.length <= 512
+		? value
+		: undefined;
 }
 
 function normalizeActiveImplementation(value: unknown): ActiveImplementationPlan | undefined {

--- a/packages/pi-plan-mode/src/state.ts
+++ b/packages/pi-plan-mode/src/state.ts
@@ -25,9 +25,19 @@ export interface SavedPlan {
 	source: PlanCompletionSource;
 }
 
+export const MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH = 512;
+
 export interface ImplementationModelOverride {
 	provider: string;
 	modelId: string;
+}
+
+export function isPendingImplementationModelIdentifier(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.trim().length > 0 &&
+		value.length <= MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH
+	);
 }
 
 export interface ImplementationRuntimeSelection {
@@ -170,10 +180,13 @@ function normalizePendingImplementationRuntime(
 		) {
 			return undefined;
 		}
-		const provider = boundedIdentifier(value.model.provider);
-		const modelId = boundedIdentifier(value.model.modelId);
-		if (!provider || !modelId) return undefined;
-		model = { provider, modelId };
+		if (
+			!isPendingImplementationModelIdentifier(value.model.provider) ||
+			!isPendingImplementationModelIdentifier(value.model.modelId)
+		) {
+			return undefined;
+		}
+		model = { provider: value.model.provider, modelId: value.model.modelId };
 	}
 	const thinkingLevel =
 		value.thinkingLevel === undefined ? undefined : fixedThinkingLevel(value.thinkingLevel);
@@ -184,12 +197,6 @@ function normalizePendingImplementationRuntime(
 		...(model ? { model } : {}),
 		...(thinkingLevel ? { thinkingLevel } : {}),
 	};
-}
-
-function boundedIdentifier(value: unknown) {
-	return typeof value === "string" && value.trim().length > 0 && value.length <= 512
-		? value
-		: undefined;
 }
 
 function normalizeActiveImplementation(value: unknown): ActiveImplementationPlan | undefined {

--- a/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
@@ -94,6 +94,57 @@ test("fresh settings select sanitized model metadata and fixed thinking in one m
 	}
 });
 
+test("fresh model picker honors the nonempty session model scope", async () => {
+	let availableReads = 0;
+	let freshVisits = 0;
+	let modelOptions: string[] = [];
+	let selectedRuntime: unknown;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		scopedModels: [{ model: AVAILABLE_MODELS[1], thinkingLevel: "high" }],
+		modelRegistry: {
+			getAvailable: () => {
+				availableReads += 1;
+				return AVAILABLE_MODELS;
+			},
+		},
+		select: async (title: string, options: string[]) => {
+			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
+			if (title.startsWith("Fresh implementation settings")) {
+				freshVisits += 1;
+				return freshVisits === 1
+					? options.find((option) => option.startsWith("Implementation model"))
+					: "Start fresh implementation";
+			}
+			if (title.startsWith("Implementation model")) {
+				modelOptions = options;
+				return options.find((option) => option.includes("provider-two/model-two"));
+			}
+			return undefined;
+		},
+	});
+
+	await showReadyPlanMenu(
+		context.ctx,
+		menuOptions({
+			implementFresh: (runtime: unknown) => {
+				selectedRuntime = runtime;
+			},
+		}),
+	);
+
+	assert.equal(availableReads, 0);
+	assert.ok(modelOptions.some((option) => option.includes("provider-two/model-two")));
+	assert.equal(
+		modelOptions.some((option) => option.includes("provider-one/model-one")),
+		false,
+	);
+	assert.deepEqual(selectedRuntime, {
+		model: { provider: "provider-two", modelId: "model-two" },
+	});
+});
+
 test("fresh model choice is searchable in TUI mode", async () => {
 	let screen = 0;
 	let filteredModelScreen = "";

--- a/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
@@ -36,6 +36,8 @@ test("fresh settings select sanitized model metadata and fixed thinking in one m
 	const context = createMockContext({
 		mode: "rpc",
 		hasUI: true,
+		model: AVAILABLE_MODELS[1],
+		thinkingLevel: "low",
 		modelRegistry: {
 			getAvailable: () => {
 				availableReads += 1;
@@ -47,19 +49,14 @@ test("fresh settings select sanitized model metadata and fixed thinking in one m
 			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
 			if (title.startsWith("Fresh implementation settings")) {
 				freshVisits += 1;
-				if (freshVisits === 1)
-					return options.find((option) => option.startsWith("Implementation model"));
-				if (freshVisits === 2) {
-					assert.ok(options.some((option) => option.includes("provider-one/model-one")));
-					return options.find((option) => option.startsWith("Implementation thinking"));
-				}
-				assert.ok(options.some((option) => option.endsWith(": max")));
+				if (freshVisits === 1) return "Model";
+				if (freshVisits === 2) return "Thinking level";
 				return "Start fresh implementation";
 			}
 			if (title.startsWith("Implementation model")) {
-				return options.find((option) => option.includes("provider-one/model-one"));
+				return options.find((option) => option.includes("model-one [provider-one]"));
 			}
-			if (title.startsWith("Implementation thinking")) return "max";
+			if (title.startsWith("Implementation thinking level")) return "max";
 			return undefined;
 		},
 	});
@@ -81,17 +78,91 @@ test("fresh settings select sanitized model metadata and fixed thinking in one m
 	const rendered = dialogs.flatMap((dialog) => [dialog.title, ...dialog.options]).join("\n");
 	assert.equal(rendered.includes("\u001b"), false);
 	assert.equal(rendered.includes("\u202e"), false);
-	assert.match(rendered, /Friendly name/u);
 	const thinkingDialog = dialogs.find((dialog) =>
-		dialog.title.startsWith("Implementation thinking"),
+		dialog.title.startsWith("Implementation thinking level"),
 	);
 	assert.ok(thinkingDialog);
 	for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max"]) {
 		assert.ok(
-			thinkingDialog.options.some((option) => option.startsWith(level)),
+			thinkingDialog.options.some((option) => option.includes(level)),
 			level,
 		);
 	}
+});
+
+test("fresh settings prioritize start and show same-as-plan defaults", async () => {
+	let screen = 0;
+	let settingsScreen = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 90);
+			screen += 1;
+			if (screen === 1) {
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else {
+				settingsScreen = harness.render().join("\n");
+				harness.handleInput("\u0003");
+			}
+			return harness.resultPromise;
+		},
+	});
+
+	await showReadyPlanMenu(context.ctx, menuOptions());
+
+	const start = settingsScreen.indexOf("Start fresh implementation");
+	const model = settingsScreen.indexOf("Model");
+	const thinking = settingsScreen.indexOf("Thinking level");
+	assert.ok(start >= 0 && start < model && model < thinking);
+	assert.match(settingsScreen, /→ Start fresh implementation/u);
+	assert.match(settingsScreen, /Model\s+Same as plan/u);
+	assert.match(settingsScreen, /Thinking level\s+Same as plan/u);
+});
+
+test("fresh thinking choice mirrors the built-in thinking layout", async () => {
+	let screen = 0;
+	let thinkingScreen = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 80);
+			screen += 1;
+			if (screen === 1) {
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else if (screen === 2) {
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else {
+				for (let index = 0; index < 3; index += 1) {
+					harness.handleInput("tui.select.down");
+				}
+				thinkingScreen = harness.render().join("\n");
+				harness.handleInput("\u0003");
+			}
+			return harness.resultPromise;
+		},
+	});
+
+	await showReadyPlanMenu(context.ctx, menuOptions());
+
+	assert.match(thinkingScreen, /Same as plan/u);
+	assert.match(thinkingScreen, /off\s+No reasoning/u);
+	assert.match(thinkingScreen, /minimal\s+Very brief reasoning \(~1k tokens\)/u);
+	assert.match(thinkingScreen, /→ low\s+Light reasoning \(~2k tokens\)/u);
+	assert.match(thinkingScreen, /✓ medium\s+Moderate reasoning \(~8k tokens\)/u);
+	assert.match(thinkingScreen, /high\s+Deep reasoning \(~16k tokens\)/u);
+	assert.match(thinkingScreen, /xhigh\s+Extra-high reasoning \(~32k tokens\)/u);
 });
 
 test("fresh model picker honors the nonempty session model scope", async () => {
@@ -113,13 +184,11 @@ test("fresh model picker honors the nonempty session model scope", async () => {
 			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
 			if (title.startsWith("Fresh implementation settings")) {
 				freshVisits += 1;
-				return freshVisits === 1
-					? options.find((option) => option.startsWith("Implementation model"))
-					: "Start fresh implementation";
+				return freshVisits === 1 ? "Model" : "Start fresh implementation";
 			}
 			if (title.startsWith("Implementation model")) {
 				modelOptions = options;
-				return options.find((option) => option.includes("provider-two/model-two"));
+				return options.find((option) => option.includes("model-two [provider-two]"));
 			}
 			return undefined;
 		},
@@ -135,9 +204,9 @@ test("fresh model picker honors the nonempty session model scope", async () => {
 	);
 
 	assert.equal(availableReads, 0);
-	assert.ok(modelOptions.some((option) => option.includes("provider-two/model-two")));
+	assert.ok(modelOptions.some((option) => option.includes("model-two [provider-two]")));
 	assert.equal(
-		modelOptions.some((option) => option.includes("provider-one/model-one")),
+		modelOptions.some((option) => option.includes("model-one [provider-one]")),
 		false,
 	);
 	assert.deepEqual(selectedRuntime, {
@@ -145,12 +214,35 @@ test("fresh model picker honors the nonempty session model scope", async () => {
 	});
 });
 
-test("fresh model choice is searchable in TUI mode", async () => {
+test("fresh model picker falls back when the scoped-model API is unavailable", async () => {
+	let availableReads = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		modelRegistry: {
+			getAvailable: () => {
+				availableReads += 1;
+				return AVAILABLE_MODELS;
+			},
+		},
+		select: async () => undefined,
+	});
+	delete (context.ctx as Partial<{ scopedModels: unknown }>).scopedModels;
+
+	await showReadyPlanMenu(context.ctx, menuOptions());
+
+	assert.equal(availableReads, 1);
+});
+
+test("fresh model choice mirrors the searchable built-in model layout in TUI mode", async () => {
 	let screen = 0;
+	let initialModelScreen = "";
 	let filteredModelScreen = "";
 	const context = createMockContext({
 		mode: "tui",
 		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
 		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
 		custom: async (factory: unknown) => {
 			const harness = createCustomSelectorHarness(factory, 80);
@@ -159,8 +251,10 @@ test("fresh model choice is searchable in TUI mode", async () => {
 				harness.handleInput("tui.select.down");
 				harness.handleInput("tui.select.confirm");
 			} else if (screen === 2) {
+				harness.handleInput("tui.select.down");
 				harness.handleInput("tui.select.confirm");
 			} else {
+				initialModelScreen = harness.render().join("\n");
 				harness.handleInput("beta");
 				filteredModelScreen = harness.render().join("\n");
 				harness.handleInput("\u0003");
@@ -171,58 +265,54 @@ test("fresh model choice is searchable in TUI mode", async () => {
 
 	await showReadyPlanMenu(context.ctx, menuOptions());
 
-	assert.match(filteredModelScreen, /provider-two\/model-two/u);
-	assert.match(filteredModelScreen, /Beta specialist/u);
-	assert.doesNotMatch(filteredModelScreen, /provider-one\/model-one/u);
+	assert.match(initialModelScreen, /→ ✓ model-one \[provider-one\] · default/u);
+	assert.match(initialModelScreen, /Model Name: Friendly name/u);
+	assert.match(filteredModelScreen, /model-two \[provider-two\]/u);
+	assert.match(filteredModelScreen, /Model Name: Beta specialist/u);
+	assert.doesNotMatch(filteredModelScreen, /model-one \[provider-one\]/u);
 });
 
-test("closing and reopening fresh settings resets its draft to destination defaults", async () => {
+test("closing and reopening fresh settings resets its draft to the plan runtime", async () => {
 	let invocation = 0;
-	let stage = 0;
-	const freshSnapshots: string[][] = [];
+	let mainVisits = 0;
+	let freshVisits = 0;
+	let selectedRuntime: unknown;
 	const context = createMockContext({
 		mode: "rpc",
 		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
 		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
 		select: async (title: string, options: string[]) => {
 			if (title.startsWith("Proposed plan ready")) {
-				if (stage === 0) {
-					stage = 1;
-					return "Start fresh and implement";
-				}
-				return undefined;
+				mainVisits += 1;
+				return invocation === 0 && mainVisits > 1 ? undefined : "Start fresh and implement";
 			}
 			if (title.startsWith("Fresh implementation settings")) {
-				freshSnapshots.push(options);
-				if (invocation === 0 && stage === 1) {
-					stage = 2;
-					return options.find((option) => option.startsWith("Implementation model"));
-				}
-				return undefined;
+				freshVisits += 1;
+				if (invocation === 0) return freshVisits === 1 ? "Model" : undefined;
+				return "Start fresh implementation";
 			}
 			if (title.startsWith("Implementation model")) {
-				return options.find((option) => option.includes("provider-two/model-two"));
+				return options.find((option) => option.includes("model-two [provider-two]"));
 			}
 			return undefined;
 		},
 	});
+	const options = menuOptions({
+		implementFresh: (runtime: unknown) => {
+			selectedRuntime = runtime;
+		},
+	});
 
-	await showReadyPlanMenu(context.ctx, menuOptions());
+	await showReadyPlanMenu(context.ctx, options);
 	invocation = 1;
-	stage = 0;
-	await showReadyPlanMenu(context.ctx, menuOptions());
+	mainVisits = 0;
+	freshVisits = 0;
+	await showReadyPlanMenu(context.ctx, options);
 
-	assert.ok(
-		freshSnapshots[1]?.some((option) =>
-			option.startsWith("Implementation model: provider-two/model-two"),
-		),
-	);
-	assert.ok(
-		freshSnapshots.at(-1)?.some((option) => option === "Implementation model: Destination default"),
-	);
-	assert.ok(
-		freshSnapshots
-			.at(-1)
-			?.some((option) => option === "Implementation thinking: Destination default"),
-	);
+	assert.deepEqual(selectedRuntime, {
+		model: { provider: "provider\u001b[31m-one", modelId: "model\u202e-one" },
+		thinkingLevel: "medium",
+	});
 });

--- a/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
@@ -90,7 +90,7 @@ test("fresh settings select sanitized model metadata and fixed thinking in one m
 	}
 });
 
-test("fresh settings prioritize start and show same-as-plan defaults", async () => {
+test("fresh settings prioritize start and show the plan runtime defaults", async () => {
 	let screen = 0;
 	let settingsScreen = "";
 	const context = createMockContext({
@@ -120,8 +120,8 @@ test("fresh settings prioritize start and show same-as-plan defaults", async () 
 	const thinking = settingsScreen.indexOf("Thinking level");
 	assert.ok(start >= 0 && start < model && model < thinking);
 	assert.match(settingsScreen, /→ Start fresh implementation/u);
-	assert.match(settingsScreen, /Model\s+Same as plan/u);
-	assert.match(settingsScreen, /Thinking level\s+Same as plan/u);
+	assert.match(settingsScreen, /Model\s+model-one \[provider-one\] · same as plan/u);
+	assert.match(settingsScreen, /Thinking level\s+medium · same as plan/u);
 });
 
 test("fresh thinking choice mirrors the built-in thinking layout", async () => {

--- a/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { showReadyPlanMenu } from "../src/plan-action-menus.js";
+import { createCustomSelectorHarness, createMockContext } from "./support.js";
+
+function menuOptions(overrides: Record<string, unknown> = {}) {
+	return {
+		signal: new AbortController().signal,
+		isCurrent: () => true,
+		implementationOutcome: () => "The plan remains available until implementation ends.",
+		getExportDestination: () => ({ configuredPath: "PLAN.md", resolvedPath: "/tmp/PLAN.md" }),
+		implementHere: () => undefined,
+		implementFresh: () => undefined,
+		exportPlan: async () => true,
+		save: () => undefined,
+		stay: () => undefined,
+		exit: () => undefined,
+		...overrides,
+	};
+}
+
+const AVAILABLE_MODELS = [
+	{
+		provider: "provider\u001b[31m-one",
+		id: "model\u202e-one",
+		name: "Friendly\u001b]8;;https://unsafe.example\u0007 name\u001b]8;;\u0007",
+	},
+	{ provider: "provider-two", id: "model-two", name: "Beta specialist" },
+];
+
+test("fresh settings select sanitized model metadata and fixed thinking in one menu flow", async () => {
+	const dialogs: Array<{ title: string; options: string[] }> = [];
+	let freshVisits = 0;
+	let availableReads = 0;
+	let selectedRuntime: unknown;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		modelRegistry: {
+			getAvailable: () => {
+				availableReads += 1;
+				return AVAILABLE_MODELS;
+			},
+		},
+		select: async (title: string, options: string[]) => {
+			dialogs.push({ title, options });
+			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
+			if (title.startsWith("Fresh implementation settings")) {
+				freshVisits += 1;
+				if (freshVisits === 1)
+					return options.find((option) => option.startsWith("Implementation model"));
+				if (freshVisits === 2) {
+					assert.ok(options.some((option) => option.includes("provider-one/model-one")));
+					return options.find((option) => option.startsWith("Implementation thinking"));
+				}
+				assert.ok(options.some((option) => option.endsWith(": max")));
+				return "Start fresh implementation";
+			}
+			if (title.startsWith("Implementation model")) {
+				return options.find((option) => option.includes("provider-one/model-one"));
+			}
+			if (title.startsWith("Implementation thinking")) return "max";
+			return undefined;
+		},
+	});
+
+	await showReadyPlanMenu(
+		context.ctx,
+		menuOptions({
+			implementFresh: (runtime: unknown) => {
+				selectedRuntime = runtime;
+			},
+		}),
+	);
+
+	assert.equal(availableReads, 1);
+	assert.deepEqual(selectedRuntime, {
+		model: { provider: "provider\u001b[31m-one", modelId: "model\u202e-one" },
+		thinkingLevel: "max",
+	});
+	const rendered = dialogs.flatMap((dialog) => [dialog.title, ...dialog.options]).join("\n");
+	assert.equal(rendered.includes("\u001b"), false);
+	assert.equal(rendered.includes("\u202e"), false);
+	assert.match(rendered, /Friendly name/u);
+	const thinkingDialog = dialogs.find((dialog) =>
+		dialog.title.startsWith("Implementation thinking"),
+	);
+	assert.ok(thinkingDialog);
+	for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max"]) {
+		assert.ok(
+			thinkingDialog.options.some((option) => option.startsWith(level)),
+			level,
+		);
+	}
+});
+
+test("fresh model choice is searchable in TUI mode", async () => {
+	let screen = 0;
+	let filteredModelScreen = "";
+	const context = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
+		custom: async (factory: unknown) => {
+			const harness = createCustomSelectorHarness(factory, 80);
+			screen += 1;
+			if (screen === 1) {
+				harness.handleInput("tui.select.down");
+				harness.handleInput("tui.select.confirm");
+			} else if (screen === 2) {
+				harness.handleInput("tui.select.confirm");
+			} else {
+				harness.handleInput("beta");
+				filteredModelScreen = harness.render().join("\n");
+				harness.handleInput("\u0003");
+			}
+			return harness.resultPromise;
+		},
+	});
+
+	await showReadyPlanMenu(context.ctx, menuOptions());
+
+	assert.match(filteredModelScreen, /provider-two\/model-two/u);
+	assert.match(filteredModelScreen, /Beta specialist/u);
+	assert.doesNotMatch(filteredModelScreen, /provider-one\/model-one/u);
+});
+
+test("closing and reopening fresh settings resets its draft to destination defaults", async () => {
+	let invocation = 0;
+	let stage = 0;
+	const freshSnapshots: string[][] = [];
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
+		select: async (title: string, options: string[]) => {
+			if (title.startsWith("Proposed plan ready")) {
+				if (stage === 0) {
+					stage = 1;
+					return "Start fresh and implement";
+				}
+				return undefined;
+			}
+			if (title.startsWith("Fresh implementation settings")) {
+				freshSnapshots.push(options);
+				if (invocation === 0 && stage === 1) {
+					stage = 2;
+					return options.find((option) => option.startsWith("Implementation model"));
+				}
+				return undefined;
+			}
+			if (title.startsWith("Implementation model")) {
+				return options.find((option) => option.includes("provider-two/model-two"));
+			}
+			return undefined;
+		},
+	});
+
+	await showReadyPlanMenu(context.ctx, menuOptions());
+	invocation = 1;
+	stage = 0;
+	await showReadyPlanMenu(context.ctx, menuOptions());
+
+	assert.ok(
+		freshSnapshots[1]?.some((option) =>
+			option.startsWith("Implementation model: provider-two/model-two"),
+		),
+	);
+	assert.ok(
+		freshSnapshots.at(-1)?.some((option) => option === "Implementation model: Destination default"),
+	);
+	assert.ok(
+		freshSnapshots
+			.at(-1)
+			?.some((option) => option === "Implementation thinking: Destination default"),
+	);
+});

--- a/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
@@ -8,6 +8,7 @@ function menuOptions(overrides: Record<string, unknown> = {}) {
 		signal: new AbortController().signal,
 		isCurrent: () => true,
 		implementationOutcome: () => "The plan remains available until implementation ends.",
+		planThinkingLevel: undefined,
 		getExportDestination: () => ({ configuredPath: "PLAN.md", resolvedPath: "/tmp/PLAN.md" }),
 		implementHere: () => undefined,
 		implementFresh: () => undefined,
@@ -90,6 +91,40 @@ test("fresh settings select sanitized model metadata and fixed thinking in one m
 	}
 });
 
+test("fresh settings use the supplied plan thinking level on older Pi contexts", async () => {
+	let selectedRuntime: unknown;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: undefined,
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
+		select: async (title: string) => {
+			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
+			if (title.startsWith("Fresh implementation settings")) {
+				return "Start fresh implementation";
+			}
+			return undefined;
+		},
+	});
+	delete (context.ctx as Partial<{ thinkingLevel: unknown }>).thinkingLevel;
+
+	await showReadyPlanMenu(
+		context.ctx,
+		menuOptions({
+			planThinkingLevel: "high",
+			implementFresh: (runtime: unknown) => {
+				selectedRuntime = runtime;
+			},
+		}),
+	);
+
+	assert.deepEqual(selectedRuntime, {
+		model: { provider: "provider\u001b[31m-one", modelId: "model\u202e-one" },
+		thinkingLevel: "high",
+	});
+});
+
 test("fresh settings prioritize start and show the plan runtime defaults", async () => {
 	let screen = 0;
 	let settingsScreen = "";
@@ -113,7 +148,7 @@ test("fresh settings prioritize start and show the plan runtime defaults", async
 		},
 	});
 
-	await showReadyPlanMenu(context.ctx, menuOptions());
+	await showReadyPlanMenu(context.ctx, menuOptions({ planThinkingLevel: "medium" }));
 
 	const start = settingsScreen.indexOf("Start fresh implementation");
 	const model = settingsScreen.indexOf("Model");
@@ -154,7 +189,7 @@ test("fresh thinking choice mirrors the built-in thinking layout", async () => {
 		},
 	});
 
-	await showReadyPlanMenu(context.ctx, menuOptions());
+	await showReadyPlanMenu(context.ctx, menuOptions({ planThinkingLevel: "medium" }));
 
 	assert.match(thinkingScreen, /Same as plan/u);
 	assert.match(thinkingScreen, /off\s+No reasoning/u);
@@ -300,6 +335,7 @@ test("closing and reopening fresh settings resets its draft to the plan runtime"
 		},
 	});
 	const options = menuOptions({
+		planThinkingLevel: "medium",
 		implementFresh: (runtime: unknown) => {
 			selectedRuntime = runtime;
 		},

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -126,7 +126,10 @@ test("fresh preflight re-resolves an explicit model and persists intent beside d
 				appendCustomMessageEntry(): string;
 				appendCustomEntry(customType: string, data: unknown): string;
 			}) => Promise<void>;
-			withSession?: (ctx: { sendUserMessage(message: string): Promise<void> }) => Promise<void>;
+			withSession?: (ctx: {
+				sessionManager: { getBranch(): unknown[] };
+				sendUserMessage(message: string): Promise<void>;
+			}) => Promise<void>;
 		}) => {
 			await options.setup?.({
 				appendCustomMessageEntry: () => "contract",
@@ -135,7 +138,10 @@ test("fresh preflight re-resolves an explicit model and persists intent beside d
 					return "state";
 				},
 			});
-			await options.withSession?.({ sendUserMessage: async () => undefined });
+			await options.withSession?.({
+				sessionManager: { getBranch: () => [] },
+				sendUserMessage: async () => undefined,
+			});
 			return { cancelled: false };
 		},
 	});
@@ -183,7 +189,10 @@ test("clear-on-start persists only temporary runtime intent when an override is 
 				appendCustomMessageEntry(): string;
 				appendCustomEntry(customType: string, data: unknown): string;
 			}) => Promise<void>;
-			withSession?: (ctx: { sendUserMessage(message: string): Promise<void> }) => Promise<void>;
+			withSession?: (ctx: {
+				sessionManager: { getBranch(): unknown[] };
+				sendUserMessage(message: string): Promise<void>;
+			}) => Promise<void>;
 		}) => {
 			await options.setup?.({
 				appendCustomMessageEntry: () => "contract",
@@ -192,7 +201,10 @@ test("clear-on-start persists only temporary runtime intent when an override is 
 					return "state";
 				},
 			});
-			await options.withSession?.({ sendUserMessage: async () => undefined });
+			await options.withSession?.({
+				sessionManager: { getBranch: () => [] },
+				sendUserMessage: async () => undefined,
+			});
 			return { cancelled: false };
 		},
 	});
@@ -714,40 +726,61 @@ test("destination preserves pre-admission prompts when shutdown interrupts runti
 	assert.deepEqual(mock.sentUserMessages, []);
 });
 
-test("destination blocks tree navigation until pre-admission prompts are admitted", async () => {
+test("destination blocks tree navigation during runtime application and admission", async () => {
+	let releaseModel!: () => void;
+	let markModelStarted!: () => void;
+	const modelStarted = new Promise<void>((resolve) => {
+		markModelStarted = resolve;
+	});
+	const modelGate = new Promise<void>((resolve) => {
+		releaseModel = resolve;
+	});
 	const branch = [
 		stateEntry({
 			enabled: false,
 			awaitingAction: false,
-			pendingImplementationRuntime: { version: 1, thinkingLevel: "high" },
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+			},
 		}),
 	];
-	const mock = createMockPi({ thinkingLevel: "low" });
+	const mock = createMockPi();
+	const setModel = mock.rawPi.setModel.bind(mock.rawPi);
+	mock.rawPi.setModel = async (model) => {
+		markModelStarted();
+		await modelGate;
+		return setModel(model);
+	};
 	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
 	const context = createMockContext({
 		hasUI: true,
 		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-	assert.equal(await submitInput(mock, context.ctx, "implement", "rpc"), undefined);
-	assert.deepEqual(await submitInput(mock, context.ctx, "queued", "rpc"), {
-		action: "handled",
-	});
+	const leading = submitInput(mock, context.ctx, "implement", "rpc");
+	await modelStarted;
+	const beforeTree = mock.events.get("session_before_tree")?.[0];
+	assert.ok(beforeTree);
 
-	const result = await mock.events.get("session_before_tree")?.[0]?.(
-		{ preparation: { targetId: "older" } },
-		context.ctx,
+	assert.deepEqual(
+		await beforeTree({ preparation: { targetId: "during-application" } }, context.ctx),
+		{ cancel: true },
 	);
-	assert.deepEqual(result, { cancel: true });
-	assert.match(context.notifications.at(-1)?.message ?? "", /queued prompts/u);
+	releaseModel();
+	assert.equal(await leading, undefined);
+	assert.deepEqual(
+		await beforeTree({ preparation: { targetId: "before-admission" } }, context.ctx),
+		{ cancel: true },
+	);
+	assert.match(context.notifications.at(-1)?.message ?? "", /pending prompts/u);
 
 	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
-	assert.deepEqual(mock.sentUserMessages, [
-		{
-			text: "queued",
-			options: { deliverAs: "followUp", expandPromptTemplates: true },
-		},
-	]);
+	assert.deepEqual(mock.sentUserMessages, []);
 });
 
 test("destination serializes a concurrent prompt while authentication is pending", async () => {
@@ -845,6 +878,73 @@ test("destination blocks a prompt until runtime intent consumption can persist",
 			?.pendingImplementationRuntime,
 		undefined,
 	);
+});
+
+test("destination retains concurrent prompts when runtime consumption is blocked", async () => {
+	let releaseModel!: () => void;
+	let markModelStarted!: () => void;
+	const modelStarted = new Promise<void>((resolve) => {
+		markModelStarted = resolve;
+	});
+	const modelGate = new Promise<void>((resolve) => {
+		releaseModel = resolve;
+	});
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+			},
+		}),
+	];
+	const mock = createMockPi();
+	const setModel = mock.rawPi.setModel.bind(mock.rawPi);
+	let firstApplication = true;
+	mock.rawPi.setModel = async (model) => {
+		if (firstApplication) {
+			firstApplication = false;
+			markModelStarted();
+			await modelGate;
+		}
+		return setModel(model);
+	};
+	const appendEntry = mock.rawPi.appendEntry.bind(mock.rawPi);
+	let persistenceAvailable = false;
+	mock.rawPi.appendEntry = (customType, data) => {
+		if (!persistenceAvailable) throw new Error("disk unavailable");
+		appendEntry(customType, data);
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const leading = submitInput(mock, context.ctx, "implement", "rpc");
+	await modelStarted;
+	const follower = submitInput(mock, context.ctx, "keep me", "rpc");
+	releaseModel();
+
+	assert.deepEqual(await Promise.all([leading, follower]), [
+		{ action: "handled" },
+		{ action: "handled" },
+	]);
+	assert.deepEqual(mock.sentUserMessages, []);
+
+	persistenceAvailable = true;
+	assert.equal(await submitInput(mock, context.ctx, "retry", "rpc"), undefined);
+	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
+	assert.deepEqual(mock.sentUserMessages, [
+		{
+			text: "keep me",
+			options: { deliverAs: "followUp", expandPromptTemplates: true },
+		},
+	]);
 });
 
 test("destination drains asynchronous model application and preserves stale runtime intent", async () => {

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -447,6 +447,52 @@ test("destination consumes and applies all runtime override classes exactly once
 	}
 });
 
+test("destination applies restored runtime during resumed session startup", async () => {
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+				thinkingLevel: "high",
+			},
+		}),
+	];
+	const order: string[] = [];
+	const mock = createMockPi({ thinkingLevel: "low" });
+	const originalSetModel = mock.rawPi.setModel.bind(mock.rawPi);
+	mock.rawPi.setModel = async (model) => {
+		order.push("model");
+		return originalSetModel(model);
+	};
+	const originalSetThinking = mock.rawPi.setThinkingLevel.bind(mock.rawPi);
+	mock.rawPi.setThinkingLevel = (level) => {
+		order.push(`thinking:${level}`);
+		originalSetThinking(level);
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: (provider: string, id: string) =>
+				provider === TARGET.provider && id === TARGET.id ? TARGET : undefined,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+
+	await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, context.ctx);
+
+	assert.deepEqual(order, ["model", "thinking:high"]);
+	assert.deepEqual(mock.setModels, [TARGET]);
+	assert.equal(mock.thinkingLevel, "high");
+	assert.equal(
+		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		undefined,
+	);
+});
+
 test("destination warns on thinking clamping and consumes a model race failure without retry", async () => {
 	const branch = [
 		stateEntry({

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -1,0 +1,472 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { startFreshImplementationSession } from "../src/fresh-implementation.js";
+import planMode from "../src/plan-mode.js";
+import { restorePlanModeState } from "../src/state.js";
+import { createMockContext, createMockPi } from "./support.js";
+
+const STATE_ENTRY_TYPE = "plan-mode-state";
+const PLAN = "# Runtime plan\n\n1. Apply destination settings.";
+const TARGET = { provider: "target-provider", id: "target-model", name: "Target" };
+
+function stateEntry(data: Record<string, unknown>) {
+	return { type: "custom" as const, customType: STATE_ENTRY_TYPE, data };
+}
+
+test("pending implementation runtime state restores only strict bounded one-shot values", () => {
+	const valid = restorePlanModeState(
+		[
+			stateEntry({
+				enabled: false,
+				awaitingAction: false,
+				pendingImplementationRuntime: {
+					version: 1,
+					model: { provider: "provider", modelId: "model" },
+					thinkingLevel: "high",
+				},
+			}),
+		],
+		STATE_ENTRY_TYPE,
+	);
+	assert.deepEqual(valid.pendingImplementationRuntime, {
+		version: 1,
+		model: { provider: "provider", modelId: "model" },
+		thinkingLevel: "high",
+	});
+
+	const invalidValues = [
+		null,
+		{},
+		{ version: 2, thinkingLevel: "high" },
+		{ version: 1, thinkingLevel: "inherit" },
+		{ version: 1, thinkingLevel: "high", unknown: true },
+		{ version: 1, model: { provider: "", modelId: "model" } },
+		{ version: 1, model: { provider: "provider", modelId: "x".repeat(513) } },
+		{ version: 1, model: { provider: "provider", modelId: "model", name: "extra" } },
+	];
+	for (const pendingImplementationRuntime of invalidValues) {
+		const restored = restorePlanModeState(
+			[stateEntry({ enabled: false, awaitingAction: false, pendingImplementationRuntime })],
+			STATE_ENTRY_TYPE,
+		);
+		assert.equal(restored.pendingImplementationRuntime, undefined);
+	}
+
+	const active = restorePlanModeState(
+		[
+			stateEntry({
+				enabled: true,
+				awaitingAction: false,
+				pendingImplementationRuntime: { version: 1, thinkingLevel: "high" },
+			}),
+		],
+		STATE_ENTRY_TYPE,
+	);
+	assert.equal(active.pendingImplementationRuntime, undefined);
+});
+
+test("fresh preflight re-resolves an explicit model and persists intent beside destination state", async () => {
+	let destinationState: unknown;
+	const authModels: unknown[] = [];
+	const source = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: { provider: "planning-provider", id: "planning-model" },
+		modelRegistry: {
+			find: (provider: string, id: string) =>
+				provider === TARGET.provider && id === TARGET.id ? TARGET : undefined,
+			getApiKeyAndHeaders: async (model: unknown) => {
+				authModels.push(model);
+				return { ok: true as const };
+			},
+		},
+		sessionManager: { getSessionFile: () => "/sessions/planning.jsonl" },
+		newSession: async (options: {
+			setup?: (manager: {
+				appendCustomMessageEntry(): string;
+				appendCustomEntry(customType: string, data: unknown): string;
+			}) => Promise<void>;
+			withSession?: (ctx: { sendUserMessage(message: string): Promise<void> }) => Promise<void>;
+		}) => {
+			await options.setup?.({
+				appendCustomMessageEntry: () => "contract",
+				appendCustomEntry(_customType, data) {
+					destinationState = data;
+					return "state";
+				},
+			});
+			await options.withSession?.({ sendUserMessage: async () => undefined });
+			return { cancelled: false };
+		},
+	});
+
+	const result = await startFreshImplementationSession(source.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "keep",
+		stateEntryType: STATE_ENTRY_TYPE,
+		runtime: {
+			model: { provider: TARGET.provider, modelId: TARGET.id },
+			thinkingLevel: "high",
+		},
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "started");
+	assert.deepEqual(authModels, [TARGET]);
+	assert.deepEqual(
+		(destinationState as { pendingImplementationRuntime?: unknown }).pendingImplementationRuntime,
+		{
+			version: 1,
+			model: { provider: TARGET.provider, modelId: TARGET.id },
+			thinkingLevel: "high",
+		},
+	);
+	assert.equal(
+		(destinationState as { activeImplementation?: { plan?: string } }).activeImplementation?.plan,
+		PLAN,
+	);
+});
+
+test("clear-on-start persists only temporary runtime intent when an override is selected", async () => {
+	let destinationState: unknown;
+	const source = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: { provider: "planning-provider", id: "planning-model" },
+		modelRegistry: {
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+		sessionManager: { getSessionFile: () => "/sessions/planning.jsonl" },
+		newSession: async (options: {
+			setup?: (manager: {
+				appendCustomMessageEntry(): string;
+				appendCustomEntry(customType: string, data: unknown): string;
+			}) => Promise<void>;
+			withSession?: (ctx: { sendUserMessage(message: string): Promise<void> }) => Promise<void>;
+		}) => {
+			await options.setup?.({
+				appendCustomMessageEntry: () => "contract",
+				appendCustomEntry(_customType, data) {
+					destinationState = data;
+					return "state";
+				},
+			});
+			await options.withSession?.({ sendUserMessage: async () => undefined });
+			return { cancelled: false };
+		},
+	});
+
+	await startFreshImplementationSession(source.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "clear-on-start",
+		stateEntryType: STATE_ENTRY_TYPE,
+		runtime: { thinkingLevel: "medium" },
+		isCurrent: () => true,
+	});
+
+	assert.deepEqual(destinationState, {
+		enabled: false,
+		awaitingAction: false,
+		pendingImplementationRuntime: { version: 1, thinkingLevel: "medium" },
+	});
+});
+
+test("missing or unauthenticated selected models reject before replacing the source session", async () => {
+	for (const failure of ["missing", "auth"] as const) {
+		let newSessionCalls = 0;
+		const context = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			model: { provider: "planning-provider", id: "planning-model" },
+			modelRegistry: {
+				find: () => (failure === "missing" ? undefined : TARGET),
+				getApiKeyAndHeaders: async () => ({ ok: false as const, error: "configure auth" }),
+			},
+			newSession: async () => {
+				newSessionCalls += 1;
+				return { cancelled: false };
+			},
+		});
+		const result = await startFreshImplementationSession(context.ctx, {
+			plan: PLAN,
+			source: "plan_mode_complete",
+			retention: "keep",
+			stateEntryType: STATE_ENTRY_TYPE,
+			runtime: { model: { provider: TARGET.provider, modelId: TARGET.id } },
+			isCurrent: () => true,
+		});
+		assert.equal(result.kind, "rejected");
+		assert.equal(newSessionCalls, 0);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			/choose another model|configure authentication/iu,
+		);
+	}
+});
+
+test("destination consumes and applies all runtime override classes exactly once", async () => {
+	const cases = [
+		{ name: "none", runtime: undefined, expectedOrder: [] },
+		{
+			name: "model only",
+			runtime: { version: 1 as const, model: { provider: TARGET.provider, modelId: TARGET.id } },
+			expectedOrder: ["model"],
+		},
+		{
+			name: "thinking only",
+			runtime: { version: 1 as const, thinkingLevel: "high" as const },
+			expectedOrder: ["thinking:high"],
+		},
+		{
+			name: "model and thinking",
+			runtime: {
+				version: 1 as const,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+				thinkingLevel: "high" as const,
+			},
+			expectedOrder: ["model", "thinking:high"],
+		},
+	];
+	for (const scenario of cases) {
+		const branch = scenario.runtime
+			? [
+					stateEntry({
+						enabled: false,
+						awaitingAction: false,
+						pendingImplementationRuntime: scenario.runtime,
+					}),
+				]
+			: [];
+		const order: string[] = [];
+		const mock = createMockPi({ thinkingLevel: "low" });
+		const originalSetModel = mock.rawPi.setModel.bind(mock.rawPi);
+		mock.rawPi.setModel = async (model) => {
+			order.push("model");
+			return originalSetModel(model);
+		};
+		const originalSetThinking = mock.rawPi.setThinkingLevel.bind(mock.rawPi);
+		mock.rawPi.setThinkingLevel = (level) => {
+			order.push(`thinking:${level}`);
+			originalSetThinking(level);
+		};
+		planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+		const sessionManager = {
+			getBranch: () => branch,
+			getEntries: () => branch,
+		};
+		const context = createMockContext({
+			sessionManager,
+			modelRegistry: {
+				find: (provider: string, id: string) =>
+					provider === TARGET.provider && id === TARGET.id ? TARGET : undefined,
+				getApiKeyAndHeaders: async () => ({ ok: true as const }),
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+		const before = mock.events.get("before_agent_start")?.[0];
+		assert.ok(before);
+		await before({ prompt: "implement", systemPrompt: "system" }, context.ctx);
+		assert.deepEqual(order, scenario.expectedOrder, scenario.name);
+		if (scenario.runtime) {
+			const consumed = mock.entries.at(-1)?.data as {
+				pendingImplementationRuntime?: unknown;
+			};
+			assert.equal(consumed.pendingImplementationRuntime, undefined, scenario.name);
+		}
+		await before({ prompt: "again", systemPrompt: "system" }, context.ctx);
+		assert.deepEqual(order, scenario.expectedOrder, `${scenario.name} reapplied`);
+	}
+});
+
+test("destination warns on thinking clamping and consumes a model race failure without retry", async () => {
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: {
+					provider: `${TARGET.provider}\u001b[31m`,
+					modelId: `${TARGET.id}\u202e`,
+				},
+				thinkingLevel: "max",
+			},
+		}),
+	];
+	const mock = createMockPi({ thinkingLevel: "low", clampThinkingLevel: () => "high" });
+	let setModelCalls = 0;
+	mock.rawPi.setModel = async () => {
+		setModelCalls += 1;
+		return false;
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const before = mock.events.get("before_agent_start")?.[0];
+	assert.ok(before);
+	await before({ prompt: "implement", systemPrompt: "system" }, context.ctx);
+	await before({ prompt: "again", systemPrompt: "system" }, context.ctx);
+
+	assert.equal(setModelCalls, 1);
+	assert.equal(mock.thinkingLevel, "high");
+	assert.ok(context.notifications.some((notice) => /could not be applied/u.test(notice.message)));
+	assert.ok(
+		context.notifications.some((notice) => /unsupported.+using high/u.test(notice.message)),
+	);
+	assert.equal(JSON.stringify(context.notifications).includes("\u001b"), false);
+	assert.equal(JSON.stringify(context.notifications).includes("\u202e"), false);
+	assert.equal(
+		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		undefined,
+	);
+});
+
+test("destination drains an asynchronous model and thinking application before shutdown", async () => {
+	let releaseModel!: () => void;
+	let markModelStarted!: () => void;
+	const modelStarted = new Promise<void>((resolve) => {
+		markModelStarted = resolve;
+	});
+	const modelGate = new Promise<void>((resolve) => {
+		releaseModel = resolve;
+	});
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+				thinkingLevel: "high",
+			},
+		}),
+	];
+	const mock = createMockPi({ thinkingLevel: "low" });
+	mock.rawPi.setModel = async () => {
+		markModelStarted();
+		await modelGate;
+		return true;
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const pending = mock.events.get("before_agent_start")?.[0]?.(
+		{ prompt: "implement", systemPrompt: "system" },
+		context.ctx,
+	);
+	await modelStarted;
+	let shutdownSettled = false;
+	const shutdown = Promise.resolve(
+		mock.events.get("session_shutdown")?.[0]?.({ reason: "new" }, context.ctx),
+	).then(() => {
+		shutdownSettled = true;
+	});
+	await Promise.resolve();
+	assert.equal(shutdownSettled, false);
+	releaseModel();
+	await Promise.all([pending, shutdown]);
+
+	assert.equal(mock.thinkingLevel, "high");
+	assert.equal(
+		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		undefined,
+	);
+});
+
+test("destination shutdown does not wait for uncancellable authentication preflight", async () => {
+	let releaseAuth!: () => void;
+	let markAuthStarted!: () => void;
+	const authStarted = new Promise<void>((resolve) => {
+		markAuthStarted = resolve;
+	});
+	const authGate = new Promise<void>((resolve) => {
+		releaseAuth = resolve;
+	});
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+			},
+		}),
+	];
+	const mock = createMockPi({ thinkingLevel: "low" });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => {
+				markAuthStarted();
+				await authGate;
+				return { ok: true as const };
+			},
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const pending = mock.events.get("before_agent_start")?.[0]?.(
+		{ prompt: "implement", systemPrompt: "system" },
+		context.ctx,
+	);
+	await authStarted;
+	await mock.events.get("session_shutdown")?.[0]?.({ reason: "new" }, context.ctx);
+	releaseAuth();
+	await pending;
+
+	assert.equal(mock.setModels.length, 0);
+	assert.equal(mock.thinkingLevel, "low");
+});
+
+test("destination consumes a thrown model application without retrying", async () => {
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+			},
+		}),
+	];
+	const mock = createMockPi();
+	let calls = 0;
+	mock.rawPi.setModel = async () => {
+		calls += 1;
+		throw new Error("provider\u001b[31m changed");
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const before = mock.events.get("before_agent_start")?.[0];
+	assert.ok(before);
+	await before({ prompt: "implement", systemPrompt: "system" }, context.ctx);
+	await before({ prompt: "again", systemPrompt: "system" }, context.ctx);
+
+	assert.equal(calls, 1);
+	assert.match(context.notifications.at(-1)?.message ?? "", /could not be applied/u);
+	assert.equal(JSON.stringify(context.notifications).includes("\u001b"), false);
+});

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -698,7 +698,7 @@ test("destination blocks a prompt until runtime intent consumption can persist",
 	);
 });
 
-test("destination drains asynchronous model application without applying stale thinking", async () => {
+test("destination drains asynchronous model application and preserves stale runtime intent", async () => {
 	let releaseModel!: () => void;
 	let markModelStarted!: () => void;
 	const modelStarted = new Promise<void>((resolve) => {
@@ -747,14 +747,18 @@ test("destination drains asynchronous model application without applying stale t
 	await Promise.all([pending, shutdown]);
 
 	assert.equal(mock.thinkingLevel, "low");
-	assert.equal(
+	assert.deepEqual(
 		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
 			?.pendingImplementationRuntime,
-		undefined,
+		{
+			version: 1,
+			model: { provider: TARGET.provider, modelId: TARGET.id },
+			thinkingLevel: "high",
+		},
 	);
 });
 
-test("destination shutdown does not wait for uncancellable authentication preflight", async () => {
+test("destination shutdown preserves intent during uncancellable authentication preflight", async () => {
 	let releaseAuth!: () => void;
 	let markAuthStarted!: () => void;
 	const authStarted = new Promise<void>((resolve) => {
@@ -795,6 +799,22 @@ test("destination shutdown does not wait for uncancellable authentication prefli
 
 	assert.equal(mock.setModels.length, 0);
 	assert.equal(mock.thinkingLevel, "low");
+	assert.deepEqual(
+		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		{
+			version: 1,
+			model: { provider: TARGET.provider, modelId: TARGET.id },
+		},
+	);
+
+	await mock.events.get("session_start")?.[0]?.({ reason: "resume" }, context.ctx);
+	assert.equal(mock.setModels.length, 1);
+	assert.equal(
+		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		undefined,
+	);
 });
 
 test("destination consumes a thrown model application without retrying", async () => {

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { startFreshImplementationSession } from "../src/fresh-implementation.js";
 import planMode from "../src/plan-mode.js";
-import { restorePlanModeState } from "../src/state.js";
+import {
+	MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH,
+	restorePlanModeState,
+} from "../src/state.js";
 import { createMockContext, createMockPi } from "./support.js";
 
 const STATE_ENTRY_TYPE = "plan-mode-state";
@@ -44,6 +47,26 @@ test("pending implementation runtime state restores only strict bounded one-shot
 		thinkingLevel: "high",
 	});
 
+	const boundaryProvider = "p".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH);
+	const boundaryModelId = "m".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH);
+	const boundary = restorePlanModeState(
+		[
+			stateEntry({
+				enabled: false,
+				awaitingAction: false,
+				pendingImplementationRuntime: {
+					version: 1,
+					model: { provider: boundaryProvider, modelId: boundaryModelId },
+				},
+			}),
+		],
+		STATE_ENTRY_TYPE,
+	);
+	assert.deepEqual(boundary.pendingImplementationRuntime?.model, {
+		provider: boundaryProvider,
+		modelId: boundaryModelId,
+	});
+
 	const invalidValues = [
 		null,
 		{},
@@ -51,7 +74,13 @@ test("pending implementation runtime state restores only strict bounded one-shot
 		{ version: 1, thinkingLevel: "inherit" },
 		{ version: 1, thinkingLevel: "high", unknown: true },
 		{ version: 1, model: { provider: "", modelId: "model" } },
-		{ version: 1, model: { provider: "provider", modelId: "x".repeat(513) } },
+		{
+			version: 1,
+			model: {
+				provider: "provider",
+				modelId: "x".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH + 1),
+			},
+		},
 		{ version: 1, model: { provider: "provider", modelId: "model", name: "extra" } },
 	];
 	for (const pendingImplementationRuntime of invalidValues) {
@@ -212,6 +241,71 @@ test("missing or unauthenticated selected models reject before replacing the sou
 		assert.match(
 			context.notifications.at(-1)?.message ?? "",
 			/choose another model|configure authentication/iu,
+		);
+	}
+});
+
+test("unpersistable selected model identifiers reject before source replacement", async () => {
+	const invalidIdentifiers = [
+		{
+			name: "overlong provider",
+			field: "provider" as const,
+			value: "x".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH + 1),
+		},
+		{
+			name: "overlong model ID",
+			field: "modelId" as const,
+			value: "x".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH + 1),
+		},
+		{ name: "blank provider", field: "provider" as const, value: " " },
+		{ name: "blank model ID", field: "modelId" as const, value: " " },
+	];
+	for (const { name, field, value } of invalidIdentifiers) {
+		let findCalls = 0;
+		let authCalls = 0;
+		let newSessionCalls = 0;
+		const context = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			model: { provider: "planning-provider", id: "planning-model" },
+			modelRegistry: {
+				find: () => {
+					findCalls += 1;
+					return TARGET;
+				},
+				getApiKeyAndHeaders: async () => {
+					authCalls += 1;
+					return { ok: true as const };
+				},
+			},
+			newSession: async () => {
+				newSessionCalls += 1;
+				return { cancelled: false };
+			},
+		});
+		const model = {
+			provider: TARGET.provider,
+			modelId: TARGET.id,
+			[field]: value,
+		};
+
+		const result = await startFreshImplementationSession(context.ctx, {
+			plan: PLAN,
+			source: "plan_mode_complete",
+			retention: "keep",
+			stateEntryType: STATE_ENTRY_TYPE,
+			runtime: { model },
+			isCurrent: () => true,
+		});
+
+		assert.equal(result.kind, "rejected", name);
+		assert.equal(findCalls, 0, name);
+		assert.equal(authCalls, 0, name);
+		assert.equal(newSessionCalls, 0, name);
+		assert.match(
+			context.notifications.at(-1)?.message ?? "",
+			new RegExp(`1-${MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH}`, "u"),
+			name,
 		);
 	}
 });

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -13,6 +13,16 @@ function stateEntry(data: Record<string, unknown>) {
 	return { type: "custom" as const, customType: STATE_ENTRY_TYPE, data };
 }
 
+async function submitInput(
+	mock: ReturnType<typeof createMockPi>,
+	ctx: unknown,
+	text = "implement",
+) {
+	const input = mock.events.get("input")?.[0];
+	assert.ok(input);
+	return Promise.resolve(input({ text, source: "extension" }, ctx));
+}
+
 test("pending implementation runtime state restores only strict bounded one-shot values", () => {
 	const valid = restorePlanModeState(
 		[
@@ -206,6 +216,71 @@ test("missing or unauthenticated selected models reject before replacing the sou
 	}
 });
 
+test("fresh preflight suppresses stale warnings and contains notification failures", async () => {
+	const staleScenarios = [
+		{
+			model: { provider: "planning-provider", id: "planning-model" },
+			runtime: { model: { provider: TARGET.provider, modelId: TARGET.id } },
+			modelRegistry: { find: () => undefined },
+		},
+		{
+			model: undefined,
+			runtime: undefined,
+			modelRegistry: {},
+		},
+		{
+			model: { provider: "planning-provider", id: "planning-model" },
+			runtime: undefined,
+			modelRegistry: {
+				getApiKeyAndHeaders: async () => {
+					throw new Error("stale auth");
+				},
+			},
+		},
+	];
+	for (const scenario of staleScenarios) {
+		let currentChecks = 0;
+		const context = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			model: scenario.model,
+			modelRegistry: scenario.modelRegistry,
+		});
+		const result = await startFreshImplementationSession(context.ctx, {
+			plan: PLAN,
+			source: "plan_mode_complete",
+			retention: "keep",
+			stateEntryType: STATE_ENTRY_TYPE,
+			runtime: scenario.runtime,
+			isCurrent: () => {
+				currentChecks += 1;
+				return currentChecks === 1;
+			},
+		});
+		assert.equal(result.kind, "rejected");
+		assert.deepEqual(context.notifications, []);
+	}
+
+	const throwingNotification = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: { provider: "planning-provider", id: "planning-model" },
+		modelRegistry: { find: () => undefined },
+	});
+	(throwingNotification.ctx as { ui: { notify(): void } }).ui.notify = () => {
+		throw new Error("stale UI");
+	};
+	const result = await startFreshImplementationSession(throwingNotification.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "keep",
+		stateEntryType: STATE_ENTRY_TYPE,
+		runtime: { model: { provider: TARGET.provider, modelId: TARGET.id } },
+		isCurrent: () => true,
+	});
+	assert.equal(result.kind, "rejected");
+});
+
 test("destination consumes and applies all runtime override classes exactly once", async () => {
 	const cases = [
 		{ name: "none", runtime: undefined, expectedOrder: [] },
@@ -265,9 +340,7 @@ test("destination consumes and applies all runtime override classes exactly once
 			},
 		});
 		await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-		const before = mock.events.get("before_agent_start")?.[0];
-		assert.ok(before);
-		await before({ prompt: "implement", systemPrompt: "system" }, context.ctx);
+		assert.equal(await submitInput(mock, context.ctx), undefined);
 		assert.deepEqual(order, scenario.expectedOrder, scenario.name);
 		if (scenario.runtime) {
 			const consumed = mock.entries.at(-1)?.data as {
@@ -275,7 +348,7 @@ test("destination consumes and applies all runtime override classes exactly once
 			};
 			assert.equal(consumed.pendingImplementationRuntime, undefined, scenario.name);
 		}
-		await before({ prompt: "again", systemPrompt: "system" }, context.ctx);
+		assert.equal(await submitInput(mock, context.ctx, "again"), undefined);
 		assert.deepEqual(order, scenario.expectedOrder, `${scenario.name} reapplied`);
 	}
 });
@@ -310,10 +383,8 @@ test("destination warns on thinking clamping and consumes a model race failure w
 		},
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-	const before = mock.events.get("before_agent_start")?.[0];
-	assert.ok(before);
-	await before({ prompt: "implement", systemPrompt: "system" }, context.ctx);
-	await before({ prompt: "again", systemPrompt: "system" }, context.ctx);
+	assert.equal(await submitInput(mock, context.ctx), undefined);
+	assert.equal(await submitInput(mock, context.ctx, "again"), undefined);
 
 	assert.equal(setModelCalls, 1);
 	assert.equal(mock.thinkingLevel, "high");
@@ -330,7 +401,148 @@ test("destination warns on thinking clamping and consumes a model race failure w
 	);
 });
 
-test("destination drains an asynchronous model and thinking application before shutdown", async () => {
+test("destination serializes concurrent prompts across the full runtime application", async () => {
+	let releaseModel!: () => void;
+	let markModelStarted!: () => void;
+	const modelStarted = new Promise<void>((resolve) => {
+		markModelStarted = resolve;
+	});
+	const modelGate = new Promise<void>((resolve) => {
+		releaseModel = resolve;
+	});
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+				thinkingLevel: "high",
+			},
+		}),
+	];
+	const mock = createMockPi({ thinkingLevel: "low" });
+	const setModel = mock.rawPi.setModel.bind(mock.rawPi);
+	mock.rawPi.setModel = async (model) => {
+		markModelStarted();
+		await modelGate;
+		return setModel(model);
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const first = submitInput(mock, context.ctx);
+	await modelStarted;
+	let secondSettled = false;
+	const second = submitInput(mock, context.ctx, "concurrent").then((result) => {
+		secondSettled = true;
+		return result;
+	});
+	await Promise.resolve();
+	assert.equal(secondSettled, false);
+	releaseModel();
+	assert.deepEqual(await Promise.all([first, second]), [undefined, undefined]);
+	assert.equal(mock.setModels.length, 1);
+	assert.equal(mock.thinkingLevel, "high");
+});
+
+test("destination serializes a concurrent prompt while authentication is pending", async () => {
+	let releaseAuth!: () => void;
+	let markAuthStarted!: () => void;
+	const authStarted = new Promise<void>((resolve) => {
+		markAuthStarted = resolve;
+	});
+	const authGate = new Promise<void>((resolve) => {
+		releaseAuth = resolve;
+	});
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+			},
+		}),
+	];
+	const mock = createMockPi();
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => {
+				markAuthStarted();
+				await authGate;
+				return { ok: true as const };
+			},
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const first = submitInput(mock, context.ctx);
+	await authStarted;
+	let secondSettled = false;
+	const second = submitInput(mock, context.ctx, "concurrent").then((result) => {
+		secondSettled = true;
+		return result;
+	});
+	await Promise.resolve();
+	assert.equal(secondSettled, false);
+	releaseAuth();
+	assert.deepEqual(await Promise.all([first, second]), [undefined, undefined]);
+	assert.equal(mock.setModels.length, 1);
+});
+
+test("destination blocks a prompt until runtime intent consumption can persist", async () => {
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: { version: 1, thinkingLevel: "high" },
+		}),
+	];
+	const mock = createMockPi({ thinkingLevel: "low" });
+	const appendEntry = mock.rawPi.appendEntry.bind(mock.rawPi);
+	const attemptedStates: unknown[] = [];
+	let persistenceAvailable = false;
+	mock.rawPi.appendEntry = (customType, data) => {
+		attemptedStates.push(data);
+		if (!persistenceAvailable) throw new Error("disk unavailable");
+		appendEntry(customType, data);
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+
+	assert.deepEqual(await submitInput(mock, context.ctx), { action: "handled" });
+	assert.equal(mock.thinkingLevel, "low");
+	assert.equal(attemptedStates.length, 2);
+	assert.deepEqual(
+		(attemptedStates.at(-1) as { pendingImplementationRuntime?: unknown })
+			.pendingImplementationRuntime,
+		{ version: 1, thinkingLevel: "high" },
+	);
+	assert.match(context.notifications.at(-1)?.message ?? "", /request was not sent/iu);
+
+	persistenceAvailable = true;
+	assert.equal(await submitInput(mock, context.ctx, "retry"), undefined);
+	assert.equal(mock.thinkingLevel, "high");
+	assert.equal(
+		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		undefined,
+	);
+});
+
+test("destination drains asynchronous model application without applying stale thinking", async () => {
 	let releaseModel!: () => void;
 	let markModelStarted!: () => void;
 	const modelStarted = new Promise<void>((resolve) => {
@@ -365,10 +577,7 @@ test("destination drains an asynchronous model and thinking application before s
 		},
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-	const pending = mock.events.get("before_agent_start")?.[0]?.(
-		{ prompt: "implement", systemPrompt: "system" },
-		context.ctx,
-	);
+	const pending = submitInput(mock, context.ctx);
 	await modelStarted;
 	let shutdownSettled = false;
 	const shutdown = Promise.resolve(
@@ -381,7 +590,7 @@ test("destination drains an asynchronous model and thinking application before s
 	releaseModel();
 	await Promise.all([pending, shutdown]);
 
-	assert.equal(mock.thinkingLevel, "high");
+	assert.equal(mock.thinkingLevel, "low");
 	assert.equal(
 		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
 			?.pendingImplementationRuntime,
@@ -422,10 +631,7 @@ test("destination shutdown does not wait for uncancellable authentication prefli
 		},
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-	const pending = mock.events.get("before_agent_start")?.[0]?.(
-		{ prompt: "implement", systemPrompt: "system" },
-		context.ctx,
-	);
+	const pending = submitInput(mock, context.ctx);
 	await authStarted;
 	await mock.events.get("session_shutdown")?.[0]?.({ reason: "new" }, context.ctx);
 	releaseAuth();
@@ -461,10 +667,8 @@ test("destination consumes a thrown model application without retrying", async (
 		},
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-	const before = mock.events.get("before_agent_start")?.[0];
-	assert.ok(before);
-	await before({ prompt: "implement", systemPrompt: "system" }, context.ctx);
-	await before({ prompt: "again", systemPrompt: "system" }, context.ctx);
+	assert.equal(await submitInput(mock, context.ctx), undefined);
+	assert.equal(await submitInput(mock, context.ctx, "again"), undefined);
 
 	assert.equal(calls, 1);
 	assert.match(context.notifications.at(-1)?.message ?? "", /could not be applied/u);

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -647,6 +647,109 @@ test("destination serializes concurrent prompts across the full runtime applicat
 	assert.equal(mock.thinkingLevel, "high");
 });
 
+test("destination preserves pre-admission prompts when shutdown interrupts runtime application", async () => {
+	let releaseModel!: () => void;
+	let markModelStarted!: () => void;
+	const modelStarted = new Promise<void>((resolve) => {
+		markModelStarted = resolve;
+	});
+	const modelGate = new Promise<void>((resolve) => {
+		releaseModel = resolve;
+	});
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+			},
+		}),
+	];
+	const mock = createMockPi();
+	const setModel = mock.rawPi.setModel.bind(mock.rawPi);
+	mock.rawPi.setModel = async (model) => {
+		markModelStarted();
+		await modelGate;
+		return setModel(model);
+	};
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: () => TARGET,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	const leading = submitInput(mock, context.ctx, "implement", "rpc");
+	await modelStarted;
+	const image = { type: "image" as const, data: "queued-image", mimeType: "image/png" };
+	const input = mock.events.get("input")?.[0];
+	assert.ok(input);
+	const follower = Promise.resolve(
+		input({ text: "queued prompt", images: [image], source: "rpc" }, context.ctx),
+	);
+	const shutdown = Promise.resolve(
+		mock.events.get("session_shutdown")?.[0]?.({ reason: "quit" }, context.ctx),
+	);
+
+	assert.deepEqual(mock.sentMessages, [
+		{
+			message: {
+				customType: "plan-mode-recovered-input",
+				content: [{ type: "text", text: "queued prompt" }, image],
+				display: true,
+				details: { source: "rpc" },
+			},
+			options: { triggerTurn: false },
+		},
+	]);
+	releaseModel();
+	assert.deepEqual(await Promise.all([leading, follower]), [
+		{ action: "handled" },
+		{ action: "handled" },
+	]);
+	await shutdown;
+	assert.deepEqual(mock.sentUserMessages, []);
+});
+
+test("destination blocks tree navigation until pre-admission prompts are admitted", async () => {
+	const branch = [
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: { version: 1, thinkingLevel: "high" },
+		}),
+	];
+	const mock = createMockPi({ thinkingLevel: "low" });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		hasUI: true,
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	assert.equal(await submitInput(mock, context.ctx, "implement", "rpc"), undefined);
+	assert.deepEqual(await submitInput(mock, context.ctx, "queued", "rpc"), {
+		action: "handled",
+	});
+
+	const result = await mock.events.get("session_before_tree")?.[0]?.(
+		{ preparation: { targetId: "older" } },
+		context.ctx,
+	);
+	assert.deepEqual(result, { cancel: true });
+	assert.match(context.notifications.at(-1)?.message ?? "", /queued prompts/u);
+
+	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
+	assert.deepEqual(mock.sentUserMessages, [
+		{
+			text: "queued",
+			options: { deliverAs: "followUp", expandPromptTemplates: true },
+		},
+	]);
+});
+
 test("destination serializes a concurrent prompt while authentication is pending", async () => {
 	let releaseAuth!: () => void;
 	let markAuthStarted!: () => void;

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -20,10 +20,11 @@ async function submitInput(
 	mock: ReturnType<typeof createMockPi>,
 	ctx: unknown,
 	text = "implement",
+	source: "extension" | "rpc" = "extension",
 ) {
 	const input = mock.events.get("input")?.[0];
 	assert.ok(input);
-	return Promise.resolve(input({ text, source: "extension" }, ctx));
+	return Promise.resolve(input({ text, source }, ctx));
 }
 
 test("pending implementation runtime state restores only strict bounded one-shot values", () => {
@@ -577,17 +578,25 @@ test("destination serializes concurrent prompts across the full runtime applicat
 		},
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-	const first = submitInput(mock, context.ctx);
+	const first = submitInput(mock, context.ctx, "implement", "rpc");
 	await modelStarted;
 	let secondSettled = false;
-	const second = submitInput(mock, context.ctx, "concurrent").then((result) => {
+	const second = submitInput(mock, context.ctx, "concurrent", "rpc").then((result) => {
 		secondSettled = true;
 		return result;
 	});
 	await Promise.resolve();
 	assert.equal(secondSettled, false);
 	releaseModel();
-	assert.deepEqual(await Promise.all([first, second]), [undefined, undefined]);
+	assert.deepEqual(await Promise.all([first, second]), [undefined, { action: "handled" }]);
+	assert.deepEqual(mock.sentUserMessages, []);
+	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
+	assert.deepEqual(mock.sentUserMessages, [
+		{
+			text: "concurrent",
+			options: { deliverAs: "followUp", expandPromptTemplates: true },
+		},
+	]);
 	assert.equal(mock.setModels.length, 1);
 	assert.equal(mock.thinkingLevel, "high");
 });
@@ -625,17 +634,24 @@ test("destination serializes a concurrent prompt while authentication is pending
 		},
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
-	const first = submitInput(mock, context.ctx);
+	const first = submitInput(mock, context.ctx, "implement", "rpc");
 	await authStarted;
 	let secondSettled = false;
-	const second = submitInput(mock, context.ctx, "concurrent").then((result) => {
+	const second = submitInput(mock, context.ctx, "concurrent", "rpc").then((result) => {
 		secondSettled = true;
 		return result;
 	});
 	await Promise.resolve();
 	assert.equal(secondSettled, false);
 	releaseAuth();
-	assert.deepEqual(await Promise.all([first, second]), [undefined, undefined]);
+	assert.deepEqual(await Promise.all([first, second]), [undefined, { action: "handled" }]);
+	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
+	assert.deepEqual(mock.sentUserMessages, [
+		{
+			text: "concurrent",
+			options: { deliverAs: "followUp", expandPromptTemplates: true },
+		},
+	]);
 	assert.equal(mock.setModels.length, 1);
 });
 

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -443,6 +443,7 @@ test("destination consumes and applies all runtime override classes exactly once
 			};
 			assert.equal(consumed.pendingImplementationRuntime, undefined, scenario.name);
 		}
+		await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
 		assert.equal(await submitInput(mock, context.ctx, "again"), undefined);
 		assert.deepEqual(order, scenario.expectedOrder, `${scenario.name} reapplied`);
 	}
@@ -494,6 +495,42 @@ test("destination applies restored runtime during resumed session startup", asyn
 	);
 });
 
+test("destination applies restored runtime during tree navigation", async () => {
+	const branch: Array<ReturnType<typeof stateEntry>> = [];
+	const mock = createMockPi({ thinkingLevel: "low" });
+	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
+	const context = createMockContext({
+		sessionManager: { getBranch: () => branch, getEntries: () => branch },
+		modelRegistry: {
+			find: (provider: string, id: string) =>
+				provider === TARGET.provider && id === TARGET.id ? TARGET : undefined,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+	});
+	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
+	branch.push(
+		stateEntry({
+			enabled: false,
+			awaitingAction: false,
+			pendingImplementationRuntime: {
+				version: 1,
+				model: { provider: TARGET.provider, modelId: TARGET.id },
+				thinkingLevel: "high",
+			},
+		}),
+	);
+
+	await mock.events.get("session_tree")?.[0]?.({}, context.ctx);
+
+	assert.deepEqual(mock.setModels, [TARGET]);
+	assert.equal(mock.thinkingLevel, "high");
+	assert.equal(
+		(mock.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		undefined,
+	);
+});
+
 test("destination warns on thinking clamping and consumes a model race failure without retry", async () => {
 	const branch = [
 		stateEntry({
@@ -525,6 +562,7 @@ test("destination warns on thinking clamping and consumes a model race failure w
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
 	assert.equal(await submitInput(mock, context.ctx), undefined);
+	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
 	assert.equal(await submitInput(mock, context.ctx, "again"), undefined);
 
 	assert.equal(setModelCalls, 1);
@@ -590,10 +628,18 @@ test("destination serializes concurrent prompts across the full runtime applicat
 	releaseModel();
 	assert.deepEqual(await Promise.all([first, second]), [undefined, { action: "handled" }]);
 	assert.deepEqual(mock.sentUserMessages, []);
+	assert.deepEqual(await submitInput(mock, context.ctx, "late", "rpc"), {
+		action: "handled",
+	});
+	assert.deepEqual(mock.sentUserMessages, []);
 	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
 	assert.deepEqual(mock.sentUserMessages, [
 		{
 			text: "concurrent",
+			options: { deliverAs: "followUp", expandPromptTemplates: true },
+		},
+		{
+			text: "late",
 			options: { deliverAs: "followUp", expandPromptTemplates: true },
 		},
 	]);
@@ -844,6 +890,7 @@ test("destination consumes a thrown model application without retrying", async (
 	});
 	await mock.events.get("session_start")?.[0]?.({ reason: "new" }, context.ctx);
 	assert.equal(await submitInput(mock, context.ctx), undefined);
+	await mock.events.get("agent_start")?.[0]?.({}, context.ctx);
 	assert.equal(await submitInput(mock, context.ctx, "again"), undefined);
 
 	assert.equal(calls, 1);

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -511,6 +511,57 @@ test("fresh handoff treats a handled runtime kickoff as partial and restores the
 	);
 });
 
+test("fresh handoff fails closed when runtime consumption cannot be inspected", async () => {
+	const replacement = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		sessionManager: {
+			getBranch() {
+				throw new Error("replacement context is stale");
+			},
+			getEntries: () => [],
+		},
+	});
+	const source = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: { provider: "test-provider", id: "test-model" },
+		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+		sessionManager: { getSessionFile: () => "/sessions/planning.jsonl" },
+		newSession: async (options: {
+			setup?: (sessionManager: FreshSetupManager) => Promise<void>;
+			withSession?: (ctx: unknown) => Promise<void>;
+		}) => {
+			await options.setup?.({
+				appendCustomEntry: () => "destination-state",
+				appendCustomMessageEntry: () => "destination-contract",
+			});
+			await options.withSession?.({
+				...(replacement.ctx as object),
+				sendUserMessage: async () => undefined,
+			});
+			return { cancelled: false };
+		},
+	});
+
+	const result = await startFreshImplementationSession(source.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "clear-on-start",
+		stateEntryType: STATE_ENTRY_TYPE,
+		runtime: { thinkingLevel: "high" },
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "partial");
+	assert.equal(replacement.editorText, formatTransferredPlanPrompt(PLAN, true));
+	assert.match(replacement.notifications.at(-1)?.message ?? "", /could not be verified/iu);
+	assert.equal(
+		replacement.notifications.some((notice) => /session started/iu.test(notice.message)),
+		false,
+	);
+});
+
 test("fresh success notification failures do not downgrade or duplicate kickoff", async () => {
 	let kickoffCalls = 0;
 	const replacement = createMockContext({ mode: "tui", hasUI: true });

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -100,6 +100,7 @@ test("ready choice descriptions stay bounded and cancellation has no side effect
 		await showReadyPlanMenu(context.ctx, {
 			signal: owner.signal,
 			isCurrent: () => !owner.signal.aborted,
+			planThinkingLevel: undefined,
 			implementationOutcome: () => "Plan reinjection: Until /plan exit\u001b]8;;unsafe\u0007.",
 			getExportDestination: () => ({ configuredPath: "PLAN.md", resolvedPath: "/tmp/PLAN.md" }),
 			implementHere: () => {

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -454,6 +454,62 @@ test("conversation-history fresh kickoff skips active state and recovers in the 
 	assert.doesNotMatch(replacement.notifications.at(-1)?.message ?? "", /active plan/i);
 });
 
+test("fresh handoff treats a handled runtime kickoff as partial and restores the prompt", async () => {
+	const destinationBranch: Array<ReturnType<typeof stateEntry>> = [];
+	const replacement = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		sessionManager: {
+			getBranch: () => destinationBranch,
+			getEntries: () => destinationBranch,
+		},
+	});
+	const source = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: { provider: "test-provider", id: "test-model" },
+		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+		sessionManager: { getSessionFile: () => "/sessions/planning.jsonl" },
+		newSession: async (options: {
+			setup?: (sessionManager: FreshSetupManager) => Promise<void>;
+			withSession?: (ctx: unknown) => Promise<void>;
+		}) => {
+			await options.setup?.({
+				appendCustomEntry(_customType, data) {
+					destinationBranch.push(stateEntry(data as Record<string, unknown>));
+					return "destination-state";
+				},
+				appendCustomMessageEntry() {
+					return "destination-contract";
+				},
+			});
+			await options.withSession?.({
+				...(replacement.ctx as object),
+				sendUserMessage: async () => undefined,
+			});
+			return { cancelled: false };
+		},
+	});
+
+	const result = await startFreshImplementationSession(source.ctx, {
+		plan: PLAN,
+		source: "plan_mode_complete",
+		retention: "clear-on-start",
+		stateEntryType: STATE_ENTRY_TYPE,
+		runtime: { thinkingLevel: "high" },
+		isCurrent: () => true,
+	});
+
+	assert.equal(result.kind, "partial");
+	assert.equal(replacement.editorText, formatTransferredPlanPrompt(PLAN, true));
+	assert.match(replacement.notifications.at(-1)?.message ?? "", /could not be consumed/iu);
+	assert.match(replacement.notifications.at(-1)?.message ?? "", /request is in the editor/iu);
+	assert.equal(
+		replacement.notifications.some((notice) => /session started/iu.test(notice.message)),
+		false,
+	);
+});
+
 test("fresh success notification failures do not downgrade or duplicate kickoff", async () => {
 	let kickoffCalls = 0;
 	const replacement = createMockContext({ mode: "tui", hasUI: true });

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -195,8 +195,11 @@ test("fresh implementation creates a linked destination and hands off only throu
 			getBranch: () => [],
 			getEntries: () => [],
 		},
-		select: async (_title: string, options: string[]) =>
-			options.includes("Start fresh and implement") ? "Start fresh and implement" : undefined,
+		select: async (_title: string, options: string[]) => {
+			if (options.includes("Start fresh and implement")) return "Start fresh and implement";
+			if (options.includes("Start fresh implementation")) return "Start fresh implementation";
+			return undefined;
+		},
 		newSession: async (options: {
 			parentSession?: string;
 			setup?: (sessionManager: FreshSetupManager) => Promise<void>;
@@ -323,7 +326,11 @@ test("fresh menu work stops after source session shutdown while waiting for idle
 		hasUI: true,
 		model: { provider: "test-provider", id: "test-model" },
 		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
-		select: async () => "Start fresh and implement",
+		select: async (_title: string, options: string[]) => {
+			if (options.includes("Start fresh and implement")) return "Start fresh and implement";
+			if (options.includes("Start fresh implementation")) return "Start fresh implementation";
+			return undefined;
+		},
 		waitForIdle: async () => {
 			markWaiting();
 			await idleGate;

--- a/packages/pi-plan-mode/test/launch-menu.test.ts
+++ b/packages/pi-plan-mode/test/launch-menu.test.ts
@@ -433,14 +433,10 @@ test("launch picker retains and sanitizes configured names pending registration"
 	rpc.assertConsumed();
 	const dialog = rpc.dialogs[0];
 	assert.ok(dialog);
-	assert.match(
-		dialog.title,
-		/Pending registration: late \[31m_tool, x+…, start-with-tools, \+1 more/u,
-	);
+	assert.match(dialog.title, /Pending registration: late_tool, x+…, start-with-tools, \+1 more/u);
 	assert.ok(
 		(dialog.options ?? []).some(
-			(option) =>
-				/late \[31m_tool.*Not registered yet/iu.test(option) && !option.includes("\u001b"),
+			(option) => /late_tool.*Not registered yet/iu.test(option) && !option.includes("\u001b"),
 		),
 	);
 	assert.equal(JSON.stringify(dialog).includes("\u001b"), false);

--- a/packages/pi-plan-mode/test/plan-action-controller.test.ts
+++ b/packages/pi-plan-mode/test/plan-action-controller.test.ts
@@ -16,6 +16,7 @@ test("stale Plan actions do not load interactive UI", async () => {
 			isCurrent: () => false,
 		}),
 		statusText: () => "off",
+		getThinkingLevel: () => "medium",
 		implementationOutcome: () => "",
 		getExportDestination: () => ({ configuredPath: "plan.md", resolvedPath: "/tmp/plan.md" }),
 		show: () => undefined,

--- a/packages/pi-plan-mode/test/workflow-mutex.test.ts
+++ b/packages/pi-plan-mode/test/workflow-mutex.test.ts
@@ -418,14 +418,14 @@ test("fresh-session cancellation and pre-shutdown success preserve the source ow
 			getSessionFile: () => undefined,
 		};
 		const mock = createMockPi({ activeTools: ["read", "write"] });
-		let implementFresh: ((signal: AbortSignal) => Promise<void>) | undefined;
+		let implementFresh: ((runtime: object, signal: AbortSignal) => Promise<void>) | undefined;
 		planMode(mock.pi, {
 			readSettings: async () => ({ kind: "missing" as const }),
 			loadInteractiveUi: async () =>
 				({
 					showPlanModeMenu: async (
 						_ctx: unknown,
-						options: { implementFresh(signal: AbortSignal): Promise<void> },
+						options: { implementFresh(runtime: object, signal: AbortSignal): Promise<void> },
 					) => {
 						implementFresh = options.implementFresh;
 					},
@@ -450,7 +450,7 @@ test("fresh-session cancellation and pre-shutdown success preserve the source ow
 		await complete("call", { plan: "# Ready plan" }, undefined, undefined, context.ctx);
 		await mock.commands.get("plan")?.handler("", context.ctx);
 		assert.ok(implementFresh);
-		await implementFresh(new AbortController().signal);
+		await implementFresh({}, new AbortController().signal);
 
 		const beforeShutdown = attempt(sessionManager);
 		mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, beforeShutdown);

--- a/test/support.ts
+++ b/test/support.ts
@@ -306,6 +306,7 @@ export function createMockContext(overrides: Record<string, unknown> = {}) {
 		mode: overrides.mode ?? (overrides.hasUI ? "tui" : undefined),
 		hasUI: overrides.hasUI ?? (overrides.mode === "tui" || overrides.mode === "rpc"),
 		model: overrides.model,
+		scopedModels: overrides.scopedModels ?? [],
 		ui: {
 			theme: overrides.theme ?? { fg: (_role: string, text: string) => text },
 			notify(message: string, level?: string) {


### PR DESCRIPTION
## Summary

- add one-shot model and thinking choices before ready-plan fresh-session handoff
- persist and consume the destination runtime intent before the first implementation request
- handle model, authentication, session replacement, shutdown, and terminal-sanitization failure paths
- document the flow and add a minor Changeset

## Verification

- `npm run check`
- `npm test` (391 files, 4,524 tests)
- audited lifecycle, TUI, state, cancellation, disposal, session replacement, shutdown, and README behavior against `docs/extension-conventions.md` and `docs/readme-conventions.md`

No package metadata or generated-runtime loading boundary changed, so no pack or package-load smoke was required. No known deviations or unverified behavior remain.
