### PR TITLE
fix(tui-kit): address selector review follow-up

### DIFF
--- a/.changeset/calm-lions-select.md
+++ b/.changeset/calm-lions-select.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": patch
+---
+
+Fix forwarded selector submissions, terminal-aware shortcut hints, and thinking-level descriptions.

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -258,9 +258,14 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			);
 			const visible = filtered.slice(start, start + viewportSize);
 			const searchRows = renderSearchInput(input, safeWidth);
-			const descriptionColumnWidth = options.inlineDescriptions
+			const requestedDescriptionColumnWidth = options.inlineDescriptions
 				? inlineDescriptionColumnWidth(visible)
 				: undefined;
+			const descriptionColumnWidth =
+				requestedDescriptionColumnWidth !== undefined &&
+				canRenderInlineDescriptions(safeWidth, requestedDescriptionColumnWidth)
+					? requestedDescriptionColumnWidth
+					: undefined;
 			const content = [
 				...searchRows,
 				"",
@@ -281,7 +286,7 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			}
 			if (filtered.length === 0) {
 				content.push(options.theme.fg("muted", "  No matching options"));
-			} else if (!options.inlineDescriptions && selected?.description) {
+			} else if (descriptionColumnWidth === undefined && selected?.description) {
 				content.push("", options.theme.fg("muted", `  ${safe(selected.description)}`));
 			}
 
@@ -427,6 +432,13 @@ function inlineDescriptionColumnWidth<Value>(rows: readonly PiSelectorRow<Value>
 	return Math.max(12, Math.min(widest, 32));
 }
 
