### PR TITLE
fix(chrome-devtools): bound wide tool output

### DIFF
--- a/.changeset/calm-geckos-fit.md
+++ b/.changeset/calm-geckos-fit.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-chrome-devtools": patch
+---
+
+Keep expanded tool output within the terminal width when it contains wide Unicode text.

--- a/.changeset/calm-geckos-fit.md
+++ b/.changeset/calm-geckos-fit.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-chrome-devtools": patch
 ---
 
-Keep expanded tool output within the terminal width when it contains wide Unicode text.
+Keep expanded tool output within the terminal width for wide Unicode text and strip untrusted terminal controls before rendering.

--- a/.changeset/calm-geckos-fit.md
+++ b/.changeset/calm-geckos-fit.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-chrome-devtools": patch
 ---
 
-Keep expanded tool output within the terminal width for wide or malformed Unicode text and strip untrusted terminal controls before rendering.
+Keep expanded tool output bounded for wide, malformed, or zero-width Unicode text and sanitize untrusted terminal controls without blocking rendering.

--- a/.changeset/calm-geckos-fit.md
+++ b/.changeset/calm-geckos-fit.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-chrome-devtools": patch
 ---
 
-Keep expanded tool output within the terminal width for wide Unicode text and strip untrusted terminal controls before rendering.
+Keep expanded tool output within the terminal width for wide or malformed Unicode text and strip untrusted terminal controls before rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6930,12 +6930,14 @@
 			"devDependencies": {
 				"@biomejs/biome": "2.5.11",
 				"@earendil-works/pi-coding-agent": "0.85.0",
+				"@earendil-works/pi-tui": "0.85.0",
 				"esbuild": "0.28.2",
 				"typebox": "1.3.25",
 				"typescript": "7.0.2"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*",
 				"typebox": "*"
 			}
 		},

--- a/packages/pi-chrome-devtools/package.json
+++ b/packages/pi-chrome-devtools/package.json
@@ -35,11 +35,13 @@
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*",
 		"typebox": "*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.11",
 		"@earendil-works/pi-coding-agent": "0.85.0",
+		"@earendil-works/pi-tui": "0.85.0",
 		"esbuild": "0.28.2",
 		"typebox": "1.3.25",
 		"typescript": "7.0.2"

--- a/packages/pi-chrome-devtools/src/display.ts
+++ b/packages/pi-chrome-devtools/src/display.ts
@@ -6,7 +6,8 @@ const MAX_SANITIZER_INPUT_CODE_UNITS = 50_000;
 export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_000) {
 	const boundedInput = truncateCodeUnits(value, MAX_SANITIZER_INPUT_CODE_UNITS);
 	const safeTerminalInput = truncateAtIncompleteTerminalSequence(boundedInput);
-	const withoutBidi = stripVTControlCharacters(stripTerminalSequences(safeTerminalInput)).replace(
+	const normalizedLineEndings = stripTerminalSequences(safeTerminalInput).replace(/\r\n/g, "\n");
+	const withoutBidi = stripVTControlCharacters(normalizedLineEndings).replace(
 		/[\u202a-\u202e\u2066-\u2069]/gu,
 		"�",
 	);

--- a/packages/pi-chrome-devtools/src/display.ts
+++ b/packages/pi-chrome-devtools/src/display.ts
@@ -12,8 +12,13 @@ export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_
 			(codePoint >= 0 && codePoint <= 8) ||
 			(codePoint >= 11 && codePoint <= 31) ||
 			(codePoint >= 127 && codePoint <= 159);
-		return unsafeControl ? "�" : character;
+		const loneSurrogate = character.length === 1 && codePoint >= 0xd800 && codePoint <= 0xdfff;
+		return unsafeControl || loneSurrogate ? "�" : character;
 	}).join("");
 	if (sanitized.length <= maxCharacters) return sanitized;
-	return `${sanitized.slice(0, Math.max(0, maxCharacters - 1))}…`;
+
+	let truncated = sanitized.slice(0, Math.max(0, maxCharacters - 1));
+	const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
+	if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) truncated = truncated.slice(0, -1);
+	return `${truncated}…`;
 }

