### PR TITLE
docs(plan-mode): add introductory workflow diagrams

### DIFF
--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -46,6 +46,44 @@ Install only from sources you trust because Pi extensions run with Pi's permissi
 Run `/plan` to open the state-aware menu, then start Plan mode and ask the agent to inspect and design the change.
 Run `/plan <prompt>` when the first planning request is already known.
 
+## 🗺️ How it works
+
+Plan mode keeps exploration and implementation on opposite sides of an explicit review boundary:
+
+```mermaid
+flowchart LR
+    start["Start<br/><code>/plan</code> or <code>/plan &lt;prompt&gt;</code>"] --> explore["Explore safely<br/>Inspect and clarify"]
+    explore --> complete["Complete the plan<br/><code>plan_mode_complete</code>"]
+    complete --> review["Review the ready plan"]
+    review -->|Revise| explore
+    review -->|Implement here| current["Current session<br/>Planning context retained"]
+    review -->|Start fresh| fresh["Linked session<br/>Approved plan transferred"]
+    review -->|Save| saved["Saved for later"]
+    review -->|Export| exported["Markdown file"]
+```
+
+During planning, the agent can inspect the project and ask material questions, but Plan mode blocks editing tools and unsafe shell forms. Implementation starts only after the plan is complete and you choose a handoff:
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Pi
+    participant Plan as Plan mode
+    participant Work as Implementation
+
+    User->>Pi: Start planning
+    Pi->>Plan: Apply the read-only tool policy
+    Plan->>User: Ask material questions when needed
+    User-->>Plan: Answer or refine the request
+    Plan->>Pi: Submit the complete plan
+    Pi-->>User: Show the ready-plan review
+    alt Implement here
+        Pi->>Work: Restore Normal mode in the current session
+    else Start fresh and implement
+        Pi->>Work: Create a linked session with the approved plan
+    end
+```
+
 ## 💬 Commands
 
 | Command | Purpose |

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -52,12 +52,13 @@ Plan mode keeps exploration and implementation on opposite sides of an explicit 
 
 ```mermaid
 flowchart LR
-    start["Start<br/><code>/plan</code> or <code>/plan &lt;prompt&gt;</code>"] --> explore["Explore safely<br/>Inspect and clarify"]
-    explore --> complete["Complete the plan<br/><code>plan_mode_complete</code>"]
+    start["Start: /plan or /plan with a prompt"]
+    start --> explore["Explore safely: inspect and clarify"]
+    explore --> complete["Complete the plan with plan_mode_complete"]
     complete --> review["Review the ready plan"]
     review -->|Revise| explore
-    review -->|Implement here| current["Current session<br/>Planning context retained"]
-    review -->|Start fresh| fresh["Linked session<br/>Approved plan transferred"]
+    review -->|Implement here| current["Current session: planning context retained"]
+    review -->|Start fresh| fresh["Linked session: approved plan transferred"]
     review -->|Save| saved["Saved for later"]
     review -->|Export| exported["Markdown file"]
 ```


### PR DESCRIPTION
## Summary

- add a Mermaid overview of the Plan mode workflow
- illustrate the current-session and fresh-session implementation handoffs
- place both diagrams near Quick start for an at-a-glance introduction

## Checks

- README heading audit
- `npm run check`
- `npm test` (4,541 tests)