### PR TITLE
fix(chrome-devtools): harden display sanitization

### DIFF
--- a/packages/pi-chrome-devtools/src/display.ts
+++ b/packages/pi-chrome-devtools/src/display.ts
@@ -1,13 +1,14 @@
 import { stripVTControlCharacters } from "node:util";
-import { stripTerminalSequences } from "@earendil-works/pi-tui";
 
 const MAX_SANITIZER_INPUT_CODE_UNITS = 50_000;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_000) {
 	const inputWasTruncated = value.length > MAX_SANITIZER_INPUT_CODE_UNITS;
-	const boundedInput = truncateCodeUnits(value, MAX_SANITIZER_INPUT_CODE_UNITS);
-	const safeTerminalInput = truncateAtIncompleteTerminalSequence(boundedInput);
-	const normalizedLineEndings = stripTerminalSequences(safeTerminalInput).replace(/\r\n/g, "\n");
+	const boundedInput = inputWasTruncated
+		? truncateAtGraphemeBoundary(value, MAX_SANITIZER_INPUT_CODE_UNITS)
+		: value;
+	const normalizedLineEndings = stripTerminalSequencesLinearly(boundedInput).replace(/\r\n/g, "\n");
 	const withoutBidi = stripVTControlCharacters(normalizedLineEndings).replace(
 		/[\u202a-\u202e\u2066-\u2069]/gu,
 		"�",
@@ -24,25 +25,38 @@ export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_
 	const outputLimit = Math.min(maxCharacters, MAX_SANITIZER_INPUT_CODE_UNITS);
 	if (!inputWasTruncated && sanitized.length <= outputLimit) return sanitized;
 
-	return `${truncateCodeUnits(sanitized, Math.max(0, outputLimit - 1))}…`;
+	return `${truncateAtGraphemeBoundary(sanitized, Math.max(0, outputLimit - 1))}…`;
 }
 
-// Preflight Pi-recognized sequences linearly so malformed suffixes never reach its parser.
-function truncateAtIncompleteTerminalSequence(value: string) {
+// Pi's parser scans malformed terminal strings repeatedly and recognizes only some CSI finals.
+function stripTerminalSequencesLinearly(value: string) {
+	const chunks: string[] = [];
+	let copiedThrough = 0;
 	let position = value.indexOf("\u001b");
 	while (position >= 0) {
 		const sequenceEnd = terminalSequenceEnd(value, position);
-		if (sequenceEnd === -1) return value.slice(0, position);
-		position = value.indexOf("\u001b", sequenceEnd ?? position + 1);
+		if (sequenceEnd === -1) {
+			chunks.push(value.slice(copiedThrough, position));
+			return chunks.join("");
+		}
+		if (sequenceEnd === undefined) {
+			position = value.indexOf("\u001b", position + 1);
+			continue;
+		}
+		chunks.push(value.slice(copiedThrough, position));
+		copiedThrough = sequenceEnd;
+		position = value.indexOf("\u001b", sequenceEnd);
 	}
-	return value;
+	chunks.push(value.slice(copiedThrough));
+	return chunks.join("");
 }
 
 function terminalSequenceEnd(value: string, position: number): number | undefined {
 	const type = value[position + 1];
 	if (type === "[") {
 		for (let index = position + 2; index < value.length; index++) {
-			if ("mGKHJ".includes(value[index] ?? "")) return index + 1;
+			const codeUnit = value.charCodeAt(index);
+			if (codeUnit >= 0x40 && codeUnit <= 0x7e) return index + 1;
 		}
 		return -1;
 	}
@@ -55,10 +69,14 @@ function terminalSequenceEnd(value: string, position: number): number | undefine
 	return -1;
 }
 
-function truncateCodeUnits(value: string, maxCodeUnits: number) {
+function truncateAtGraphemeBoundary(value: string, maxCodeUnits: number) {
 	if (value.length <= maxCodeUnits) return value;
-	let truncated = value.slice(0, Math.max(0, maxCodeUnits));
-	const lastCodeUnit = truncated.charCodeAt(truncated.length - 1);
-	if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) truncated = truncated.slice(0, -1);
-	return truncated;
+	const boundedLookahead = value.slice(0, Math.max(0, maxCodeUnits) + 2);
+	let safeEnd = 0;
+	for (const { index, segment } of graphemeSegmenter.segment(boundedLookahead)) {
+		const segmentEnd = index + segment.length;
+		if (segmentEnd > maxCodeUnits) break;
+		safeEnd = segmentEnd;
+	}
+	return value.slice(0, safeEnd);
 }

--- a/packages/pi-chrome-devtools/src/display.ts
+++ b/packages/pi-chrome-devtools/src/display.ts
@@ -1,5 +1,3 @@
-import { stripVTControlCharacters } from "node:util";
-
 const MAX_SANITIZER_INPUT_CODE_UNITS = 50_000;
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
@@ -8,65 +6,23 @@ export function sanitizeChromeDevtoolsDisplay(value: string, maxCharacters = 50_
 	const boundedInput = inputWasTruncated
 		? truncateAtGraphemeBoundary(value, MAX_SANITIZER_INPUT_CODE_UNITS)
 		: value;
-	const normalizedLineEndings = stripTerminalSequencesLinearly(boundedInput).replace(/\r\n/g, "\n");
-	const withoutBidi = stripVTControlCharacters(normalizedLineEndings).replace(
-		/[\u202a-\u202e\u2066-\u2069]/gu,
-		"�",
-	);
-	const sanitized = Array.from(withoutBidi, (character) => {
+	const normalizedLineEndings = boundedInput.replace(/\r\n/g, "\n");
+	// Neutralize controls without parsing untrusted terminal sequences; keep printable payload visible.
+	const sanitized = Array.from(normalizedLineEndings, (character) => {
 		const codePoint = character.codePointAt(0) ?? 0;
 		const unsafeControl =
 			(codePoint >= 0 && codePoint <= 8) ||
 			(codePoint >= 11 && codePoint <= 31) ||
 			(codePoint >= 127 && codePoint <= 159);
+		const unsafeBidi =
+			(codePoint >= 0x202a && codePoint <= 0x202e) || (codePoint >= 0x2066 && codePoint <= 0x2069);
 		const loneSurrogate = character.length === 1 && codePoint >= 0xd800 && codePoint <= 0xdfff;
-		return unsafeControl || loneSurrogate ? "�" : character;
+		return unsafeControl || unsafeBidi || loneSurrogate ? "�" : character;
 	}).join("");
 	const outputLimit = Math.min(maxCharacters, MAX_SANITIZER_INPUT_CODE_UNITS);
 	if (!inputWasTruncated && sanitized.length <= outputLimit) return sanitized;
 
 	return `${truncateAtGraphemeBoundary(sanitized, Math.max(0, outputLimit - 1))}…`;
-}
-
-// Pi's parser scans malformed terminal strings repeatedly and recognizes only some CSI finals.
-function stripTerminalSequencesLinearly(value: string) {
-	const chunks: string[] = [];
-	let copiedThrough = 0;
-	let position = value.indexOf("\u001b");
-	while (position >= 0) {
-		const sequenceEnd = terminalSequenceEnd(value, position);
-		if (sequenceEnd === -1) {
-			chunks.push(value.slice(copiedThrough, position));
-			return chunks.join("");
-		}
-		if (sequenceEnd === undefined) {
-			position = value.indexOf("\u001b", position + 1);
-			continue;
-		}
-		chunks.push(value.slice(copiedThrough, position));
-		copiedThrough = sequenceEnd;
-		position = value.indexOf("\u001b", sequenceEnd);
-	}
-	chunks.push(value.slice(copiedThrough));
-	return chunks.join("");
-}
-
-function terminalSequenceEnd(value: string, position: number): number | undefined {
-	const type = value[position + 1];
-	if (type === "[") {
-		for (let index = position + 2; index < value.length; index++) {
-			const codeUnit = value.charCodeAt(index);
-			if (codeUnit >= 0x40 && codeUnit <= 0x7e) return index + 1;
-		}
-		return -1;
-	}
-	if (type !== "]" && type !== "_") return undefined;
-
-	for (let index = position + 2; index < value.length; index++) {
-		if (value[index] === "\u0007") return index + 1;
-		if (value[index] === "\u001b" && value[index + 1] === "\\") return index + 2;
-	}
-	return -1;
 }
 
 function truncateAtGraphemeBoundary(value: string, maxCodeUnits: number) {

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -745,6 +745,7 @@ test("status display sanitizes untrusted text and remains bounded", () => {
 	assert.equal(sanitizeChromeDevtoolsDisplay("12345", 4), "123…");
 	assert.equal(sanitizeChromeDevtoolsDisplay("🙂x", 3), "🙂x");
 	assert.equal(sanitizeChromeDevtoolsDisplay("🙂xy", 2), "…");
+	assert.equal(sanitizeChromeDevtoolsDisplay("👩‍💻x", 4), "…");
 	const atInputLimit = sanitizeChromeDevtoolsDisplay("x".repeat(50_000));
 	assert.equal(atInputLimit.length, 50_000);
 	assert.equal(atInputLimit.endsWith("…"), false);
@@ -753,6 +754,27 @@ test("status display sanitizes untrusted text and remains bounded", () => {
 	assert.ok(beyondInputLimit.startsWith("x".repeat(49_999)));
 	assert.ok(beyondInputLimit.endsWith("…"));
 	assert.equal(sanitizeChromeDevtoolsDisplay("\u001b[31m".repeat(10_001)), "…");
+
+	const removablePrefix = "\u001b[000m".repeat(8_333);
+	assert.equal(removablePrefix.length, 49_998);
+	assert.equal(sanitizeChromeDevtoolsDisplay(`${removablePrefix}👩‍💻x`), "…");
+	assert.equal(sanitizeChromeDevtoolsDisplay(`${removablePrefix}a\r\nx`), "a…");
+});
+
+test.each([
+	["Pi-recognized CSI final", "\u001b[31m"],
+	["lowest CSI final byte", "\u001b[@"],
+	["cursor CSI final", "\u001b[2A"],
+	["private CSI final", "\u001b[?25l"],
+	["intermediate CSI final", "\u001b[1 q"],
+	["highest CSI final byte", "\u001b[1~"],
+	["single-character escape", "\u001b7"],
+	["OSC with BEL", "\u001b]0;title\u0007"],
+	["OSC with ST", "\u001b]0;title\u001b\\"],
+	["APC with BEL", "\u001b_payload\u0007"],
+	["APC with ST", "\u001b_payload\u001b\\"],
+] as const)("status display strips %s without consuming following text", (_name, sequence) => {
+	assert.equal(sanitizeChromeDevtoolsDisplay(`before${sequence}aftermore`), "beforeaftermore");
 });
 
 test("endpoint helpers normalize ports, hosts, and launch quoting", () => {

--- a/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
+++ b/packages/pi-chrome-devtools/test/chrome-devtools.test.ts
@@ -735,11 +735,12 @@ test("removing WebMCP gateway availability aborts active page work", async () =>
 	});
 });
 
-test("status display sanitizes untrusted text and remains bounded", () => {
+test("status display neutralizes untrusted text and remains bounded", () => {
 	assert.equal(
 		sanitizeChromeDevtoolsDisplay("safe\u001b]8;;https://evil\u0007link\u001b]8;;\u0007"),
-		"safelink",
+		"safe�]8;;https://evil�link�]8;;�",
 	);
+	assert.equal(sanitizeChromeDevtoolsDisplay("before\u001b[2Aaftermore"), "before�[2Aaftermore");
 	assert.equal(sanitizeChromeDevtoolsDisplay("safe\u202eend"), "safe�end");
 	assert.equal(sanitizeChromeDevtoolsDisplay("\ud800safe\udfff"), "�safe�");
 	assert.equal(sanitizeChromeDevtoolsDisplay("12345", 4), "123…");
@@ -753,28 +754,14 @@ test("status display sanitizes untrusted text and remains bounded", () => {
 	assert.equal(beyondInputLimit.length, 50_000);
 	assert.ok(beyondInputLimit.startsWith("x".repeat(49_999)));
 	assert.ok(beyondInputLimit.endsWith("…"));
-	assert.equal(sanitizeChromeDevtoolsDisplay("\u001b[31m".repeat(10_001)), "…");
+	const hostileInput = sanitizeChromeDevtoolsDisplay("\u001b[31m".repeat(10_001));
+	assert.equal(hostileInput.length, 50_000);
+	assert.equal(hostileInput.includes("\u001b"), false);
+	assert.ok(hostileInput.endsWith("…"));
 
-	const removablePrefix = "\u001b[000m".repeat(8_333);
-	assert.equal(removablePrefix.length, 49_998);
-	assert.equal(sanitizeChromeDevtoolsDisplay(`${removablePrefix}👩‍💻x`), "…");
-	assert.equal(sanitizeChromeDevtoolsDisplay(`${removablePrefix}a\r\nx`), "a…");
-});
-
-test.each([
-	["Pi-recognized CSI final", "\u001b[31m"],
-	["lowest CSI final byte", "\u001b[@"],
-	["cursor CSI final", "\u001b[2A"],
-	["private CSI final", "\u001b[?25l"],
-	["intermediate CSI final", "\u001b[1 q"],
-	["highest CSI final byte", "\u001b[1~"],
-	["single-character escape", "\u001b7"],
-	["OSC with BEL", "\u001b]0;title\u0007"],
-	["OSC with ST", "\u001b]0;title\u001b\\"],
-	["APC with BEL", "\u001b_payload\u0007"],
-	["APC with ST", "\u001b_payload\u001b\\"],
-] as const)("status display strips %s without consuming following text", (_name, sequence) => {
-	assert.equal(sanitizeChromeDevtoolsDisplay(`before${sequence}aftermore`), "beforeaftermore");
+	const zeroWidthPrefix = "\u200b".repeat(49_998);
+	assert.equal(sanitizeChromeDevtoolsDisplay(`${zeroWidthPrefix}👩‍💻x`), `${zeroWidthPrefix}…`);
+	assert.equal(sanitizeChromeDevtoolsDisplay(`${zeroWidthPrefix}a\r\nx`), `${zeroWidthPrefix}a…`);
 });
 
 test("endpoint helpers normalize ports, hosts, and launch quoting", () => {

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -62,9 +62,15 @@ test("expanded output normalizes lone surrogates before measuring terminal width
 	assert.equal(stripTerminalSequences(renderExpanded("🙂", 2)[0] ?? ""), "🙂");
 });
 
-test("expanded output bounds incomplete terminal-sequence parsing", () => {
-	for (const introducer of ["\u001b[", "\u001b]", "\u001b_"]) {
-		assert.deepEqual(renderExpanded(introducer.repeat(16_000), 3), []);
+test("expanded output bounds control-only text without parsing terminal sequences", () => {
+	for (const [introducer, expected] of [
+		["\u001b[", "�[�"],
+		["\u001b]", "�]�"],
+		["\u001b_", "�_�"],
+	] as const) {
+		assert.deepEqual(renderExpanded(introducer.repeat(16_000), 3).map(stripTerminalSequences), [
+			expected,
+		]);
 	}
 });
 
@@ -81,12 +87,12 @@ test("expanded output bounds zero-width text by code units", () => {
 });
 
 test("expanded output preserves display boundaries at the sanitizer input cap", () => {
-	const removablePrefix = "\u001b[000m".repeat(8_333);
+	const zeroWidthPrefix = "\u200b".repeat(49_998);
 	for (const [suffix, expected] of [
-		["👩‍💻x", "…"],
-		["a\r\nx", "a…"],
+		["👩‍💻x", `${zeroWidthPrefix}…`],
+		["a\r\nx", `${zeroWidthPrefix}a…`],
 	] as const) {
-		const input = `${removablePrefix}${suffix}`;
+		const input = `${zeroWidthPrefix}${suffix}`;
 		const result = textResult(input);
 
 		assert.deepEqual(
@@ -106,16 +112,17 @@ test("expanded output sanitizes terminal controls before truncation", () => {
 	const result = textResult(input);
 	const component = renderTextResult(result, { expanded: true, isPartial: false }, plainTheme);
 
-	assert.deepEqual(component.render(80), ["safe redkeptlink���end"]);
+	assert.deepEqual(component.render(200), [
+		"safe�[31m red�[0m�[2Akept�]8;;https://evil.example�link�]8;;��_hidden�\\���end",
+	]);
 	assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, input);
-	assert.deepEqual(
-		renderTextResult(
-			textResult("\u001b[31m".repeat(10_000)),
-			{ expanded: true, isPartial: false },
-			plainTheme,
-		).render(80),
-		[],
-	);
+	const controlOnly = renderTextResult(
+		textResult("\u001b[31m".repeat(10_000)),
+		{ expanded: true, isPartial: false },
+		plainTheme,
+	).render(80);
+	assert.deepEqual(controlOnly.map(stripTerminalSequences), ["�[31m".repeat(16)]);
+	assert.ok(controlOnly.every((line) => visibleWidth(line) <= 80));
 });
 
 test("tool rendering preserves compact, progress, tab, line, and truncation behavior", () => {

--- a/packages/pi-chrome-devtools/test/render.test.ts
+++ b/packages/pi-chrome-devtools/test/render.test.ts
@@ -80,15 +80,33 @@ test("expanded output bounds zero-width text by code units", () => {
 	assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, input);
 });
 
+test("expanded output preserves display boundaries at the sanitizer input cap", () => {
+	const removablePrefix = "\u001b[000m".repeat(8_333);
+	for (const [suffix, expected] of [
+		["👩‍💻x", "…"],
+		["a\r\nx", "a…"],
+	] as const) {
+		const input = `${removablePrefix}${suffix}`;
+		const result = textResult(input);
+
+		assert.deepEqual(
+			renderTextResult(result, { expanded: true, isPartial: false }, plainTheme).render(80),
+			[expected],
+		);
+		assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, input);
+	}
+});
+
 test("expanded output sanitizes terminal controls before truncation", () => {
 	const input =
 		"safe\u001b[31m red\u001b[0m" +
+		"\u001b[2Akept" +
 		"\u001b]8;;https://evil.example\u0007link\u001b]8;;\u0007" +
 		"\u001b_hidden\u001b\\\u0001\u0085\u202eend";
 	const result = textResult(input);
 	const component = renderTextResult(result, { expanded: true, isPartial: false }, plainTheme);
 
-	assert.deepEqual(component.render(80), ["safe redlink���end"]);
+	assert.deepEqual(component.render(80), ["safe redkeptlink���end"]);
 	assert.equal(result.content[0]?.type === "text" ? result.content[0].text : undefined, input);
 	assert.deepEqual(
 		renderTextResult(


### PR DESCRIPTION
## Summary

- preserve complete grapheme clusters and CRLF pairs when the display sanitizer reaches its raw or output code-unit cap
- neutralize terminal control code points before width truncation without parsing untrusted CSI, OSC, or APC sequences
- keep printable sequence payload and following text visible instead of risking parser complexity or accidental consumption
- add regression coverage for cap boundaries, hostile control-only input, width bounds, and unchanged raw tool results

Follow-up to #1264 and review 5170706948.

The existing unreleased `@narumitw/pi-chrome-devtools` patch Changeset on `main` covers this follow-up.

## Verification

- focused Chrome DevTools tests — 49 passed
- `npm run check` — passed
- `npm test` — 389 files and 4,523 tests passed
- `npm run changeset:status` — patch bump recognized
- `npm run package:pack -- chrome-devtools` — packed 37 expected files

## Risks and unverified paths

- Sanitized escape syntax remains visible with each control replaced by `�`; no terminal control reaches rendering.
- The exact Windows Terminal interaction was not rerun because this harness prohibits interactive TUI commands. Deterministic renderer tests cover grapheme and CRLF boundaries, CSI/OSC/APC introducers, control-only input, width bounds, and raw-payload preservation.
