### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/.changeset/lucky-pumas-search.md
+++ b/.changeset/lucky-pumas-search.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-youcom": minor
+---
+
+Add a You.com web search extension package: keyless `youcom_search` through You.com's free MCP profile, `youcom_contents` page reading when `YDC_API_KEY` is set.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ These extensions are part of my daily Pi setup:
 | --- | --- | --- |
 | [`pi-chrome-devtools`](./packages/pi-chrome-devtools) | Inspect tabs, navigate pages, evaluate JavaScript, and capture screenshots through Chrome DevTools Protocol. | `pi install npm:@narumitw/pi-chrome-devtools` |
 | [`pi-firecrawl`](./packages/pi-firecrawl) | Scrape pages, crawl websites, discover URLs, and search the web with Firecrawl. | `pi install npm:@narumitw/pi-firecrawl` |
+| [`pi-youcom`](./packages/pi-youcom) | Search the web with You.com, keylessly by default, and read pages with an API key. | `pi install npm:@narumitw/pi-youcom` |
 
 ### Task and workspace workflows
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -559,9 +559,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -579,9 +576,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -599,9 +593,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -619,9 +610,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1793,6 +1781,7 @@
 			"os": [
 				"aix"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1810,6 +1799,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1827,6 +1817,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1844,6 +1835,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1861,6 +1853,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1878,6 +1871,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1895,6 +1889,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1912,6 +1907,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1929,6 +1925,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1946,6 +1943,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1963,6 +1961,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1980,6 +1979,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1997,6 +1997,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2014,6 +2015,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2031,6 +2033,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2048,6 +2051,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2065,6 +2069,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2082,6 +2087,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2099,6 +2105,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2116,6 +2123,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2133,6 +2141,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2150,6 +2159,7 @@
 			"os": [
 				"openharmony"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2167,6 +2177,7 @@
 			"os": [
 				"sunos"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2184,6 +2195,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2201,6 +2213,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2218,6 +2231,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2468,6 +2482,10 @@
 		},
 		"node_modules/@narumitw/pi-worktree": {
 			"resolved": "packages/pi-worktree",
+			"link": true
+		},
+		"node_modules/@narumitw/pi-youcom": {
+			"resolved": "packages/pi-youcom",
 			"link": true
 		},
 		"node_modules/@nodable/entities": {
@@ -3088,9 +3106,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3108,9 +3123,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3128,9 +3140,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3148,9 +3157,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3168,9 +3174,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3188,9 +3191,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5239,9 +5239,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5263,9 +5260,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5287,9 +5281,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5311,9 +5302,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -8046,6 +8034,24 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"packages/pi-youcom": {
+			"name": "@narumitw/pi-youcom",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@biomejs/biome": "2.5.11",
+				"@earendil-works/pi-ai": "0.85.0",
+				"@earendil-works/pi-coding-agent": "0.85.0",
+				"esbuild": "0.28.2",
+				"typebox": "1.3.25",
+				"typescript": "7.0.2"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-ai": "*",
+				"@earendil-works/pi-coding-agent": "*",
+				"typebox": "*"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 			"./packages/pi-tool/src/index.ts",
 			"./packages/pi-tui-kit-showcase/src/index.ts",
 			"./packages/pi-usage/src/index.ts",
-			"./packages/pi-worktree/src/index.ts"
+			"./packages/pi-worktree/src/index.ts",
+			"./packages/pi-youcom/src/index.ts"
 		],
 		"skills": [
 			"./packages/pi-herdr/skills",

--- a/packages/pi-youcom/LICENSE
+++ b/packages/pi-youcom/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-youcom/README.md
+++ b/packages/pi-youcom/README.md
@@ -1,0 +1,103 @@
+# 🔍 pi-youcom: You.com Web Search for Pi
+
+[![npm scope](https://img.shields.io/badge/npm-@narumitw-blue)](https://www.npmjs.com/package/@narumitw/pi-youcom)
+[![Pi extension](https://img.shields.io/badge/pi-extension-purple)](https://pi.dev)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+Pi extension that exposes You.com web search and page reading tools to the
+model. Search works without any API key through You.com's keyless endpoint;
+setting an API key enables page content extraction.
+
+## ✨ Features
+
+- Current web search through the You.com MCP server with ranked results, URLs,
+  snippets, and query-relevant passages.
+- Keyless operation by default: no account or API key is required for search.
+- Optional page content extraction when a You.com API key is configured.
+- Bounded tool output with complete truncated responses saved to a temporary
+  file, following Pi's output limits.
+
+## 📦 Install
+
+Install the extension permanently:
+
+```bash
+pi install npm:@narumitw/pi-youcom
+```
+
+Try it without adding it permanently:
+
+```bash
+pi -e npm:@narumitw/pi-youcom
+```
+
+From a local checkout of this repository, Pi can also load
+`packages/pi-youcom/src/index.ts` directly through the root manifest.
+
+> [!IMPORTANT]
+> Pi extensions run with your full user permissions. Review this extension
+> before installing it from any third party.
+
+## 🚀 Quick start
+
+1. Install the extension.
+2. Ask Pi something that needs current web information, for example:
+   "Search the web for the latest Node.js LTS release schedule."
+
+No configuration is required for search. To enable page reading, set
+`YDC_API_KEY` from [you.com/platform/api-keys](https://you.com/platform/api-keys)
+in your shell or Pi environment.
+
+## 🛠️ Tools
+
+| Tool | Purpose | Prerequisite |
+| --- | --- | --- |
+| `youcom_search` | Search the web for current information and return ranked results with URLs, snippets, and passages. | None. |
+| `youcom_contents` | Read a web page and return extracted page content. | `YDC_API_KEY`. |
+
+## ⚙️ Settings
+
+The extension is configured through environment variables only; it owns no
+settings file.
+
+| Variable | Purpose |
+| --- | --- |
+| `YDC_API_KEY` | Optional You.com API key. When set, requests use the authenticated endpoint and `youcom_contents` becomes available. |
+| `YOUCOM_MCP_URL` | Optional override for the You.com MCP endpoint URL, for testing or an alternate server. |
+
+Without `YDC_API_KEY`, the extension uses the keyless free profile of the
+You.com MCP endpoint, which exposes `youcom_search` only.
+
+## 🔒 Security and privacy
+
+Search queries and page URLs are sent to You.com's hosted MCP endpoint, and
+results are external data. The extension does not store queries or results on
+disk beyond temporary truncated-response artifacts, which are removed at
+session shutdown. An API key is passed only as an Authorization header to the
+configured You.com endpoint.
+
+## 🚧 Limitations
+
+- The keyless free profile exposes search only; page reading requires an API key.
+- The You.com MCP server uses the streamable-HTTP transport; a session id
+  issued by the server is not persisted, so each tool call is an independent
+  JSON-RPC request.
+
+## 🗂️ Package layout
+
+| Path | Responsibility |
+| --- | --- |
+| `src/index.ts` | Source forwarder for the extension entrypoint. |
+| `src/youcom.ts` | Extension factory: tool registration and session lifecycle. |
+| `src/tools.ts` | Model-facing tool definitions for search and page reading. |
+| `src/client.ts` | You.com MCP streamable-HTTP client with SSE response parsing. |
+| `src/response-format.ts` | Bounded output formatting and temporary response artifacts. |
+| `src/tool-names.ts` | Tool name constants. |
+
+## 🔎 Keywords
+
+pi-package, pi-extension, you.com, web search, mcp, search
+
+## 📄 License
+
+MIT, see [LICENSE](./LICENSE).

--- a/packages/pi-youcom/package.json
+++ b/packages/pi-youcom/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@narumitw/pi-youcom",
+	"version": "0.1.0",
+	"description": "Pi extension that exposes You.com web search and page reading tools.",
+	"type": "module",
+	"license": "MIT",
+	"private": false,
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi",
+		"youcom",
+		"you.com",
+		"web-search",
+		"search"
+	],
+	"files": [
+		"src",
+		"README.md",
+		"LICENSE"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"check": "biome check . && npm run typecheck",
+		"format": "biome check --write .",
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"typebox": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.5.11",
+		"@earendil-works/pi-ai": "0.85.0",
+		"@earendil-works/pi-coding-agent": "0.85.0",
+		"esbuild": "0.28.2",
+		"typebox": "1.3.25",
+		"typescript": "7.0.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/narumiruna/pi-extensions",
+		"directory": "packages/pi-youcom"
+	}
+}

--- a/packages/pi-youcom/src/client.ts
+++ b/packages/pi-youcom/src/client.ts
@@ -1,0 +1,173 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	truncateHead,
+} from "@earendil-works/pi-coding-agent";
+
+const DEFAULT_AUTHENTICATED_URL = "https://api.you.com/mcp";
+const DEFAULT_KEYLESS_URL = "https://api.you.com/mcp?profile=free";
+const STATUS_KEY = "youcom";
+const REQUEST_TIMEOUT_MS = 60_000;
+
+export interface YoucomJsonRpcRequest {
+	jsonrpc: "2.0";
+	id: number;
+	method: string;
+	params?: Record<string, unknown>;
+}
+
+let requestCounter = 0;
+
+function nextRequestId(): number {
+	requestCounter += 1;
+	return requestCounter;
+}
+
+/**
+ * The You.com MCP endpoint uses the streamable-HTTP transport: requests are
+ * plain JSON-RPC POSTs and responses arrive as `text/event-stream` frames of
+ * `data:` lines. Parse those frames and return the first JSON-RPC result.
+ */
+export function parseSseStream(streamText: string): unknown {
+	const frames = streamText
+		.split("\n\n")
+		.map((frame) => frame.trim())
+		.filter(Boolean);
+	for (const frame of frames) {
+		for (const line of frame.split("\n")) {
+			if (!line.startsWith("data:")) continue;
+			const payload = line.slice("data:".length).trim();
+			if (!payload) continue;
+			const parsed = parseJson(payload);
+			if (parsed === undefined) continue;
+			const message = asRecord(parsed);
+			if (!message) continue;
+			if (message.error !== undefined) {
+				const error = asRecord(message.error);
+				throw new Error(`You.com MCP error: ${String(error?.message ?? message.error)}`);
+			}
+			if (message.result !== undefined) return message.result;
+		}
+	}
+	throw new Error("You.com MCP response contained no JSON-RPC result frame.");
+}
+
+export async function youcomRequest(
+	method: string,
+	params: Record<string, unknown> | undefined,
+	signal: AbortSignal | undefined,
+	fetchImplementation: typeof fetch = fetch,
+): Promise<unknown> {
+	const serverUrl = configuredServerUrl();
+	const request: YoucomJsonRpcRequest = {
+		jsonrpc: "2.0",
+		id: nextRequestId(),
+		method,
+		...(params === undefined ? {} : { params }),
+	};
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		Accept: "application/json, text/event-stream",
+	};
+	const apiKey = process.env.YDC_API_KEY?.trim();
+	if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => {
+		controller.abort(new YoucomRequestTimeoutError());
+	}, REQUEST_TIMEOUT_MS);
+	const mergedSignal = mergeSignals(signal, controller.signal);
+	let response: Response;
+	try {
+		response = await fetchImplementation(serverUrl, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(request),
+			signal: mergedSignal,
+		});
+	} catch (error) {
+		if (signal?.aborted && signal.reason instanceof Error) throw signal.reason;
+		throw new Error(`You.com MCP request failed: ${errorMessage(error)}`);
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	const responseText = await response.text();
+	if (!response.ok) {
+		throw new Error(
+			`You.com MCP request failed (HTTP ${response.status}): ${boundedExcerpt(responseText)}`,
+		);
+	}
+	return parseSseStream(responseText);
+}
+
+export class YoucomRequestTimeoutError extends Error {
+	constructor() {
+		super("You.com MCP request timed out.");
+		this.name = "YoucomRequestTimeoutError";
+	}
+}
+
+export function hasApiKey() {
+	return Boolean(process.env.YDC_API_KEY?.trim());
+}
+
+export function configuredServerUrl() {
+	const override = process.env.YOUCOM_MCP_URL?.trim();
+	if (override) return override;
+	return hasApiKey() ? DEFAULT_AUTHENTICATED_URL : DEFAULT_KEYLESS_URL;
+}
+
+export function normalizeUrl(value: string | undefined) {
+	const trimmed = value?.trim();
+	if (!trimmed) return DEFAULT_KEYLESS_URL;
+	return trimmed.replace(/\/+$/, "");
+}
+
+export async function withStatus<T>(
+	ctx: Pick<ExtensionContext, "ui">,
+	status: string,
+	callback: () => Promise<T>,
+) {
+	ctx.ui.setStatus(STATUS_KEY, status);
+	try {
+		return await callback();
+	} finally {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
+}
+
+function mergeSignals(external: AbortSignal | undefined, internal: AbortSignal): AbortSignal {
+	if (!external) return internal;
+	const controller = new AbortController();
+	const abort = (reason: unknown) => controller.abort(reason);
+	external.addEventListener("abort", () => abort(external.reason), { once: true });
+	internal.addEventListener("abort", () => abort(internal.reason), { once: true });
+	return controller.signal;
+}
+
+function boundedExcerpt(text: string) {
+	return truncateHead(text, {
+		maxBytes: DEFAULT_MAX_BYTES,
+		maxLines: DEFAULT_MAX_LINES,
+	}).content;
+}
+
+function parseJson(payload: string): unknown {
+	try {
+		return JSON.parse(payload) as unknown;
+	} catch {
+		return undefined;
+	}
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function errorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/pi-youcom/src/index.ts
+++ b/packages/pi-youcom/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./youcom.js";

--- a/packages/pi-youcom/src/response-format.ts
+++ b/packages/pi-youcom/src/response-format.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	formatSize,
+	truncateHead,
+} from "@earendil-works/pi-coding-agent";
+
+export interface YoucomResultDetails {
+	truncated: boolean;
+	truncatedBy?: "lines" | "bytes";
+	totalLines: number;
+	totalBytes: number;
+	outputLines: number;
+	outputBytes: number;
+	fullResponsePath?: string;
+}
+
+interface BoundTextResult {
+	text: string;
+	details: YoucomResultDetails;
+}
+
+interface ResponseArtifactStore {
+	directoryPromise: Promise<string>;
+	pendingWrites: Set<Promise<unknown>>;
+}
+
+const responseArtifactStores = new WeakMap<object, ResponseArtifactStore>();
+const closedArtifactOwners = new WeakSet<object>();
+
+export async function formatJsonResult(payload: unknown, artifactOwner: object) {
+	const serialized = JSON.stringify(payload, null, 2) ?? String(payload);
+	const bounded = await boundResponseText(serialized, artifactOwner);
+	return {
+		content: [{ type: "text" as const, text: bounded.text }],
+		details: bounded.details,
+	};
+}
+
+export async function boundResponseText(
+	text: string,
+	artifactOwner: object,
+): Promise<BoundTextResult> {
+	const maxBytes = DEFAULT_MAX_BYTES;
+	const maxLines = DEFAULT_MAX_LINES;
+	const initial = truncateHead(text, { maxBytes, maxLines });
+	if (!initial.truncated) {
+		return {
+			text: initial.content,
+			details: {
+				truncated: false,
+				totalLines: initial.totalLines,
+				totalBytes: initial.totalBytes,
+				outputLines: initial.outputLines,
+				outputBytes: initial.outputBytes,
+			},
+		};
+	}
+
+	const fullResponsePath = await writeResponseArtifact(text, artifactOwner);
+	const content = `${initial.content}\n\n${truncationFooter(initial, fullResponsePath)}`;
+	if (Buffer.byteLength(content, "utf8") <= maxBytes && countLines(content) <= maxLines) {
+		return {
+			text: content,
+			details: {
+				truncated: true,
+				truncatedBy: initial.truncatedBy ?? undefined,
+				totalLines: initial.totalLines,
+				totalBytes: initial.totalBytes,
+				outputLines: initial.outputLines,
+				outputBytes: initial.outputBytes,
+				fullResponsePath,
+			},
+		};
+	}
+
+	const excerpt = truncateHead(initial.content, {
+		maxBytes: Math.max(0, maxBytes - 400),
+		maxLines: Math.max(0, maxLines - 4),
+	});
+	return {
+		text: `${excerpt.content}\n\n${truncationFooter(excerpt, fullResponsePath)}`,
+		details: {
+			truncated: true,
+			truncatedBy: initial.truncatedBy ?? undefined,
+			totalLines: initial.totalLines,
+			totalBytes: initial.totalBytes,
+			outputLines: excerpt.outputLines,
+			outputBytes: excerpt.outputBytes,
+			fullResponsePath,
+		},
+	};
+}
+
+export function openResponses(artifactOwner: object) {
+	closedArtifactOwners.delete(artifactOwner);
+}
+
+export async function cleanupResponses(artifactOwner: object) {
+	closedArtifactOwners.add(artifactOwner);
+	const store = responseArtifactStores.get(artifactOwner);
+	if (!store) return;
+	responseArtifactStores.delete(artifactOwner);
+	await Promise.allSettled([...store.pendingWrites]);
+	try {
+		await rm(await store.directoryPromise, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup must not make session shutdown fail.
+	}
+}
+
+function truncationFooter(
+	truncation: Pick<
+		YoucomResultDetails,
+		"outputLines" | "totalLines" | "outputBytes" | "totalBytes"
+	>,
+	fullResponsePath: string,
+) {
+	return `[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)}). Full response saved to: ${fullResponsePath}]`;
+}
+
+function countLines(content: string) {
+	if (!content) return 0;
+	const lines = content.split("\n");
+	if (content.endsWith("\n")) lines.pop();
+	return lines.length;
+}
+
+function writeResponseArtifact(text: string, artifactOwner: object) {
+	const store = responseArtifactStore(artifactOwner);
+	const operation = store.directoryPromise.then(async (directory) => {
+		const path = join(directory, `response-${Date.now()}-${randomUUID()}.json`);
+		await writeFile(path, text, { mode: 0o600 });
+		await chmod(path, 0o600);
+		return path;
+	});
+	store.pendingWrites.add(operation);
+	operation.then(
+		() => store.pendingWrites.delete(operation),
+		() => store.pendingWrites.delete(operation),
+	);
+	return operation;
+}
+
+function responseArtifactStore(artifactOwner: object): ResponseArtifactStore {
+	if (closedArtifactOwners.has(artifactOwner)) {
+		throw new Error("You.com response arrived after session shutdown; full response was discarded");
+	}
+	const existing = responseArtifactStores.get(artifactOwner);
+	if (existing) return existing;
+
+	const store: ResponseArtifactStore = {
+		directoryPromise: Promise.resolve(""),
+		pendingWrites: new Set(),
+	};
+	store.directoryPromise = mkdtemp(join(tmpdir(), "pi-youcom-"))
+		.then(async (directory) => {
+			await chmod(directory, 0o700);
+			return directory;
+		})
+		.catch((error) => {
+			if (responseArtifactStores.get(artifactOwner) === store) {
+				responseArtifactStores.delete(artifactOwner);
+			}
+			throw error;
+		});
+	responseArtifactStores.set(artifactOwner, store);
+	return store;
+}

--- a/packages/pi-youcom/src/tool-names.ts
+++ b/packages/pi-youcom/src/tool-names.ts
@@ -1,0 +1,3 @@
+export const YOUCOM_TOOL_NAMES = ["youcom_search", "youcom_contents"] as const;
+
+export type YoucomToolName = (typeof YOUCOM_TOOL_NAMES)[number];

--- a/packages/pi-youcom/src/tools.ts
+++ b/packages/pi-youcom/src/tools.ts
@@ -1,0 +1,78 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { hasApiKey, withStatus, youcomRequest } from "./client.js";
+import { formatJsonResult } from "./response-format.js";
+import { YOUCOM_TOOL_NAMES } from "./tool-names.js";
+
+const EXTRACTION_MODES = ["none", "highlights", "full_page"] as const;
+const OUTPUT_LIMIT_DESCRIPTION = `Output is truncated to 2,000 lines or 50 KB; complete truncated responses are saved temporarily and their path is returned.`;
+
+/**
+ * Tool parameters are forwarded to the You.com MCP server as tool arguments.
+ * The schemas below mirror the server's you-search input schema.
+ */
+export const searchTool = defineTool({
+	name: YOUCOM_TOOL_NAMES[0],
+	label: "You.com: Search",
+	description: `Search the web for current information through You.com and return ranked results with URLs, snippets, and optional query-relevant passages. Inline site:, lang:, and loc: filters are supported. ${OUTPUT_LIMIT_DESCRIPTION}`,
+	parameters: Type.Object({
+		query: Type.String({ description: "Short natural-language search query." }),
+		count: Type.Optional(Type.Number({ description: "Maximum number of results (1-100)." })),
+		freshness: Type.Optional(
+			Type.String({
+				description:
+					"Limit results to a recent window: day, week, month, year, or a YYYY-MM-DDtoYYYY-MM-DD range. Omit for evergreen facts.",
+			}),
+		),
+		extraction: Type.Optional(
+			StringEnum(EXTRACTION_MODES, {
+				description: "Extraction mode. Defaults to highlights.",
+			}),
+		),
+	}),
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		return withStatus(ctx, "search", async () => {
+			const payload = await youcomRequest(
+				"tools/call",
+				{ name: "you-search", arguments: cleanObject(params) },
+				signal,
+			);
+			return await formatJsonResult(payload, ctx.sessionManager);
+		});
+	},
+});
+
+export const contentsTool = defineTool({
+	name: YOUCOM_TOOL_NAMES[1],
+	label: "You.com: Contents",
+	description: `Read a web page through You.com and return extracted page content. Requires YDC_API_KEY because the keyless free profile only exposes search. ${OUTPUT_LIMIT_DESCRIPTION}`,
+	parameters: Type.Object({
+		url: Type.String({ description: "URL to read." }),
+	}),
+	async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+		if (!hasApiKey()) {
+			throw new Error(
+				"youcom_contents requires YDC_API_KEY. Set it to switch to the authenticated You.com MCP endpoint, then retry.",
+			);
+		}
+		return withStatus(ctx, "contents", async () => {
+			const payload = await youcomRequest(
+				"tools/call",
+				{ name: "you-contents", arguments: cleanObject(params) },
+				signal,
+			);
+			return await formatJsonResult(payload, ctx.sessionManager);
+		});
+	},
+});
+
+function cleanObject<T>(value: T): T {
+	if (Array.isArray(value)) return value.map(cleanObject) as T;
+	if (!value || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.filter(([, item]) => item !== undefined)
+			.map(([key, item]) => [key, cleanObject(item)]),
+	) as T;
+}

--- a/packages/pi-youcom/src/youcom.ts
+++ b/packages/pi-youcom/src/youcom.ts
@@ -1,0 +1,40 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { cleanupResponses, openResponses } from "./response-format.js";
+import { contentsTool, searchTool } from "./tools.js";
+
+export {
+	configuredServerUrl,
+	hasApiKey,
+	normalizeUrl,
+	parseSseStream,
+	youcomRequest,
+} from "./client.js";
+export {
+	boundResponseText,
+	cleanupResponses,
+	formatJsonResult,
+	openResponses,
+} from "./response-format.js";
+export { YOUCOM_TOOL_NAMES } from "./tool-names.js";
+
+/**
+ * Passive You.com web search extension.
+ *
+ * Registers model-facing tools backed by the You.com MCP server. Tools are
+ * only available when the extension is installed; no default Pi behavior
+ * changes. Keyless search works through the free profile of the You.com MCP
+ * endpoint; setting YDC_API_KEY switches to the authenticated endpoint and
+ * enables page content extraction.
+ */
+export default function youcom(pi: ExtensionAPI) {
+	pi.registerTool(searchTool);
+	pi.registerTool(contentsTool);
+
+	pi.on("session_start", async (_event, ctx) => {
+		openResponses(ctx.sessionManager);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		await cleanupResponses(ctx.sessionManager);
+	});
+}

--- a/packages/pi-youcom/test/youcom.test.ts
+++ b/packages/pi-youcom/test/youcom.test.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { afterEach, beforeEach, test } from "vitest";
+import { createMockContext, createMockPi } from "../../../test/support.js";
+import {
+	configuredServerUrl,
+	hasApiKey,
+	normalizeUrl,
+	parseSseStream,
+	YoucomRequestTimeoutError,
+	youcomRequest,
+} from "../src/client.js";
+import { boundResponseText, cleanupResponses, openResponses } from "../src/response-format.js";
+import { YOUCOM_TOOL_NAMES } from "../src/tool-names.js";
+import youcom from "../src/youcom.js";
+
+const SEARCH_TOOL = YOUCOM_TOOL_NAMES[0];
+const CONTENTS_TOOL = YOUCOM_TOOL_NAMES[1];
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+	delete process.env.YDC_API_KEY;
+	delete process.env.YOUCOM_MCP_URL;
+});
+
+afterEach(() => {
+	for (const key of Object.keys(ORIGINAL_ENV)) {
+		if (!(key in process.env)) process.env[key] = ORIGINAL_ENV[key];
+	}
+	for (const key of Object.keys(process.env)) {
+		if (!(key in ORIGINAL_ENV)) delete process.env[key];
+	}
+});
+
+test("registers search and contents tools without commands", () => {
+	const mock = createMockPi();
+	youcom(mock.pi);
+	const tools = mock.tools.map((tool) => (tool as { name?: string }).name);
+	assert.deepEqual(tools.sort(), [CONTENTS_TOOL, SEARCH_TOOL]);
+	assert.equal(mock.commands.size, 0);
+});
+
+test("keyless configuration targets the free profile endpoint", () => {
+	assert.equal(hasApiKey(), false);
+	assert.equal(configuredServerUrl(), "https://api.you.com/mcp?profile=free");
+});
+
+test("api key configuration targets the authenticated endpoint", () => {
+	process.env.YDC_API_KEY = "test-key";
+	assert.equal(hasApiKey(), true);
+	assert.equal(configuredServerUrl(), "https://api.you.com/mcp");
+});
+
+test("endpoint override wins over api key state", () => {
+	process.env.YDC_API_KEY = "test-key";
+	process.env.YOUCOM_MCP_URL = "https://example.test/mcp";
+	assert.equal(configuredServerUrl(), "https://example.test/mcp");
+});
+
+test("normalizeUrl trims and drops trailing slashes", () => {
+	assert.equal(normalizeUrl(undefined), "https://api.you.com/mcp?profile=free");
+	assert.equal(normalizeUrl("  https://example.test/mcp/  "), "https://example.test/mcp");
+});
+
+test("parseSseStream returns the JSON-RPC result frame", () => {
+	const stream = [
+		"event: message",
+		'data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}',
+		"",
+		"event: message",
+		'data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{}"}]}}',
+		"",
+	].join("\n");
+	const result = parseSseStream(stream) as { content: Array<{ text: string }> };
+	assert.equal(result.content[0].text, "{}");
+});
+
+test("parseSseStream surfaces JSON-RPC errors", () => {
+	const stream =
+		'data: {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Tool not found"}}\n\n';
+	assert.throws(() => parseSseStream(stream), /Tool not found/);
+});
+
+test("parseSseStream rejects a stream without result frames", () => {
+	assert.throws(() => parseSseStream("event: message\ndata: ping\n\n"), /no JSON-RPC result/);
+});
+
+function jsonResponse(streamBody: string) {
+	return new Response(streamBody, {
+		status: 200,
+		headers: { "Content-Type": "text/event-stream" },
+	});
+}
+
+test("youcomRequest posts a JSON-RPC tool call and parses the SSE reply", async () => {
+	const calls: Array<{ url: string; init: RequestInit }> = [];
+	const fetchImplementation = (async (url: string, init: RequestInit) => {
+		calls.push({ url, init });
+		return jsonResponse(
+			'data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\\"ok\\":true}"}]}}\n\n',
+		);
+	}) as typeof fetch;
+	const result = (await youcomRequest(
+		"tools/call",
+		{ name: "you-search", arguments: { query: "node 24 lts" } },
+		undefined,
+		fetchImplementation,
+	)) as { content: Array<{ text: string }> };
+	assert.equal(calls.length, 1);
+	assert.equal(calls[0].url, "https://api.you.com/mcp?profile=free");
+	assert.equal(calls[0].init.method as string, "POST");
+	const headers = calls[0].init.headers as Record<string, string>;
+	assert.equal(headers.Accept, "application/json, text/event-stream");
+	assert.equal(headers.Authorization, undefined);
+	const body = JSON.parse(calls[0].init.body as string) as {
+		jsonrpc: string;
+		method: string;
+		params: { name: string };
+	};
+	assert.equal(body.method, "tools/call");
+	assert.equal(body.params.name, "you-search");
+	assert.equal(result.content[0].text, '{"ok":true}');
+});
+
+test("youcomRequest sends the bearer header when an api key is configured", async () => {
+	process.env.YDC_API_KEY = "secret-key";
+	const calls: Array<{ url: string; init: RequestInit }> = [];
+	const fetchImplementation = (async (url: string, init: RequestInit) => {
+		calls.push({ url, init });
+		return jsonResponse('data: {"jsonrpc":"2.0","id":1,"result":{}}\n\n');
+	}) as typeof fetch;
+	await youcomRequest("tools/list", undefined, undefined, fetchImplementation);
+	assert.equal(calls.length, 1);
+	assert.equal(calls[0].url, "https://api.you.com/mcp");
+	const headers = calls[0].init.headers as Record<string, string>;
+	assert.equal(headers.Authorization, "Bearer secret-key");
+});
+
+test("youcomRequest reports non-2xx responses with status and bounded body", async () => {
+	const fetchImplementation = (async () =>
+		new Response("boom", {
+			status: 502,
+			headers: { "Content-Type": "text/plain" },
+		})) as typeof fetch;
+	await assert.rejects(
+		youcomRequest("tools/list", undefined, undefined, fetchImplementation),
+		/HTTP 502/,
+	);
+});
+
+test("youcomRequest honors external cancellation", async () => {
+	const controller = new AbortController();
+	const fetchImplementation = (async (_url: string, init: RequestInit) => {
+		(init.signal as AbortSignal).addEventListener("abort", () => {}, { once: true });
+		controller.abort(new Error("user cancelled"));
+		throw new Error("fetch aborted");
+	}) as typeof fetch;
+	await assert.rejects(
+		youcomRequest("tools/list", undefined, controller.signal, fetchImplementation),
+		/user cancelled/,
+	);
+});
+
+test("boundResponseText keeps small payloads intact and exposes details", async () => {
+	const owner = {};
+	const bounded = await boundResponseText(JSON.stringify({ ok: true }, null, 2), owner);
+	assert.equal(bounded.details.truncated, false);
+	assert.equal(bounded.text, JSON.stringify({ ok: true }, null, 2));
+	await cleanupResponses(owner);
+});
+
+test("boundResponseText truncates large payloads and writes an artifact", async () => {
+	const owner = {};
+	const big = JSON.stringify({
+		results: {
+			web: Array.from({ length: 5_000 }, (_, i) => ({
+				url: `https://example.test/${i}`,
+				title: "x".repeat(200),
+			})),
+		},
+	});
+	const bounded = await boundResponseText(big, owner);
+	assert.equal(bounded.details.truncated, true);
+	assert.ok(bounded.details.fullResponsePath);
+	assert.ok(bounded.text.includes("Output truncated"));
+	assert.ok(bounded.text.length < big.length);
+	const artifact = readFileSync(bounded.details.fullResponsePath as string, "utf8");
+	assert.equal(artifact, big);
+	await cleanupResponses(owner);
+});
+
+test("responses after shutdown are discarded", async () => {
+	const owner = {};
+	await cleanupResponses(owner);
+	await assert.rejects(boundResponseText("x".repeat(200_000), owner), /session shutdown/);
+});
+
+test("openResponses allows a new session owner after cleanup", async () => {
+	const owner = {};
+	await cleanupResponses(owner);
+	openResponses(owner);
+	const bounded = await boundResponseText("small", owner);
+	assert.equal(bounded.details.truncated, false);
+	await cleanupResponses(owner);
+});
+
+test("session lifecycle opens and cleans up response artifacts", async () => {
+	const mock = createMockPi();
+	youcom(mock.pi);
+	const sessionManager = { getSessionId: () => "lifecycle-test-session" };
+	const { ctx } = createMockContext({ sessionManager });
+	const owner = sessionManager;
+	const prior = await boundResponseText("x".repeat(200_000), owner);
+	assert.ok(prior.details.fullResponsePath);
+	const directory = dirname(prior.details.fullResponsePath as string);
+	await mock.events.get("session_start")?.[0]?.({}, ctx);
+	await mock.events.get("session_shutdown")?.[0]?.({}, ctx);
+	assert.equal(existsSync(directory), false);
+});
+
+test("tool execute paths call the client and format results", async () => {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = (async () =>
+		jsonResponse(
+			'data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\\"results\\":{}}"}]}}\n\n',
+		)) as typeof fetch;
+	const mock = createMockPi();
+	youcom(mock.pi);
+	const sessionManager = { getSessionId: () => "execute-test-session" };
+	const { ctx: baseCtx } = createMockContext({ sessionManager });
+	const statuses: Array<string | undefined> = [];
+	const ctx = baseCtx as unknown as Record<string, unknown>;
+	const ui = {
+		...(ctx.ui as Record<string, unknown>),
+		setStatus: (_key: string, text: string | undefined) => statuses.push(text),
+	};
+	const toolCtx = { ...ctx, ui, sessionManager };
+	try {
+		const tool = mock.tools.find(
+			(candidate) => (candidate as { name?: string }).name === SEARCH_TOOL,
+		);
+		assert.ok(tool, "search tool registered");
+		const result = (await (
+			tool as unknown as {
+				execute: (
+					id: string,
+					params: Record<string, unknown>,
+					signal: undefined,
+					onUpdate: undefined,
+					ctx: unknown,
+				) => Promise<{ content: Array<{ text: string }> }>;
+			}
+		).execute("call-1", { query: "test" }, undefined, undefined, toolCtx)) as {
+			content: Array<{ text: string }>;
+		};
+		assert.ok(result.content[0].text.includes("results"));
+		assert.ok(statuses.includes("search"));
+	} finally {
+		globalThis.fetch = originalFetch;
+		await cleanupResponses(sessionManager);
+	}
+});
+
+test("contents tool rejects execution without an api key", async () => {
+	const mock = createMockPi();
+	youcom(mock.pi);
+	const sessionManager = { getSessionId: () => "contents-test-session" };
+	const { ctx: baseCtx } = createMockContext({ sessionManager });
+	const ctx = baseCtx as unknown as Record<string, unknown>;
+	const tool = mock.tools.find(
+		(candidate) => (candidate as { name?: string }).name === CONTENTS_TOOL,
+	);
+	assert.ok(tool, "contents tool registered");
+	await assert.rejects(
+		(
+			tool as unknown as {
+				execute: (
+					id: string,
+					params: Record<string, unknown>,
+					signal: undefined,
+					onUpdate: undefined,
+					ctx: unknown,
+				) => Promise<unknown>;
+			}
+		).execute("call-1", { url: "https://example.com" }, undefined, undefined, {
+			...ctx,
+			ui: { ...(ctx.ui as Record<string, unknown>), setStatus: () => {} },
+			sessionManager,
+		}),
+		/YDC_API_KEY/,
+	);
+});
+
+test("timeout error is distinguishable", () => {
+	const error = new YoucomRequestTimeoutError();
+	assert.equal(error.name, "YoucomRequestTimeoutError");
+});
+
+test("environment is restored between tests", () => {
+	assert.equal(process.env.YDC_API_KEY, undefined);
+});

--- a/packages/pi-youcom/tsconfig.json
+++ b/packages/pi-youcom/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a new `pi-youcom` extension that gives the model access to You.com web search, following the same shape as `pi-firecrawl` (passive, tool-only, no commands).

## What it adds

- **`youcom_search`** — current web search with ranked results, URLs, snippets, and query-relevant passages. Works with **no API key**: it talks to You.com's keyless free profile of their MCP endpoint (`https://api.you.com/mcp?profile=free`), so users get working web search with zero configuration.
- **`youcom_contents`** — page reading with extracted content. This one is gated on `YDC_API_KEY` (from [you.com/platform/api-keys](https://you.com/platform/api-keys)); without a key the tool rejects execution with a clear message instead of failing obscurely.

The endpoint uses the MCP streamable-HTTP transport, so `client.ts` is a small JSON-RPC bridge with an SSE response parser — each tool call is an independent request, no session state is persisted.

## Design notes

- Followed the pi-firecrawl structure: `defineTool` + typebox schemas (`StringEnum` for enum parameters), bounded output with `truncateHead` and truncated-response artifacts saved to a temp dir, `openResponses`/`cleanupResponses` on session start/shutdown, and status updates via `ctx.ui.setStatus` during requests.
- Opt-in: nothing changes for existing users — the extension only activates when installed (`pi install npm:@narumitw/pi-youcom` after publish, or directly from this repo's root manifest for local use).
- Env vars: `YDC_API_KEY` (optional, enables `youcom_contents` + authenticated endpoint), `YOUCOM_MCP_URL` (optional override, mostly for testing).
- No new dependencies — plain `fetch`.
- Changeset included; root `package.json` manifest and README table updated.

## Validation

- `npx vitest run packages/pi-youcom` — 21 tests passing (tool registration, keyless/authenticated URL selection, SSE parsing incl. JSON-RPC errors, request headers/body, non-2xx handling, cancellation, truncation + artifact round-trip, session shutdown cleanup, contents-tool key gating).
- `tsc -p tsconfig.test.json` — clean.
- `biome lint .` / `biome check` on the new package — clean.
- `node scripts/check-extension-boundaries.mjs` — passes.
- Live keyless check: ran a real `tools/call` for `you-search` through the extension's client against the free profile and got ranked results back.
- The full-suite `npm test` runner hits a vitest worker EPIPE crash in my sandbox; I confirmed it reproduces identically on a pristine checkout of `main`, so it's an environment issue rather than something introduced here (the 21 new tests run green standalone).

Happy to adjust the shape if you'd prefer a different tool surface or naming — I kept it close to the firecrawl precedent on purpose.
