### PR TITLE
feat(tui-kit): add searchable default-aware selectors

### DIFF
--- a/.changeset/smart-owls-select.md
+++ b/.changeset/smart-owls-select.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": minor
+---
+
+Add searchable default-aware selectors with current/default markers and effective Ctrl+S save-default actions.

--- a/packages/pi-tui-kit/README.md
+++ b/packages/pi-tui-kit/README.md
@@ -10,6 +10,7 @@ Consumers reuse its navigation, rendering, cancellation, and mode adaptation ins
 ## ✨ Features
 
 - Defines typed action, detail, browse, choice, settings, input, review, and multi-select screens.
+- Provides searchable default-aware selectors for model and thinking choices, with configurable save-default actions (Ctrl+S by default).
 - Adapts shared menu and interaction flows across Pi TUI and RPC modes.
 - Handles interaction navigation, cancellation, disposal, horizontal framing, and width-safe rendering.
 - Provides task, confirmation, questionnaire, live-choice, custom-interaction, terminal-document, terminal-text, interaction-hint, editor-status-widget, horizontal-rule, and testing helpers.
@@ -67,6 +68,8 @@ Pi TUI Kit and its consumers version independently through Changesets.
 Publish a new Kit API before raising a consumer's compatibility floor.
 Declare Kit in that consumer so local hoisting cannot hide an incompatible or missing published dependency.
 
+The default-aware selectors use an explicit API-admission exception for two convergent selection flows requested by the maintainer. Consumer migrations remain deferred, and each consumer retains default-setting persistence.
+
 Searchable review and browse-detail screens use an explicit pre-adoption API-admission exception.
 Review behavior converges in `pi-starship` configuration documents and `pi-recall` saved-message previews, while browse-detail behavior converges in `pi-tool` exact tool documents and `pi-analytics` detail catalogs.
 Those consumers cannot adopt the fields until this Kit minor is published, so this release keeps their compatibility floors unchanged and defers consumer migration.