--- a/packages/pi-chrome-devtools/src/display.ts
+++ b/packages/pi-chrome-devtools/src/display.ts
@@ -4,6 +4,7 @@ import { stripTerminalSequences } from "@earendil-works/pi-tui";
 const MAX_SANITIZER_INPUT_CODE_UNITS = 50_000;
 
 export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_000) {
+	const inputWasTruncated = value.length > MAX_SANITIZER_INPUT_CODE_UNITS;
 	const boundedInput = truncateCodeUnits(value, MAX_SANITIZER_INPUT_CODE_UNITS);
 	const safeTerminalInput = truncateAtIncompleteTerminalSequence(boundedInput);
 	const normalizedLineEndings = stripTerminalSequences(safeTerminalInput).replace(/\r\n/g, "\n");
@@ -20,9 +21,10 @@ export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_
 		const loneSurrogate = character.length === 1 && codePoint >= 0xd800 && codePoint <= 0xdfff;
 		return unsafeControl || loneSurrogate ? "�" : character;
 	}).join("");
-	if (sanitized.length <= maxCharacters) return sanitized;
+	const outputLimit = Math.min(maxCharacters, MAX_SANITIZER_INPUT_CODE_UNITS);
+	if (!inputWasTruncated && sanitized.length <= outputLimit) return sanitized;
 
-	return `${truncateCodeUnits(sanitized, Math.max(0, maxCharacters - 1))}…`;
+	return `${truncateCodeUnits(sanitized, Math.max(0, outputLimit - 1))}…`;
 }
 
 // Preflight Pi-recognized sequences linearly so malformed suffixes never reach its parser.

--- a/packages/pi-chrome-devtools/src/display.ts
+++ b/packages/pi-chrome-devtools/src/display.ts
@@ -1,8 +1,12 @@
 import { stripVTControlCharacters } from "node:util";
 import { stripTerminalSequences } from "@earendil-works/pi-tui";
 
+const MAX_SANITIZER_INPUT_CODE_UNITS = 50_000;
+
 export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_000) {
-	const withoutBidi = stripVTControlCharacters(stripTerminalSequences(value)).replace(
+	const boundedInput = truncateCodeUnits(value, MAX_SANITIZER_INPUT_CODE_UNITS);
+	const safeTerminalInput = truncateAtIncompleteTerminalSequence(boundedInput);
+	const withoutBidi = stripVTControlCharacters(stripTerminalSequences(safeTerminalInput)).replace(
 		/[\u202a-\u202e\u2066-\u2069]/gu,
 		"�",
 	);
@@ -17,8 +21,41 @@ export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_
 	}).join("");
 	if (sanitized.length <= maxCharacters) return sanitized;
 
-	let truncated = sanitized.slice(0, Math.max(0, maxCharacters - 1));
+	return `${truncateCodeUnits(sanitized, Math.max(0, maxCharacters - 1))}…`;
+}
+
+// Preflight Pi-recognized sequences linearly so malformed suffixes never reach its parser.
+function truncateAtIncompleteTerminalSequence(value: string) {
+	let position = value.indexOf("\u001b");
+	while (position >= 0) {
+		const sequenceEnd = terminalSequenceEnd(value, position);
+		if (sequenceEnd === -1) return value.slice(0, position);
+		position = value.indexOf("\u001b", sequenceEnd ?? position + 1);
+	}
+	return value;
+}
+
+function terminalSequenceEnd(value: string, position: number): number | undefined {
+	const type = value[position + 1];
+	if (type === "[") {
+		for (let index = position + 2; index < value.length; index++) {
+			if ("mGKHJ".includes(value[index] ?? "")) return index + 1;
+		}
+		return -1;
+	}
+	if (type !== "]" && type !== "_") return undefined;
+
+	for (let index = position + 2; index < value.length; index++) {
+		if (value[index] === "\u0007") return index + 1;
+		if (value[index] === "\u001b" && value[index + 1] === "\\") return index + 2;
+	}
+	return -1;
+}
+
+function truncateCodeUnits(value: string, maxCodeUnits: number) {
+	if (value.length <= maxCodeUnits) return value;
+	let truncated = value.slice(0, Math.max(0, maxCodeUnits));
 	const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
 	if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) truncated = truncated.slice(0, -1);
-	return `${truncated}…`;
+	return truncated;
 }