+function canRenderInlineDescriptions(width: number, columnWidth: number) {
+	const prefixWidth = 4;
+	if (width <= 40) return false;
+	const effectiveColumnWidth = Math.max(1, Math.min(columnWidth, width - prefixWidth - 4));
+	return width - prefixWidth - effectiveColumnWidth - 2 > 10;
+}
+
 function renderSearchInput(input: Input, width: number) {
 	const prefix = "  ";
 	const inputWidth = Math.max(1, width - visibleWidth(prefix));
@@ -497,6 +509,9 @@ function keysOverlap(first: string, second: string) {
 }
 
 function inputsForKey(key: string) {
+	const cacheKey = `${isLocalWindowsTerminalSession() ? "windows" : "other"}:${key}`;
+	const cached = LEGACY_KEY_INPUT_CACHE.get(cacheKey);
+	if (cached) return cached;
 	const parts = key.split("+");
 	const base = parts.pop() ?? "";
 	const modifier = parts.reduce(
@@ -508,7 +523,18 @@ function inputsForKey(key: string) {
 		codepoint === undefined
 			? LEGACY_KEY_INPUTS
 			: [...LEGACY_KEY_INPUTS, `\u001b[${codepoint};${modifier + 1}u`];
-	return candidates.filter((input) => matchesKey(input, key as KeyId));
+	const inputs = candidates.filter((input) => matchesKey(input, key as KeyId));
+	LEGACY_KEY_INPUT_CACHE.set(cacheKey, inputs);
+	return inputs;
+}
+
+function isLocalWindowsTerminalSession() {
+	return (
+		Boolean(process.env.WT_SESSION) &&
+		!process.env.SSH_CONNECTION &&
+		!process.env.SSH_CLIENT &&
+		!process.env.SSH_TTY
+	);
 }
 
 function isExecutableKey(base: string, modifiers: readonly string[]) {
@@ -558,6 +584,7 @@ const LEGACY_FUNCTION_INPUT_SUFFIXES = [
 // Probe every cross-identity legacy collision through Pi's live matcher. CSI-u,
 // keypad, lock-bit, shifted-letter, and modifyOtherKeys forms normalize to the
 // same key and modifiers, so one generated CSI-u identity covers those branches.
+const LEGACY_KEY_INPUT_CACHE = new Map<string, readonly string[]>();
 const LEGACY_KEY_INPUTS = [
 	...Array.from({ length: 128 }, (_, code) => String.fromCharCode(code)),
 	...Array.from({ length: 128 }, (_, code) => `\u001b${String.fromCharCode(code)}`),

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -4,6 +4,7 @@ import {
 	Input,
 	isKittyProtocolActive,
 	Key,
+	type KeyId,
 	matchesKey,
 	parseKey,
 	type TUI,
@@ -43,6 +44,7 @@ export interface PiSelectorOptions<Value> {
 	saveBinding: "app.models.save";
 	cycleBinding?: "app.thinking.cycle";
 	filterSelection: "bestMatch" | "preserveValue";
+	inlineDescriptions?: boolean;
 	prioritizeDefaultPrefix?: boolean;
 	valueEquals(left: Value, right: Value): boolean;
 	onComplete(
@@ -106,9 +108,10 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 		if (!selected || disposed) return;
 		options.onComplete({ kind, value: selected.value });
 	};
+	input.onSubmit = () => completeSelected("selected");
 	const handleSearchInput = (data: string) => {
 		input.handleInput(parseKey(data) === undefined ? safe(data) : data);
-		refilter();
+		if (!disposed) refilter();
 	};
 	const saveDefault = (data: string) => {
 		if (!matchesBinding(options.keybindings, data, options.saveBinding)) return false;
@@ -255,10 +258,22 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			);
 			const visible = filtered.slice(start, start + viewportSize);
 			const searchRows = renderSearchInput(input, safeWidth);
+			const descriptionColumnWidth = options.inlineDescriptions
+				? inlineDescriptionColumnWidth(visible)
+				: undefined;
 			const content = [
 				...searchRows,
 				"",
-				...visible.map((row, index) => renderRow(row, start + index, selectedIndex, options.theme)),
+				...visible.map((row, index) =>
+					renderRow(
+						row,
+						start + index,
+						selectedIndex,
+						options.theme,
+						safeWidth,
+						descriptionColumnWidth,
+					),
+				),
 			];
 			const selected = filtered[selectedIndex];
 			if (start > 0 || start + visible.length < filtered.length) {
@@ -266,7 +281,7 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			}
 			if (filtered.length === 0) {
 				content.push(options.theme.fg("muted", "  No matching options"));
-			} else if (selected?.description) {
+			} else if (!options.inlineDescriptions && selected?.description) {
 				content.push("", options.theme.fg("muted", `  ${safe(selected.description)}`));
 			}
 
@@ -370,6 +385,8 @@ function renderRow<Value>(
 	index: number,
 	selectedIndex: number,
 	theme: Theme,
+	width: number,
+	descriptionColumnWidth: number | undefined,
 ) {
 	const selected = index === selectedIndex;
 	const cursor = selected ? theme.fg("accent", "→ ") : "  ";
@@ -377,7 +394,37 @@ function renderRow<Value>(
 	const primary = selected ? theme.fg("accent", safe(row.primary)) : safe(row.primary);
 	const secondary = row.secondary ? ` ${theme.fg("muted", safe(row.secondary))}` : "";
 	const defaultBadge = row.default ? theme.fg("muted", " · default") : "";
-	return `${cursor}${current}${primary}${secondary}${defaultBadge}`;
+	const prefix = `${cursor}${current}`;
+	const primaryText = `${primary}${secondary}${defaultBadge}`;
+	if (descriptionColumnWidth !== undefined && row.description && width > 40) {
+		const effectiveColumnWidth = Math.max(
+			1,
+			Math.min(descriptionColumnWidth, width - visibleWidth(prefix) - 4),
+		);
+		const truncatedPrimary = truncateToWidth(
+			primaryText,
+			Math.max(1, effectiveColumnWidth - 2),
+			"",
+		);
+		const spacing = " ".repeat(Math.max(1, effectiveColumnWidth - visibleWidth(truncatedPrimary)));
+		const remainingWidth =
+			width - visibleWidth(prefix) - visibleWidth(truncatedPrimary) - spacing.length - 2;
+		if (remainingWidth > 10) {
+			const description = truncateToWidth(safe(row.description), remainingWidth, "");
+			return `${prefix}${truncatedPrimary}${theme.fg("muted", `${spacing}${description}`)}`;
+		}
+	}
+	return `${prefix}${primaryText}`;
+}
+
+function inlineDescriptionColumnWidth<Value>(rows: readonly PiSelectorRow<Value>[]) {
+	const widest = rows.reduce((width, row) => {
+		const primary = `${safe(row.primary)}${row.secondary ? ` ${safe(row.secondary)}` : ""}${
+			row.default ? " · default" : ""
+		}`;
+		return Math.max(width, visibleWidth(primary) + 2);
+	}, 0);
+	return Math.max(12, Math.min(widest, 32));
 }
 
 function renderSearchInput(input: Input, width: number) {
@@ -398,16 +445,14 @@ function selectorKeyPlan(
 	saveBinding: "app.models.save",
 	cycleBinding: "app.thinking.cycle" | undefined,
 ): SelectorKeyPlan {
-	const claimed = new Set([keyClaimIdentity("ctrl+c")]);
+	const claimed = ["ctrl+c"];
 	const claim = (binding: string | undefined) => {
 		const available: string[] = [];
 		if (!binding) return available;
 		for (const key of getBindingKeys(keybindings, binding)) {
 			const canonical = canonicalKeyId(key);
-			if (!canonical) continue;
-			const identity = keyClaimIdentity(canonical);
-			if (claimed.has(identity)) continue;
-			claimed.add(identity);
+			if (!canonical || claimed.some((other) => keysOverlap(canonical, other))) continue;
+			claimed.push(canonical);
 			available.push(canonical);
 		}
 		return available;
@@ -446,17 +491,24 @@ function canonicalKeyId(value: string): string | undefined {
 	return [...modifiers, base].join("+");
 }
 
-function keyClaimIdentity(canonical: string): string {
-	if (isKittyProtocolActive()) return canonical;
-	if (canonical === "ctrl+i") return "tab";
-	if (canonical === "ctrl+j" || canonical === "ctrl+m") return "enter";
-	if (canonical === "ctrl+[") return "escape";
-	if (canonical === "ctrl+_") return "ctrl+-";
-	if (canonical === "alt+b") return "alt+left";
-	if (canonical === "alt+f") return "alt+right";
-	if (canonical === "alt+p") return "alt+up";
-	if (canonical === "alt+n") return "alt+down";
-	return canonical;
+function keysOverlap(first: string, second: string) {
+	if (isKittyProtocolActive()) return first === second;
+	return inputsForKey(first).some((input) => matchesKey(input, second as KeyId));
+}
+
+function inputsForKey(key: string) {
+	const parts = key.split("+");
+	const base = parts.pop() ?? "";
+	const modifier = parts.reduce(
+		(mask, part) => mask | (KEY_MODIFIER_MASKS[part as keyof typeof KEY_MODIFIER_MASKS] ?? 0),
+		0,
+	);
+	const codepoint = KEY_CODEPOINTS[base] ?? (base.length === 1 ? base.charCodeAt(0) : undefined);
+	const candidates =
+		codepoint === undefined
+			? LEGACY_KEY_INPUTS
+			: [...LEGACY_KEY_INPUTS, `\u001b[${codepoint};${modifier + 1}u`];
+	return candidates.filter((input) => matchesKey(input, key as KeyId));
 }
 
 function isExecutableKey(base: string, modifiers: readonly string[]) {
@@ -471,6 +523,51 @@ function isExecutableKey(base: string, modifiers: readonly string[]) {
 	return true;
 }
 
+const KEY_MODIFIER_MASKS = { shift: 1, alt: 2, ctrl: 4, super: 8 } as const;
+const KEY_CODEPOINTS: Record<string, number> = {
+	escape: 27,
+	tab: 9,
+	enter: 13,
+	space: 32,
+	backspace: 127,
+	insert: 57425,
+	delete: 57426,
+	home: 57423,
+	end: 57424,
+	pageup: 57421,
+	pagedown: 57422,
+	left: 57417,
+	right: 57418,
+	up: 57419,
+	down: 57420,
+};
+const LEGACY_FUNCTION_INPUT_SUFFIXES = [
+	"OP",
+	"OQ",
+	"OR",
+	"OS",
+	"[15~",
+	"[17~",
+	"[18~",
+	"[19~",
+	"[20~",
+	"[21~",
+	"[23~",
+	"[24~",
+];
+// Probe every cross-identity legacy collision through Pi's live matcher. CSI-u,
+// keypad, lock-bit, shifted-letter, and modifyOtherKeys forms normalize to the
+// same key and modifiers, so one generated CSI-u identity covers those branches.
+const LEGACY_KEY_INPUTS = [
+	...Array.from({ length: 128 }, (_, code) => String.fromCharCode(code)),
+	...Array.from({ length: 128 }, (_, code) => `\u001b${String.fromCharCode(code)}`),
+	"\u001b[Z",
+	"\u001bOM",
+	"\u001b[E",
+	"\u001b[e",
+	"\u001bOe",
+	...LEGACY_FUNCTION_INPUT_SUFFIXES.map((suffix) => `\u001b${suffix}`),
+];
 const KEY_BASES = new Set([
 	..."abcdefghijklmnopqrstuvwxyz0123456789`-=[]\\;',./!@#$%^&*()_|~{}:<>?",
 	"escape",

--- a/packages/pi-tui-kit/src/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/pi-selectors.ts
@@ -160,6 +160,7 @@ export async function runThinkingSelector<Context extends MenuContext = Extensio
 				saveBinding: "app.models.save",
 				cycleBinding: "app.thinking.cycle",
 				filterSelection: "preserveValue",
+				inlineDescriptions: true,
 				valueEquals: (left, right) => left === right,
 				onComplete: complete,
 				tui,

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
-import { matchesKey, setKittyProtocolActive, visibleWidth } from "@earendil-works/pi-tui";
-import { test } from "vitest";
+import {
+	getKeybindings,
+	KeybindingsManager,
+	matchesKey,
+	setKeybindings,
+	setKittyProtocolActive,
+	TUI_KEYBINDINGS,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import { test, vi } from "vitest";
 import { createMockContext } from "../../../test/support.js";
 import { runModelSelector, runThinkingSelector } from "../src/index.js";
 import { createTuiHarness } from "../src/testing/index.js";
@@ -164,6 +172,33 @@ test("model selector routes Home and End to query editing", async () => {
 	assert.deepEqual(await running, { kind: "selected", model: alpha });
 });
 
+test("model selector completes remapped and newline Input submissions", async () => {
+	const previousKeybindings = getKeybindings();
+	try {
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.input.submit": "ctrl+q",
+			}),
+		);
+		for (const data of ["\x11", "\n"]) {
+			const tui = createTuiHarness({
+				keybindings: {
+					matches: (input, binding) => (binding === "tui.select.confirm" ? input === "x" : false),
+					getKeys: (binding) => (binding === "tui.select.confirm" ? ["x"] : []),
+				},
+			});
+			const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+			const running = runModelSelector(context.ctx, { models: [models[0]] });
+			await tui.waitForOpen();
+
+			tui.send(data);
+			assert.deepEqual(await running, { kind: "selected", model: models[0] });
+		}
+	} finally {
+		setKeybindings(previousKeybindings);
+	}
+});
+
 test("model selector gives save-default priority except for hard Ctrl+C", async () => {
 	for (const scenario of [
 		{ key: "enter", data: "\r", expected: "saveDefault", shadowedHint: "enter select" },
@@ -231,16 +266,30 @@ test("selector hints honor semantic key collisions and usable fallbacks", async 
 				shown: ["ctrl+s set as default", "enter select"],
 				hidden: ["not-a-key", "ctrl+c set as default"],
 			},
-			{
-				name: "legacy collision",
-				kitty: false,
-				saveKeys: ["ctrl+i"],
-				confirmKeys: ["tab"],
-				data: "\t",
-				expectedKind: "saveDefault",
-				shown: ["ctrl+i set as default"],
-				hidden: ["tab select"],
-			},
+			...(
+				[
+					["Ctrl+I / Tab", "ctrl+i", "tab", "\t"],
+					["Ctrl+J / Enter", "ctrl+j", "enter", "\n"],
+					["Ctrl+M / Enter", "ctrl+m", "enter", "\r"],
+					["Ctrl+[ / Escape", "ctrl+[", "escape", "\x1b"],
+					["Ctrl+- / Ctrl+_", "ctrl+-", "ctrl+_", "\x1f"],
+					["Alt+B / Alt+Left", "alt+b", "alt+left", "\x1bb"],
+					["Alt+F / Alt+Right", "alt+f", "alt+right", "\x1bf"],
+					["Alt+P / Alt+Up", "alt+p", "alt+up", "\x1bp"],
+					["Alt+N / Alt+Down", "alt+n", "alt+down", "\x1bn"],
+					["Ctrl+Alt+H / Alt+Backspace", "ctrl+alt+h", "alt+backspace", "\x1b\x08"],
+					["Ctrl+Alt+M / Alt+Enter", "ctrl+alt+m", "alt+enter", "\x1b\r"],
+				] as const
+			).map(([name, save, confirm, data]) => ({
+				name: `legacy ${name}`,
+				kitty: false as const,
+				saveKeys: [save],
+				confirmKeys: [confirm],
+				data,
+				expectedKind: "saveDefault" as const,
+				shown: [`${save} set as default`],
+				hidden: [`${confirm} select`],
+			})),
 			{
 				name: "Kitty disambiguation",
 				kitty: true,
@@ -281,6 +330,56 @@ test("selector hints honor semantic key collisions and usable fallbacks", async 
 		}
 	} finally {
 		setKittyProtocolActive(false);
+	}
+});
+
+test("selector hints follow Pi's live raw-backspace matcher overlap", async () => {
+	try {
+		setKittyProtocolActive(false);
+		for (const scenario of [
+			{
+				name: "legacy or remote terminal",
+				windowsTerminal: false,
+				data: "\x08",
+				expectedKind: "saveDefault",
+				showsConfirm: false,
+			},
+			{
+				name: "local Windows Terminal",
+				windowsTerminal: true,
+				data: "\x7f",
+				expectedKind: "selected",
+				showsConfirm: true,
+			},
+		] as const) {
+			vi.stubEnv("WT_SESSION", scenario.windowsTerminal ? "test" : "");
+			for (const name of ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]) vi.stubEnv(name, "");
+			const keys = (binding: string): readonly string[] => {
+				if (binding === "app.models.save") return ["ctrl+h"];
+				if (binding === "tui.select.confirm") return ["backspace"];
+				if (binding === "tui.select.cancel") return ["escape"];
+				return [];
+			};
+			const tui = createTuiHarness({
+				keybindings: {
+					matches: (data, binding) =>
+						keys(String(binding)).some((key) => matchesKey(data, key as never)),
+					getKeys: (binding) => [...keys(String(binding))] as never,
+				},
+			});
+			const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+			const running = runModelSelector(context.ctx, { models: [models[0]] });
+			await tui.waitForOpen();
+			const frame = tui.render().join("\n");
+			assert.ok(frame.includes("ctrl+h set as default"), scenario.name);
+			assert.equal(frame.includes("backspace select"), scenario.showsConfirm, scenario.name);
+
+			tui.send(scenario.data);
+			assert.equal((await running).kind, scenario.expectedKind, scenario.name);
+		}
+	} finally {
+		setKittyProtocolActive(false);
+		vi.unstubAllEnvs();
 	}
 });
 
@@ -341,6 +440,44 @@ test("thinking selector honors remapped cycle and save-default bindings", async 
 	tui.send("\x1bt");
 	tui.send("x");
 	assert.deepEqual(await running, { kind: "saveDefault", level: "high" });
+});
+
+test("thinking selector renders every description beside its choice on wide terminals", async () => {
+	const tui = createTuiHarness({ width: 100, rows: 30 });
+	const context = createMockContext({ mode: "tui", hasUI: true, custom: tui.custom });
+	const running = runThinkingSelector(context.ctx, {
+		availableLevels: ["off", "low", "high"],
+		currentLevel: "low",
+		defaultLevel: "off",
+	});
+	await tui.waitForOpen();
+	const frame = tui.render().map(stripVTControlCharacters);
+	for (const [level, description] of [
+		["off", "No reasoning"],
+		["low", "Light reasoning (~2k tokens)"],
+		["high", "Deep reasoning (~16k tokens)"],
+	] as const) {
+		const row = frame.find((line) => line.includes(level));
+		assert.ok(row?.includes(description), `${level} renders ${description}`);
+	}
+	assert.ok(frame.every((line) => visibleWidth(line) <= 100));
+	tui.press("ctrl+c");
+	assert.deepEqual(await running, { kind: "closed", reason: "close" });
+
+	const narrowTui = createTuiHarness({ width: 30, rows: 20 });
+	const narrowContext = createMockContext({
+		mode: "tui",
+		hasUI: true,
+		custom: narrowTui.custom,
+	});
+	const narrowRunning = runThinkingSelector(narrowContext.ctx, {
+		availableLevels: ["off", "low", "high"],
+		currentLevel: "low",
+	});
+	await narrowTui.waitForOpen();
+	assert.ok(narrowTui.render().every((line) => visibleWidth(line) <= 30));
+	narrowTui.press("ctrl+c");
+	assert.deepEqual(await narrowRunning, { kind: "closed", reason: "close" });
 });
 
 test("thinking selector named cycle key emits Shift+Tab", async () => {

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -475,7 +475,9 @@ test("thinking selector renders every description beside its choice on wide term
 		currentLevel: "low",
 	});
 	await narrowTui.waitForOpen();
-	assert.ok(narrowTui.render().every((line) => visibleWidth(line) <= 30));
+	const narrowFrame = narrowTui.render().map(stripVTControlCharacters);
+	assert.ok(narrowFrame.some((line) => line.includes("Light reasoning")));
+	assert.ok(narrowFrame.every((line) => visibleWidth(line) <= 30));
 	narrowTui.press("ctrl+c");
 	assert.deepEqual(await narrowRunning, { kind: "closed", reason: "close" });
 });


### PR DESCRIPTION
## Summary

- complete selections when a remapped `tui.input.submit` reaches the embedded search input
- make selector hints follow Pi's live legacy matcher collisions, including terminal-dependent raw Backspace behavior
- render every thinking-level description beside its choice on wide terminals while preserving narrow width bounds
- add a patch Changeset for `@narumitw/pi-tui-kit`

Follow-up to #1267 and its three post-merge review threads.

## Verification

- `npx vitest run packages/pi-tui-kit/test/pi-selectors.test.ts` (21 tests)
- `npm --workspace @narumitw/pi-tui-kit run check`
- `npm run check`
- `npm test` (392 files, 4,573 tests)
- `npm run package:pack -- tui-kit` (82 packaged files)
- `npm run changeset:status`