@@ -98,6 +101,7 @@ These fields reveal dependencies deferred from import time to the first interact
 The [API reference](./docs/api.md) contains the complete examples and contracts:
 
 - [Menus and standalone interactions](./docs/api.md#-complete-menu-example) — typed actions, tasks, confirmations, live previews, questionnaires, and custom components.
+- [Default-aware selectors](./docs/api.md#searchable-default-aware-selectors) — searchable choices with current/default state and save-default shortcuts.
 - [Standard screens](./docs/api.md#-standard-screens) — actions, detail, browse, choice, settings, input, review, and multi-select.
 - [Runtime and modes](./docs/api.md#-runtime-and-mode-behavior) — TUI/RPC adaptation, result types, cancellation, and session ownership.
 - [Ownership boundary](./docs/api.md#-ownership-boundary) — what Kit owns and what each extension must keep local.

--- a/packages/pi-tui-kit/docs/api.md
+++ b/packages/pi-tui-kit/docs/api.md
@@ -7,6 +7,7 @@
 - [Bounded frames](#bounded-frames)
 - [Complete menu example](#-complete-menu-example)
 - [Standalone interactions](#standalone-tasks)
+- [Searchable default-aware selectors](#searchable-default-aware-selectors)
 - [Standard screens](#-standard-screens)
 - [Runtime and mode behavior](#-runtime-and-mode-behavior)
 - [Ownership boundary](#-ownership-boundary)
@@ -337,6 +338,56 @@ Pi's RPC editor API has no abort signal, so owner cancellation during an open ed
 Print and JSON return `unsupported`.
 Owner abort, stale state, external disposal, invalid options, and UI failures remain distinct typed results.
 The caller owns question-count and option-count policy, domain validation, side effects, result persistence, and mapping answer IDs back to domain objects.
+
+### Searchable default-aware selectors
+
+Use `runModelSelector()` and `runThinkingSelector()` for searchable selection flows that distinguish the active value from the saved default. The selectors use the callback-provided theme and effective keybindings, and return `saveDefault` when the user presses the configured save shortcut (`Ctrl+S` by default).
+
+```ts
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+  runModelSelector,
+  runThinkingSelector,
+} from "@narumitw/pi-tui-kit";
+
+declare function saveDefaultModel(provider: string, modelId: string): Promise<void>;
+declare function saveDefaultThinking(level: string): Promise<void>;
+
+export async function chooseModel(pi: ExtensionAPI, ctx: ExtensionCommandContext) {
+  const models = ctx.scopedModels.length
+    ? ctx.scopedModels.map(({ model }) => model)
+    : ctx.modelRegistry.getAvailable();
+  const result = await runModelSelector(ctx, {
+    models,
+    currentModel: ctx.model,
+    // Load this through the consumer's Pi settings owner when it wants a default marker.
+    defaultModel: undefined,
+  });
+  if (result.kind === "selected") await pi.setModel(result.model);
+  if (result.kind === "saveDefault") {
+    if (await pi.setModel(result.model)) {
+      await saveDefaultModel(result.model.provider, result.model.id);
+    }
+  }
+}
+
+export async function chooseThinking(pi: ExtensionAPI, ctx: ExtensionCommandContext) {
+  const result = await runThinkingSelector(ctx, {
+    availableLevels: ctx.model ? getSupportedThinkingLevels(ctx.model) : ["off"],
+    currentLevel: pi.getThinkingLevel(),
+  });
+  if (result.kind === "selected") pi.setThinkingLevel(result.level);
+  if (result.kind === "saveDefault") {
+    pi.setThinkingLevel(result.level);
+    await saveDefaultThinking(result.level);
+  }
+}
+```
+
+The selectors deliberately return intent instead of writing Pi's `settings.json`. The consumer owns default persistence, ordered writes, failure reporting, and any rollback because it owns the relevant settings manager. A `saveDefault` result should normally apply the highlighted value to the current session as well as save it, matching Pi's built-in behavior.
+
+Both selectors are TUI-only and return `unsupported` in RPC, print, and JSON modes. The model selector renders the supplied snapshot and does not refresh provider catalogs or choose between all and scoped models; pass `ctx.scopedModels` when session scope applies, as shown above. Escape returns Back, while Ctrl+C remains a hard Close path.
 
 ### Custom interactions and display helpers
 
@@ -826,6 +877,7 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `runTask()` — runs typed abort-aware work with a cancellable TUI loader and direct non-TUI fallback.
 - `runConfirmation()` — preserves Confirmed, Back, Close, Stale, Unsupported, and Error for one standalone confirmation without owning the confirmed side effect.
 - `runLiveChoice()` — adapts live-preview choice to TUI and RPC while preserving typed selection, gating, shortcuts, and lifecycle outcomes.
+- `runModelSelector()` and `runThinkingSelector()` — provide searchable TUI selectors with current/default markers and typed save-default intent.
 - `runQuestionnaire()` — adapts choices, free-form answers, optional TUI notes, direct single-question submission, multi-question review, and sequential RPC.
 - `formatInteractionHints()` — formats sanitized, normalized, de-duplicated bindings and literal keys; `@narumitw/pi-tui-kit/interaction-hints` also exports it and its types.
 - `sanitizeTerminalDocument()` — normalizes and sanitizes untrusted multiline display text while retaining LF and tabs; `@narumitw/pi-tui-kit/terminal-document` also exports it.
@@ -839,7 +891,8 @@ Consumer fixtures continue to own domain state, persistence, generation checks, 
 - `createMenuNavigator()` — lower-level stack and selection state helper.
 - exported screen, item, action, transition, runtime option, `BrowseDetailDocument`, `MenuCloseReason`, and result types.
 - `@narumitw/pi-tui-kit/testing` — test-only subpath for `createTuiHarness()`, `createRpcHarness()`, strict scripts, and their types; the production root does not re-export it.
-- `PI_EXTENSION_MENU_API_VERSION` — current API version (`16`).
+- `PI_EXTENSION_MENU_API_VERSION` — current API version (`17`).
+Version 17 adds searchable default-aware selectors while version-16 menu definitions remain valid.
 Version 16 adds the stateless bounded-frame helper while version-15 menu definitions remain valid.
 Version 15 adds opt-in review and browse-detail search plus public multiline terminal-document helpers while version-14 menu definitions remain valid.
 Version 14 adds the standalone `runQuestionnaire()` interaction while version-13 menu definitions remain valid.

--- a/packages/pi-tui-kit/docs/api.md
+++ b/packages/pi-tui-kit/docs/api.md
@@ -836,7 +836,7 @@ const frame = tui.render();
 const result = await running;
 ```
 
-The TUI harness supports semantic Kit bindings, explicit raw input, Ctrl+C, Home, End, focus, and invalidation.
+The TUI harness supports semantic Kit bindings, explicit raw input, normalized mouse events, Ctrl+C, Home, End, focus, and invalidation.
 It also supports live dimension changes, render-request observations, pending-action draining, sequential screens, result observation, and external disposal.
 `done`, disposal, factory failure, and obsolete async openings settle exactly once; input after closure is inert.
 Supply optional callback-compatible theme/keybinding overrides only when a test needs them.

--- a/packages/pi-tui-kit/src/bounded-frame.ts
+++ b/packages/pi-tui-kit/src/bounded-frame.ts
@@ -19,21 +19,33 @@ export interface BoundedFrameOptions {
 	focusedRow?: number;
 }
 
+interface FrameRow {
+	line: string;
+	contentIndex?: number;
+}
+
 /** Frame terminal-formatted rows without owning input, persistence, or terminal reservations. */
 export function renderBoundedFrame(options: BoundedFrameOptions): string[] {
+	return renderBoundedFrameLayout(options).lines;
+}
+
+/** Internal layout metadata for components that route normalized pointer coordinates. */
+export function renderBoundedFrameLayout(options: BoundedFrameOptions) {
 	const width = dimension(options.width);
 	const maxRows = dimension(options.maxRows);
-	if (maxRows === 0) return [];
+	if (maxRows === 0) return { lines: [], contentRows: [] };
 	const { rule, title, content, hints = [], context = [], compactHint = "" } = options;
-	const full = [
-		rule,
-		...title,
-		...context,
-		...(content.length ? ["", ...content] : []),
-		...hints,
-		rule,
+	const full: FrameRow[] = [
+		{ line: rule },
+		...title.map((line) => ({ line })),
+		...context.map((line) => ({ line })),
+		...(content.length
+			? [{ line: "" }, ...content.map((line, contentIndex) => ({ line, contentIndex }))]
+			: []),
+		...hints.map((line) => ({ line })),
+		{ line: rule },
 	];
-	if (full.length <= maxRows) return full.map((line) => truncateToWidth(line, width, ""));
+	if (full.length <= maxRows) return finalizeLayout(full, width);
 
 	const framed = maxRows >= 5;
 	const available = maxRows - (framed ? 2 : 0);
@@ -48,7 +60,7 @@ export function renderBoundedFrame(options: BoundedFrameOptions): string[] {
 		? compactContent(
 				title,
 				context,
-				rows.map(({ line }) => line),
+				rows,
 				options.compactHints ?? hints,
 				compactHint,
 				available,
@@ -56,7 +68,16 @@ export function renderBoundedFrame(options: BoundedFrameOptions): string[] {
 				focused,
 			)
 		: compactStatic(title, context, compactHint, available);
-	return (framed ? [rule, ...body, rule] : body).map((line) => truncateToWidth(line, width, ""));
+	return finalizeLayout(framed ? [{ line: rule }, ...body, { line: rule }] : body, width);
+}
+
+function finalizeLayout(rows: readonly FrameRow[], width: number) {
+	return {
+		lines: rows.map(({ line }) => truncateToWidth(line, width, "")),
+		contentRows: rows.flatMap(({ contentIndex }, frameIndex) =>
+			contentIndex === undefined ? [] : [{ contentIndex, frameIndex }],
+		),
+	};
 }
 
 function dimension(value: number): number {
@@ -66,13 +87,13 @@ function dimension(value: number): number {
 function compactContent(
 	title: readonly string[],
 	context: readonly string[],
-	content: readonly string[],
+	content: readonly { line: string; index: number }[],
 	hints: readonly string[],
 	compactHint: string,
 	available: number,
 	priorities: readonly number[],
 	focused: number,
-): string[] {
+): FrameRow[] {
 	const hintBudget = compactHint && available > 1 ? 1 : 0;
 	const minimumContent = Math.min(available - hintBudget, Math.max(1, priorities.length));
 	let remaining = Math.max(0, available - hintBudget - minimumContent);
@@ -97,10 +118,15 @@ function compactContent(
 		indexes.add(index);
 	}
 	return [
-		...title.slice(0, titleBudget),
-		...context.slice(0, contextBudget),
-		...[...indexes].sort((left, right) => left - right).map((index) => content[index] ?? ""),
-		...(hintBudget ? (fullHints ? hints : [compactHint]) : []),
+		...title.slice(0, titleBudget).map((line) => ({ line })),
+		...context.slice(0, contextBudget).map((line) => ({ line })),
+		...[...indexes]
+			.sort((left, right) => left - right)
+			.map((index) => ({
+				line: content[index]?.line ?? "",
+				contentIndex: content[index]?.index,
+			})),
+		...(hintBudget ? (fullHints ? hints : [compactHint]).map((line) => ({ line })) : []),
 	];
 }
 
@@ -109,16 +135,18 @@ function compactStatic(
 	context: readonly string[],
 	compactHint: string,
 	available: number,
-): string[] {
-	if (available === 1) return [context[0] || compactHint || title[0] || ""];
+): FrameRow[] {
+	if (available === 1) return [{ line: context[0] || compactHint || title[0] || "" }];
 	const hintBudget = compactHint ? 1 : 0;
 	const minimumContext = context.length > 0 ? 1 : 0;
 	let remaining = Math.max(0, available - hintBudget - minimumContext);
 	const titleBudget = title.length > 0 && remaining > 0 ? 1 : 0;
 	remaining -= titleBudget;
 	return [
-		...title.slice(0, titleBudget),
-		...context.slice(0, Math.min(context.length, minimumContext + remaining)),
-		...(hintBudget ? [compactHint] : []),
+		...title.slice(0, titleBudget).map((line) => ({ line })),
+		...context
+			.slice(0, Math.min(context.length, minimumContext + remaining))
+			.map((line) => ({ line })),
+		...(hintBudget ? [{ line: compactHint }] : []),
 	];
 }

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -2,6 +2,7 @@ import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent"
 import {
 	fuzzyFilter,
 	Input,
+	isKittyProtocolActive,
 	Key,
 	matchesKey,
 	parseKey,
@@ -16,6 +17,7 @@ import { HorizontalRule } from "../horizontal-rule.js";
 import { formatInteractionHints } from "../interaction-hints.js";
 import { sanitizeTerminalText } from "../terminal-text.js";
 import type { MenuCloseReason } from "../types.js";
+import { componentRows } from "./rendering.js";
 
 const BRACKETED_PASTE_START = "\u001b[200~";
 const BRACKETED_PASTE_END = "\u001b[201~";
@@ -186,7 +188,9 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 		const pasted = pasteBuffer.slice(0, pasteEnd);
 		const remaining = pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
 		pasteBuffer = undefined;
-		input.handleInput(`${BRACKETED_PASTE_START}${safe(pasted)}${BRACKETED_PASTE_END}`);
+		input.handleInput(
+			`${BRACKETED_PASTE_START}${normalizePastedInput(pasted)}${BRACKETED_PASTE_END}`,
+		);
 		refilter();
 		if (remaining && !disposed) routeInput(remaining);
 	}
@@ -266,7 +270,13 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 				content.push("", options.theme.fg("muted", `  ${safe(selected.description)}`));
 			}
 
-			const hint = selectorHint(options.keybindings, options.saveBinding);
+			const keyPlan = selectorKeyPlan(
+				options.keybindings,
+				options.saveBinding,
+				options.cycleBinding,
+			);
+			const hint = selectorHint(keyPlan);
+			const cycleHint = selectorCycleHint(keyPlan);
 			const listSelectedIndex = selectedIndex - start;
 			const selectedContentIndex = searchRows.length + 1 + listSelectedIndex;
 			const rule =
@@ -275,12 +285,13 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 				}).render(safeWidth)[0] ?? "";
 			const layout = renderBoundedFrameLayout({
 				width: safeWidth,
-				maxRows: Number.isFinite(options.tui.terminal.rows)
-					? Math.max(0, Math.floor(options.tui.terminal.rows))
-					: 0,
+				maxRows: componentRows(options.tui.terminal.rows),
 				rule,
 				title: options.title ? [safe(options.title)] : [],
-				context: (options.context ?? []).map((line) => safe(line)),
+				context: [
+					...(cycleHint ? [cycleHint] : []),
+					...(options.context ?? []).map((line) => safe(line)),
+				],
 				content,
 				hints: hint ? [options.theme.fg("dim", `  ${hint}`)] : [],
 				compactHint: hint ? options.theme.fg("dim", hint) : "",
@@ -329,7 +340,7 @@ function filterRows<Value>(
 	const safeQuery = safe(query).trim();
 	if (!safeQuery) return [...rows];
 	const filtered = fuzzyFilter([...rows], safeQuery, (row) =>
-		[row.primary, row.secondary, row.description, row.searchText]
+		[row.searchText, row.primary, row.secondary, row.description]
 			.filter((value): value is string => Boolean(value))
 			.map(safe)
 			.join(" "),
@@ -375,28 +386,111 @@ function renderSearchInput(input: Input, width: number) {
 	return input.render(inputWidth).map((line) => truncateToWidth(`${prefix}${line}`, width, ""));
 }
 
-function selectorHint(keybindings: KeybindingsManager, saveBinding: "app.models.save") {
-	const saveKeys = getBindingKeys(keybindings, saveBinding);
-	const confirmKeys = getBindingKeys(keybindings, "tui.select.confirm");
-	return formatInteractionHints(
-		{
-			getKeys: (binding: string) => getBindingKeys(keybindings, binding),
-		},
-		[
-			{
-				bindings: ["tui.select.confirm"],
-				excludeKeys: ["ctrl+c", ...saveKeys],
-				label: "select",
-			},
-			{ bindings: [saveBinding], excludeKeys: ["ctrl+c"], label: "set as default" },
-			{
-				bindings: ["tui.select.cancel"],
-				excludeKeys: ["ctrl+c", ...saveKeys, ...confirmKeys],
-				label: "cancel",
-			},
-		],
-	);
+interface SelectorKeyPlan {
+	save: readonly string[];
+	confirm: readonly string[];
+	cancel: readonly string[];
+	cycle: readonly string[];
 }
+
+function selectorKeyPlan(
+	keybindings: KeybindingsManager,
+	saveBinding: "app.models.save",
+	cycleBinding: "app.thinking.cycle" | undefined,
+): SelectorKeyPlan {
+	const claimed = new Set([keyClaimIdentity("ctrl+c")]);
+	const claim = (binding: string | undefined) => {
+		const available: string[] = [];
+		if (!binding) return available;
+		for (const key of getBindingKeys(keybindings, binding)) {
+			const canonical = canonicalKeyId(key);
+			if (!canonical) continue;
+			const identity = keyClaimIdentity(canonical);
+			if (claimed.has(identity)) continue;
+			claimed.add(identity);
+			available.push(canonical);
+		}
+		return available;
+	};
+	return {
+		save: claim(saveBinding),
+		confirm: claim("tui.select.confirm"),
+		cancel: claim("tui.select.cancel"),
+		cycle: claim(cycleBinding),
+	};
+}
+
+function selectorHint(plan: SelectorKeyPlan) {
+	return formatInteractionHints({ getKeys: () => [] }, [
+		{ keys: plan.confirm, label: "select" },
+		{ keys: plan.save, label: "set as default" },
+		{ keys: plan.cancel, label: "cancel" },
+	]);
+}
+
+function selectorCycleHint(plan: SelectorKeyPlan) {
+	return formatInteractionHints({ getKeys: () => [] }, [
+		{ keys: plan.cycle, label: "cycle choice" },
+	]);
+}
+
+function canonicalKeyId(value: string): string | undefined {
+	const parts = safe(value).toLowerCase().split("+");
+	const rawBase = parts.at(-1);
+	if (!rawBase) return undefined;
+	const base = rawBase === "esc" ? "escape" : rawBase === "return" ? "enter" : rawBase;
+	const modifiers = ["shift", "ctrl", "alt", "super"].filter((modifier) =>
+		parts.includes(modifier),
+	);
+	if (!isExecutableKey(base, modifiers)) return undefined;
+	return [...modifiers, base].join("+");
+}
+
+function keyClaimIdentity(canonical: string): string {
+	if (isKittyProtocolActive()) return canonical;
+	if (canonical === "ctrl+i") return "tab";
+	if (canonical === "ctrl+j" || canonical === "ctrl+m") return "enter";
+	if (canonical === "ctrl+[") return "escape";
+	if (canonical === "ctrl+_") return "ctrl+-";
+	if (canonical === "alt+b") return "alt+left";
+	if (canonical === "alt+f") return "alt+right";
+	if (canonical === "alt+p") return "alt+up";
+	if (canonical === "alt+n") return "alt+down";
+	return canonical;
+}
+
+function isExecutableKey(base: string, modifiers: readonly string[]) {
+	if (!KEY_BASES.has(base)) return false;
+	if (base === "escape" || /^f(?:[1-9]|1[0-2])$/u.test(base)) return modifiers.length === 0;
+	if (base === "clear") {
+		return (
+			modifiers.length === 0 ||
+			(modifiers.length === 1 && (modifiers[0] === "shift" || modifiers[0] === "ctrl"))
+		);
+	}
+	return true;
+}
+
+const KEY_BASES = new Set([
+	..."abcdefghijklmnopqrstuvwxyz0123456789`-=[]\\;',./!@#$%^&*()_|~{}:<>?",
+	"escape",
+	"enter",
+	"tab",
+	"space",
+	"backspace",
+	"delete",
+	"insert",
+	"clear",
+	"home",
+	"end",
+	"pageup",
+	"pagedown",
+	"up",
+	"down",
+	"left",
+	"right",
+	...Array.from({ length: 12 }, (_, index) => `f${index + 1}`),
+]);
 
 function matchesBinding(keybindings: KeybindingsManager, data: string, binding: string) {
 	return (keybindings.matches as (input: string, keybinding: string) => boolean)(data, binding);
@@ -412,6 +506,12 @@ function normalizeViewportSize(value: number | undefined) {
 
 function safe(value: string) {
 	return sanitizeTerminalText(value);
+}
+
+function normalizePastedInput(value: string) {
+	return safe(
+		value.replace(/\r\n/gu, "").replace(/\r/gu, "").replace(/\n/gu, "").replace(/\t/gu, "    "),
+	);
 }
 
 function trailingMarkerPrefixLength(value: string, marker: string) {

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -14,6 +14,9 @@ import { formatInteractionHints } from "../interaction-hints.js";
 import { sanitizeTerminalText } from "../terminal-text.js";
 import type { MenuCloseReason } from "../types.js";
 
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+
 export interface PiSelectorRow<Value> {
 	value: Value;
 	primary: string;
@@ -31,8 +34,8 @@ export interface PiSelectorOptions<Value> {
 	initialValue?: Value;
 	initialSearchInput?: string;
 	viewportSize?: number;
-	saveBinding: "app.models.save" | "app.thinking.save";
-	savePriority: "beforeSelection" | "afterCancel";
+	saveBinding: "app.models.save";
+	cycleBinding?: "app.thinking.cycle";
 	filterSelection: "bestMatch" | "preserveValue";
 	valueEquals(left: Value, right: Value): boolean;
 	onComplete(
@@ -56,6 +59,8 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			? 0
 			: initialIndex(filtered, options.initialValue, options.valueEquals);
 	let disposed = false;
+	let pasteStartBuffer = "";
+	let pasteBuffer: string | undefined;
 
 	const select = (index: number, wrap: boolean) => {
 		if (filtered.length === 0) return;
@@ -81,6 +86,92 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 		if (!selected || disposed) return;
 		options.onComplete({ kind, value: selected.value });
 	};
+	const handleSearchInput = (data: string) => {
+		input.handleInput(data);
+		const sanitized = safe(input.getValue());
+		if (sanitized !== input.getValue()) input.setValue(sanitized);
+		refilter();
+	};
+	const saveDefault = (data: string) => {
+		if (!matchesBinding(options.keybindings, data, options.saveBinding)) return false;
+		completeSelected("saveDefault");
+		return true;
+	};
+	const handleNonPasteInput = (data: string) => {
+		if (matchesKey(data, Key.ctrl("c"))) {
+			options.onComplete({ kind: "closed", reason: "close" });
+			return;
+		}
+		if (saveDefault(data)) return;
+		if (options.keybindings.matches(data, "tui.select.confirm")) {
+			completeSelected("selected");
+			return;
+		}
+		if (options.keybindings.matches(data, "tui.select.cancel")) {
+			options.onComplete({ kind: "closed", reason: "back" });
+			return;
+		}
+		if (options.cycleBinding && matchesBinding(options.keybindings, data, options.cycleBinding)) {
+			select(selectedIndex + 1, true);
+			return;
+		}
+		if (options.keybindings.matches(data, "tui.select.up")) select(selectedIndex - 1, true);
+		else if (options.keybindings.matches(data, "tui.select.down")) {
+			select(selectedIndex + 1, true);
+		} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
+			select(selectedIndex - normalizeViewportSize(options.viewportSize), false);
+		} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
+			select(selectedIndex + normalizeViewportSize(options.viewportSize), false);
+		} else handleSearchInput(data);
+	};
+	const isClaimedShortcut = (data: string) =>
+		matchesKey(data, Key.ctrl("c")) ||
+		matchesBinding(options.keybindings, data, options.saveBinding) ||
+		options.keybindings.matches(data, "tui.select.confirm") ||
+		options.keybindings.matches(data, "tui.select.cancel") ||
+		(options.cycleBinding
+			? matchesBinding(options.keybindings, data, options.cycleBinding)
+			: false) ||
+		options.keybindings.matches(data, "tui.select.up") ||
+		options.keybindings.matches(data, "tui.select.down") ||
+		options.keybindings.matches(data, "tui.select.pageUp") ||
+		options.keybindings.matches(data, "tui.select.pageDown");
+
+	function routeInput(data: string) {
+		if (pasteBuffer !== undefined) {
+			pasteBuffer += data;
+			flushPasteBuffer();
+			return;
+		}
+		const combined = pasteStartBuffer + data;
+		pasteStartBuffer = "";
+		const pasteStart = combined.indexOf(BRACKETED_PASTE_START);
+		if (pasteStart >= 0) {
+			if (pasteStart > 0) handleNonPasteInput(combined.slice(0, pasteStart));
+			if (disposed) return;
+			pasteBuffer = combined.slice(pasteStart + BRACKETED_PASTE_START.length);
+			flushPasteBuffer();
+			return;
+		}
+		const prefixLength = trailingMarkerPrefixLength(combined, BRACKETED_PASTE_START);
+		const outsidePaste = combined.slice(0, combined.length - prefixLength);
+		if (outsidePaste) handleNonPasteInput(outsidePaste);
+		if (disposed) return;
+		const prefix = combined.slice(combined.length - prefixLength);
+		if (prefix && isClaimedShortcut(prefix)) handleNonPasteInput(prefix);
+		else pasteStartBuffer = prefix;
+	}
+
+	function flushPasteBuffer() {
+		if (pasteBuffer === undefined) return;
+		const pasteEnd = pasteBuffer.indexOf(BRACKETED_PASTE_END);
+		if (pasteEnd < 0) return;
+		const pasted = pasteBuffer.slice(0, pasteEnd);
+		const remaining = pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
+		pasteBuffer = undefined;
+		handleSearchInput(`${BRACKETED_PASTE_START}${pasted}${BRACKETED_PASTE_END}`);
+		if (remaining && !disposed) routeInput(remaining);
+	}
 
 	return {
 		get focused() {
@@ -140,46 +231,12 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			input.invalidate();
 		},
 		handleInput(data: string) {
-			if (disposed) return;
-			const saveDefault = () => {
-				if (!matchesBinding(options.keybindings, data, options.saveBinding)) return false;
-				completeSelected("saveDefault");
-				return true;
-			};
-			if (options.savePriority === "beforeSelection" && saveDefault()) return;
-			if (options.keybindings.matches(data, "tui.select.confirm")) {
-				completeSelected("selected");
-				return;
-			}
-			if (
-				matchesKey(data, Key.ctrl("c")) ||
-				options.keybindings.matches(data, "tui.select.cancel")
-			) {
-				options.onComplete({
-					kind: "closed",
-					reason: matchesKey(data, Key.ctrl("c")) ? "close" : "back",
-				});
-				return;
-			}
-			if (options.savePriority === "afterCancel" && saveDefault()) return;
-			if (options.keybindings.matches(data, "tui.select.up")) select(selectedIndex - 1, true);
-			else if (options.keybindings.matches(data, "tui.select.down")) {
-				select(selectedIndex + 1, true);
-			} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
-				select(selectedIndex - normalizeViewportSize(options.viewportSize), false);
-			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
-				select(selectedIndex + normalizeViewportSize(options.viewportSize), false);
-			} else if (matchesKey(data, Key.home)) select(0, false);
-			else if (matchesKey(data, Key.end)) select(filtered.length - 1, false);
-			else {
-				input.handleInput(data);
-				const sanitized = safe(input.getValue());
-				if (sanitized !== input.getValue()) input.setValue(sanitized);
-				refilter();
-			}
+			if (!disposed) routeInput(data);
 		},
 		dispose() {
 			disposed = true;
+			pasteStartBuffer = "";
+			pasteBuffer = undefined;
 		},
 	};
 }
@@ -234,18 +291,25 @@ function renderSearchInput(input: Input, width: number) {
 	return input.render(inputWidth).map((line) => truncateToWidth(`${prefix}${line}`, width, ""));
 }
 
-function selectorHint(
-	keybindings: KeybindingsManager,
-	saveBinding: "app.models.save" | "app.thinking.save",
-) {
+function selectorHint(keybindings: KeybindingsManager, saveBinding: "app.models.save") {
+	const saveKeys = getBindingKeys(keybindings, saveBinding);
+	const confirmKeys = getBindingKeys(keybindings, "tui.select.confirm");
 	return formatInteractionHints(
 		{
 			getKeys: (binding: string) => getBindingKeys(keybindings, binding),
 		},
 		[
-			{ bindings: ["tui.select.confirm"], label: "select" },
-			{ bindings: [saveBinding], label: "set as default" },
-			{ bindings: ["tui.select.cancel"], excludeKeys: ["ctrl+c"], label: "cancel" },
+			{
+				bindings: ["tui.select.confirm"],
+				excludeKeys: ["ctrl+c", ...saveKeys],
+				label: "select",
+			},
+			{ bindings: [saveBinding], excludeKeys: ["ctrl+c"], label: "set as default" },
+			{
+				bindings: ["tui.select.cancel"],
+				excludeKeys: ["ctrl+c", ...saveKeys, ...confirmKeys],
+				label: "cancel",
+			},
 		],
 	);
 }
@@ -264,4 +328,11 @@ function normalizeViewportSize(value: number | undefined) {
 
 function safe(value: string) {
 	return sanitizeTerminalText(value);
+}
+
+function trailingMarkerPrefixLength(value: string, marker: string) {
+	for (let length = Math.min(value.length, marker.length - 1); length > 0; length -= 1) {
+		if (value.endsWith(marker.slice(0, length))) return length;
+	}
+	return 0;
 }

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -4,11 +4,14 @@ import {
 	Input,
 	Key,
 	matchesKey,
+	parseKey,
 	type TUI,
+	type TuiMouseEvent,
+	type TuiMouseEventResult,
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import { renderBoundedFrame } from "../bounded-frame.js";
+import { renderBoundedFrameLayout } from "../bounded-frame.js";
 import { HorizontalRule } from "../horizontal-rule.js";
 import { formatInteractionHints } from "../interaction-hints.js";
 import { sanitizeTerminalText } from "../terminal-text.js";
@@ -16,6 +19,7 @@ import type { MenuCloseReason } from "../types.js";
 
 const BRACKETED_PASTE_START = "\u001b[200~";
 const BRACKETED_PASTE_END = "\u001b[201~";
+const INPUT_PREFIX_TIMEOUT_MS = 10;
 
 export interface PiSelectorRow<Value> {
 	value: Value;
@@ -37,6 +41,7 @@ export interface PiSelectorOptions<Value> {
 	saveBinding: "app.models.save";
 	cycleBinding?: "app.thinking.cycle";
 	filterSelection: "bestMatch" | "preserveValue";
+	prioritizeDefaultPrefix?: boolean;
 	valueEquals(left: Value, right: Value): boolean;
 	onComplete(
 		result:
@@ -53,7 +58,11 @@ export interface PiSelectorOptions<Value> {
 export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 	const input = new Input();
 	if (options.initialSearchInput) input.setValue(safe(options.initialSearchInput));
-	let filtered = filterRows(options.rows, input.getValue());
+	let filtered = filterRows(
+		options.rows,
+		input.getValue(),
+		options.prioritizeDefaultPrefix ?? false,
+	);
 	let selectedIndex =
 		options.filterSelection === "bestMatch" && input.getValue()
 			? 0
@@ -61,6 +70,15 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 	let disposed = false;
 	let pasteStartBuffer = "";
 	let pasteBuffer: string | undefined;
+	let pasteStartTimer: ReturnType<typeof setTimeout> | undefined;
+	let mousePressedIndex: number | undefined;
+	let mouseLayout:
+		| {
+				width: number;
+				inputFrameRow?: number;
+				itemByFrameRow: ReadonlyMap<number, number>;
+		  }
+		| undefined;
 
 	const select = (index: number, wrap: boolean) => {
 		if (filtered.length === 0) return;
@@ -71,7 +89,7 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 	};
 	const refilter = () => {
 		const previous = filtered[selectedIndex]?.value;
-		filtered = filterRows(options.rows, input.getValue());
+		filtered = filterRows(options.rows, input.getValue(), options.prioritizeDefaultPrefix ?? false);
 		if (options.filterSelection === "preserveValue" && previous !== undefined) {
 			const preserved = filtered.findIndex((row) => options.valueEquals(row.value, previous));
 			selectedIndex = Math.max(0, preserved);
@@ -87,9 +105,7 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 		options.onComplete({ kind, value: selected.value });
 	};
 	const handleSearchInput = (data: string) => {
-		input.handleInput(data);
-		const sanitized = safe(input.getValue());
-		if (sanitized !== input.getValue()) input.setValue(sanitized);
+		input.handleInput(parseKey(data) === undefined ? safe(data) : data);
 		refilter();
 	};
 	const saveDefault = (data: string) => {
@@ -124,20 +140,8 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			select(selectedIndex + normalizeViewportSize(options.viewportSize), false);
 		} else handleSearchInput(data);
 	};
-	const isClaimedShortcut = (data: string) =>
-		matchesKey(data, Key.ctrl("c")) ||
-		matchesBinding(options.keybindings, data, options.saveBinding) ||
-		options.keybindings.matches(data, "tui.select.confirm") ||
-		options.keybindings.matches(data, "tui.select.cancel") ||
-		(options.cycleBinding
-			? matchesBinding(options.keybindings, data, options.cycleBinding)
-			: false) ||
-		options.keybindings.matches(data, "tui.select.up") ||
-		options.keybindings.matches(data, "tui.select.down") ||
-		options.keybindings.matches(data, "tui.select.pageUp") ||
-		options.keybindings.matches(data, "tui.select.pageDown");
-
 	function routeInput(data: string) {
+		clearPasteStartTimer();
 		if (pasteBuffer !== undefined) {
 			pasteBuffer += data;
 			flushPasteBuffer();
@@ -158,8 +162,21 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 		if (outsidePaste) handleNonPasteInput(outsidePaste);
 		if (disposed) return;
 		const prefix = combined.slice(combined.length - prefixLength);
-		if (prefix && isClaimedShortcut(prefix)) handleNonPasteInput(prefix);
-		else pasteStartBuffer = prefix;
+		if (prefix) {
+			pasteStartBuffer = prefix;
+			pasteStartTimer = setTimeout(() => {
+				pasteStartTimer = undefined;
+				const pending = pasteStartBuffer;
+				pasteStartBuffer = "";
+				if (!disposed && pending) handleNonPasteInput(pending);
+			}, INPUT_PREFIX_TIMEOUT_MS);
+		}
+	}
+
+	function clearPasteStartTimer() {
+		if (!pasteStartTimer) return;
+		clearTimeout(pasteStartTimer);
+		pasteStartTimer = undefined;
 	}
 
 	function flushPasteBuffer() {
@@ -169,8 +186,52 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 		const pasted = pasteBuffer.slice(0, pasteEnd);
 		const remaining = pasteBuffer.slice(pasteEnd + BRACKETED_PASTE_END.length);
 		pasteBuffer = undefined;
-		handleSearchInput(`${BRACKETED_PASTE_START}${pasted}${BRACKETED_PASTE_END}`);
+		input.handleInput(`${BRACKETED_PASTE_START}${safe(pasted)}${BRACKETED_PASTE_END}`);
+		refilter();
 		if (remaining && !disposed) routeInput(remaining);
+	}
+
+	function handleMouse(event: TuiMouseEvent): TuiMouseEventResult | undefined {
+		if (disposed || !mouseLayout || event.width !== mouseLayout.width) return undefined;
+		if (event.y === mouseLayout.inputFrameRow) {
+			return input.handleMouse({
+				...event,
+				x: event.x - 2,
+				y: 0,
+				width: Math.max(1, event.width - 2),
+				height: 1,
+			});
+		}
+		const itemIndex = mouseLayout.itemByFrameRow.get(event.y);
+		if (itemIndex === undefined) return undefined;
+		if (event.type === "wheel" && event.wheelDelta) {
+			const next = Math.max(
+				0,
+				Math.min(filtered.length - 1, selectedIndex + (event.wheelDelta < 0 ? -1 : 1)),
+			);
+			const changed = next !== selectedIndex;
+			if (changed) select(next, false);
+			return { handled: true, render: changed };
+		}
+		if (event.type !== "move" && event.button !== "left") return undefined;
+		if (event.type === "move" || event.type === "press") {
+			if (event.type === "press") mousePressedIndex = itemIndex;
+			const changed = itemIndex !== selectedIndex;
+			if (changed) select(itemIndex, false);
+			return {
+				handled: true,
+				focus: event.type === "press",
+				...(event.type === "move" ? { render: changed } : {}),
+			};
+		}
+		if (event.type === "click") {
+			const clickedIndex = mousePressedIndex ?? itemIndex;
+			mousePressedIndex = undefined;
+			selectedIndex = clickedIndex;
+			completeSelected("selected");
+			return { handled: true };
+		}
+		return undefined;
 	}
 
 	return {
@@ -212,7 +273,7 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 				new HorizontalRule({
 					ruleStyle: (text) => options.theme.fg("borderMuted", text),
 				}).render(safeWidth)[0] ?? "";
-			return renderBoundedFrame({
+			const layout = renderBoundedFrameLayout({
 				width: safeWidth,
 				maxRows: Number.isFinite(options.tui.terminal.rows)
 					? Math.max(0, Math.floor(options.tui.terminal.rows))
@@ -226,17 +287,36 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 				priorityRows: [0, selectedContentIndex],
 				focusedRow: selectedContentIndex,
 			});
+			const frameRowByContent = new Map(
+				layout.contentRows.map(({ contentIndex, frameIndex }) => [contentIndex, frameIndex]),
+			);
+			mouseLayout = {
+				width: safeWidth,
+				inputFrameRow: frameRowByContent.get(0),
+				itemByFrameRow: new Map(
+					visible.flatMap((_, index) => {
+						const frameRow = frameRowByContent.get(searchRows.length + 1 + index);
+						return frameRow === undefined ? [] : [[frameRow, start + index] as const];
+					}),
+				),
+			};
+			return layout.lines;
 		},
 		invalidate() {
+			mouseLayout = undefined;
 			input.invalidate();
 		},
 		handleInput(data: string) {
 			if (!disposed) routeInput(data);
 		},
+		handleMouse,
 		dispose() {
 			disposed = true;
+			clearPasteStartTimer();
 			pasteStartBuffer = "";
 			pasteBuffer = undefined;
+			mousePressedIndex = undefined;
+			mouseLayout = undefined;
 		},
 	};
 }
@@ -244,17 +324,21 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 function filterRows<Value>(
 	rows: readonly PiSelectorRow<Value>[],
 	query: string,
+	prioritizeDefaultPrefix: boolean,
 ): PiSelectorRow<Value>[] {
 	const safeQuery = safe(query).trim();
 	if (!safeQuery) return [...rows];
-	return [
-		...fuzzyFilter([...rows], safeQuery, (row) =>
-			[row.primary, row.secondary, row.description, row.searchText]
-				.filter((value): value is string => Boolean(value))
-				.map(safe)
-				.join(" "),
-		),
-	];
+	const filtered = fuzzyFilter([...rows], safeQuery, (row) =>
+		[row.primary, row.secondary, row.description, row.searchText]
+			.filter((value): value is string => Boolean(value))
+			.map(safe)
+			.join(" "),
+	);
+	if (!prioritizeDefaultPrefix || !"default".startsWith(safeQuery.toLowerCase())) {
+		return filtered;
+	}
+	const defaults = rows.filter((row) => row.default);
+	return [...defaults, ...filtered.filter((row) => !row.default)];
 }
 
 function initialIndex<Value>(

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -1,0 +1,267 @@
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	fuzzyFilter,
+	Input,
+	Key,
+	matchesKey,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import { renderBoundedFrame } from "../bounded-frame.js";
+import { HorizontalRule } from "../horizontal-rule.js";
+import { formatInteractionHints } from "../interaction-hints.js";
+import { sanitizeTerminalText } from "../terminal-text.js";
+import type { MenuCloseReason } from "../types.js";
+
+export interface PiSelectorRow<Value> {
+	value: Value;
+	primary: string;
+	secondary?: string;
+	description?: string;
+	searchText?: string;
+	current?: boolean;
+	default?: boolean;
+}
+
+export interface PiSelectorOptions<Value> {
+	title?: string;
+	context?: readonly string[];
+	rows: readonly PiSelectorRow<Value>[];
+	initialValue?: Value;
+	initialSearchInput?: string;
+	viewportSize?: number;
+	saveBinding: "app.models.save" | "app.thinking.save";
+	savePriority: "beforeSelection" | "afterCancel";
+	filterSelection: "bestMatch" | "preserveValue";
+	valueEquals(left: Value, right: Value): boolean;
+	onComplete(
+		result:
+			| { kind: "selected"; value: Value }
+			| { kind: "saveDefault"; value: Value }
+			| { kind: "closed"; reason: MenuCloseReason },
+	): void;
+	tui: TUI;
+	theme: Theme;
+	keybindings: KeybindingsManager;
+}
+
+/** Shared public-primitive implementation for searchable default-aware selectors. */
+export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
+	const input = new Input();
+	if (options.initialSearchInput) input.setValue(safe(options.initialSearchInput));
+	let filtered = filterRows(options.rows, input.getValue());
+	let selectedIndex =
+		options.filterSelection === "bestMatch" && input.getValue()
+			? 0
+			: initialIndex(filtered, options.initialValue, options.valueEquals);
+	let disposed = false;
+
+	const select = (index: number, wrap: boolean) => {
+		if (filtered.length === 0) return;
+		selectedIndex = wrap
+			? (index + filtered.length) % filtered.length
+			: Math.max(0, Math.min(index, filtered.length - 1));
+		options.tui.requestRender();
+	};
+	const refilter = () => {
+		const previous = filtered[selectedIndex]?.value;
+		filtered = filterRows(options.rows, input.getValue());
+		if (options.filterSelection === "preserveValue" && previous !== undefined) {
+			const preserved = filtered.findIndex((row) => options.valueEquals(row.value, previous));
+			selectedIndex = Math.max(0, preserved);
+		} else {
+			selectedIndex = filtered.length === 0 ? 0 : Math.min(selectedIndex, filtered.length - 1);
+			if (input.getValue()) selectedIndex = 0;
+		}
+		options.tui.requestRender();
+	};
+	const completeSelected = (kind: "selected" | "saveDefault") => {
+		const selected = filtered[selectedIndex];
+		if (!selected || disposed) return;
+		options.onComplete({ kind, value: selected.value });
+	};
+
+	return {
+		get focused() {
+			return input.focused;
+		},
+		set focused(value: boolean) {
+			input.focused = value;
+		},
+		render(width: number) {
+			if (!Number.isFinite(width) || width <= 0) return [];
+			const safeWidth = Math.max(1, Math.floor(width));
+			const viewportSize = normalizeViewportSize(options.viewportSize);
+			const start = Math.max(
+				0,
+				Math.min(selectedIndex - Math.floor(viewportSize / 2), filtered.length - viewportSize),
+			);
+			const visible = filtered.slice(start, start + viewportSize);
+			const searchRows = renderSearchInput(input, safeWidth);
+			const content = [
+				...searchRows,
+				"",
+				...visible.map((row, index) => renderRow(row, start + index, selectedIndex, options.theme)),
+			];
+			const selected = filtered[selectedIndex];
+			if (start > 0 || start + visible.length < filtered.length) {
+				content.push(options.theme.fg("muted", `  (${selectedIndex + 1}/${filtered.length})`));
+			}
+			if (filtered.length === 0) {
+				content.push(options.theme.fg("muted", "  No matching options"));
+			} else if (selected?.description) {
+				content.push("", options.theme.fg("muted", `  ${safe(selected.description)}`));
+			}
+
+			const hint = selectorHint(options.keybindings, options.saveBinding);
+			const listSelectedIndex = selectedIndex - start;
+			const selectedContentIndex = searchRows.length + 1 + listSelectedIndex;
+			const rule =
+				new HorizontalRule({
+					ruleStyle: (text) => options.theme.fg("borderMuted", text),
+				}).render(safeWidth)[0] ?? "";
+			return renderBoundedFrame({
+				width: safeWidth,
+				maxRows: Number.isFinite(options.tui.terminal.rows)
+					? Math.max(0, Math.floor(options.tui.terminal.rows))
+					: 0,
+				rule,
+				title: options.title ? [safe(options.title)] : [],
+				context: (options.context ?? []).map((line) => safe(line)),
+				content,
+				hints: hint ? [options.theme.fg("dim", `  ${hint}`)] : [],
+				compactHint: hint ? options.theme.fg("dim", hint) : "",
+				priorityRows: [0, selectedContentIndex],
+				focusedRow: selectedContentIndex,
+			});
+		},
+		invalidate() {
+			input.invalidate();
+		},
+		handleInput(data: string) {
+			if (disposed) return;
+			const saveDefault = () => {
+				if (!matchesBinding(options.keybindings, data, options.saveBinding)) return false;
+				completeSelected("saveDefault");
+				return true;
+			};
+			if (options.savePriority === "beforeSelection" && saveDefault()) return;
+			if (options.keybindings.matches(data, "tui.select.confirm")) {
+				completeSelected("selected");
+				return;
+			}
+			if (
+				matchesKey(data, Key.ctrl("c")) ||
+				options.keybindings.matches(data, "tui.select.cancel")
+			) {
+				options.onComplete({
+					kind: "closed",
+					reason: matchesKey(data, Key.ctrl("c")) ? "close" : "back",
+				});
+				return;
+			}
+			if (options.savePriority === "afterCancel" && saveDefault()) return;
+			if (options.keybindings.matches(data, "tui.select.up")) select(selectedIndex - 1, true);
+			else if (options.keybindings.matches(data, "tui.select.down")) {
+				select(selectedIndex + 1, true);
+			} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
+				select(selectedIndex - normalizeViewportSize(options.viewportSize), false);
+			} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
+				select(selectedIndex + normalizeViewportSize(options.viewportSize), false);
+			} else if (matchesKey(data, Key.home)) select(0, false);
+			else if (matchesKey(data, Key.end)) select(filtered.length - 1, false);
+			else {
+				input.handleInput(data);
+				const sanitized = safe(input.getValue());
+				if (sanitized !== input.getValue()) input.setValue(sanitized);
+				refilter();
+			}
+		},
+		dispose() {
+			disposed = true;
+		},
+	};
+}
+
+function filterRows<Value>(
+	rows: readonly PiSelectorRow<Value>[],
+	query: string,
+): PiSelectorRow<Value>[] {
+	const safeQuery = safe(query).trim();
+	if (!safeQuery) return [...rows];
+	return [
+		...fuzzyFilter([...rows], safeQuery, (row) =>
+			[row.primary, row.secondary, row.description, row.searchText]
+				.filter((value): value is string => Boolean(value))
+				.map(safe)
+				.join(" "),
+		),
+	];
+}
+
+function initialIndex<Value>(
+	rows: readonly PiSelectorRow<Value>[],
+	initialValue: Value | undefined,
+	equals: (left: Value, right: Value) => boolean,
+) {
+	if (initialValue !== undefined) {
+		const explicit = rows.findIndex((row) => equals(row.value, initialValue));
+		if (explicit >= 0) return explicit;
+	}
+	const current = rows.findIndex((row) => row.current);
+	return Math.max(0, current);
+}
+
+function renderRow<Value>(
+	row: PiSelectorRow<Value>,
+	index: number,
+	selectedIndex: number,
+	theme: Theme,
+) {
+	const selected = index === selectedIndex;
+	const cursor = selected ? theme.fg("accent", "→ ") : "  ";
+	const current = row.current ? theme.fg("accent", "✓ ") : "  ";
+	const primary = selected ? theme.fg("accent", safe(row.primary)) : safe(row.primary);
+	const secondary = row.secondary ? ` ${theme.fg("muted", safe(row.secondary))}` : "";
+	const defaultBadge = row.default ? theme.fg("muted", " · default") : "";
+	return `${cursor}${current}${primary}${secondary}${defaultBadge}`;
+}
+
+function renderSearchInput(input: Input, width: number) {
+	const prefix = "  ";
+	const inputWidth = Math.max(1, width - visibleWidth(prefix));
+	return input.render(inputWidth).map((line) => truncateToWidth(`${prefix}${line}`, width, ""));
+}
+
+function selectorHint(
+	keybindings: KeybindingsManager,
+	saveBinding: "app.models.save" | "app.thinking.save",
+) {
+	return formatInteractionHints(
+		{
+			getKeys: (binding: string) => getBindingKeys(keybindings, binding),
+		},
+		[
+			{ bindings: ["tui.select.confirm"], label: "select" },
+			{ bindings: [saveBinding], label: "set as default" },
+			{ bindings: ["tui.select.cancel"], excludeKeys: ["ctrl+c"], label: "cancel" },
+		],
+	);
+}
+
+function matchesBinding(keybindings: KeybindingsManager, data: string, binding: string) {
+	return (keybindings.matches as (input: string, keybinding: string) => boolean)(data, binding);
+}
+
+function getBindingKeys(keybindings: KeybindingsManager, binding: string) {
+	return (keybindings.getKeys as (keybinding: string) => readonly string[])(binding);
+}
+
+function normalizeViewportSize(value: number | undefined) {
+	return Number.isInteger(value) && (value ?? 0) > 0 ? (value as number) : 10;
+}
+
+function safe(value: string) {
+	return sanitizeTerminalText(value);
+}

--- a/packages/pi-tui-kit/src/custom-interaction.ts
+++ b/packages/pi-tui-kit/src/custom-interaction.ts
@@ -168,6 +168,12 @@ function wrapComponent(
 		...(component.handleInput
 			? { handleInput: (data: string) => component.handleInput?.(data) }
 			: {}),
+		...(component.handleMouse
+			? {
+					handleMouse: (event: Parameters<NonNullable<Component["handleMouse"]>>[0]) =>
+						component.handleMouse?.(event),
+				}
+			: {}),
 		...(component.waitForPending
 			? { waitForPending: () => component.waitForPending?.() ?? Promise.resolve() }
 			: {}),

--- a/packages/pi-tui-kit/src/index.ts
+++ b/packages/pi-tui-kit/src/index.ts
@@ -37,6 +37,16 @@ export {
 export { defineMenu, resolveMenuScreen } from "./model.js";
 export { createMenuNavigator, type MenuNavigator } from "./navigator.js";
 export {
+	type ModelSelectorItem,
+	type RunModelSelectorOptions,
+	type RunModelSelectorResult,
+	type RunThinkingSelectorOptions,
+	type RunThinkingSelectorResult,
+	runModelSelector,
+	runThinkingSelector,
+	type ThinkingLevel,
+} from "./pi-selectors.js";
+export {
 	type QuestionnaireAnswer,
 	type QuestionnaireLabels,
 	type QuestionnaireOption,
@@ -81,4 +91,4 @@ export type {
 	SettingsScreen,
 } from "./types.js";
 
-export const PI_EXTENSION_MENU_API_VERSION = 16;
+export const PI_EXTENSION_MENU_API_VERSION = 17;

--- a/packages/pi-tui-kit/src/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/pi-selectors.ts
@@ -1,7 +1,6 @@
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { createPiSelector, type PiSelectorRow } from "./components/pi-selectors.js";
 import { runCustomInteraction } from "./custom-interaction.js";
-import { formatInteractionHints } from "./interaction-hints.js";
 import { sanitizeTerminalText } from "./terminal-text.js";
 import type { MenuCloseReason, MenuContext } from "./types.js";
 
@@ -84,9 +83,7 @@ export async function runModelSelector<
 		primary: model.id,
 		secondary: `[${model.provider}]`,
 		description: model.name ? `Model Name: ${model.name}` : undefined,
-		searchText: [model.searchText, sameModel(model, options.defaultModel) ? "default" : undefined]
-			.filter((value): value is string => Boolean(value))
-			.join(" "),
+		searchText: modelSelectorSearchText(model, sameModel(model, options.defaultModel)),
 		current: sameModel(model, options.currentModel),
 		default: sameModel(model, options.defaultModel),
 	}));
@@ -154,23 +151,8 @@ export async function runThinkingSelector<Context extends MenuContext = Extensio
 		create: ({ tui, theme, keybindings, complete }) => {
 			validateViewportSize(options.viewportSize);
 			validateThinkingLevels(options.availableLevels, options.currentLevel);
-			const getKeys = (binding: string) =>
-				(keybindings.getKeys as (keybinding: string) => readonly string[])(binding);
-			const cycleHint = formatInteractionHints({ getKeys }, [
-				{
-					bindings: ["app.thinking.cycle"],
-					excludeKeys: [
-						"ctrl+c",
-						...getKeys("app.models.save"),
-						...getKeys("tui.select.confirm"),
-						...getKeys("tui.select.cancel"),
-					],
-					label: "cycle choice",
-				},
-			]);
 			return createPiSelector({
 				title: "Thinking Level",
-				context: cycleHint ? [cycleHint] : [],
 				rows,
 				initialValue: options.currentLevel,
 				initialSearchInput: options.initialSearchInput,
@@ -192,6 +174,20 @@ export async function runThinkingSelector<Context extends MenuContext = Extensio
 		return { kind: "saveDefault", level: result.value.value };
 	}
 	return result.value;
+}
+
+function modelSelectorSearchText(model: ModelSelectorItem, isDefault: boolean) {
+	return [
+		model.provider,
+		`${model.provider}/${model.id}`,
+		model.provider,
+		model.id,
+		model.name,
+		model.searchText,
+		isDefault ? "default" : undefined,
+	]
+		.filter((value): value is string => Boolean(value))
+		.join(" ");
 }
 
 function sortModels<Item extends ModelSelectorItem>(

--- a/packages/pi-tui-kit/src/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/pi-selectors.ts
@@ -111,6 +111,7 @@ export async function runModelSelector<
 				viewportSize: options.viewportSize,
 				saveBinding: "app.models.save",
 				filterSelection: "bestMatch",
+				prioritizeDefaultPrefix: true,
 				valueEquals: sameModel,
 				onComplete: complete,
 				tui,

--- a/packages/pi-tui-kit/src/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/pi-selectors.ts
@@ -1,0 +1,259 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { createPiSelector, type PiSelectorRow } from "./components/pi-selectors.js";
+import { runCustomInteraction } from "./custom-interaction.js";
+import { formatInteractionHints } from "./interaction-hints.js";
+import { sanitizeTerminalText } from "./terminal-text.js";
+import type { MenuCloseReason, MenuContext } from "./types.js";
+
+type ExtensionMode = MenuContext["mode"];
+
+export interface ModelSelectorItem {
+	provider: string;
+	id: string;
+	name?: string;
+	/** Additional non-rendered text used by fuzzy search. */
+	searchText?: string;
+}
+
+interface PiSelectorLifecycleOptions<Context extends MenuContext> {
+	initialSearchInput?: string;
+	viewportSize?: number;
+	signal?: AbortSignal;
+	isCurrent?(): boolean;
+	onError?(ctx: Context, error: unknown): void | Promise<void>;
+	onUnsupportedMode?(ctx: Context, mode: ExtensionMode): void | Promise<void>;
+}
+
+export interface RunModelSelectorOptions<
+	Item extends ModelSelectorItem,
+	Context extends MenuContext = ExtensionCommandContext,
+> extends PiSelectorLifecycleOptions<Context> {
+	models: readonly Item[];
+	currentModel?: Pick<ModelSelectorItem, "provider" | "id">;
+	defaultModel?: Pick<ModelSelectorItem, "provider" | "id">;
+	/** Optional context shown above search, such as a provider or scope note. */
+	lines?: readonly string[];
+}
+
+export type RunModelSelectorResult<Item extends ModelSelectorItem = ModelSelectorItem> =
+	| { kind: "selected"; model: Item }
+	| { kind: "saveDefault"; model: Item }
+	| { kind: "closed"; reason: MenuCloseReason }
+	| { kind: "stale" }
+	| { kind: "unsupported"; mode: ExtensionMode }
+	| { kind: "error"; error: unknown };
+
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+export interface RunThinkingSelectorOptions<Context extends MenuContext = ExtensionCommandContext>
+	extends PiSelectorLifecycleOptions<Context> {
+	availableLevels: readonly ThinkingLevel[];
+	currentLevel: ThinkingLevel;
+	defaultLevel?: ThinkingLevel;
+}
+
+export type RunThinkingSelectorResult =
+	| { kind: "selected"; level: ThinkingLevel }
+	| { kind: "saveDefault"; level: ThinkingLevel }
+	| { kind: "closed"; reason: MenuCloseReason }
+	| { kind: "stale" }
+	| { kind: "unsupported"; mode: ExtensionMode }
+	| { kind: "error"; error: unknown };
+
+const LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
+	off: "No reasoning",
+	minimal: "Very brief reasoning (~1k tokens)",
+	low: "Light reasoning (~2k tokens)",
+	medium: "Moderate reasoning (~8k tokens)",
+	high: "Deep reasoning (~16k tokens)",
+	xhigh: "Extra-high reasoning (~32k tokens)",
+	max: "Maximum reasoning",
+};
+
+/** Open a searchable TUI model selector with current and default state. */
+export async function runModelSelector<
+	const Item extends ModelSelectorItem,
+	Context extends MenuContext = ExtensionCommandContext,
+>(
+	ctx: Context,
+	options: RunModelSelectorOptions<Item, Context>,
+): Promise<RunModelSelectorResult<Item>> {
+	const models = sortModels(options.models, options.currentModel, options.defaultModel);
+	const rows: PiSelectorRow<Item>[] = models.map((model) => ({
+		value: model,
+		primary: model.id,
+		secondary: `[${model.provider}]`,
+		description: model.name ? `Model Name: ${model.name}` : undefined,
+		searchText: [model.searchText, sameModel(model, options.defaultModel) ? "default" : undefined]
+			.filter((value): value is string => Boolean(value))
+			.join(" "),
+		current: sameModel(model, options.currentModel),
+		default: sameModel(model, options.defaultModel),
+	}));
+	const result = await runCustomInteraction<
+		| { kind: "selected"; value: Item }
+		| { kind: "saveDefault"; value: Item }
+		| { kind: "closed"; reason: MenuCloseReason },
+		Context
+	>(ctx, {
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		onError: options.onError,
+		onUnsupportedMode: options.onUnsupportedMode,
+		create: ({ tui, theme, keybindings, complete }) => {
+			validateViewportSize(options.viewportSize);
+			validateModelRows(models);
+			return createPiSelector({
+				rows,
+				context: options.lines,
+				initialValue: models.find((model) => sameModel(model, options.currentModel)),
+				initialSearchInput: options.initialSearchInput,
+				viewportSize: options.viewportSize,
+				saveBinding: "app.models.save",
+				savePriority: "afterCancel",
+				filterSelection: "bestMatch",
+				valueEquals: sameModel,
+				onComplete: complete,
+				tui,
+				theme,
+				keybindings,
+			});
+		},
+	});
+	if (result.kind !== "completed") return result;
+	if (result.value.kind === "selected") return { kind: "selected", model: result.value.value };
+	if (result.value.kind === "saveDefault") {
+		return { kind: "saveDefault", model: result.value.value };
+	}
+	return result.value;
+}
+
+/** Open a searchable TUI thinking selector with current and default state. */
+export async function runThinkingSelector<Context extends MenuContext = ExtensionCommandContext>(
+	ctx: Context,
+	options: RunThinkingSelectorOptions<Context>,
+): Promise<RunThinkingSelectorResult> {
+	const rows: PiSelectorRow<ThinkingLevel>[] = options.availableLevels.map((level) => ({
+		value: level,
+		primary: level,
+		description: LEVEL_DESCRIPTIONS[level],
+		current: level === options.currentLevel,
+		default: level === options.defaultLevel,
+		searchText: level === options.defaultLevel ? "default" : undefined,
+	}));
+	const result = await runCustomInteraction<
+		| { kind: "selected"; value: ThinkingLevel }
+		| { kind: "saveDefault"; value: ThinkingLevel }
+		| { kind: "closed"; reason: MenuCloseReason },
+		Context
+	>(ctx, {
+		signal: options.signal,
+		isCurrent: options.isCurrent,
+		onError: options.onError,
+		onUnsupportedMode: options.onUnsupportedMode,
+		create: ({ tui, theme, keybindings, complete }) => {
+			validateViewportSize(options.viewportSize);
+			validateThinkingLevels(options.availableLevels, options.currentLevel);
+			const cycleHint = formatInteractionHints(
+				{
+					getKeys: (binding: string) =>
+						(keybindings.getKeys as (keybinding: string) => readonly string[])(binding),
+				},
+				[
+					{
+						bindings: ["app.thinking.cycle"],
+						label: "cycles thinking levels in-session",
+					},
+				],
+			);
+			return createPiSelector({
+				title: "Thinking Level",
+				context: cycleHint ? [cycleHint] : [],
+				rows,
+				initialValue: options.currentLevel,
+				initialSearchInput: options.initialSearchInput,
+				viewportSize: options.viewportSize ?? options.availableLevels.length,
+				saveBinding: "app.thinking.save",
+				savePriority: "beforeSelection",
+				filterSelection: "preserveValue",
+				valueEquals: (left, right) => left === right,
+				onComplete: complete,
+				tui,
+				theme,
+				keybindings,
+			});
+		},
+	});
+	if (result.kind !== "completed") return result;
+	if (result.value.kind === "selected") return { kind: "selected", level: result.value.value };
+	if (result.value.kind === "saveDefault") {
+		return { kind: "saveDefault", level: result.value.value };
+	}
+	return result.value;
+}
+
+function sortModels<Item extends ModelSelectorItem>(
+	models: readonly Item[],
+	current: Pick<ModelSelectorItem, "provider" | "id"> | undefined,
+	defaultModel: Pick<ModelSelectorItem, "provider" | "id"> | undefined,
+) {
+	return models
+		.map((model, index) => ({ model, index }))
+		.sort((left, right) => {
+			const currentOrder =
+				Number(sameModel(right.model, current)) - Number(sameModel(left.model, current));
+			if (currentOrder !== 0) return currentOrder;
+			const defaultOrder =
+				Number(sameModel(right.model, defaultModel)) - Number(sameModel(left.model, defaultModel));
+			return (
+				defaultOrder ||
+				sanitizeSortText(left.model.provider).localeCompare(
+					sanitizeSortText(right.model.provider),
+				) ||
+				left.index - right.index
+			);
+		})
+		.map(({ model }) => model);
+}
+
+function sameModel(
+	left: Pick<ModelSelectorItem, "provider" | "id">,
+	right: Pick<ModelSelectorItem, "provider" | "id"> | undefined,
+) {
+	return left.provider === right?.provider && left.id === right.id;
+}
+
+function sanitizeSortText(value: string) {
+	return sanitizeTerminalText(value);
+}
+
+function validateViewportSize(viewportSize: number | undefined) {
+	if (
+		viewportSize !== undefined &&
+		(!Number.isInteger(viewportSize) || !Number.isFinite(viewportSize) || viewportSize <= 0)
+	) {
+		throw new Error("Selector viewport size must be a positive integer");
+	}
+}
+
+function validateModelRows(models: readonly ModelSelectorItem[]) {
+	if (models.length === 0) throw new Error("Model selector requires at least one model");
+	const identities = new Set<string>();
+	for (const model of models) {
+		const identity = `${model.provider}\0${model.id}`;
+		if (identities.has(identity)) {
+			throw new Error(`Model selector contains duplicate model ${model.provider}/${model.id}`);
+		}
+		identities.add(identity);
+	}
+}
+
+function validateThinkingLevels(levels: readonly ThinkingLevel[], current: ThinkingLevel) {
+	if (levels.length === 0) throw new Error("Thinking selector requires at least one level");
+	if (new Set(levels).size !== levels.length) {
+		throw new Error("Thinking selector contains duplicate levels");
+	}
+	if (!levels.includes(current)) {
+		throw new Error(`Current thinking level ${current} is not available`);
+	}
+}

--- a/packages/pi-tui-kit/src/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/pi-selectors.ts
@@ -110,7 +110,6 @@ export async function runModelSelector<
 				initialSearchInput: options.initialSearchInput,
 				viewportSize: options.viewportSize,
 				saveBinding: "app.models.save",
-				savePriority: "afterCancel",
 				filterSelection: "bestMatch",
 				valueEquals: sameModel,
 				onComplete: complete,
@@ -154,18 +153,20 @@ export async function runThinkingSelector<Context extends MenuContext = Extensio
 		create: ({ tui, theme, keybindings, complete }) => {
 			validateViewportSize(options.viewportSize);
 			validateThinkingLevels(options.availableLevels, options.currentLevel);
-			const cycleHint = formatInteractionHints(
+			const getKeys = (binding: string) =>
+				(keybindings.getKeys as (keybinding: string) => readonly string[])(binding);
+			const cycleHint = formatInteractionHints({ getKeys }, [
 				{
-					getKeys: (binding: string) =>
-						(keybindings.getKeys as (keybinding: string) => readonly string[])(binding),
+					bindings: ["app.thinking.cycle"],
+					excludeKeys: [
+						"ctrl+c",
+						...getKeys("app.models.save"),
+						...getKeys("tui.select.confirm"),
+						...getKeys("tui.select.cancel"),
+					],
+					label: "cycle choice",
 				},
-				[
-					{
-						bindings: ["app.thinking.cycle"],
-						label: "cycles thinking levels in-session",
-					},
-				],
-			);
+			]);
 			return createPiSelector({
 				title: "Thinking Level",
 				context: cycleHint ? [cycleHint] : [],
@@ -173,8 +174,8 @@ export async function runThinkingSelector<Context extends MenuContext = Extensio
 				initialValue: options.currentLevel,
 				initialSearchInput: options.initialSearchInput,
 				viewportSize: options.viewportSize ?? options.availableLevels.length,
-				saveBinding: "app.thinking.save",
-				savePriority: "beforeSelection",
+				saveBinding: "app.models.save",
+				cycleBinding: "app.thinking.cycle",
 				filterSelection: "preserveValue",
 				valueEquals: (left, right) => left === right,
 				onComplete: complete,
@@ -242,7 +243,8 @@ function validateModelRows(models: readonly ModelSelectorItem[]) {
 	for (const model of models) {
 		const identity = `${model.provider}\0${model.id}`;
 		if (identities.has(identity)) {
-			throw new Error(`Model selector contains duplicate model ${model.provider}/${model.id}`);
+			const reference = `${sanitizeTerminalText(model.provider)}/${sanitizeTerminalText(model.id)}`;
+			throw new Error(`Model selector contains duplicate model ${reference}`);
 		}
 		identities.add(identity);
 	}
@@ -254,6 +256,6 @@ function validateThinkingLevels(levels: readonly ThinkingLevel[], current: Think
 		throw new Error("Thinking selector contains duplicate levels");
 	}
 	if (!levels.includes(current)) {
-		throw new Error(`Current thinking level ${current} is not available`);
+		throw new Error(`Current thinking level ${sanitizeTerminalText(current)} is not available`);
 	}
 }

--- a/packages/pi-tui-kit/src/testing/index.ts
+++ b/packages/pi-tui-kit/src/testing/index.ts
@@ -6,6 +6,7 @@ export type {
 	RpcHarnessStep,
 	TuiHarness,
 	TuiHarnessKey,
+	TuiHarnessMouseEvent,
 	TuiHarnessOptions,
 	TuiHarnessResize,
 } from "./types.js";

--- a/packages/pi-tui-kit/src/testing/tui-harness.ts
+++ b/packages/pi-tui-kit/src/testing/tui-harness.ts
@@ -1,6 +1,12 @@
 import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import { type Component, isFocusable, Key, matchesKey, type TUI } from "@earendil-works/pi-tui";
-import type { TuiHarness, TuiHarnessKey, TuiHarnessOptions, TuiHarnessResize } from "./types.js";
+import type {
+	TuiHarness,
+	TuiHarnessKey,
+	TuiHarnessMouseEvent,
+	TuiHarnessOptions,
+	TuiHarnessResize,
+} from "./types.js";
 
 interface HarnessComponent extends Component {
 	waitForPending?(): Promise<void>;
@@ -185,6 +191,29 @@ export function createTuiHarness(options: TuiHarnessOptions = {}): TuiHarness {
 		return session.open ? render() : lastFrame;
 	}
 
+	function mouse(event: TuiHarnessMouseEvent): readonly string[] {
+		const session = currentOpen();
+		if (!session?.component) return lastFrame;
+		if (lastFrame.length === 0) render();
+		const result = session.component.handleMouse?.({
+			type: event.type,
+			button: event.button ?? (event.type === "move" || event.type === "wheel" ? "none" : "left"),
+			x: event.x,
+			y: event.y,
+			screenX: event.x,
+			screenY: event.y,
+			width,
+			height: lastFrame.length,
+			shift: event.shift ?? false,
+			alt: event.alt ?? false,
+			ctrl: event.ctrl ?? false,
+			...(event.wheelDelta === undefined ? {} : { wheelDelta: event.wheelDelta }),
+			...(event.clickCount === undefined ? {} : { clickCount: event.clickCount }),
+		});
+		if (result?.focus && isFocusable(session.component)) session.component.focused = true;
+		return session.open ? render() : lastFrame;
+	}
+
 	return {
 		custom,
 		get openCount() {
@@ -222,6 +251,7 @@ export function createTuiHarness(options: TuiHarnessOptions = {}): TuiHarness {
 		press(key: TuiHarnessKey) {
 			return send(keyData(key));
 		},
+		mouse,
 		send,
 		type(text: string) {
 			return send(text);

--- a/packages/pi-tui-kit/src/testing/tui-harness.ts
+++ b/packages/pi-tui-kit/src/testing/tui-harness.ts
@@ -272,9 +272,9 @@ function validDimension(value: number, name: string) {
 function keyData(key: TuiHarnessKey) {
 	switch (key) {
 		case "app.models.save":
-		case "app.thinking.save":
 			return "\u0013";
 		case "app.thinking.cycle":
+			return "\u001b[Z";
 		case "tui.input.tab":
 			return "\t";
 		case "tui.select.up":
@@ -333,7 +333,6 @@ function testingKeybindings(override?: TuiHarnessOptions["keybindings"]) {
 			if (getKeys) return getKeys(binding as Parameters<HarnessKeybindings["getKeys"]>[0]);
 			switch (binding) {
 				case "app.models.save":
-				case "app.thinking.save":
 					return ["ctrl+s"];
 				case "app.thinking.cycle":
 					return ["shift+tab"];
@@ -362,7 +361,6 @@ function testingKeybindings(override?: TuiHarnessOptions["keybindings"]) {
 function bindingKey(binding: string) {
 	switch (binding) {
 		case "app.models.save":
-		case "app.thinking.save":
 			return Key.ctrl("s");
 		case "app.thinking.cycle":
 			return Key.shift("tab");

--- a/packages/pi-tui-kit/src/testing/tui-harness.ts
+++ b/packages/pi-tui-kit/src/testing/tui-harness.ts
@@ -271,6 +271,12 @@ function validDimension(value: number, name: string) {
 
 function keyData(key: TuiHarnessKey) {
 	switch (key) {
+		case "app.models.save":
+		case "app.thinking.save":
+			return "\u0013";
+		case "app.thinking.cycle":
+		case "tui.input.tab":
+			return "\t";
 		case "tui.select.up":
 			return "\u001b[A";
 		case "tui.select.down":
@@ -326,6 +332,13 @@ function testingKeybindings(override?: TuiHarnessOptions["keybindings"]) {
 		getKeys(binding: string): readonly string[] {
 			if (getKeys) return getKeys(binding as Parameters<HarnessKeybindings["getKeys"]>[0]);
 			switch (binding) {
+				case "app.models.save":
+				case "app.thinking.save":
+					return ["ctrl+s"];
+				case "app.thinking.cycle":
+					return ["shift+tab"];
+				case "tui.input.tab":
+					return ["tab"];
 				case "tui.select.up":
 					return ["up"];
 				case "tui.select.down":
@@ -348,6 +361,13 @@ function testingKeybindings(override?: TuiHarnessOptions["keybindings"]) {
 
 function bindingKey(binding: string) {
 	switch (binding) {
+		case "app.models.save":
+		case "app.thinking.save":
+			return Key.ctrl("s");
+		case "app.thinking.cycle":
+			return Key.shift("tab");
+		case "tui.input.tab":
+			return Key.tab;
 		case "tui.select.up":
 			return Key.up;
 		case "tui.select.down":

--- a/packages/pi-tui-kit/src/testing/types.ts
+++ b/packages/pi-tui-kit/src/testing/types.ts
@@ -2,7 +2,6 @@ import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-work
 
 export type TuiHarnessKey =
 	| "app.models.save"
-	| "app.thinking.save"
 	| "app.thinking.cycle"
 	| "tui.input.tab"
 	| "tui.select.up"

--- a/packages/pi-tui-kit/src/testing/types.ts
+++ b/packages/pi-tui-kit/src/testing/types.ts
@@ -1,6 +1,10 @@
 import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 
 export type TuiHarnessKey =
+	| "app.models.save"
+	| "app.thinking.save"
+	| "app.thinking.cycle"
+	| "tui.input.tab"
 	| "tui.select.up"
 	| "tui.select.down"
 	| "tui.select.pageUp"

--- a/packages/pi-tui-kit/src/testing/types.ts
+++ b/packages/pi-tui-kit/src/testing/types.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext, KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import type { TuiMouseEvent } from "@earendil-works/pi-tui";
 
 export type TuiHarnessKey =
 	| "app.models.save"
@@ -27,6 +28,18 @@ export interface TuiHarnessResize {
 	rows?: number;
 }
 
+export interface TuiHarnessMouseEvent {
+	type: TuiMouseEvent["type"];
+	x: number;
+	y: number;
+	button?: TuiMouseEvent["button"];
+	shift?: boolean;
+	alt?: boolean;
+	ctrl?: boolean;
+	wheelDelta?: number;
+	clickCount?: number;
+}
+
 export interface TuiHarness {
 	readonly custom: ExtensionContext["ui"]["custom"];
 	readonly openCount: number;
@@ -39,6 +52,7 @@ export interface TuiHarness {
 	waitForOpen(): Promise<number>;
 	render(width?: number): readonly string[];
 	press(key: TuiHarnessKey): readonly string[];
+	mouse(event: TuiHarnessMouseEvent): readonly string[];
 	send(data: string): readonly string[];
 	type(text: string): readonly string[];
 	resize(size: TuiHarnessResize): readonly string[];

--- a/packages/pi-tui-kit/test/menu-model.test.ts
+++ b/packages/pi-tui-kit/test/menu-model.test.ts
@@ -41,7 +41,7 @@ function testMenu(): MenuDefinition<State, ScreenId, ActionId> {
 	});
 }
 
-test("package exposes API version 16 and Markdown document types", () => {
+test("package exposes API version 17 and Markdown document types", () => {
 	const markdown: ReviewFormat = {
 		kind: "markdown",
 		renderLatex: false,
@@ -56,9 +56,9 @@ test("package exposes API version 16 and Markdown document types", () => {
 		label: "Schema",
 		detailDocument: document,
 	};
-	const apiVersion: 16 = PI_EXTENSION_MENU_API_VERSION;
+	const apiVersion: 17 = PI_EXTENSION_MENU_API_VERSION;
 	assert.equal(item.detailDocument, document);
-	assert.equal(apiVersion, 16);
+	assert.equal(apiVersion, 17);
 	assert.equal(resolveMenuScreen(testMenu(), "main", { count: 0 }).kind, "actions");
 });
 

--- a/packages/pi-tui-kit/test/package-exports.test.ts
+++ b/packages/pi-tui-kit/test/package-exports.test.ts
@@ -19,7 +19,7 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 	const terminalDocument = await import(terminalDocumentSpecifier);
 	const terminalText = await import(terminalTextSpecifier);
 	const testing = await import(testingSpecifier);
-	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 16);
+	assert.equal(production.PI_EXTENSION_MENU_API_VERSION, 17);
 	assert.equal(typeof production.renderBoundedFrame, "function");
 	assert.equal(typeof production.sanitizeTerminalDocument, "function");
 	assert.equal(typeof production.hardWrapTerminalDocument, "function");
@@ -30,6 +30,8 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 	assert.equal(typeof production.runConfirmation, "function");
 	assert.equal(typeof production.runCustomInteraction, "function");
 	assert.equal(typeof production.runLiveChoice, "function");
+	assert.equal(typeof production.runModelSelector, "function");
+	assert.equal(typeof production.runThinkingSelector, "function");
 	assert.equal(typeof production.runQuestionnaire, "function");
 	assert.equal("createTuiHarness" in production, false);
 	assert.equal("createRpcHarness" in production, false);
@@ -55,7 +57,7 @@ test("built package entrypoints resolve their documented exports", async (t) => 
 			`import { hardWrapTerminalDocument, sanitizeTerminalDocument } from "@narumitw/pi-tui-kit/terminal-document";\n` +
 			`import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";\n` +
 			`import { createRpcHarness, createTuiHarness } from "@narumitw/pi-tui-kit/testing";\n` +
-			`const version: 16 = PI_EXTENSION_MENU_API_VERSION;\n` +
+			`const version: 17 = PI_EXTENSION_MENU_API_VERSION;\n` +
 			`const frame: import("@narumitw/pi-tui-kit").BoundedFrameOptions = { width: 20, maxRows: 3, rule: "─", title: [], content: ["row"] };\n` +
 			`void (await import("@narumitw/pi-tui-kit")).renderBoundedFrame(frame);\n` +
 			`const keybindings: InteractionKeybindings<"confirm"> = { getKeys: () => ["return"] };\n` +

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -32,6 +32,22 @@ test("model selector renders current and default models and returns Ctrl+S save-
 	assert.deepEqual(await running, { kind: "saveDefault", model: models[0] });
 });
 
+test("model selector keeps the saved default first for default-prefix searches", async () => {
+	const saved = { provider: "test", id: "alpha" };
+	const distractor = { provider: "test", id: "default-model" };
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runModelSelector(context.ctx, {
+		models: [distractor, saved],
+		defaultModel: saved,
+	});
+	await tui.waitForOpen();
+
+	tui.type("def");
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", model: saved });
+});
+
 test("model selector fuzzy-searches sanitized model fields and selects the raw item", async () => {
 	const unsafe = {
 		provider: "vendor\u001b[31m",
@@ -56,6 +72,26 @@ test("model selector fuzzy-searches sanitized model fields and selects the raw i
 	);
 	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, { kind: "selected", model: unsafe });
+});
+
+test("model selector preserves the query cursor while sanitizing inserted text", async () => {
+	const expected = { provider: "test", id: "abXYcd" };
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runModelSelector(context.ctx, {
+		models: [expected, { provider: "test", id: "other" }],
+		initialSearchInput: "abcd",
+	});
+	await tui.waitForOpen();
+
+	tui.press("home");
+	tui.send("\x1b[C");
+	tui.send("\x1b[C");
+	tui.send("X\u202e");
+	tui.type("Y");
+	assert.doesNotMatch(tui.render().join("\n"), /No matching options/u);
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", model: expected });
 });
 
 test("model selector routes Home and End to query editing", async () => {
@@ -187,36 +223,71 @@ test("thinking selector named cycle key emits Shift+Tab", async () => {
 	assert.deepEqual(await running, { kind: "selected", level: "low" });
 });
 
-test("thinking selector keeps split bracketed paste ahead of remapped shortcuts", async () => {
-	const tui = createTuiHarness({
-		keybindings: {
-			matches: (data, binding) => {
-				if (String(binding) === "app.models.save") return data === "x";
-				if (binding === "tui.select.confirm") return data === "\r";
-				if (binding === "tui.select.cancel") return data === "\x1b" || data === "\x03";
-				return false;
+test("thinking selector keeps every split paste-start boundary ahead of shortcuts", async () => {
+	const pasteStart = "\x1b[200~";
+	for (let split = 1; split < pasteStart.length; split += 1) {
+		const tui = createTuiHarness({
+			keybindings: {
+				matches: (data, binding) => {
+					if (String(binding) === "app.models.save") return data === "x";
+					if (binding === "tui.select.confirm") return data === "\r";
+					if (binding === "tui.select.cancel") return data === "\x1b" || data === "\x03";
+					return false;
+				},
+				getKeys: (binding) => {
+					if (String(binding) === "app.models.save") return ["x"];
+					if (binding === "tui.select.confirm") return ["enter"];
+					if (binding === "tui.select.cancel") return ["escape", "ctrl+c"];
+					return [];
+				},
 			},
-			getKeys: (binding) => {
-				if (String(binding) === "app.models.save") return ["x"];
-				if (binding === "tui.select.confirm") return ["enter"];
-				if (binding === "tui.select.cancel") return ["escape", "ctrl+c"];
-				return [];
-			},
-		},
-	});
-	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
-	const running = runThinkingSelector(context.ctx, {
-		availableLevels: ["off", "low"],
-		currentLevel: "off",
-	});
-	await tui.waitForOpen();
+		});
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = runThinkingSelector(context.ctx, {
+			availableLevels: ["off", "low"],
+			currentLevel: "off",
+		});
+		await tui.waitForOpen();
 
-	tui.send("\x1b[20");
-	tui.send("0~");
-	tui.send("x");
-	assert.equal(tui.isOpen, true);
-	tui.send("\x1b[201~\x03");
-	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+		tui.send(pasteStart.slice(0, split));
+		tui.send(`${pasteStart.slice(split)}x\x1b[201~`);
+		assert.equal(tui.isOpen, true);
+		assert.match(tui.render().join("\n"), /No matching options/u);
+		tui.press("ctrl+c");
+		assert.deepEqual(await running, { kind: "closed", reason: "close" });
+	}
+});
+
+test("selectors forward normalized mouse input and row selection", async () => {
+	const edited = { provider: "test", id: "abXcd" };
+	const inputTui = createTuiHarness();
+	const inputContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: inputTui.custom,
+	});
+	const inputRunning = runModelSelector(inputContext.ctx, {
+		models: [edited, { provider: "test", id: "other" }],
+		initialSearchInput: "abcd",
+	});
+	await inputTui.waitForOpen();
+	const inputRow = inputTui.render().findIndex((line) => line.includes("> "));
+	assert.notEqual(inputRow, -1);
+	inputTui.mouse({ type: "press", x: 6, y: inputRow });
+	inputTui.type("X");
+	inputTui.press("tui.select.confirm");
+	assert.deepEqual(await inputRunning, { kind: "selected", model: edited });
+
+	const rowTui = createTuiHarness();
+	const rowContext = createMockContext({ mode: "tui", hasUI: true, custom: rowTui.custom });
+	const rowRunning = runModelSelector(rowContext.ctx, { models });
+	await rowTui.waitForOpen();
+	let row = rowTui.render().findIndex((line) => line.includes("gemini-pro"));
+	assert.notEqual(row, -1);
+	rowTui.mouse({ type: "press", x: 4, y: row });
+	row = rowTui.render().findIndex((line) => line.includes("gemini-pro"));
+	rowTui.mouse({ type: "click", x: 4, y: row });
+	assert.deepEqual(await rowRunning, { kind: "selected", model: models[2] });
 });
 
 test("thinking selector sanitizes invalid current levels in consumer-visible errors", async () => {

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { stripVTControlCharacters } from "node:util";
+import { matchesKey, setKittyProtocolActive, visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
 import { createMockContext } from "../../../test/support.js";
 import { runModelSelector, runThinkingSelector } from "../src/index.js";
@@ -48,6 +49,21 @@ test("model selector keeps the saved default first for default-prefix searches",
 	assert.deepEqual(await running, { kind: "selected", model: saved });
 });
 
+test("model selector ranks a direct provider match before a proxy model ID", async () => {
+	const direct = { provider: "openai", id: "gpt-5" };
+	const proxy = { provider: "openrouter", id: "openai/gpt-5" };
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runModelSelector(context.ctx, {
+		models: [proxy, direct],
+		initialSearchInput: "openai/gpt-5",
+	});
+	await tui.waitForOpen();
+
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", model: direct });
+});
+
 test("model selector fuzzy-searches sanitized model fields and selects the raw item", async () => {
 	const unsafe = {
 		provider: "vendor\u001b[31m",
@@ -92,6 +108,38 @@ test("model selector preserves the query cursor while sanitizing inserted text",
 	assert.doesNotMatch(tui.render().join("\n"), /No matching options/u);
 	tui.press("tui.select.confirm");
 	assert.deepEqual(await running, { kind: "selected", model: expected });
+});
+
+test("model selector preserves Input paste normalization before sanitizing", async () => {
+	for (const scenario of [
+		{ pasted: "foo\nbar", expectedQuery: "foobar", alternativeId: "foo bar" },
+		{ pasted: "foo\r\nbar", expectedQuery: "foobar", alternativeId: "foo bar" },
+		{ pasted: "foo\rbar", expectedQuery: "foobar", alternativeId: "foo bar" },
+		{ pasted: "foo\tbar", expectedQuery: "foo    bar", alternativeId: "foo bar" },
+		{ pasted: "foo\u202ebar", expectedQuery: "foobar", alternativeId: "foo bar" },
+	] as const) {
+		const expected = { provider: "test", id: scenario.expectedQuery };
+		const tui = createTuiHarness();
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = runModelSelector(context.ctx, {
+			models: [{ provider: "test", id: scenario.alternativeId }, expected],
+		});
+		await tui.waitForOpen();
+
+		tui.send(`\x1b[200~${scenario.pasted}\x1b[201~`);
+		const inputRow = tui
+			.render()
+			.map(stripVTControlCharacters)
+			.find((line) => line.includes("> "));
+		assert.ok(inputRow?.includes(`> ${scenario.expectedQuery}`));
+		if (scenario.pasted.includes("\t")) {
+			tui.press("ctrl+c");
+			assert.deepEqual(await running, { kind: "closed", reason: "close" });
+		} else {
+			tui.press("tui.select.confirm");
+			assert.deepEqual(await running, { kind: "selected", model: expected });
+		}
+	}
 });
 
 test("model selector routes Home and End to query editing", async () => {
@@ -147,6 +195,92 @@ test("model selector gives save-default priority except for hard Ctrl+C", async 
 		if (scenario.expected === "saveDefault") {
 			assert.deepEqual(result, { kind: "saveDefault", model: models[0] });
 		} else assert.deepEqual(result, { kind: "closed", reason: "close" });
+	}
+});
+
+test("selector hints honor semantic key collisions and usable fallbacks", async () => {
+	try {
+		for (const scenario of [
+			{
+				name: "modifier order",
+				kitty: true,
+				saveKeys: ["shift+ctrl+x"],
+				confirmKeys: ["ctrl+shift+x"],
+				data: "\x1b[120;6u",
+				expectedKind: "saveDefault",
+				shown: ["shift+ctrl+x set as default"],
+				hidden: ["shift+ctrl+x select"],
+			},
+			{
+				name: "matcher aliases",
+				kitty: false,
+				saveKeys: ["return"],
+				confirmKeys: ["enter"],
+				data: "\r",
+				expectedKind: "saveDefault",
+				shown: ["enter set as default"],
+				hidden: ["enter select"],
+			},
+			{
+				name: "invalid and hard-cancel fallbacks",
+				kitty: false,
+				saveKeys: ["not-a-key", "ctrl+c", "ctrl+s"],
+				confirmKeys: ["enter"],
+				data: "\x13",
+				expectedKind: "saveDefault",
+				shown: ["ctrl+s set as default", "enter select"],
+				hidden: ["not-a-key", "ctrl+c set as default"],
+			},
+			{
+				name: "legacy collision",
+				kitty: false,
+				saveKeys: ["ctrl+i"],
+				confirmKeys: ["tab"],
+				data: "\t",
+				expectedKind: "saveDefault",
+				shown: ["ctrl+i set as default"],
+				hidden: ["tab select"],
+			},
+			{
+				name: "Kitty disambiguation",
+				kitty: true,
+				saveKeys: ["ctrl+i"],
+				confirmKeys: ["tab"],
+				data: "\x1b[9u",
+				expectedKind: "selected",
+				shown: ["tab select", "ctrl+i set as default"],
+				hidden: [],
+			},
+		] as const) {
+			setKittyProtocolActive(scenario.kitty);
+			const keys = (binding: string): readonly string[] => {
+				if (binding === "app.models.save") return scenario.saveKeys;
+				if (binding === "tui.select.confirm") return scenario.confirmKeys;
+				if (binding === "tui.select.cancel") return ["escape"];
+				return [];
+			};
+			const tui = createTuiHarness({
+				keybindings: {
+					matches: (data, binding) =>
+						keys(String(binding)).some((key) => matchesKey(data, key as never)),
+					getKeys: (binding) => [...keys(String(binding))] as never,
+				},
+			});
+			const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+			const running = runModelSelector(context.ctx, { models: [models[0]] });
+			await tui.waitForOpen();
+			const frame = tui.render().join("\n");
+			for (const text of scenario.shown) {
+				assert.ok(frame.includes(text), `${scenario.name}: expected ${text}`);
+			}
+			for (const text of scenario.hidden) {
+				assert.equal(frame.includes(text), false, `${scenario.name}: hid ${text}`);
+			}
+			tui.send(scenario.data);
+			assert.equal((await running).kind, scenario.expectedKind, scenario.name);
+		}
+	} finally {
+		setKittyProtocolActive(false);
 	}
 });
 
@@ -256,6 +390,22 @@ test("thinking selector keeps every split paste-start boundary ahead of shortcut
 		tui.press("ctrl+c");
 		assert.deepEqual(await running, { kind: "closed", reason: "close" });
 	}
+});
+
+test("selectors reserve Pi-owned terminal rows", async () => {
+	const tui = createTuiHarness({ width: 30, rows: 6 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runModelSelector(context.ctx, {
+		models,
+		lines: ["Provider context"],
+	});
+	await tui.waitForOpen();
+
+	const frame = tui.render();
+	assert.equal(frame.length, 3);
+	assert.ok(frame.every((line) => visibleWidth(line) <= 30));
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
 });
 
 test("selectors forward normalized mouse input and row selection", async () => {

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -58,17 +58,97 @@ test("model selector fuzzy-searches sanitized model fields and selects the raw i
 	assert.deepEqual(await running, { kind: "selected", model: unsafe });
 });
 
-test("thinking selector honors remapped save-default binding", async () => {
+test("model selector routes Home and End to query editing", async () => {
+	const alpha = { provider: "test", id: "alpha" };
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runModelSelector(context.ctx, {
+		models: [alpha, { provider: "test", id: "beta" }],
+	});
+	await tui.waitForOpen();
+
+	tui.type("lph");
+	tui.press("home");
+	tui.type("a");
+	tui.press("end");
+	tui.type("a");
+	const frame = tui.render().join("\n");
+	assert.match(frame, /alpha/u);
+	assert.doesNotMatch(frame, /No matching options/u);
+
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", model: alpha });
+});
+
+test("model selector gives save-default priority except for hard Ctrl+C", async () => {
+	for (const scenario of [
+		{ key: "enter", data: "\r", expected: "saveDefault", shadowedHint: "enter select" },
+		{ key: "escape", data: "\x1b", expected: "saveDefault", shadowedHint: "esc cancel" },
+		{ key: "ctrl+c", data: "\x03", expected: "closed", shadowedHint: "ctrl+c set as default" },
+	] as const) {
+		const tui = createTuiHarness({
+			keybindings: {
+				matches: (data, binding) => {
+					if (String(binding) === "app.models.save") return data === scenario.data;
+					if (binding === "tui.select.confirm") return data === "\r";
+					if (binding === "tui.select.cancel") return data === "\x1b" || data === "\x03";
+					return false;
+				},
+				getKeys: (binding) => {
+					if (String(binding) === "app.models.save") return [scenario.key];
+					if (binding === "tui.select.confirm") return ["enter"];
+					if (binding === "tui.select.cancel") return ["escape", "ctrl+c"];
+					return [];
+				},
+			},
+		});
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = runModelSelector(context.ctx, { models: [models[0]] });
+		await tui.waitForOpen();
+		assert.equal(tui.render().join("\n").includes(scenario.shadowedHint), false);
+		tui.send(scenario.data);
+		const result = await running;
+		if (scenario.expected === "saveDefault") {
+			assert.deepEqual(result, { kind: "saveDefault", model: models[0] });
+		} else assert.deepEqual(result, { kind: "closed", reason: "close" });
+	}
+});
+
+test("model selector sanitizes duplicate identities in consumer-visible errors", async () => {
+	const model = {
+		provider: "anthropic\x1b]0;owned\x07\u202e",
+		id: "claude\x1b[31m",
+		name: "Claude",
+	};
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	let reported: unknown;
+
+	const result = await runModelSelector(context.ctx, {
+		models: [model, model],
+		currentModel: model,
+		onError: (_ctx, error) => {
+			reported = error;
+		},
+	});
+
+	assert.equal(result.kind, "error");
+	assert.ok(reported instanceof Error);
+	assert.equal(reported.message, "Model selector contains duplicate model anthropic/claude");
+});
+
+test("thinking selector honors remapped cycle and save-default bindings", async () => {
 	const tui = createTuiHarness({
 		keybindings: {
 			matches: (data, binding) => {
-				if (String(binding) === "app.thinking.save") return data === "x";
+				if (String(binding) === "app.thinking.cycle") return data === "\x1bt";
+				if (String(binding) === "app.models.save") return data === "x";
 				if (binding === "tui.select.down") return data === "j";
 				if (binding === "tui.select.cancel") return data === "q";
 				return data === "\r" && binding === "tui.select.confirm";
 			},
 			getKeys: (binding) => {
-				if (String(binding) === "app.thinking.save") return ["x"];
+				if (String(binding) === "app.models.save") return ["x"];
 				if (String(binding) === "app.thinking.cycle") return ["alt+t"];
 				if (binding === "tui.select.down") return ["j"];
 				if (binding === "tui.select.cancel") return ["q"];
@@ -85,12 +165,76 @@ test("thinking selector honors remapped save-default binding", async () => {
 	});
 	await tui.waitForOpen();
 	const frame = tui.render();
-	assert.ok(frame.some((line) => line.includes("alt+t cycles thinking levels in-session")));
+	assert.ok(frame.some((line) => line.includes("alt+t cycle choice")));
 	assert.ok(frame.some((line) => line.includes("x set as default")));
 
-	tui.send("j");
+	tui.send("\x1bt");
 	tui.send("x");
 	assert.deepEqual(await running, { kind: "saveDefault", level: "high" });
+});
+
+test("thinking selector named cycle key emits Shift+Tab", async () => {
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runThinkingSelector(context.ctx, {
+		availableLevels: ["off", "low"],
+		currentLevel: "off",
+	});
+	await tui.waitForOpen();
+
+	tui.press("app.thinking.cycle");
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", level: "low" });
+});
+
+test("thinking selector keeps split bracketed paste ahead of remapped shortcuts", async () => {
+	const tui = createTuiHarness({
+		keybindings: {
+			matches: (data, binding) => {
+				if (String(binding) === "app.models.save") return data === "x";
+				if (binding === "tui.select.confirm") return data === "\r";
+				if (binding === "tui.select.cancel") return data === "\x1b" || data === "\x03";
+				return false;
+			},
+			getKeys: (binding) => {
+				if (String(binding) === "app.models.save") return ["x"];
+				if (binding === "tui.select.confirm") return ["enter"];
+				if (binding === "tui.select.cancel") return ["escape", "ctrl+c"];
+				return [];
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runThinkingSelector(context.ctx, {
+		availableLevels: ["off", "low"],
+		currentLevel: "off",
+	});
+	await tui.waitForOpen();
+
+	tui.send("\x1b[20");
+	tui.send("0~");
+	tui.send("x");
+	assert.equal(tui.isOpen, true);
+	tui.send("\x1b[201~\x03");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+});
+
+test("thinking selector sanitizes invalid current levels in consumer-visible errors", async () => {
+	const tui = createTuiHarness();
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	let reported: unknown;
+
+	const result = await runThinkingSelector(context.ctx, {
+		availableLevels: ["low"],
+		currentLevel: "unsafe\x1b]0;owned\x07\u202e" as never,
+		onError: (_ctx, error) => {
+			reported = error;
+		},
+	});
+
+	assert.equal(result.kind, "error");
+	assert.ok(reported instanceof Error);
+	assert.equal(reported.message, "Current thinking level unsafe is not available");
 });
 
 test("selectors preserve Escape and Ctrl+C close reasons", async () => {

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { createMockContext } from "../../../test/support.js";
+import { runModelSelector, runThinkingSelector } from "../src/index.js";
+import { createTuiHarness } from "../src/testing/index.js";
+
+const models = [
+	{ provider: "openai", id: "gpt-5", name: "GPT 5" },
+	{ provider: "anthropic", id: "claude-sonnet", name: "Claude Sonnet" },
+	{ provider: "google", id: "gemini-pro", name: "Gemini Pro" },
+] as const;
+
+test("model selector renders current and default models and returns Ctrl+S save-default", async () => {
+	const tui = createTuiHarness({ width: 48, rows: 20 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runModelSelector(context.ctx, {
+		models,
+		currentModel: models[1],
+		defaultModel: models[0],
+	});
+	await tui.waitForOpen();
+
+	const frame = tui.render();
+	assert.ok(frame.some((line) => line.includes("✓ claude-sonnet [anthropic]")));
+	assert.ok(frame.some((line) => line.includes("gpt-5 [openai] · default")));
+	assert.ok(frame.some((line) => line.includes("ctrl+s set as default")));
+	assert.ok(frame.every((line) => visibleWidth(line) <= 48));
+
+	tui.type("default");
+	tui.press("app.models.save");
+	assert.deepEqual(await running, { kind: "saveDefault", model: models[0] });
+});
+
+test("model selector fuzzy-searches sanitized model fields and selects the raw item", async () => {
+	const unsafe = {
+		provider: "vendor\u001b[31m",
+		id: "model\u202e-one",
+		name: "Unsafe\nName",
+		metadata: 42,
+	};
+	const tui = createTuiHarness({ width: 32 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runModelSelector(context.ctx, { models: [models[0], unsafe] });
+	await tui.waitForOpen();
+	tui.send("\u001b[200~Unsafe\u001b]0;hidden\u0007 Name\u001b[201~");
+	const frame = tui.render();
+	assert.ok(frame.some((line) => line.includes("model-one")));
+	assert.ok(
+		frame.every(
+			(line) =>
+				!line.includes("\u001b[31m") &&
+				!line.includes("\u001b]0;hidden") &&
+				!line.includes("\u202e"),
+		),
+	);
+	tui.press("tui.select.confirm");
+	assert.deepEqual(await running, { kind: "selected", model: unsafe });
+});
+
+test("thinking selector honors remapped save-default binding", async () => {
+	const tui = createTuiHarness({
+		keybindings: {
+			matches: (data, binding) => {
+				if (String(binding) === "app.thinking.save") return data === "x";
+				if (binding === "tui.select.down") return data === "j";
+				if (binding === "tui.select.cancel") return data === "q";
+				return data === "\r" && binding === "tui.select.confirm";
+			},
+			getKeys: (binding) => {
+				if (String(binding) === "app.thinking.save") return ["x"];
+				if (String(binding) === "app.thinking.cycle") return ["alt+t"];
+				if (binding === "tui.select.down") return ["j"];
+				if (binding === "tui.select.cancel") return ["q"];
+				if (binding === "tui.select.confirm") return ["enter"];
+				return [];
+			},
+		},
+	});
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runThinkingSelector(context.ctx, {
+		availableLevels: ["off", "low", "high"],
+		currentLevel: "low",
+		defaultLevel: "off",
+	});
+	await tui.waitForOpen();
+	const frame = tui.render();
+	assert.ok(frame.some((line) => line.includes("alt+t cycles thinking levels in-session")));
+	assert.ok(frame.some((line) => line.includes("x set as default")));
+
+	tui.send("j");
+	tui.send("x");
+	assert.deepEqual(await running, { kind: "saveDefault", level: "high" });
+});
+
+test("selectors preserve Escape and Ctrl+C close reasons", async () => {
+	for (const [key, reason] of [
+		["tui.select.cancel", "back"],
+		["ctrl+c", "close"],
+	] as const) {
+		const tui = createTuiHarness();
+		const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+		const running = runThinkingSelector(context.ctx, {
+			availableLevels: ["off"],
+			currentLevel: "off",
+		});
+		await tui.waitForOpen();
+		tui.press(key);
+		assert.deepEqual(await running, { kind: "closed", reason });
+	}
+});
+
+test("selectors reject non-TUI modes without opening custom UI", async () => {
+	let customCalls = 0;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		custom: async () => {
+			customCalls += 1;
+			return undefined;
+		},
+	});
+	assert.deepEqual(await runModelSelector(context.ctx, { models }), {
+		kind: "unsupported",
+		mode: "rpc",
+	});
+	assert.equal(customCalls, 0);
+});


### PR DESCRIPTION
## Summary

- add a reusable searchable selector flow that distinguishes the active choice from the saved default
- support effective save-default keybindings (`Ctrl+S` by default), typed outcomes, Back, and hard Close behavior
- preserve bounded rendering, terminal-input sanitization, paste behavior, and custom-interaction lifecycle ownership
- expose `runModelSelector()` and `runThinkingSelector()` as focused adapters over the shared selector behavior
- document consumer-owned default persistence and add a minor Changeset

## Persistence boundary

Selectors return typed `selected` or `saveDefault` intent instead of writing Pi's `settings.json`. Each consumer applies the chosen value and owns ordered persistence, error reporting, and rollback.

## Verification

- `npm run check`
- `npm test` (390 files, 4527 tests)
- `npm run package:pack -- tui-kit` (82 packaged files)
- `npm run changeset:status`
- `npm --workspace @narumitw/pi-tui-kit run check` after the wording revision

A real interactive-terminal visual smoke was not run. RPC, print, and JSON modes intentionally return `unsupported` for these custom TUI selectors.
