### PR TITLE
docs(plan-mode): correct workflow diagram claims

### DIFF
--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -58,7 +58,7 @@ flowchart LR
     complete --> review["Review the ready plan"]
     review -->|Revise| explore
     review -->|Implement here| current["Current session: planning context retained"]
-    review -->|Start fresh| fresh["Linked session: approved plan transferred"]
+    review -->|Start fresh| fresh["Fresh session: approved plan transferred"]
     review -->|Save| saved["Saved for later"]
     review -->|Export| exported["Markdown file"]
 ```
@@ -73,7 +73,7 @@ sequenceDiagram
     participant Work as Implementation
 
     User->>Pi: Start planning
-    Pi->>Plan: Apply the read-only tool policy
+    Pi->>Plan: Apply the configured Plan tool policy
     Plan->>User: Ask material questions when needed
     User-->>Plan: Answer or refine the request
     Plan->>Pi: Submit the complete plan
@@ -81,7 +81,7 @@ sequenceDiagram
     alt Implement here
         Pi->>Work: Restore Normal mode in the current session
     else Start fresh and implement
-        Pi->>Work: Create a linked session with the approved plan
+        Pi->>Work: Create a fresh session with the approved plan
     end
 ```
 


### PR DESCRIPTION
## Summary

- describe fresh implementation as a fresh session without promising a parent link for in-memory sources
- describe planning as using the configured Plan tool policy instead of a read-only policy
- address the two findings from the post-merge review on #1269

## Review outcomes

- https://github.com/narumiruna/pi-extensions/pull/1269#discussion_r3985832121: corrected both new diagram labels that implied every fresh session is linked
- https://github.com/narumiruna/pi-extensions/pull/1269#discussion_r3985832124: corrected the sequence diagram's read-only claim
- https://github.com/narumiruna/pi-extensions/pull/1269#discussion_r3985671832: already addressed by #1269 commit `efcd0ef7`; the Mermaid blocks remain free of HTML tags

## Checks

- fenced-code-aware heading audit (29 package READMEs)
- focused semantic and Mermaid HTML audits
- `npm run check`
- `npm test` (392 files, 4,570 tests)

Documentation-only; no changeset, package pack, or Pi runtime smoke required.