--- a/packages/pi-chrome-devtools/src/display.ts
+++ b/packages/pi-chrome-devtools/src/display.ts
@@ -1,0 +1,19 @@
+import { stripVTControlCharacters } from "node:util";
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
+
+export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_000) {
+	const withoutBidi = stripVTControlCharacters(stripTerminalSequences(value)).replace(
+		/[\u202a-\u202e\u2066-\u2069]/gu,
+		"�",
+	);
+	const sanitized = Array.from(withoutBidi, (character) => {
+		const codePoint = character.codePointAt(0) ?? 0;
+		const unsafeControl =
+			(codePoint >= 0 && codePoint <= 8) ||
+			(codePoint >= 11 && codePoint <= 31) ||
+			(codePoint >= 127 && codePoint <= 159);
+		return unsafeControl ? "�" : character;
+	}).join("");
+	if (sanitized.length <= maxCharacters) return sanitized;
+	return `${sanitized.slice(0, Math.max(0, maxCharacters - 1))}…`;
+}

--- a/packages/pi-chrome-devtools/src/render.ts
+++ b/packages/pi-chrome-devtools/src/render.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
+import { sanitizeChromeDevtoolsDisplay } from "./display.js";
 
 const STATUS_KEY = "chrome-devtools";
 interface StatusContext {
@@ -85,8 +86,9 @@ class PiTextComponent implements RenderComponent {
 	}
 
 	render(width: number) {
-		if (!this.text.trim()) return [];
-		return this.text
+		const sanitizedText = sanitizeChromeDevtoolsDisplay(this.text, Number.MAX_SAFE_INTEGER);
+		if (!sanitizedText.trim()) return [];
+		return sanitizedText
 			.replace(/\t/g, "   ")
 			.split(/\r?\n/)
 			.map((line) => {

--- a/packages/pi-chrome-devtools/src/render.ts
+++ b/packages/pi-chrome-devtools/src/render.ts
@@ -86,7 +86,7 @@ class PiTextComponent implements RenderComponent {
 	}
 
 	render(width: number) {
-		const sanitizedText = sanitizeChromeDevtoolsDisplay(this.text, Number.MAX_SAFE_INTEGER);
+		const sanitizedText = sanitizeChromeDevtoolsDisplay(this.text);
 		if (!sanitizedText.trim()) return [];
 		return sanitizedText
 			.replace(/\t/g, "   ")

--- a/packages/pi-chrome-devtools/src/render.ts
+++ b/packages/pi-chrome-devtools/src/render.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 
 const STATUS_KEY = "chrome-devtools";
 interface StatusContext {
@@ -89,14 +90,10 @@ class PiTextComponent implements RenderComponent {
 			.replace(/\t/g, "   ")
 			.split(/\r?\n/)
 			.map((line) => {
-				const truncatedLine = truncateLine(line, Math.max(1, width));
+				const truncatedLine = truncateToWidth(line, Math.max(0, width), "");
 				return this.theme && this.color ? this.theme.fg(this.color, truncatedLine) : truncatedLine;
 			});
 	}
-}
-
-function truncateLine(line: string, maxWidth: number) {
-	return Array.from(line).slice(0, maxWidth).join("");
 }
 
 export async function withStatus<T>(

--- a/packages/pi-chrome-devtools/src/tool-selector.ts
+++ b/packages/pi-chrome-devtools/src/tool-selector.ts
@@ -1,4 +1,3 @@
-import { stripVTControlCharacters } from "node:util";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
 	browserCandidateHint,
@@ -12,6 +11,7 @@ import {
 	launchModeLabel,
 	managedBrowserForOwner,
 } from "./browser-manager.js";
+import { sanitizeChromeDevtoolsDisplay } from "./display.js";
 import {
 	applyAvailableChromeDevtoolsTools,
 	availableChromeDevtoolsTools,
@@ -26,6 +26,8 @@ import {
 	CORE_CHROME_DEVTOOLS_TOOL_NAMES,
 	isWebMcpToolName,
 } from "./tool-names.js";
+
+export { sanitizeChromeDevtoolsDisplay };
 
 type CommandContext = ExtensionCommandContext;
 
@@ -274,23 +276,6 @@ export function buildSettingsSetupMessage(owner: object) {
 			endpointConfigHint(),
 		].join("\n"),
 	);
-}
-
-export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_000) {
-	const withoutBidi = stripVTControlCharacters(value).replace(
-		/[\u202a-\u202e\u2066-\u2069]/gu,
-		"�",
-	);
-	const sanitized = Array.from(withoutBidi, (character) => {
-		const codePoint = character.codePointAt(0) ?? 0;
-		const unsafeControl =
-			(codePoint >= 0 && codePoint <= 8) ||
-			(codePoint >= 11 && codePoint <= 31) ||
-			(codePoint >= 127 && codePoint <= 159);
-		return unsafeControl ? "�" : character;
-	}).join("");
-	if (sanitized.length <= maxCharacters) return sanitized;
-	return `${sanitized.slice(0, Math.max(0, maxCharacters - 1))}…`;
 }
 
 function browserSettingsStatusLines(owner: object) {

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -745,6 +745,14 @@ test("status display sanitizes untrusted text and remains bounded", () => {
 	assert.equal(sanitizeChromeDevtoolsDisplay("12345", 4), "123…");
 	assert.equal(sanitizeChromeDevtoolsDisplay("🙂x", 3), "🙂x");
 	assert.equal(sanitizeChromeDevtoolsDisplay("🙂xy", 2), "…");
+	const atInputLimit = sanitizeChromeDevtoolsDisplay("x".repeat(50_000));
+	assert.equal(atInputLimit.length, 50_000);
+	assert.equal(atInputLimit.endsWith("…"), false);
+	const beyondInputLimit = sanitizeChromeDevtoolsDisplay(`${"x".repeat(49_999)}🙂`);
+	assert.equal(beyondInputLimit.length, 50_000);
+	assert.ok(beyondInputLimit.startsWith("x".repeat(49_999)));
+	assert.ok(beyondInputLimit.endsWith("…"));
+	assert.equal(sanitizeChromeDevtoolsDisplay("\u001b[31m".repeat(10_001)), "…");
 });
 
 test("endpoint helpers normalize ports, hosts, and launch quoting", () => {

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -735,13 +735,16 @@ test("removing WebMCP gateway availability aborts active page work", async () =>
 	});
 });
 
-test("status display strips terminal controls and remains bounded", () => {
+test("status display sanitizes untrusted text and remains bounded", () => {
 	assert.equal(
 		sanitizeChromeDevtoolsDisplay("safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007"),
 		"safelink",
 	);
 	assert.equal(sanitizeChromeDevtoolsDisplay("safe\u202eend"), "safe�end");
+	assert.equal(sanitizeChromeDevtoolsDisplay("\ud800safe\udfff"), "�safe�");
 	assert.equal(sanitizeChromeDevtoolsDisplay("12345", 4), "123…");
+	assert.equal(sanitizeChromeDevtoolsDisplay("🙂x", 3), "🙂x");
+	assert.equal(sanitizeChromeDevtoolsDisplay("🙂xy", 2), "…");
 });
 
 test("endpoint helpers normalize ports, hosts, and launch quoting", () => {

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -74,7 +74,8 @@ test("expanded output bounds zero-width text by code units", () => {
 	const component = renderTextResult(result, { expanded: true, isPartial: false }, plainTheme);
 	const rendered = component.render(3)[0] ?? "";
 
-	assert.ok(rendered.length <= 50_000);
+	assert.equal(rendered.length, 50_000);
+	assert.ok(rendered.endsWith("…"));
 	assert.ok(visibleWidth(rendered) <= 3);
 	assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, input);
 });

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -1,6 +1,70 @@
 import assert from "node:assert/strict";
+import type { AgentToolResult } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
-import { withStatus } from "../src/render.js";
+import { renderTextResult, renderToolCall, withStatus } from "../src/render.js";
+
+const theme = {
+	bold: (text: string) => text,
+	fg: (_color: string, text: string) => `\u001b[31m${text}\u001b[0m`,
+};
+
+function textResult(text: string): AgentToolResult<unknown> {
+	return { content: [{ type: "text", text }], details: undefined };
+}
+
+function renderExpanded(text: string, width: number) {
+	return renderTextResult(textResult(text), { expanded: true, isPartial: false }, theme).render(
+		width,
+	);
+}
+
+test("expanded evaluation output stays within the supplied terminal width", () => {
+	const value = "一一一一一".repeat(50);
+	const output = JSON.stringify({ result: { type: "string", value } }, null, 2);
+	const width = 110;
+	const lines = renderExpanded(output, width);
+
+	assert.ok(lines.every((line) => visibleWidth(line) <= width));
+});
+
+test.each([
+	{ name: "CJK at one column", input: "一", width: 1, expected: "" },
+	{ name: "emoji at three columns", input: "🙂".repeat(3), width: 3, expected: "🙂" },
+	{
+		name: "combining graphemes",
+		input: "e\u0301".repeat(5),
+		width: 3,
+		expected: "e\u0301".repeat(3),
+	},
+	{ name: "zero-width rendering", input: "abc", width: 0, expected: "" },
+])("bounds $name without splitting graphemes", ({ input, width, expected }) => {
+	const lines = renderExpanded(input, width);
+
+	assert.ok(lines.every((line) => visibleWidth(line) <= width));
+	assert.equal(stripTerminalSequences(lines[0] ?? ""), expected);
+});
+
+test("tool rendering preserves compact, progress, tab, line, and truncation behavior", () => {
+	assert.deepEqual(
+		renderTextResult(textResult("hidden"), { expanded: false, isPartial: false }, theme).render(80),
+		[],
+	);
+	assert.equal(
+		stripTerminalSequences(
+			renderTextResult(textResult("ignored"), { expanded: true, isPartial: true }, theme).render(
+				80,
+			)[0] ?? "",
+		),
+		"Running...",
+	);
+	assert.deepEqual(renderExpanded("first\tvalue\nsecond", 80).map(stripTerminalSequences), [
+		"first   value",
+		"second",
+	]);
+	assert.equal(stripTerminalSequences(renderExpanded("abcdef", 3)[0] ?? ""), "abc");
+	assert.deepEqual(renderToolCall("evaluate")().render(0), [""]);
+});
 
 test("concurrent tool statuses restore the latest remaining activity", async () => {
 	const statuses: Array<string | undefined> = [];

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -49,6 +49,19 @@ test.each([
 	assert.equal(stripTerminalSequences(lines[0] ?? ""), expected);
 });
 
+test("expanded output normalizes lone surrogates before measuring terminal width", () => {
+	const width = 3;
+	for (const surrogate of ["\ud800", "\udfff"]) {
+		const lines = renderExpanded(surrogate.repeat(100), width);
+		const terminalText = lines.map((line) => Buffer.from(line).toString()).join("\n");
+
+		assert.ok(lines.every((line) => visibleWidth(Buffer.from(line).toString()) <= width));
+		assert.equal(stripTerminalSequences(terminalText), "�".repeat(width));
+	}
+
+	assert.equal(stripTerminalSequences(renderExpanded("🙂", 2)[0] ?? ""), "🙂");
+});
+
 test("expanded output sanitizes terminal controls before truncation", () => {
 	const input =
 		"safe\u001b[31m red\u001b[0m" +

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -4,8 +4,12 @@ import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { renderTextResult, renderToolCall, withStatus } from "../src/render.js";
 
-const theme = {
+const plainTheme = {
 	bold: (text: string) => text,
+	fg: (_color: string, text: string) => text,
+};
+const theme = {
+	...plainTheme,
 	fg: (_color: string, text: string) => `\u001b[31m${text}\u001b[0m`,
 };
 
@@ -43,6 +47,26 @@ test.each([
 
 	assert.ok(lines.every((line) => visibleWidth(line) <= width));
 	assert.equal(stripTerminalSequences(lines[0] ?? ""), expected);
+});
+
+test("expanded output sanitizes terminal controls before truncation", () => {
+	const input =
+		"safe\u001b[31m red\u001b[0m" +
+		"\u001b]8;;https://evil.example\u0007link\u001b]8;;\u0007" +
+		"\u001b_hidden\u001b\\\u0001\u0085\u202eend";
+	const result = textResult(input);
+	const component = renderTextResult(result, { expanded: true, isPartial: false }, plainTheme);
+
+	assert.deepEqual(component.render(80), ["safe redlink���end"]);
+	assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, input);
+	assert.deepEqual(
+		renderTextResult(
+			textResult("\u001b[31m".repeat(10_000)),
+			{ expanded: true, isPartial: false },
+			plainTheme,
+		).render(80),
+		[],
+	);
 });
 
 test("tool rendering preserves compact, progress, tab, line, and truncation behavior", () => {

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -112,10 +112,14 @@ test("tool rendering preserves compact, progress, tab, line, and truncation beha
 		),
 		"Running...",
 	);
-	assert.deepEqual(renderExpanded("first\tvalue\nsecond", 80).map(stripTerminalSequences), [
+	assert.deepEqual(renderExpanded("first\tvalue\r\nsecond", 80).map(stripTerminalSequences), [
 		"first   value",
 		"second",
 	]);
+	assert.equal(
+		stripTerminalSequences(renderExpanded("first\rsecond", 80)[0] ?? ""),
+		"first�second",
+	);
 	assert.equal(stripTerminalSequences(renderExpanded("abcdef", 3)[0] ?? ""), "abc");
 	assert.deepEqual(renderToolCall("evaluate")().render(0), [""]);
 });

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -62,6 +62,23 @@ test("expanded output normalizes lone surrogates before measuring terminal width
 	assert.equal(stripTerminalSequences(renderExpanded("🙂", 2)[0] ?? ""), "🙂");
 });
 
+test("expanded output bounds incomplete terminal-sequence parsing", () => {
+	for (const introducer of ["\u001b[", "\u001b]", "\u001b_"]) {
+		assert.deepEqual(renderExpanded(introducer.repeat(16_000), 3), []);
+	}
+});
+
+test("expanded output bounds zero-width text by code units", () => {
+	const input = "\u200b".repeat(100_000);
+	const result = textResult(input);
+	const component = renderTextResult(result, { expanded: true, isPartial: false }, plainTheme);
+	const rendered = component.render(3)[0] ?? "";
+
+	assert.ok(rendered.length <= 50_000);
+	assert.ok(visibleWidth(rendered) <= 3);
+	assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, input);
+});
+
 test("expanded output sanitizes terminal controls before truncation", () => {
 	const input =
 		"safe\u001b[31m red\u001b[0m" +


### PR DESCRIPTION
## Summary

- truncate Chrome DevTools tool output by terminal columns instead of Unicode code points
- sanitize terminal controls and malformed UTF-16 before layout while leaving raw tool results unchanged
- preserve CRLF line breaks while replacing isolated carriage returns and other unsafe controls
- bound hostile incomplete-sequence parsing and zero-width output at 50,000 code units
- preserve a visible truncation marker whenever the input ceiling discards output
- preserve valid grapheme clusters and surrogate pairs, and respect zero-width rendering without adding a width-truncation ellipsis
- declare the Pi TUI runtime peer and add regression coverage plus a patch Changeset

Closes #1261.

## Verification

- baseline renderer regression — 6 of 7 tests failed before the width fix
- baseline terminal-control regression — the sanitization test failed before the first review fix
- baseline malformed-Unicode regression — repeated lone high and low surrogates exceeded the supplied width after Node UTF-8 encoding before the second review fix
- baseline hostile-input regressions — incomplete terminal sequences took up to 9.7 seconds locally, and 100,000 zero-width code units bypassed the renderer ceiling
- baseline CRLF regression — `first\r\nsecond` rendered a replacement character before the newline
- baseline input-cap regression — content beyond 50,000 code units was discarded without a truncation marker
- post-fix hostile-input benchmark — 64,000-code-unit incomplete CSI, OSC, and APC inputs each sanitize in under 1 ms locally; 100,000 zero-width code units are capped at 50,000
- focused Chrome DevTools tests — 63 tests passed
- `npm run check` — passed
- `npm test` — 389 files and 4,522 tests passed
- `npm run changeset:status` — patch bump recognized
- `npm run package:pack -- chrome-devtools` — packed 37 expected files
- generated runtime inspection — Pi TUI imports remain external, sanitization precedes truncation, and the Jiti loader test passes

## Risks and unverified paths

- The exact Windows Terminal Ctrl+O interaction was not run because this harness prohibits interactive TUI commands. Deterministic renderer regressions cover terminal width after output encoding, CRLF handling, wide and zero-width Unicode, malformed UTF-16, complete or incomplete terminal sequences, and input-cap markers, while Pi Jiti loader tests cover runtime resolution.
