### PR TITLE
fix(tui-kit): respect extended key protocols

### DIFF
--- a/.changeset/calm-lions-select.md
+++ b/.changeset/calm-lions-select.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-tui-kit": patch
 ---
 
-Fix forwarded selector submissions, terminal-aware shortcut hints, and thinking-level descriptions.
+Fix forwarded selector submissions, accurate shortcut hints across legacy and extended keyboard protocols, and thinking-level descriptions.

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -113,8 +113,15 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 		input.handleInput(parseKey(data) === undefined ? safe(data) : data);
 		if (!disposed) refilter();
 	};
+	const matchesAction = (data: string, binding: string) =>
+		matchesSelectorBinding(
+			options.keybindings,
+			data,
+			binding,
+			usesDisambiguatedKeyProtocol(options.tui),
+		);
 	const saveDefault = (data: string) => {
-		if (!matchesBinding(options.keybindings, data, options.saveBinding)) return false;
+		if (!matchesAction(data, options.saveBinding)) return false;
 		completeSelected("saveDefault");
 		return true;
 	};
@@ -124,24 +131,24 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 			return;
 		}
 		if (saveDefault(data)) return;
-		if (options.keybindings.matches(data, "tui.select.confirm")) {
+		if (matchesAction(data, "tui.select.confirm")) {
 			completeSelected("selected");
 			return;
 		}
-		if (options.keybindings.matches(data, "tui.select.cancel")) {
+		if (matchesAction(data, "tui.select.cancel")) {
 			options.onComplete({ kind: "closed", reason: "back" });
 			return;
 		}
-		if (options.cycleBinding && matchesBinding(options.keybindings, data, options.cycleBinding)) {
+		if (options.cycleBinding && matchesAction(data, options.cycleBinding)) {
 			select(selectedIndex + 1, true);
 			return;
 		}
-		if (options.keybindings.matches(data, "tui.select.up")) select(selectedIndex - 1, true);
-		else if (options.keybindings.matches(data, "tui.select.down")) {
+		if (matchesAction(data, "tui.select.up")) select(selectedIndex - 1, true);
+		else if (matchesAction(data, "tui.select.down")) {
 			select(selectedIndex + 1, true);
-		} else if (options.keybindings.matches(data, "tui.select.pageUp")) {
+		} else if (matchesAction(data, "tui.select.pageUp")) {
 			select(selectedIndex - normalizeViewportSize(options.viewportSize), false);
-		} else if (options.keybindings.matches(data, "tui.select.pageDown")) {
+		} else if (matchesAction(data, "tui.select.pageDown")) {
 			select(selectedIndex + normalizeViewportSize(options.viewportSize), false);
 		} else handleSearchInput(data);
 	};
@@ -523,6 +530,20 @@ function usesDisambiguatedKeyProtocol(tui: TUI) {
 function keysOverlap(first: string, second: string, disambiguatedKeyProtocol: boolean) {
 	if (disambiguatedKeyProtocol) return first === second;
 	return inputsForKey(first).some((input) => matchesKey(input, second as KeyId));
+}
+
+function matchesSelectorBinding(
+	keybindings: KeybindingsManager,
+	data: string,
+	binding: string,
+	disambiguatedKeyProtocol: boolean,
+) {
+	if (!disambiguatedKeyProtocol) return matchesBinding(keybindings, data, binding);
+	const inputKey = canonicalKeyId(parseKey(data) ?? "");
+	return (
+		inputKey !== undefined &&
+		getBindingKeys(keybindings, binding).some((key) => canonicalKeyId(key) === inputKey)
+	);
 }
 
 function inputsForKey(key: string) {

--- a/packages/pi-tui-kit/src/components/pi-selectors.ts
+++ b/packages/pi-tui-kit/src/components/pi-selectors.ts
@@ -294,6 +294,7 @@ export function createPiSelector<Value>(options: PiSelectorOptions<Value>) {
 				options.keybindings,
 				options.saveBinding,
 				options.cycleBinding,
+				usesDisambiguatedKeyProtocol(options.tui),
 			);
 			const hint = selectorHint(keyPlan);
 			const cycleHint = selectorCycleHint(keyPlan);
@@ -456,6 +457,7 @@ function selectorKeyPlan(
 	keybindings: KeybindingsManager,
 	saveBinding: "app.models.save",
 	cycleBinding: "app.thinking.cycle" | undefined,
+	disambiguatedKeyProtocol: boolean,
 ): SelectorKeyPlan {
 	const claimed = ["ctrl+c"];
 	const claim = (binding: string | undefined) => {
@@ -463,7 +465,11 @@ function selectorKeyPlan(
 		if (!binding) return available;
 		for (const key of getBindingKeys(keybindings, binding)) {
 			const canonical = canonicalKeyId(key);
-			if (!canonical || claimed.some((other) => keysOverlap(canonical, other))) continue;
+			if (
+				!canonical ||
+				claimed.some((other) => keysOverlap(canonical, other, disambiguatedKeyProtocol))
+			)
+				continue;
 			claimed.push(canonical);
 			available.push(canonical);
 		}
@@ -503,8 +509,19 @@ function canonicalKeyId(value: string): string | undefined {
 	return [...modifiers, base].join("+");
 }
 
-function keysOverlap(first: string, second: string) {
-	if (isKittyProtocolActive()) return first === second;
+function usesDisambiguatedKeyProtocol(tui: TUI) {
+	const terminal = tui.terminal as typeof tui.terminal & {
+		readonly modifyOtherKeysActive?: boolean;
+	};
+	return (
+		isKittyProtocolActive() ||
+		terminal.kittyProtocolActive ||
+		terminal.modifyOtherKeysActive === true
+	);
+}
+
+function keysOverlap(first: string, second: string, disambiguatedKeyProtocol: boolean) {
+	if (disambiguatedKeyProtocol) return first === second;
 	return inputsForKey(first).some((input) => matchesKey(input, second as KeyId));
 }
 

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
 import {
 	getKeybindings,
+	isKittyProtocolActive,
 	KeybindingsManager,
 	matchesKey,
 	setKeybindings,
@@ -384,47 +385,69 @@ test("selector hints follow Pi's live raw-backspace matcher overlap", async () =
 	}
 });
 
-test("selector hints preserve modifyOtherKeys-disambiguated actions", () => {
-	setKittyProtocolActive(false);
-	const keys = (binding: string): readonly string[] => {
-		if (binding === "app.models.save") return ["ctrl+h"];
-		if (binding === "tui.select.confirm") return ["backspace"];
-		if (binding === "tui.select.cancel") return ["escape"];
-		return [];
-	};
-	const keybindings = {
-		matches: (data: string, binding: string) =>
-			keys(binding).some((key) => matchesKey(data, key as never)),
-		getKeys: (binding: string) => [...keys(binding)],
-	} as never;
-	const tui = {
-		terminal: { rows: 20, modifyOtherKeysActive: true },
-		requestRender() {},
-	} as never;
-	const theme = { fg: (_role: string, text: string) => text } as never;
-
-	for (const scenario of [
-		{ data: "\x1b[27;5;104~", expectedKind: "saveDefault" },
-		{ data: "\x7f", expectedKind: "selected" },
-	] as const) {
-		let completed: { kind: string } | undefined;
-		const component = createPiSelector({
-			rows: [{ value: "model", primary: "model" }],
-			saveBinding: "app.models.save",
-			filterSelection: "bestMatch",
-			valueEquals: (left, right) => left === right,
-			onComplete: (result) => {
-				completed = result;
+test("selector hints and dispatch preserve modifyOtherKeys-disambiguated actions", () => {
+	const previousKittyProtocol = isKittyProtocolActive();
+	try {
+		setKittyProtocolActive(false);
+		for (const keyPair of [
+			{
+				name: "Ctrl+H and Backspace",
+				saveKey: "ctrl+h",
+				confirmKey: "backspace",
+				saveData: "\x1b[27;5;104~",
+				confirmData: "\x7f",
 			},
-			tui,
-			theme,
-			keybindings,
-		});
-		const frame = component.render(80).join("\n");
-		assert.ok(frame.includes("ctrl+h set as default"));
-		assert.ok(frame.includes("backspace select"));
-		component.handleInput(scenario.data);
-		assert.equal(completed?.kind, scenario.expectedKind);
+			{
+				name: "Ctrl+I and Tab",
+				saveKey: "ctrl+i",
+				confirmKey: "tab",
+				saveData: "\x1b[27;5;105~",
+				confirmData: "\t",
+			},
+		] as const) {
+			const keys = (binding: string): readonly string[] => {
+				if (binding === "app.models.save") return [keyPair.saveKey];
+				if (binding === "tui.select.confirm") return [keyPair.confirmKey];
+				if (binding === "tui.select.cancel") return ["escape"];
+				return [];
+			};
+			const keybindings = {
+				matches: (data: string, binding: string) =>
+					keys(binding).some((key) => matchesKey(data, key as never)),
+				getKeys: (binding: string) => [...keys(binding)],
+			} as never;
+			const tui = {
+				terminal: { rows: 20, modifyOtherKeysActive: true },
+				requestRender() {},
+			} as never;
+			const theme = { fg: (_role: string, text: string) => text } as never;
+
+			for (const action of [
+				{ data: keyPair.saveData, expectedKind: "saveDefault" },
+				{ data: keyPair.confirmData, expectedKind: "selected" },
+			] as const) {
+				let completed: { kind: string } | undefined;
+				const component = createPiSelector({
+					rows: [{ value: "model", primary: "model" }],
+					saveBinding: "app.models.save",
+					filterSelection: "bestMatch",
+					valueEquals: (left, right) => left === right,
+					onComplete: (result) => {
+						completed = result;
+					},
+					tui,
+					theme,
+					keybindings,
+				});
+				const frame = component.render(80).join("\n");
+				assert.ok(frame.includes(`${keyPair.saveKey} set as default`), keyPair.name);
+				assert.ok(frame.includes(`${keyPair.confirmKey} select`), keyPair.name);
+				component.handleInput(action.data);
+				assert.equal(completed?.kind, action.expectedKind, keyPair.name);
+			}
+		}
+	} finally {
+		setKittyProtocolActive(previousKittyProtocol);
 	}
 });
 

--- a/packages/pi-tui-kit/test/pi-selectors.test.ts
+++ b/packages/pi-tui-kit/test/pi-selectors.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { test, vi } from "vitest";
 import { createMockContext } from "../../../test/support.js";
+import { createPiSelector } from "../src/components/pi-selectors.js";
 import { runModelSelector, runThinkingSelector } from "../src/index.js";
 import { createTuiHarness } from "../src/testing/index.js";
 
@@ -380,6 +381,50 @@ test("selector hints follow Pi's live raw-backspace matcher overlap", async () =
 	} finally {
 		setKittyProtocolActive(false);
 		vi.unstubAllEnvs();
+	}
+});
+
+test("selector hints preserve modifyOtherKeys-disambiguated actions", () => {
+	setKittyProtocolActive(false);
+	const keys = (binding: string): readonly string[] => {
+		if (binding === "app.models.save") return ["ctrl+h"];
+		if (binding === "tui.select.confirm") return ["backspace"];
+		if (binding === "tui.select.cancel") return ["escape"];
+		return [];
+	};
+	const keybindings = {
+		matches: (data: string, binding: string) =>
+			keys(binding).some((key) => matchesKey(data, key as never)),
+		getKeys: (binding: string) => [...keys(binding)],
+	} as never;
+	const tui = {
+		terminal: { rows: 20, modifyOtherKeysActive: true },
+		requestRender() {},
+	} as never;
+	const theme = { fg: (_role: string, text: string) => text } as never;
+
+	for (const scenario of [
+		{ data: "\x1b[27;5;104~", expectedKind: "saveDefault" },
+		{ data: "\x7f", expectedKind: "selected" },
+	] as const) {
+		let completed: { kind: string } | undefined;
+		const component = createPiSelector({
+			rows: [{ value: "model", primary: "model" }],
+			saveBinding: "app.models.save",
+			filterSelection: "bestMatch",
+			valueEquals: (left, right) => left === right,
+			onComplete: (result) => {
+				completed = result;
+			},
+			tui,
+			theme,
+			keybindings,
+		});
+		const frame = component.render(80).join("\n");
+		assert.ok(frame.includes("ctrl+h set as default"));
+		assert.ok(frame.includes("backspace select"));
+		component.handleInput(scenario.data);
+		assert.equal(completed?.kind, scenario.expectedKind);
 	}
 });
 


### PR DESCRIPTION
## Summary

- preserve distinct selector hints when Kitty or xterm `modifyOtherKeys` disambiguates modified keys
- align extended-protocol action dispatch with parsed canonical key identities so unmodified Tab cannot be consumed by Ctrl+I
- retain Pi's live matcher behavior when no extended keyboard protocol is active
- cover Ctrl+H/Backspace and Ctrl+I/Tab hints, actions, and protocol-state cleanup
- clarify the pending selector changeset

This is the remaining review follow-up from merged PR #1272; that PR merged while the final feedback fix was being verified.

## Verification

- `npx vitest run packages/pi-tui-kit/test/pi-selectors.test.ts` (22 passed)
- `npm --workspace @narumitw/pi-tui-kit run check`
- `npm run check`
- `npm test` (4,574 passed)
- `npm run package:pack -- tui-kit` (82 files)
- `npm run changeset:status`
