### PR TITLE
feat(plan-mode): add fresh runtime defaults

### DIFF
--- a/.changeset/fresh-plan-runtime-defaults.md
+++ b/.changeset/fresh-plan-runtime-defaults.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": minor
+---
+
+Add persistent fresh implementation model and thinking defaults with a same-as-plan fallback.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -11,7 +11,7 @@ Use a Codex-like `/plan` mode to explore a codebase, resolve important questions
 - Uses structured questions for important ambiguity and explicit completion for a decision-ready plan.
 - Reviews the complete plan before implementation, export, save, further planning, or discard.
 - Implements in the planning session or a fresh linked session with the approved plan.
-- Optionally selects a one-shot destination model and thinking level before a fresh ready-plan handoff.
+- Configures persistent or one-shot destination model and thinking choices for fresh implementation.
 - Restores Plan state and one saved plan across resume and compaction.
 - Configures the Plan tool allowlist, reviewed shell commands, user-trusted subcommands, export path, plan reinjection, shortcut, and thinking level.
 - Publishes statusline state and cooperates anonymously with Workflow Mutex Protocol v1 participants.
@@ -97,11 +97,12 @@ sequenceDiagram
 | `/plan finalize` | Ask the active planner to finish or ask one remaining material question. |
 | `/plan implement` | Implement a completed or saved plan in this session, without a selector. |
 | `/plan save` | Save a ready plan in this Pi session and leave Plan mode. |
+| `/plan settings` | Open the same Plan Settings screen available from the menus. |
 | `/plan export [path]` | Write a ready, saved, or active implementation plan to Markdown. |
 | `/plan exit` (alias: `off`) | Leave Plan mode and discard its ready plan, or clear a saved/active plan. |
 
 All routes support TUI and RPC.
-Print and JSON modes reject the menu and `tools`; stored-plan display and implementation have [additional mode restrictions](#-planning-and-implementation).
+Print and JSON modes reject the menu, `tools`, and `settings`; stored-plan display and implementation have [additional mode restrictions](#-planning-and-implementation).
 Exact subcommand words select routes; other text is a planning prompt, so `/plan start a migration` sends a prompt rather than rejecting trailing text.
 There is no startup flag.
 
@@ -195,9 +196,11 @@ The same flat menu shows **Implement here** and **Start fresh and implement**, e
 Its searchable model list snapshots the session's scoped models when configured, otherwise Pi's currently available models, and shows each provider, model ID, and friendly name.
 Pi 0.80.6–0.82.1 does not expose session model scopes to extensions, so the list uses all currently available models on those releases.
 One-shot provider and model identifiers are limited to 512 characters each; longer custom identifiers are rejected before the source session is replaced.
-The model and thinking rows show the planning session's current values with **same as plan** by default and carry those values into the fresh session independently; the fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
-Back navigation preserves this menu-local draft, while closing and reopening the menu resets both rows.
-The saved-plan menu keeps its direct fresh-session action without these optional rows.
+The model and thinking rows start from the persistent **Fresh model** and **Fresh thinking** defaults; when either setting is omitted, they show the planning session's current value with **same as plan** and carry it into the fresh session independently.
+The fixed thinking choices are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+Back navigation preserves this menu-local draft, while closing and reopening the menu restores both persistent defaults.
+If the configured model is outside the current scope or no longer available, the row reports the fallback and uses **same as plan** without deleting the stored preference.
+The saved-plan menu keeps its direct fresh-session action without optional rows and applies the same persistent defaults and fallback.
 
 Starting from that settings page waits for the source session to become idle, re-resolves and authenticates an explicit model, creates a new session linked to the persisted source as its parent, and transfers the exact approved plan without copying planning messages, tool results, or compaction/branch summaries.
 The destination consumes the one-shot choices before its first provider request, applies an explicit model first, and then applies explicit thinking.
@@ -338,18 +341,23 @@ Guaranteed coexistence with Goal requires `@narumitw/pi-goal` `0.53.0` or newer 
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu, or edit `<getAgentDir()>/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`).
+Run `/plan settings`, open **Settings** from an inactive `/plan` menu, or edit `<getAgentDir()>/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`).
 The optional file is read at session start and watched for changes; only an explicit save creates it.
 
 ```json
 {
   "thinkingLevel": "inherit",
   "implementationPlanRetention": "clear-on-start",
+  "defaultImplementationModel": {
+    "provider": "anthropic",
+    "modelId": "claude-sonnet-4-5"
+  },
+  "defaultImplementationThinkingLevel": "high",
   "defaultPlanExportPath": "PLAN.md"
 }
 ```
 
-By default, Plan mode inherits thinking, allows active safe built-ins, exports to `PLAN.md`, and relies on ordinary conversation history after implementation starts.
+By default, Plan mode inherits thinking, allows active safe built-ins, uses the planning model and thinking level for fresh implementation, exports to `PLAN.md`, and relies on ordinary conversation history after implementation starts.
 The shortcut is disabled unless configured.
 Settings saves apply to later workflows; an active implementation keeps its captured reinjection policy.
 The export destination affects the next export immediately.

--- a/packages/pi-plan-mode/docs/settings.md
+++ b/packages/pi-plan-mode/docs/settings.md
@@ -4,6 +4,7 @@
 
 - [Default Plan policy tools](#default-plan-policy-tools)
 - [Plan reinjection](#plan-reinjection)
+- [Fresh implementation runtime](#fresh-implementation-runtime)
 - [Export destination](#export-destination)
 - [Toggle shortcut](#toggle-shortcut)
 - [Safe shell subcommands](#safe-shell-subcommands)
@@ -11,7 +12,7 @@
 
 ## ⚙️ Settings
 
-Open **Settings** from an inactive `/plan` menu to edit **Plan thinking**, **Plan policy tools**, **Plan reinjection**, **Export destination**, and **Plan mode shortcut**.
+Run `/plan settings` or open **Settings** from an inactive `/plan` menu to edit **Plan thinking**, **Plan policy tools**, **Plan reinjection**, **Fresh model**, **Fresh thinking**, **Export destination**, and **Plan mode shortcut**.
 You can also edit `$PI_CODING_AGENT_DIR/pi-plan-mode.json` (normally `~/.pi/agent/pi-plan-mode.json`) manually.
 `safeSubcommands` is JSON-only.
 The optional file is read at session start, watched for changes, and created only by an explicit Settings save or manual edit.
@@ -21,6 +22,11 @@ The shortcut is disabled when `toggleShortcut` is omitted.
   "thinkingLevel": "inherit",
   "defaultPlanTools": ["read", "bash", "grep", "find", "ls"],
   "implementationPlanRetention": "clear-on-start",
+  "defaultImplementationModel": {
+    "provider": "anthropic",
+    "modelId": "claude-sonnet-4-5"
+  },
+  "defaultImplementationThinkingLevel": "high",
   "defaultPlanExportPath": "PLAN.md",
   "safeSubcommands": {
     "git": ["rev-parse", "blame"],
@@ -77,6 +83,24 @@ Failed handoff delivery restores the ready or saved plan and does not run automa
 Changing this setting applies to the next Implement action only.
 Each guaranteed-plan implementation stores its effective policy, so a later Settings save cannot shorten or extend an implementation already in progress.
 Conversation-history-only implementation has no active Plan-mode state to show, export, or clear after kickoff.
+
+### Fresh implementation runtime
+
+Omit `defaultImplementationModel` and `defaultImplementationThinkingLevel` to use **same as plan**, the default.
+A configured model is an object with non-empty `provider` and `modelId` strings of at most 512 characters each.
+`defaultImplementationThinkingLevel` accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`; use omission rather than `inherit` for **same as plan**.
+Choosing **Same as plan** in Settings removes the corresponding field.
+
+The model picker snapshots the current session's scoped models when a non-empty scope exists, otherwise Pi's currently available models.
+A configured model outside that catalogue remains stored but is ineffective for that handoff: Settings and the ready-plan fresh screen report that it is unavailable and fall back to the planning session model.
+The preference becomes effective again if the model returns to the applicable catalogue.
+This fallback also protects a persistent default that disappears while the ready-plan fresh screen is open.
+Authentication and one-shot model races still use the normal fresh-handoff preflight and recovery behavior.
+
+These persistent values seed each ready-plan **Start fresh and implement** screen, where either choice can be overridden once without changing Settings.
+The saved-plan direct fresh action applies the persistent values without an extra picker and warns when its configured model falls back.
+Changes save immediately and apply to later fresh implementation actions; an already open fresh-action screen keeps its own menu-local draft.
+They never switch the planning session's current model or thinking level.
 
 ### Export destination
 
@@ -141,7 +165,7 @@ A missing file stays absent until an explicit save.
 Invalid JSON, invalid values, oversized content, non-regular files, and read failures make Settings read-only; the existing bytes and previous effective settings remain.
 This in-process queue is not a cross-process lock, so concurrent separate Pi processes can still race.
 
-Invalid settings produce a warning and fall back to inherited thinking, available safe-built-in tool defaults, `clear-on-start`, and `PLAN.md`.
+Invalid settings produce a warning and fall back to inherited Plan thinking, available safe-built-in tool defaults, `clear-on-start`, same-as-plan fresh runtime choices, and `PLAN.md`.
 Compatibility: a valid legacy `plan-mode.json` remains readable with a warning and is never modified automatically.
 If Settings is explicitly saved while only that legacy file exists, the extension creates canonical `pi-plan-mode.json` from the complete legacy document, applies the selected change, preserves unknown fields, and leaves the legacy file untouched.
 If both files exist, the canonical filename takes precedence.

--- a/packages/pi-plan-mode/src/command.ts
+++ b/packages/pi-plan-mode/src/command.ts
@@ -10,6 +10,7 @@ const PLAN_COMMAND_COMPLETIONS: readonly CommandArgumentCompletion[] = [
 	{ value: "finalize", label: "finalize", description: "Request a completed plan" },
 	{ value: "implement", label: "implement", description: "Implement the completed or saved plan" },
 	{ value: "save", label: "save", description: "Save the completed plan for later" },
+	{ value: "settings", label: "settings", description: "Open Plan mode settings" },
 	{ value: "export", label: "export", description: "Export the stored plan to a Markdown file" },
 	{ value: "exit", label: "exit", description: "Leave Plan mode or clear a saved/active plan" },
 	{ value: "off", label: "off", description: "Leave Plan mode or clear a saved/active plan" },

--- a/packages/pi-plan-mode/src/implementation-models.ts
+++ b/packages/pi-plan-mode/src/implementation-models.ts
@@ -24,10 +24,17 @@ export function isPendingImplementationModelIdentifier(value: unknown): value is
 export function snapshotAvailableImplementationModels(
 	ctx: ExtensionContext,
 ): AvailableImplementationModel[] {
-	const scopedModels = ctx.scopedModels ?? [];
-	if (scopedModels.length > 0) return scopedModels.map((entry) => entry.model);
 	const getAvailable = ctx.modelRegistry.getAvailable;
-	return typeof getAvailable === "function" ? getAvailable.call(ctx.modelRegistry) : [];
+	const availableModels =
+		typeof getAvailable === "function" ? getAvailable.call(ctx.modelRegistry) : [];
+	const scopedModels = ctx.scopedModels ?? [];
+	if (scopedModels.length === 0) return availableModels;
+	return scopedModels.flatMap((entry) => {
+		const availableModel = availableModels.find(
+			(model) => model.provider === entry.model.provider && model.id === entry.model.id,
+		);
+		return availableModel ? [availableModel] : [];
+	});
 }
 
 export function findAvailableImplementationModel(

--- a/packages/pi-plan-mode/src/implementation-models.ts
+++ b/packages/pi-plan-mode/src/implementation-models.ts
@@ -1,0 +1,41 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+export const MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH = 512;
+
+export interface ImplementationModelOverride {
+	provider: string;
+	modelId: string;
+}
+
+export interface AvailableImplementationModel {
+	provider: string;
+	id: string;
+	name?: string;
+}
+
+export function isPendingImplementationModelIdentifier(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.trim().length > 0 &&
+		value.length <= MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH
+	);
+}
+
+export function snapshotAvailableImplementationModels(
+	ctx: ExtensionContext,
+): AvailableImplementationModel[] {
+	const scopedModels = ctx.scopedModels ?? [];
+	if (scopedModels.length > 0) return scopedModels.map((entry) => entry.model);
+	const getAvailable = ctx.modelRegistry.getAvailable;
+	return typeof getAvailable === "function" ? getAvailable.call(ctx.modelRegistry) : [];
+}
+
+export function findAvailableImplementationModel(
+	models: readonly AvailableImplementationModel[],
+	configured: ImplementationModelOverride | undefined,
+): AvailableImplementationModel | undefined {
+	if (!configured) return undefined;
+	return models.find(
+		(model) => model.provider === configured.provider && model.id === configured.modelId,
+	);
+}

--- a/packages/pi-plan-mode/src/plan-action-controller.ts
+++ b/packages/pi-plan-mode/src/plan-action-controller.ts
@@ -1,6 +1,15 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	findAvailableImplementationModel,
+	snapshotAvailableImplementationModels,
+} from "./implementation-models.js";
 import type { PlanExportDestination } from "./plan-export.js";
-import type { PlanModeFixedThinkingLevel } from "./settings.js";
+import {
+	configuredImplementationModel,
+	configuredImplementationThinkingLevel,
+	type PlanModeFixedThinkingLevel,
+	type PlanModeSettings,
+} from "./settings.js";
 import type { ImplementationRuntimeSelection, PlanModeState } from "./state.js";
 
 type InteractiveUi = typeof import("./interactive-ui.js");
@@ -16,6 +25,7 @@ interface PlanActionControllerOptions {
 	captureLifecycle(): MenuLifecycle;
 	statusText(): string;
 	getThinkingLevel(): PlanModeFixedThinkingLevel | undefined;
+	getSettings(): PlanModeSettings;
 	implementationOutcome(): string;
 	getExportDestination(ctx: ExtensionContext): PlanExportDestination;
 	show(ctx: ExtensionContext): void;
@@ -40,6 +50,39 @@ interface PlanActionControllerOptions {
 }
 
 export function createPlanActionController(options: PlanActionControllerOptions) {
+	const configuredDefaults = (): ImplementationRuntimeSelection => {
+		const settings = options.getSettings();
+		const model = configuredImplementationModel(settings);
+		const thinkingLevel = configuredImplementationThinkingLevel(settings);
+		return {
+			...(model ? { model: { ...model } } : {}),
+			...(thinkingLevel ? { thinkingLevel } : {}),
+		};
+	};
+	const effectiveDefaults = (ctx: ExtensionContext): ImplementationRuntimeSelection => {
+		const configured = configuredDefaults();
+		const availableModel = findAvailableImplementationModel(
+			snapshotAvailableImplementationModels(ctx),
+			configured.model,
+		);
+		if (configured.model && !availableModel) {
+			ctx.ui.notify(
+				"The configured fresh implementation model is unavailable; using the planning model.",
+				"warning",
+			);
+		}
+		const planModel = ctx.model
+			? { provider: ctx.model.provider, modelId: ctx.model.id }
+			: undefined;
+		const model = availableModel
+			? { provider: availableModel.provider, modelId: availableModel.id }
+			: planModel;
+		const thinkingLevel = configured.thinkingLevel ?? options.getThinkingLevel();
+		return {
+			...(model ? { model } : {}),
+			...(thinkingLevel ? { thinkingLevel } : {}),
+		};
+	};
 	const freshAction = (
 		ctx: ExtensionContext,
 		lifecycle: MenuLifecycle,
@@ -61,7 +104,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				isCurrent: lifecycle.isCurrent,
 				show: () => options.show(ctx),
 				implementHere: () => options.implementHere(ctx),
-				implementFresh: (signal) => freshAction(ctx, lifecycle, signal),
+				implementFresh: (signal) => freshAction(ctx, lifecycle, signal, effectiveDefaults(ctx)),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				settings: (signal) => options.settings(ctx, signal, lifecycle.isCurrent),
 				clear: () => options.clearSaved(ctx),
@@ -79,6 +122,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 			await ui.showPlanModeMenu(ctx, {
 				statusText: options.statusText(),
 				planThinkingLevel: options.getThinkingLevel(),
+				implementationDefaults: configuredDefaults(),
 				hasReadyPlan: options.getState().latestPlan !== undefined,
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
@@ -101,6 +145,7 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 			await ui.showReadyPlanMenu(ctx, {
 				...lifecycle,
 				planThinkingLevel: options.getThinkingLevel(),
+				implementationDefaults: configuredDefaults(),
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
 				implementHere: () => options.implementHere(ctx),

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -1,8 +1,14 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { defineMenu, runMenu, sanitizeTerminalText } from "@narumitw/pi-tui-kit";
+import {
+	type AvailableImplementationModel,
+	findAvailableImplementationModel,
+	type ImplementationModelOverride,
+	snapshotAvailableImplementationModels,
+} from "./implementation-models.js";
 import { type PlanExportDestinationProvider, planExportInputScreen } from "./plan-export-screen.js";
-import type { PlanModeFixedThinkingLevel } from "./settings.js";
-import type { ImplementationModelOverride, ImplementationRuntimeSelection } from "./state.js";
+import { IMPLEMENTATION_THINKING_LEVELS, type PlanModeFixedThinkingLevel } from "./settings.js";
+import type { ImplementationRuntimeSelection } from "./state.js";
 
 interface MenuLifecycle {
 	signal: AbortSignal;
@@ -13,16 +19,6 @@ const IMPLEMENTATION_CONTEXT_LINES = [
 	"Implement here keeps this planning conversation.",
 	"Start fresh transfers only the approved plan to a new session.",
 ] as const;
-
-const FIXED_THINKING_LEVELS: readonly PlanModeFixedThinkingLevel[] = [
-	"off",
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-	"max",
-];
 
 const THINKING_LEVEL_DESCRIPTIONS: Record<PlanModeFixedThinkingLevel, string> = {
 	off: "No reasoning",
@@ -37,6 +33,7 @@ const THINKING_LEVEL_DESCRIPTIONS: Record<PlanModeFixedThinkingLevel, string> = 
 interface PlanMenuOptions extends MenuLifecycle {
 	statusText: string;
 	planThinkingLevel: PlanModeFixedThinkingLevel | undefined;
+	implementationDefaults?: ImplementationRuntimeSelection;
 	hasReadyPlan: boolean;
 	implementationOutcome(): string;
 	getExportDestination: PlanExportDestinationProvider;
@@ -69,6 +66,7 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 	const freshFlow = createFreshImplementationFlow(
 		ctx,
 		options.planThinkingLevel,
+		options.implementationDefaults,
 		options.implementFresh,
 	);
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
@@ -165,6 +163,7 @@ export async function showPlanModeMenu(ctx: ExtensionContext, options: PlanMenuO
 
 interface ReadyPlanMenuOptions extends MenuLifecycle {
 	planThinkingLevel: PlanModeFixedThinkingLevel | undefined;
+	implementationDefaults?: ImplementationRuntimeSelection;
 	implementationOutcome(): string;
 	getExportDestination: PlanExportDestinationProvider;
 	implementHere(): void | Promise<void>;
@@ -192,6 +191,7 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 	const freshFlow = createFreshImplementationFlow(
 		ctx,
 		options.planThinkingLevel,
+		options.implementationDefaults,
 		options.implementFresh,
 	);
 	const menu = defineMenu<undefined, Screen, Action, ExtensionContext>({
@@ -269,6 +269,7 @@ export async function showReadyPlanMenu(ctx: ExtensionContext, options: ReadyPla
 interface ModelChoice {
 	itemId: string;
 	model: ImplementationModelOverride;
+	modelInfo: AvailableImplementationModel;
 	label: string;
 	summary: string;
 	details?: readonly string[];
@@ -279,6 +280,7 @@ interface ModelChoice {
 function createFreshImplementationFlow(
 	ctx: ExtensionContext,
 	planThinkingLevel: PlanModeFixedThinkingLevel | undefined,
+	implementationDefaults: ImplementationRuntimeSelection | undefined,
 	implementFresh: (
 		runtime: ImplementationRuntimeSelection,
 		signal: AbortSignal,
@@ -289,13 +291,29 @@ function createFreshImplementationFlow(
 	const planModelSummary = ctx.model
 		? `${safeModelMetadata(ctx.model.id, "unknown model")} [${safeModelMetadata(ctx.model.provider, "unknown provider")}]`
 		: undefined;
-	let selectedModel: ModelChoice | undefined;
-	let selectedThinkingLevel: PlanModeFixedThinkingLevel | undefined;
+	const configuredModel = implementationDefaults?.model;
+	const configuredAvailableModel = findAvailableImplementationModel(
+		models.map((choice) => choice.modelInfo),
+		configuredModel,
+	);
+	let unavailableDefaultActive = configuredModel !== undefined && !configuredAvailableModel;
+	let selectedModel = configuredAvailableModel
+		? models.find((choice) => choice.modelInfo === configuredAvailableModel)
+		: undefined;
+	let selectedModelUsesDefault = selectedModel !== undefined;
+	let selectedThinkingLevel = implementationDefaults?.thinkingLevel;
 	return {
 		settingsScreen: () => ({
 			kind: "actions" as const,
 			title: "Fresh implementation settings",
-			lines: ["These choices apply once to the new implementation session."],
+			lines: [
+				"These choices apply once to the new implementation session.",
+				...(unavailableDefaultActive && configuredModel
+					? [
+							`Configured default ${safeModelReference(configuredModel)} is unavailable; using same as plan.`,
+						]
+					: []),
+			],
 			items: [
 				{
 					id: "start-fresh",
@@ -344,7 +362,7 @@ function createFreshImplementationFlow(
 					id: "same-as-plan",
 					label: "Same as plan",
 				},
-				...FIXED_THINKING_LEVELS.map((level) => ({
+				...IMPLEMENTATION_THINKING_LEVELS.map((level) => ({
 					id: level,
 					label: `${level === planThinkingLevel ? "✓ " : ""}${level}`,
 					description: THINKING_LEVEL_DESCRIPTIONS[level],
@@ -352,16 +370,34 @@ function createFreshImplementationFlow(
 			],
 			action: "select-thinking" as const,
 			initialItemId: selectedThinkingLevel ?? "same-as-plan",
-			viewportSize: FIXED_THINKING_LEVELS.length + 1,
+			viewportSize: IMPLEMENTATION_THINKING_LEVELS.length + 1,
 		}),
 		selectModel(itemId: string) {
 			const choice = models.find((candidate) => candidate.itemId === itemId);
 			selectedModel = choice?.isPlanModel ? undefined : choice;
+			selectedModelUsesDefault = false;
+			unavailableDefaultActive = false;
 		},
 		selectThinking(itemId: string) {
-			selectedThinkingLevel = FIXED_THINKING_LEVELS.find((level) => level === itemId);
+			selectedThinkingLevel = IMPLEMENTATION_THINKING_LEVELS.find((level) => level === itemId);
 		},
 		start(signal: AbortSignal) {
+			if (
+				selectedModelUsesDefault &&
+				selectedModel &&
+				!findAvailableImplementationModel(
+					snapshotAvailableImplementationModels(ctx),
+					selectedModel.model,
+				)
+			) {
+				selectedModel = undefined;
+				selectedModelUsesDefault = false;
+				unavailableDefaultActive = true;
+				ctx.ui.notify(
+					`Configured default ${safeModelReference(configuredModel)} is unavailable; using same as plan.`,
+					"warning",
+				);
+			}
 			const model = selectedModel?.model ?? planModel;
 			const thinkingLevel = selectedThinkingLevel ?? planThinkingLevel;
 			return implementFresh(
@@ -376,15 +412,7 @@ function createFreshImplementationFlow(
 }
 
 function snapshotAvailableModels(ctx: ExtensionContext): ModelChoice[] {
-	const getAvailable = ctx.modelRegistry.getAvailable;
-	const scopedModels = ctx.scopedModels ?? [];
-	const models =
-		scopedModels.length > 0
-			? scopedModels.map((entry) => entry.model)
-			: typeof getAvailable === "function"
-				? getAvailable.call(ctx.modelRegistry)
-				: [];
-	return models
+	return snapshotAvailableImplementationModels(ctx)
 		.map((model, index) => {
 			const provider = safeModelMetadata(model.provider, "unknown provider");
 			const modelId = safeModelMetadata(model.id, "unknown model");
@@ -394,6 +422,7 @@ function snapshotAvailableModels(ctx: ExtensionContext): ModelChoice[] {
 			return {
 				itemId: `model-${index}`,
 				model: { provider: model.provider, modelId: model.id },
+				modelInfo: model,
 				label: `${isPlanModel ? "✓ " : ""}${summary}${isPlanModel ? " · default" : ""}`,
 				summary,
 				...(name ? { details: [`Model Name: ${name}`] } : {}),
@@ -402,6 +431,11 @@ function snapshotAvailableModels(ctx: ExtensionContext): ModelChoice[] {
 			};
 		})
 		.sort((left, right) => Number(right.isPlanModel) - Number(left.isPlanModel));
+}
+
+function safeModelReference(model: ImplementationModelOverride | undefined) {
+	if (!model) return "configured model";
+	return `${safeModelMetadata(model.modelId, "unknown model")} [${safeModelMetadata(model.provider, "unknown provider")}]`;
 }
 
 function safeModelMetadata(value: unknown, fallback: string) {

--- a/packages/pi-plan-mode/src/plan-action-menus.ts
+++ b/packages/pi-plan-mode/src/plan-action-menus.ts
@@ -343,14 +343,21 @@ function createFreshImplementationFlow(
 		modelScreen: () => ({
 			kind: "choice" as const,
 			title: "Implementation model",
-			items: models.map((choice) => ({
-				id: choice.itemId,
-				label: choice.label,
-				details: choice.details,
-				searchText: choice.searchText,
-			})),
+			items: [
+				{
+					id: "same-as-plan",
+					label: "Same as plan",
+					...(planModelSummary ? { description: planModelSummary } : {}),
+				},
+				...models.map((choice) => ({
+					id: choice.itemId,
+					label: choice.label,
+					details: choice.details,
+					searchText: choice.searchText,
+				})),
+			],
 			action: "select-model" as const,
-			initialItemId: selectedModel?.itemId ?? models.find((choice) => choice.isPlanModel)?.itemId,
+			initialItemId: selectedModel?.itemId ?? "same-as-plan",
 			enableSearch: true,
 			viewportSize: 10,
 		}),
@@ -374,7 +381,7 @@ function createFreshImplementationFlow(
 		}),
 		selectModel(itemId: string) {
 			const choice = models.find((candidate) => candidate.itemId === itemId);
-			selectedModel = choice?.isPlanModel ? undefined : choice;
+			selectedModel = itemId === "same-as-plan" || choice?.isPlanModel ? undefined : choice;
 			selectedModelUsesDefault = false;
 			unavailableDefaultActive = false;
 		},

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -197,6 +197,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		// ExtensionContext.thinkingLevel was added after the supported Pi 0.80.6 floor.
 		// ExtensionAPI has exposed the same runtime value throughout that compatibility range.
 		getThinkingLevel: () => pi.getThinkingLevel(),
+		getSettings: () => settings,
 		implementationOutcome,
 		getExportDestination: (ctx) => planExports.getDestination(ctx),
 		show: (ctx) => showStoredPlan(pi, ctx, state),
@@ -318,6 +319,14 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			}
 			if (command === "save") {
 				savePlanForLater(ctx);
+				return;
+			}
+			if (command === "settings") {
+				if (!ctx.hasUI) {
+					throw new Error("/plan settings requires TUI or RPC mode and is unavailable here.");
+				}
+				const lifecycle = captureMenuLifecycle();
+				await showSettings(ctx, lifecycle.signal, lifecycle.isCurrent);
 				return;
 			}
 			const exportMatch = /^export(?:\s+([\s\S]+))?$/iu.exec(prompt);

--- a/packages/pi-plan-mode/src/settings-menu.ts
+++ b/packages/pi-plan-mode/src/settings-menu.ts
@@ -1,14 +1,28 @@
 import type { ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent";
-import { defineMenu, type RunMenuResult, runMenu } from "@narumitw/pi-tui-kit";
+import {
+	defineMenu,
+	type RunMenuResult,
+	runMenu,
+	sanitizeTerminalText,
+} from "@narumitw/pi-tui-kit";
 import { PLAN_MODE_COMPLETE_TOOL_NAME } from "./completion-tool.js";
+import {
+	type AvailableImplementationModel,
+	findAvailableImplementationModel,
+	type ImplementationModelOverride,
+	snapshotAvailableImplementationModels,
+} from "./implementation-models.js";
 import { retentionLabel } from "./implementation-retention.js";
 import { planExportDestination } from "./plan-export.js";
 import { PLAN_MODE_QUESTION_TOOL_NAME } from "./question-tool.js";
 import {
+	configuredImplementationModel,
 	configuredImplementationPlanRetention,
+	configuredImplementationThinkingLevel,
 	configuredPlanExportPath,
 	configuredPlanModeToggleShortcut,
 	IMPLEMENTATION_PLAN_RETENTIONS,
+	IMPLEMENTATION_THINKING_LEVELS,
 	normalizeKeyId,
 	PLAN_MODE_THINKING_LEVELS,
 	type PlanModeSettings,
@@ -44,13 +58,16 @@ export interface PlanModeSettingsMenuOptions {
 	onSaved(settings: PlanModeSettings): void;
 }
 
-type Screen = "settings" | "tools" | "export" | "shortcut";
+type Screen = "settings" | "tools" | "implementation-model" | "export" | "shortcut";
 type Action =
 	| "set-thinking"
 	| "open-tools"
 	| "toggle-tool"
 	| "reset-tools"
 	| "set-retention"
+	| "open-implementation-model"
+	| "set-implementation-model"
+	| "set-implementation-thinking"
 	| "open-export"
 	| "set-export"
 	| "open-shortcut"
@@ -74,6 +91,13 @@ export async function showPlanModeSettings(
 		tools.map((tool, index) => [tool.name, `plan-settings-tool:${index}`]),
 	);
 	const toolsByItemId = new Map(tools.map((tool) => [toolItemIds.get(tool.name) as string, tool]));
+	const implementationModels = snapshotAvailableImplementationModels(ctx);
+	const modelItemIds = new Map(
+		implementationModels.map((model, index) => [model, `plan-settings-model:${index}`]),
+	);
+	const modelsByItemId = new Map(
+		implementationModels.map((model) => [modelItemIds.get(model) as string, model]),
+	);
 
 	const loadState = async (): Promise<SettingsMenuState> => {
 		const loaded = await readSettings(options.settingsPath);
@@ -131,6 +155,23 @@ export async function showPlanModeSettings(
 									action: "set-retention",
 								},
 								{
+									id: "defaultImplementationModel",
+									label: "Fresh model",
+									description: "Choose the default model for a fresh implementation session.",
+									currentValue: implementationModelValue(state.settings, implementationModels),
+									action: "open-implementation-model",
+								},
+								{
+									id: "defaultImplementationThinkingLevel",
+									label: "Fresh thinking",
+									description:
+										"Choose the default thinking level for a fresh implementation session.",
+									currentValue:
+										configuredImplementationThinkingLevel(state.settings) ?? "same as plan",
+									values: ["same as plan", ...IMPLEMENTATION_THINKING_LEVELS],
+									action: "set-implementation-thinking",
+								},
+								{
 									id: "defaultPlanExportPath",
 									label: "Export destination",
 									description: "Set the destination used when an export omits its path.",
@@ -170,6 +211,21 @@ export async function showPlanModeSettings(
 						action: "reset-tools",
 					},
 				],
+				hint: "back",
+			}),
+			"implementation-model": ({ state }) => ({
+				kind: "choice",
+				title: "Fresh implementation model",
+				lines: ["Same as plan is the default and fallback when a configured model is unavailable."],
+				items: implementationModelItems(implementationModels, modelItemIds),
+				action: "set-implementation-model",
+				initialItemId: implementationModelItemId(
+					configuredImplementationModel(state.settings),
+					implementationModels,
+					modelItemIds,
+				),
+				enableSearch: true,
+				viewportSize: 10,
 				hint: "back",
 			}),
 			export: ({ state }) => {
@@ -225,6 +281,52 @@ export async function showPlanModeSettings(
 					{ implementationPlanRetention },
 					signal,
 					`Plan reinjection: ${retentionLabel(implementationPlanRetention)}. Applies to the next Implement action.`,
+				);
+			},
+			"open-implementation-model": async () => ({
+				kind: "to",
+				screen: "implementation-model",
+			}),
+			"set-implementation-model": async ({ ctx: actionCtx, itemId, signal }) => {
+				const model = itemId ? modelsByItemId.get(itemId) : undefined;
+				if (itemId !== "same-as-plan" && !model) return { kind: "rejected" };
+				const defaultImplementationModel = model
+					? { provider: model.provider, modelId: model.id }
+					: null;
+				const result = await savePatch(
+					actionCtx,
+					{ defaultImplementationModel },
+					signal,
+					model
+						? `Fresh implementation model: ${safeModelReference({ provider: model.provider, modelId: model.id })}.`
+						: "Fresh implementation model: same as plan.",
+				);
+				return result.kind === "stay" ? { kind: "to", screen: "settings" } : result;
+			},
+			"set-implementation-thinking": async ({ ctx: actionCtx, value, signal }) => {
+				if (value === "same as plan") {
+					return savePatch(
+						actionCtx,
+						{ defaultImplementationThinkingLevel: null },
+						signal,
+						"Fresh implementation thinking: same as plan.",
+					);
+				}
+				if (
+					!IMPLEMENTATION_THINKING_LEVELS.includes(
+						value as (typeof IMPLEMENTATION_THINKING_LEVELS)[number],
+					)
+				) {
+					return { kind: "rejected" };
+				}
+				return savePatch(
+					actionCtx,
+					{
+						defaultImplementationThinkingLevel:
+							value as PlanModeSettings["defaultImplementationThinkingLevel"],
+					},
+					signal,
+					`Fresh implementation thinking: ${value}.`,
 				);
 			},
 			"open-export": async () => ({ kind: "to", screen: "export" }),
@@ -347,6 +449,59 @@ function invalidScreen(settingsPath: string, state: SettingsMenuState) {
 
 function retentionFromLabel(value: string | undefined) {
 	return IMPLEMENTATION_PLAN_RETENTIONS.find((retention) => retentionLabel(retention) === value);
+}
+
+function implementationModelValue(
+	settings: PlanModeSettings,
+	models: readonly AvailableImplementationModel[],
+) {
+	const configured = configuredImplementationModel(settings);
+	if (!configured) return "same as plan";
+	return findAvailableImplementationModel(models, configured)
+		? safeModelReference(configured)
+		: `same as plan · ${safeModelReference(configured)} unavailable`;
+}
+
+function implementationModelItems(
+	models: readonly AvailableImplementationModel[],
+	itemIds: ReadonlyMap<AvailableImplementationModel, string>,
+) {
+	return [
+		{
+			id: "same-as-plan",
+			label: "Same as plan",
+			description: "Use the planning session model.",
+		},
+		...models.map((model) => {
+			const reference = safeModelReference({ provider: model.provider, modelId: model.id });
+			const name = safeModelMetadata(model.name, "");
+			return {
+				id: itemIds.get(model) as string,
+				label: reference,
+				...(name ? { details: [`Model Name: ${name}`] } : {}),
+				searchText: [reference, name].filter(Boolean).join(" "),
+			};
+		}),
+	];
+}
+
+function implementationModelItemId(
+	configured: ImplementationModelOverride | undefined,
+	models: readonly AvailableImplementationModel[],
+	itemIds: ReadonlyMap<AvailableImplementationModel, string>,
+) {
+	const model = findAvailableImplementationModel(models, configured);
+	return model ? itemIds.get(model) : "same-as-plan";
+}
+
+function safeModelReference(model: ImplementationModelOverride) {
+	return `${safeModelMetadata(model.modelId, "unknown model")} [${safeModelMetadata(model.provider, "unknown provider")}]`;
+}
+
+function safeModelMetadata(value: unknown, fallback: string) {
+	if (typeof value !== "string") return fallback;
+	const safe = sanitizeTerminalText(value).trim() || fallback;
+	return [...safe].slice(0, 512).join("");
 }
 
 function defaultToolsValue(configured: string[] | undefined) {

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -4,6 +4,10 @@ import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
+import {
+	type ImplementationModelOverride,
+	isPendingImplementationModelIdentifier,
+} from "./implementation-models.js";
 import type { SafeSubcommands } from "./tool-policy.js";
 
 export const PLAN_MODE_SETTINGS_FILE = "pi-plan-mode.json";
@@ -11,6 +15,15 @@ const LEGACY_PLAN_MODE_SETTINGS_FILE = "plan-mode.json";
 const MAX_SETTINGS_BYTES = 64 * 1024;
 export const PLAN_MODE_THINKING_LEVELS = [
 	"inherit",
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+export const IMPLEMENTATION_THINKING_LEVELS = [
 	"off",
 	"minimal",
 	"low",
@@ -83,11 +96,13 @@ const MAX_PLAN_EXPORT_PATH_LENGTH = 4096;
 
 export type PlanModeThinkingLevel = (typeof PLAN_MODE_THINKING_LEVELS)[number];
 export type ImplementationPlanRetention = (typeof IMPLEMENTATION_PLAN_RETENTIONS)[number];
-export type PlanModeFixedThinkingLevel = Exclude<PlanModeThinkingLevel, "inherit">;
+export type PlanModeFixedThinkingLevel = (typeof IMPLEMENTATION_THINKING_LEVELS)[number];
 export interface PlanModeSettings {
 	thinkingLevel: PlanModeThinkingLevel;
 	defaultPlanTools?: string[];
 	implementationPlanRetention?: ImplementationPlanRetention;
+	defaultImplementationModel?: ImplementationModelOverride;
+	defaultImplementationThinkingLevel?: PlanModeFixedThinkingLevel;
 	defaultPlanExportPath?: string;
 	safeSubcommands?: SafeSubcommands;
 	toggleShortcut?: KeyId;
@@ -96,6 +111,8 @@ export interface PlanModeSettingsPatch {
 	thinkingLevel?: PlanModeThinkingLevel;
 	defaultPlanTools?: readonly string[] | null;
 	implementationPlanRetention?: ImplementationPlanRetention;
+	defaultImplementationModel?: ImplementationModelOverride | null;
+	defaultImplementationThinkingLevel?: PlanModeFixedThinkingLevel | null;
 	defaultPlanExportPath?: string | null;
 	toggleShortcut?: KeyId | null;
 }
@@ -154,6 +171,28 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 		settings.implementationPlanRetention =
 			implementationPlanRetention as ImplementationPlanRetention;
 	}
+	if (Object.hasOwn(value, "defaultImplementationModel")) {
+		const defaultImplementationModel = normalizeImplementationModel(
+			Reflect.get(value, "defaultImplementationModel"),
+		);
+		if (!defaultImplementationModel) return undefined;
+		settings.defaultImplementationModel = defaultImplementationModel;
+	}
+	if (Object.hasOwn(value, "defaultImplementationThinkingLevel")) {
+		const defaultImplementationThinkingLevel = Reflect.get(
+			value,
+			"defaultImplementationThinkingLevel",
+		);
+		if (
+			!IMPLEMENTATION_THINKING_LEVELS.includes(
+				defaultImplementationThinkingLevel as PlanModeFixedThinkingLevel,
+			)
+		) {
+			return undefined;
+		}
+		settings.defaultImplementationThinkingLevel =
+			defaultImplementationThinkingLevel as PlanModeFixedThinkingLevel;
+	}
 	if (Object.hasOwn(value, "defaultPlanExportPath")) {
 		const defaultPlanExportPath = normalizePlanExportPath(
 			Reflect.get(value, "defaultPlanExportPath"),
@@ -172,6 +211,18 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 		settings.safeSubcommands = safeSubcommands;
 	}
 	return settings;
+}
+
+function normalizeImplementationModel(value: unknown): ImplementationModelOverride | undefined {
+	if (
+		!isSettingsDocument(value) ||
+		Object.keys(value).some((key) => key !== "provider" && key !== "modelId") ||
+		!isPendingImplementationModelIdentifier(value.provider) ||
+		!isPendingImplementationModelIdentifier(value.modelId)
+	) {
+		return undefined;
+	}
+	return { provider: value.provider, modelId: value.modelId };
 }
 
 function normalizeToolNames(value: unknown) {
@@ -295,6 +346,15 @@ export function updatePlanModeSettings(
 		}
 		if (patch.implementationPlanRetention !== undefined) {
 			updated.implementationPlanRetention = patch.implementationPlanRetention;
+		}
+		if (patch.defaultImplementationModel === null) delete updated.defaultImplementationModel;
+		else if (patch.defaultImplementationModel !== undefined) {
+			updated.defaultImplementationModel = { ...patch.defaultImplementationModel };
+		}
+		if (patch.defaultImplementationThinkingLevel === null) {
+			delete updated.defaultImplementationThinkingLevel;
+		} else if (patch.defaultImplementationThinkingLevel !== undefined) {
+			updated.defaultImplementationThinkingLevel = patch.defaultImplementationThinkingLevel;
 		}
 		if (patch.defaultPlanExportPath === null) delete updated.defaultPlanExportPath;
 		else if (patch.defaultPlanExportPath !== undefined) {
@@ -476,6 +536,18 @@ export function configuredImplementationPlanRetention(
 	settings: PlanModeSettings,
 ): ImplementationPlanRetention {
 	return settings.implementationPlanRetention ?? "clear-on-start";
+}
+
+export function configuredImplementationModel(
+	settings: PlanModeSettings,
+): ImplementationModelOverride | undefined {
+	return settings.defaultImplementationModel;
+}
+
+export function configuredImplementationThinkingLevel(
+	settings: PlanModeSettings,
+): PlanModeFixedThinkingLevel | undefined {
+	return settings.defaultImplementationThinkingLevel;
 }
 
 export function configuredPlanExportPath(settings: PlanModeSettings) {

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -216,13 +216,19 @@ export function normalizePlanModeSettings(value: unknown): PlanModeSettings | un
 function normalizeImplementationModel(value: unknown): ImplementationModelOverride | undefined {
 	if (
 		!isSettingsDocument(value) ||
-		Object.keys(value).some((key) => key !== "provider" && key !== "modelId") ||
-		!isPendingImplementationModelIdentifier(value.provider) ||
-		!isPendingImplementationModelIdentifier(value.modelId)
+		Object.keys(value).some((key) => key !== "provider" && key !== "modelId")
 	) {
 		return undefined;
 	}
-	return { provider: value.provider, modelId: value.modelId };
+	const provider = typeof value.provider === "string" ? value.provider.trim() : value.provider;
+	const modelId = typeof value.modelId === "string" ? value.modelId.trim() : value.modelId;
+	if (
+		!isPendingImplementationModelIdentifier(provider) ||
+		!isPendingImplementationModelIdentifier(modelId)
+	) {
+		return undefined;
+	}
+	return { provider, modelId };
 }
 
 function normalizeToolNames(value: unknown) {
@@ -349,7 +355,9 @@ export function updatePlanModeSettings(
 		}
 		if (patch.defaultImplementationModel === null) delete updated.defaultImplementationModel;
 		else if (patch.defaultImplementationModel !== undefined) {
-			updated.defaultImplementationModel = { ...patch.defaultImplementationModel };
+			const model = normalizeImplementationModel(patch.defaultImplementationModel);
+			if (!model) throw invalidSettingsError(settingsPath, "invalid implementation model");
+			updated.defaultImplementationModel = model;
 		}
 		if (patch.defaultImplementationThinkingLevel === null) {
 			delete updated.defaultImplementationThinkingLevel;

--- a/packages/pi-plan-mode/src/state.ts
+++ b/packages/pi-plan-mode/src/state.ts
@@ -4,11 +4,21 @@ import {
 	planFromCompletionDetails,
 } from "./completion-tool.js";
 import {
+	type ImplementationModelOverride,
+	isPendingImplementationModelIdentifier,
+} from "./implementation-models.js";
+import {
 	IMPLEMENTATION_PLAN_RETENTIONS,
 	type ImplementationPlanRetention,
 	PLAN_MODE_THINKING_LEVELS,
 	type PlanModeFixedThinkingLevel,
 } from "./settings.js";
+
+export type { ImplementationModelOverride } from "./implementation-models.js";
+export {
+	isPendingImplementationModelIdentifier,
+	MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH,
+} from "./implementation-models.js";
 
 export type PlanCompletionSource = typeof PLAN_MODE_COMPLETE_TOOL_NAME | "legacy_proposed_plan";
 
@@ -23,21 +33,6 @@ export interface ActiveImplementationPlan {
 export interface SavedPlan {
 	plan: string;
 	source: PlanCompletionSource;
-}
-
-export const MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH = 512;
-
-export interface ImplementationModelOverride {
-	provider: string;
-	modelId: string;
-}
-
-export function isPendingImplementationModelIdentifier(value: unknown): value is string {
-	return (
-		typeof value === "string" &&
-		value.trim().length > 0 &&
-		value.length <= MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH
-	);
 }
 
 export interface ImplementationRuntimeSelection {

--- a/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
@@ -242,6 +242,53 @@ test("unavailable persistent model defaults fall back to same as plan", async ()
 	assert.match(context.notifications.at(-1)?.message ?? "", /unavailable.*same as plan/iu);
 });
 
+test("stale scoped persistent model defaults fall back to same as plan", async () => {
+	let availableReads = 0;
+	let selectedRuntime: unknown;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
+		scopedModels: [{ model: AVAILABLE_MODELS[1] }],
+		modelRegistry: {
+			getAvailable: () => {
+				availableReads += 1;
+				return [AVAILABLE_MODELS[0]];
+			},
+		},
+		select: async (title: string) => {
+			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
+			if (title.startsWith("Fresh implementation settings")) {
+				return "Start fresh implementation";
+			}
+			return undefined;
+		},
+	});
+
+	await showReadyPlanMenu(
+		context.ctx,
+		menuOptions({
+			implementationDefaults: {
+				model: { provider: "provider-two", modelId: "model-two" },
+				thinkingLevel: "high",
+			},
+			implementFresh: (runtime: unknown) => {
+				selectedRuntime = runtime;
+			},
+		}),
+	);
+
+	assert.equal(availableReads, 1);
+	assert.deepEqual(selectedRuntime, {
+		model: {
+			provider: "provider\u001b[31m-one",
+			modelId: "model\u202e-one",
+		},
+		thinkingLevel: "high",
+	});
+});
+
 test("fresh thinking choice mirrors the built-in thinking layout", async () => {
 	let screen = 0;
 	let thinkingScreen = "";
@@ -321,7 +368,7 @@ test("fresh model picker honors the nonempty session model scope", async () => {
 		}),
 	);
 
-	assert.equal(availableReads, 0);
+	assert.equal(availableReads, 1);
 	assert.ok(modelOptions.some((option) => option.includes("model-two [provider-two]")));
 	assert.equal(
 		modelOptions.some((option) => option.includes("model-one [provider-one]")),
@@ -329,6 +376,58 @@ test("fresh model picker honors the nonempty session model scope", async () => {
 	);
 	assert.deepEqual(selectedRuntime, {
 		model: { provider: "provider-two", modelId: "model-two" },
+	});
+});
+
+test("fresh model picker keeps same as plan available outside the model scope", async () => {
+	let freshVisits = 0;
+	let modelOptions: string[] = [];
+	let selectedRuntime: unknown;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
+		scopedModels: [{ model: AVAILABLE_MODELS[1] }],
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
+		select: async (title: string, options: string[]) => {
+			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
+			if (title.startsWith("Fresh implementation settings")) {
+				freshVisits += 1;
+				return freshVisits === 1 ? "Model" : "Start fresh implementation";
+			}
+			if (title.startsWith("Implementation model")) {
+				modelOptions = options;
+				return options.find((option) => option.startsWith("Same as plan"));
+			}
+			return undefined;
+		},
+	});
+
+	await showReadyPlanMenu(
+		context.ctx,
+		menuOptions({
+			planThinkingLevel: "medium",
+			implementationDefaults: {
+				model: { provider: "provider-two", modelId: "model-two" },
+			},
+			implementFresh: (runtime: unknown) => {
+				selectedRuntime = runtime;
+			},
+		}),
+	);
+
+	assert.ok(modelOptions.some((option) => option.startsWith("Same as plan")));
+	assert.equal(
+		modelOptions.some((option) => option.includes("model-one [provider-one]")),
+		false,
+	);
+	assert.deepEqual(selectedRuntime, {
+		model: {
+			provider: "provider\u001b[31m-one",
+			modelId: "model\u202e-one",
+		},
+		thinkingLevel: "medium",
 	});
 });
 
@@ -355,6 +454,7 @@ test("fresh model picker falls back when the scoped-model API is unavailable", a
 test("fresh model choice mirrors the searchable built-in model layout in TUI mode", async () => {
 	let screen = 0;
 	let initialModelScreen = "";
+	let selectedModelScreen = "";
 	let filteredModelScreen = "";
 	const context = createMockContext({
 		mode: "tui",
@@ -373,6 +473,8 @@ test("fresh model choice mirrors the searchable built-in model layout in TUI mod
 				harness.handleInput("tui.select.confirm");
 			} else {
 				initialModelScreen = harness.render().join("\n");
+				harness.handleInput("tui.select.down");
+				selectedModelScreen = harness.render().join("\n");
 				harness.handleInput("beta");
 				filteredModelScreen = harness.render().join("\n");
 				harness.handleInput("\u0003");
@@ -383,8 +485,9 @@ test("fresh model choice mirrors the searchable built-in model layout in TUI mod
 
 	await showReadyPlanMenu(context.ctx, menuOptions());
 
-	assert.match(initialModelScreen, /→ ✓ model-one \[provider-one\] · default/u);
-	assert.match(initialModelScreen, /Model Name: Friendly name/u);
+	assert.match(initialModelScreen, /→ Same as plan/u);
+	assert.match(initialModelScreen, /✓ model-one \[provider-one\] · default/u);
+	assert.match(selectedModelScreen, /Model Name: Friendly name/u);
 	assert.match(filteredModelScreen, /model-two \[provider-two\]/u);
 	assert.match(filteredModelScreen, /Model Name: Beta specialist/u);
 	assert.doesNotMatch(filteredModelScreen, /model-one \[provider-one\]/u);

--- a/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-menu.test.ts
@@ -159,6 +159,89 @@ test("fresh settings prioritize start and show the plan runtime defaults", async
 	assert.match(settingsScreen, /Thinking level\s+medium · same as plan/u);
 });
 
+test("fresh settings start from persistent model and thinking defaults", async () => {
+	let selectedRuntime: unknown;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
+		select: async (title: string) => {
+			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
+			if (title.startsWith("Fresh implementation settings")) {
+				return "Start fresh implementation";
+			}
+			return undefined;
+		},
+	});
+
+	await showReadyPlanMenu(
+		context.ctx,
+		menuOptions({
+			implementationDefaults: {
+				model: { provider: "provider-two", modelId: "model-two" },
+				thinkingLevel: "high",
+			},
+			implementFresh: (runtime: unknown) => {
+				selectedRuntime = runtime;
+			},
+		}),
+	);
+
+	assert.deepEqual(selectedRuntime, {
+		model: { provider: "provider-two", modelId: "model-two" },
+		thinkingLevel: "high",
+	});
+});
+
+test("unavailable persistent model defaults fall back to same as plan", async () => {
+	let availableReads = 0;
+	let selectedRuntime: unknown;
+	const context = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: AVAILABLE_MODELS[0],
+		thinkingLevel: "medium",
+		modelRegistry: {
+			getAvailable: () => {
+				availableReads += 1;
+				return availableReads === 1 ? AVAILABLE_MODELS : [AVAILABLE_MODELS[0]];
+			},
+		},
+		select: async (title: string) => {
+			if (title.startsWith("Proposed plan ready")) return "Start fresh and implement";
+			if (title.startsWith("Fresh implementation settings")) {
+				return "Start fresh implementation";
+			}
+			return undefined;
+		},
+	});
+
+	await showReadyPlanMenu(
+		context.ctx,
+		menuOptions({
+			implementationDefaults: {
+				model: { provider: "provider-two", modelId: "model-two" },
+				thinkingLevel: "high",
+			},
+			implementFresh: (runtime: unknown) => {
+				selectedRuntime = runtime;
+			},
+		}),
+	);
+
+	assert.equal(availableReads, 2);
+	assert.deepEqual(selectedRuntime, {
+		model: {
+			provider: "provider\u001b[31m-one",
+			modelId: "model\u202e-one",
+		},
+		thinkingLevel: "high",
+	});
+	assert.match(context.notifications.at(-1)?.message ?? "", /unavailable.*same as plan/iu);
+});
+
 test("fresh thinking choice mirrors the built-in thinking layout", async () => {
 	let screen = 0;
 	let thinkingScreen = "";

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -279,7 +279,10 @@ test("saved plans can start fresh without consuming the source session state", a
 		select: async () => "Start fresh and implement",
 		newSession: async (options: {
 			setup?: (sessionManager: FreshSetupManager) => Promise<void>;
-			withSession?: (ctx: { sendUserMessage(message: string): Promise<void> }) => Promise<void>;
+			withSession?: (ctx: {
+				sessionManager: { getBranch(): unknown[] };
+				sendUserMessage(message: string): Promise<void>;
+			}) => Promise<void>;
 		}) => {
 			newSessionCalls += 1;
 			await options.setup?.({
@@ -292,6 +295,7 @@ test("saved plans can start fresh without consuming the source session state", a
 				},
 			});
 			await options.withSession?.({
+				sessionManager: { getBranch: () => [] },
 				sendUserMessage: async (message) => {
 					replacementMessage = message;
 				},
@@ -305,7 +309,15 @@ test("saved plans can start fresh without consuming the source session state", a
 	assert.equal(newSessionCalls, 1);
 	assert.equal(context.statuses.get("plan-mode"), "plan saved");
 	assert.equal(mock.entries.length, 0);
-	assert.equal(destinationState, undefined);
+	assert.deepEqual(destinationState, {
+		enabled: false,
+		awaitingAction: false,
+		pendingImplementationRuntime: {
+			version: 1,
+			model: { provider: "test-provider", modelId: "test-model" },
+			thinkingLevel: "off",
+		},
+	});
 	assert.match(replacementMessage, /Implement the plan in a fresh context/);
 	assert.match(replacementMessage, /Fresh implementation plan/);
 });

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -256,21 +256,59 @@ test("fresh implementation creates a linked destination and hands off only throu
 });
 
 test("saved plans can start fresh without consuming the source session state", async () => {
+	const target = { provider: "test-provider", id: "test-model" };
 	const savedEntry = stateEntry({
 		enabled: false,
 		awaitingAction: false,
 		savedPlan: { plan: PLAN, source: "plan_mode_complete" },
 	});
-	const mock = createMockPi({ activeTools: ["read", "edit"] });
-	planMode(mock.pi, MISSING_SETTINGS);
+	const source = createMockPi({ activeTools: ["read", "edit"] });
+	planMode(source.pi, {
+		readSettings: async () => ({
+			kind: "loaded" as const,
+			settings: {
+				thinkingLevel: "inherit" as const,
+				defaultImplementationModel: {
+					provider: target.provider,
+					modelId: target.id,
+				},
+				defaultImplementationThinkingLevel: "high" as const,
+			},
+		}),
+	});
+	const destination = createMockPi({ thinkingLevel: "low" });
+	planMode(destination.pi, MISSING_SETTINGS);
+	const destinationSetupEntries: unknown[] = [];
+	const destinationBranch = () => [
+		...destinationSetupEntries,
+		...destination.entries.map((entry) => ({ type: "custom" as const, ...entry })),
+	];
+	const destinationContext = createMockContext({
+		mode: "rpc",
+		hasUI: true,
+		model: { provider: "destination-provider", id: "destination-model" },
+		modelRegistry: {
+			find: (provider: string, id: string) =>
+				provider === target.provider && id === target.id ? target : undefined,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
+		sessionManager: {
+			getSessionFile: () => undefined,
+			getBranch: destinationBranch,
+			getEntries: destinationBranch,
+		},
+	});
 	let destinationState: unknown;
 	let replacementMessage = "";
 	let newSessionCalls = 0;
 	const context = createMockContext({
 		mode: "rpc",
 		hasUI: true,
-		model: { provider: "test-provider", id: "test-model" },
-		modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+		model: target,
+		modelRegistry: {
+			getAvailable: () => [target],
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		},
 		sessionManager: {
 			getSessionFile: () => "/sessions/saved-plan.jsonl",
 			getBranch: () => [savedEntry],
@@ -279,45 +317,65 @@ test("saved plans can start fresh without consuming the source session state", a
 		select: async () => "Start fresh and implement",
 		newSession: async (options: {
 			setup?: (sessionManager: FreshSetupManager) => Promise<void>;
-			withSession?: (ctx: {
-				sessionManager: { getBranch(): unknown[] };
-				sendUserMessage(message: string): Promise<void>;
-			}) => Promise<void>;
+			withSession?: (ctx: unknown) => Promise<void>;
 		}) => {
 			newSessionCalls += 1;
+			await destination.events.get("session_start")?.[0]?.(
+				{ reason: "new" },
+				destinationContext.ctx,
+			);
 			await options.setup?.({
-				appendCustomEntry(_customType, data) {
+				appendCustomEntry(customType, data) {
 					destinationState = data;
+					destinationSetupEntries.push({ type: "custom", customType, data });
 					return "destination-state";
 				},
-				appendCustomMessageEntry() {
+				appendCustomMessageEntry(customType, content, display, details) {
+					destinationSetupEntries.push({
+						type: "custom_message",
+						customType,
+						content,
+						display,
+						details,
+					});
 					return "destination-contract";
 				},
 			});
 			await options.withSession?.({
-				sessionManager: { getBranch: () => [] },
-				sendUserMessage: async (message) => {
+				...(destinationContext.ctx as object),
+				sendUserMessage: async (message: string) => {
 					replacementMessage = message;
+					await destination.events.get("input")?.[0]?.(
+						{ text: message, source: "extension" },
+						destinationContext.ctx,
+					);
 				},
 			});
 			return { cancelled: false };
 		},
 	});
-	await mock.events.get("session_start")?.[0]?.({}, context.ctx);
-	await mock.commands.get("plan")?.handler("", context.ctx);
+	await source.events.get("session_start")?.[0]?.({}, context.ctx);
+	await source.commands.get("plan")?.handler("", context.ctx);
 
 	assert.equal(newSessionCalls, 1);
 	assert.equal(context.statuses.get("plan-mode"), "plan saved");
-	assert.equal(mock.entries.length, 0);
+	assert.equal(source.entries.length, 0);
 	assert.deepEqual(destinationState, {
 		enabled: false,
 		awaitingAction: false,
 		pendingImplementationRuntime: {
 			version: 1,
-			model: { provider: "test-provider", modelId: "test-model" },
-			thinkingLevel: "off",
+			model: { provider: target.provider, modelId: target.id },
+			thinkingLevel: "high",
 		},
 	});
+	assert.deepEqual(destination.setModels, [target]);
+	assert.equal(destination.thinkingLevel, "high");
+	assert.equal(
+		(destination.entries.at(-1)?.data as { pendingImplementationRuntime?: unknown } | undefined)
+			?.pendingImplementationRuntime,
+		undefined,
+	);
 	assert.match(replacementMessage, /Implement the plan in a fresh context/);
 	assert.match(replacementMessage, /Fresh implementation plan/);
 });

--- a/packages/pi-plan-mode/test/plan-action-controller.test.ts
+++ b/packages/pi-plan-mode/test/plan-action-controller.test.ts
@@ -42,7 +42,17 @@ test("stale Plan actions do not load interactive UI", async () => {
 
 test("saved-plan fresh actions use persistent defaults and fall back from missing models", async () => {
 	const target = { provider: "target-provider", id: "target-model" };
-	for (const modelAvailable of [true, false]) {
+	const scenarios = [
+		{ name: "available", availableModels: [target], scopedModels: undefined, usesTarget: true },
+		{ name: "missing", availableModels: [], scopedModels: undefined, usesTarget: false },
+		{
+			name: "stale scoped model",
+			availableModels: [],
+			scopedModels: [{ model: target }],
+			usesTarget: false,
+		},
+	];
+	for (const scenario of scenarios) {
 		let selectedRuntime: unknown;
 		const controller = createPlanActionController({
 			loadInteractiveUi: async () =>
@@ -90,20 +100,26 @@ test("saved-plan fresh actions use persistent defaults and fall back from missin
 		const context = createMockContext({
 			hasUI: true,
 			model: { provider: "planning-provider", id: "planning-model" },
-			modelRegistry: { getAvailable: () => (modelAvailable ? [target] : []) },
+			...(scenario.scopedModels ? { scopedModels: scenario.scopedModels } : {}),
+			modelRegistry: { getAvailable: () => scenario.availableModels },
 		});
 
 		await controller.showSaved(context.ctx);
 
-		assert.deepEqual(selectedRuntime, {
-			model: modelAvailable
-				? { provider: target.provider, modelId: target.id }
-				: { provider: "planning-provider", modelId: "planning-model" },
-			thinkingLevel: "high",
-		});
+		assert.deepEqual(
+			selectedRuntime,
+			{
+				model: scenario.usesTarget
+					? { provider: target.provider, modelId: target.id }
+					: { provider: "planning-provider", modelId: "planning-model" },
+				thinkingLevel: "high",
+			},
+			scenario.name,
+		);
 		assert.equal(
 			context.notifications.some((notice) => /unavailable/u.test(notice.message)),
-			!modelAvailable,
+			!scenario.usesTarget,
+			scenario.name,
 		);
 	}
 });

--- a/packages/pi-plan-mode/test/plan-action-controller.test.ts
+++ b/packages/pi-plan-mode/test/plan-action-controller.test.ts
@@ -17,6 +17,7 @@ test("stale Plan actions do not load interactive UI", async () => {
 		}),
 		statusText: () => "off",
 		getThinkingLevel: () => "medium",
+		getSettings: () => ({ thinkingLevel: "inherit" }),
 		implementationOutcome: () => "",
 		getExportDestination: () => ({ configuredPath: "plan.md", resolvedPath: "/tmp/plan.md" }),
 		show: () => undefined,
@@ -37,4 +38,72 @@ test("stale Plan actions do not load interactive UI", async () => {
 	await controller.showReady(context.ctx);
 
 	assert.equal(interactiveLoads, 0);
+});
+
+test("saved-plan fresh actions use persistent defaults and fall back from missing models", async () => {
+	const target = { provider: "target-provider", id: "target-model" };
+	for (const modelAvailable of [true, false]) {
+		let selectedRuntime: unknown;
+		const controller = createPlanActionController({
+			loadInteractiveUi: async () =>
+				({
+					showSavedPlanMenu: async (_ctx: unknown, menuOptions: Record<string, unknown>) => {
+						await (menuOptions.implementFresh as (signal: AbortSignal) => Promise<void>)(
+							new AbortController().signal,
+						);
+					},
+				}) as never,
+			getState: () => ({
+				enabled: false,
+				awaitingAction: false,
+				savedPlan: { plan: "# Plan", source: "plan_mode_complete" },
+			}),
+			captureLifecycle: () => ({
+				signal: new AbortController().signal,
+				isCurrent: () => true,
+			}),
+			statusText: () => "saved",
+			getThinkingLevel: () => "medium",
+			getSettings: () => ({
+				thinkingLevel: "inherit",
+				defaultImplementationModel: {
+					provider: target.provider,
+					modelId: target.id,
+				},
+				defaultImplementationThinkingLevel: "high",
+			}),
+			implementationOutcome: () => "",
+			getExportDestination: () => ({ configuredPath: "plan.md", resolvedPath: "/tmp/plan.md" }),
+			show: () => undefined,
+			finalize: () => undefined,
+			implementHere: () => undefined,
+			implementFresh: (_ctx, _isCurrent, runtime) => {
+				selectedRuntime = runtime;
+			},
+			exportPlan: async () => false,
+			settings: async () => false,
+			save: () => undefined,
+			stay: () => undefined,
+			exitReady: () => undefined,
+			clearSaved: () => undefined,
+		});
+		const context = createMockContext({
+			hasUI: true,
+			model: { provider: "planning-provider", id: "planning-model" },
+			modelRegistry: { getAvailable: () => (modelAvailable ? [target] : []) },
+		});
+
+		await controller.showSaved(context.ctx);
+
+		assert.deepEqual(selectedRuntime, {
+			model: modelAvailable
+				? { provider: target.provider, modelId: target.id }
+				: { provider: "planning-provider", modelId: "planning-model" },
+			thinkingLevel: "high",
+		});
+		assert.equal(
+			context.notifications.some((notice) => /unavailable/u.test(notice.message)),
+			!modelAvailable,
+		);
+	}
 });

--- a/packages/pi-plan-mode/test/plan-export.test.ts
+++ b/packages/pi-plan-mode/test/plan-export.test.ts
@@ -36,7 +36,18 @@ async function withTempDirectory(run: (directory: string) => Promise<void>) {
 test("plan export autocomplete exposes a path-taking public route", () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.value),
-		["start", "show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
+		[
+			"start",
+			"show",
+			"finalize",
+			"implement",
+			"save",
+			"settings",
+			"export",
+			"exit",
+			"off",
+			"tools",
+		],
 	);
 	assert.deepEqual(
 		completePlanArguments("ex")?.map((item) => item.value),

--- a/packages/pi-plan-mode/test/plan-mode.test.ts
+++ b/packages/pi-plan-mode/test/plan-mode.test.ts
@@ -57,6 +57,48 @@ test("non-interactive Plan routes do not load interactive UI", async () => {
 	assert.equal(interactiveLoads, 0);
 });
 
+test("/plan settings opens in TUI and RPC and rejects print and JSON modes", async () => {
+	const mock = createMockPi({ activeTools: ["read", "bash"] });
+	let interactiveLoads = 0;
+	const settingsModes: string[] = [];
+	planMode(mock.pi, {
+		readSettings: async () => ({ kind: "missing" as const }),
+		loadInteractiveUi: async () => {
+			interactiveLoads += 1;
+			return {
+				showPlanModeSettings: async (ctx: { mode: string }) => {
+					settingsModes.push(ctx.mode);
+					return { kind: "closed", reason: "close" } as const;
+				},
+			} as never;
+		},
+	});
+	const planCommand = mock.commands.get("plan");
+	assert.ok(planCommand);
+
+	for (const mode of ["tui", "rpc"] as const) {
+		const context = createMockContext({ mode, hasUI: true });
+		await planCommand.handler("settings", context.ctx);
+	}
+	for (const mode of ["print", "json"] as const) {
+		const context = createMockContext({ mode, hasUI: false });
+		await assert.rejects(
+			async () => planCommand.handler("settings", context.ctx),
+			/requires TUI or RPC/u,
+		);
+	}
+
+	assert.equal(interactiveLoads, 2);
+	assert.deepEqual(settingsModes, ["tui", "rpc"]);
+	assert.deepEqual(mock.rawPi.getActiveTools(), [
+		"read",
+		"bash",
+		"plan_mode_question",
+		"plan_mode_complete",
+	]);
+	assert.deepEqual(mock.entries, []);
+});
+
 test("stale Plan settings callbacks do not reload interactive UI", async () => {
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	let interactiveLoads = 0;
@@ -120,7 +162,18 @@ test("plan_mode_complete result renders the plan as Markdown", () => {
 test("completePlanArguments suggests management tokens only", () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.label),
-		["start", "show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
+		[
+			"start",
+			"show",
+			"finalize",
+			"implement",
+			"save",
+			"settings",
+			"export",
+			"exit",
+			"off",
+			"tools",
+		],
 	);
 	assert.deepEqual(
 		completePlanArguments("to")?.map((item) => item.value),

--- a/packages/pi-plan-mode/test/saved-plan.test.ts
+++ b/packages/pi-plan-mode/test/saved-plan.test.ts
@@ -573,7 +573,18 @@ test("session shutdown disposes a saved Plan menu without a late transition", as
 test("plan save autocomplete is public and saving fails closed without a ready plan", async () => {
 	assert.deepEqual(
 		completePlanArguments("")?.map((item) => item.value),
-		["start", "show", "finalize", "implement", "save", "export", "exit", "off", "tools"],
+		[
+			"start",
+			"show",
+			"finalize",
+			"implement",
+			"save",
+			"settings",
+			"export",
+			"exit",
+			"off",
+			"tools",
+		],
 	);
 	assert.deepEqual(
 		completePlanArguments("sa")?.map((item) => item.value),

--- a/packages/pi-plan-mode/test/settings-menu.test.ts
+++ b/packages/pi-plan-mode/test/settings-menu.test.ts
@@ -10,6 +10,11 @@ import { builtinTool, createMockContext, extensionTool } from "../../../test/sup
 import type { PlanModeSettings } from "../src/settings.js";
 import { showPlanModeSettings } from "../src/settings-menu.js";
 
+const AVAILABLE_MODELS = [
+	{ provider: "provider-one", id: "model-one", name: "General model" },
+	{ provider: "provider-two", id: "model-two", name: "Specialist model" },
+];
+
 async function withSettingsMenu(
 	run: (fixture: {
 		settingsPath: string;
@@ -27,6 +32,7 @@ async function withSettingsMenu(
 		mode: "tui",
 		hasUI: true,
 		custom: tui.custom,
+		modelRegistry: { getAvailable: () => AVAILABLE_MODELS },
 	});
 	const saved: PlanModeSettings[] = [];
 	try {
@@ -52,7 +58,7 @@ function menuOptions(
 	};
 }
 
-test("Plan settings show five flat workflow rows without materializing a missing file", async () => {
+test("Plan settings show seven flat workflow rows without materializing a missing file", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
@@ -61,6 +67,8 @@ test("Plan settings show five flat workflow rows without materializing a missing
 		assert.match(frame, /Plan thinking\s+inherit/);
 		assert.match(frame, /Plan policy tools\s+Automatic safe built-ins/);
 		assert.match(frame, /Plan reinjection\s+Off — conversation history only/);
+		assert.match(frame, /Fresh model\s+same as plan/);
+		assert.match(frame, /Fresh thinking\s+same as plan/);
 		assert.match(frame, /Export destination\s+PLAN\.md/);
 		assert.match(frame, /Plan mode shortcut\s+none/);
 		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
@@ -89,6 +97,90 @@ test("Plan settings save thinking immediately for the next workflow", async () =
 		assert.match(tui.render().join("\n"), /Plan thinking\s+off/);
 		tui.press("ctrl+c");
 		await running;
+	});
+});
+
+test("Fresh runtime defaults save a model and thinking level, then reset the model", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
+		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.match(tui.render().join("\n"), /Fresh implementation model/u);
+		assert.match(tui.render().join("\n"), /Same as plan/u);
+		tui.press("tui.select.down");
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.deepEqual(saved.at(-1)?.defaultImplementationModel, {
+			provider: "provider-two",
+			modelId: "model-two",
+		});
+		assert.match(tui.render().join("\n"), /Fresh model\s+model-two \[provider-two\]/u);
+
+		tui.press("tui.select.down");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.defaultImplementationThinkingLevel, "off");
+		assert.match(tui.render().join("\n"), /Fresh thinking\s+off/u);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			defaultImplementationModel: { provider: "provider-two", modelId: "model-two" },
+			defaultImplementationThinkingLevel: "off",
+		});
+
+		tui.press("tui.select.up");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		tui.press("tui.select.up");
+		tui.press("tui.select.up");
+		tui.press("tui.select.confirm");
+		await tui.waitForPending();
+		await tui.waitForOpen();
+		assert.equal(saved.at(-1)?.defaultImplementationModel, undefined);
+		assert.match(tui.render().join("\n"), /Fresh model\s+same as plan/u);
+		assert.equal(
+			Object.hasOwn(JSON.parse(await readFile(settingsPath, "utf8")), "defaultImplementationModel"),
+			false,
+		);
+		tui.press("ctrl+c");
+		await running;
+	});
+});
+
+test("Unavailable configured fresh models display a sanitized same-as-plan fallback", async () => {
+	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
+		await writeFile(
+			settingsPath,
+			JSON.stringify({
+				defaultImplementationModel: {
+					provider: "missing\u001b[31m-provider",
+					modelId: "missing\u202e-model",
+				},
+			}),
+		);
+		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
+		await tui.waitForOpen();
+		const frame = tui.render(160).join("\n");
+		assert.match(frame, /Fresh model\s+same as plan .* unavailable/u);
+		assert.match(frame, /missing-provider/u);
+		assert.equal(frame.includes("\u202e"), false);
+		assert.ok(tui.render(34).every((line) => visibleWidth(line) <= 34));
+		tui.press("ctrl+c");
+		await running;
+		assert.deepEqual(saved, []);
+		assert.equal(
+			(
+				JSON.parse(await readFile(settingsPath, "utf8")) as {
+					defaultImplementationModel: { modelId: string };
+				}
+			).defaultImplementationModel.modelId,
+			"missing\u202e-model",
+		);
 	});
 });
 
@@ -178,7 +270,7 @@ test("Plan reinjection cycles outcomes and export destination saves, previews, r
 		assert.equal(saved.at(-1)?.implementationPlanRetention, "clear-after-first-run");
 		assert.match(tui.render().join("\n"), /Plan reinjection\s+Through first implementation run/);
 
-		tui.press("tui.select.down");
+		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		await tui.waitForOpen();
@@ -226,10 +318,7 @@ test("Plan mode shortcut can be set and reset in Settings", async () => {
 	await withSettingsMenu(async ({ settingsPath, tui, ctx, saved }) => {
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
-		tui.press("tui.select.down");
-		tui.press("tui.select.down");
-		tui.press("tui.select.down");
-		tui.press("tui.select.down");
+		for (let index = 0; index < 6; index += 1) tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		await tui.waitForOpen();
@@ -265,7 +354,7 @@ test("long export previews stay within narrow terminal widths", async () => {
 		await writeFile(settingsPath, JSON.stringify({ defaultPlanExportPath: longPath }));
 		const running = showPlanModeSettings(ctx, menuOptions(settingsPath, saved));
 		await tui.waitForOpen();
-		for (let index = 0; index < 3; index += 1) tui.press("tui.select.down");
+		for (let index = 0; index < 5; index += 1) tui.press("tui.select.down");
 		tui.press("tui.select.confirm");
 		await tui.waitForPending();
 		await tui.waitForOpen();
@@ -339,6 +428,8 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan thinking (inherit)",
 					"Plan policy tools (Automatic safe built-ins)",
 					"Plan reinjection (Off — conversation history only)",
+					"Fresh model (same as plan)",
+					"Fresh thinking (same as plan)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
@@ -351,6 +442,8 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan thinking (inherit)",
 					"Plan policy tools (Automatic safe built-ins)",
 					"Plan reinjection (Through first implementation run)",
+					"Fresh model (same as plan)",
+					"Fresh thinking (same as plan)",
 					"Export destination (PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
@@ -368,6 +461,8 @@ test("RPC Settings changes retention and export destination with the same flat n
 					"Plan thinking (inherit)",
 					"Plan policy tools (Automatic safe built-ins)",
 					"Plan reinjection (Through first implementation run)",
+					"Fresh model (same as plan)",
+					"Fresh thinking (same as plan)",
 					"Export destination (rpc/PLAN.md)",
 					"Plan mode shortcut (none)",
 					"Back",
@@ -394,6 +489,8 @@ test("Plan settings adapt to RPC cancellation and disposal aborts an in-flight s
 				"Plan thinking (inherit)",
 				"Plan policy tools (Automatic safe built-ins)",
 				"Plan reinjection (Off — conversation history only)",
+				"Fresh model (same as plan)",
+				"Fresh thinking (same as plan)",
 				"Export destination (PLAN.md)",
 				"Plan mode shortcut (none)",
 				"Back",

--- a/packages/pi-plan-mode/test/settings.test.ts
+++ b/packages/pi-plan-mode/test/settings.test.ts
@@ -14,13 +14,16 @@ import { join } from "node:path";
 import { test } from "vitest";
 import {
 	awaitPlanModeSettingsWrites,
+	configuredImplementationModel,
 	configuredImplementationPlanRetention,
+	configuredImplementationThinkingLevel,
 	configuredPlanExportPath,
 	configuredPlanModeToggleShortcut,
 	normalizePlanModeSettings,
 	readPlanModeSettings,
 	updatePlanModeSettings,
 } from "../src/settings.js";
+import { MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH } from "../src/state.js";
 
 test("Plan-mode settings validate inherit and fixed thinking levels", async () => {
 	assert.deepEqual(normalizePlanModeSettings({}), { thinkingLevel: "inherit" });
@@ -158,6 +161,42 @@ test("Plan-mode settings validate implementation retention and export defaults",
 	}
 });
 
+test("Plan-mode settings validate fresh implementation runtime defaults", () => {
+	const configured = normalizePlanModeSettings({
+		defaultImplementationModel: { provider: "provider", modelId: "model" },
+		defaultImplementationThinkingLevel: "high",
+	});
+	assert.ok(configured);
+	assert.deepEqual(configuredImplementationModel(configured), {
+		provider: "provider",
+		modelId: "model",
+	});
+	assert.equal(configuredImplementationThinkingLevel(configured), "high");
+
+	const defaults = normalizePlanModeSettings({});
+	assert.ok(defaults);
+	assert.equal(configuredImplementationModel(defaults), undefined);
+	assert.equal(configuredImplementationThinkingLevel(defaults), undefined);
+
+	for (const defaultImplementationModel of [
+		null,
+		"provider/model",
+		{},
+		{ provider: "", modelId: "model" },
+		{ provider: "provider", modelId: " " },
+		{ provider: "provider", modelId: "model", extra: true },
+		{
+			provider: "provider",
+			modelId: "x".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH + 1),
+		},
+	]) {
+		assert.equal(normalizePlanModeSettings({ defaultImplementationModel }), undefined);
+	}
+	for (const defaultImplementationThinkingLevel of ["inherit", "extreme", null, 42]) {
+		assert.equal(normalizePlanModeSettings({ defaultImplementationThinkingLevel }), undefined);
+	}
+});
+
 test("Plan-mode settings ignore unknown top-level fields", () => {
 	assert.deepEqual(
 		normalizePlanModeSettings({
@@ -249,7 +288,7 @@ test("Plan-mode settings updates create only on explicit save and preserve unkno
 	}
 });
 
-test("Plan-mode settings patch retention and export fields from the latest document", async () => {
+test("Plan-mode settings patch implementation defaults, retention, and export fields", async () => {
 	const directory = await mkdtemp(join(tmpdir(), "pi-plan-mode-settings-new-fields-"));
 	const settingsPath = join(directory, "pi-plan-mode.json");
 	try {
@@ -260,11 +299,20 @@ test("Plan-mode settings patch retention and export fields from the latest docum
 		await updatePlanModeSettings(
 			{
 				implementationPlanRetention: "clear-after-first-run",
+				defaultImplementationModel: { provider: "provider", modelId: "model" },
+				defaultImplementationThinkingLevel: "high",
 				defaultPlanExportPath: "docs/PLAN.md",
 			},
 			{ settingsPath },
 		);
-		await updatePlanModeSettings({ defaultPlanExportPath: null }, { settingsPath });
+		await updatePlanModeSettings(
+			{
+				defaultImplementationModel: null,
+				defaultImplementationThinkingLevel: null,
+				defaultPlanExportPath: null,
+			},
+			{ settingsPath },
+		);
 
 		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
 			thinkingLevel: "low",

--- a/packages/pi-plan-mode/test/settings.test.ts
+++ b/packages/pi-plan-mode/test/settings.test.ts
@@ -172,6 +172,17 @@ test("Plan-mode settings validate fresh implementation runtime defaults", () => 
 		modelId: "model",
 	});
 	assert.equal(configuredImplementationThinkingLevel(configured), "high");
+	const trimmed = normalizePlanModeSettings({
+		defaultImplementationModel: {
+			provider: "  provider  ",
+			modelId: `  ${"m".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH)}  `,
+		},
+	});
+	assert.ok(trimmed);
+	assert.deepEqual(configuredImplementationModel(trimmed), {
+		provider: "provider",
+		modelId: "m".repeat(MAX_PENDING_IMPLEMENTATION_MODEL_IDENTIFIER_LENGTH),
+	});
 
 	const defaults = normalizePlanModeSettings({});
 	assert.ok(defaults);
@@ -299,12 +310,20 @@ test("Plan-mode settings patch implementation defaults, retention, and export fi
 		await updatePlanModeSettings(
 			{
 				implementationPlanRetention: "clear-after-first-run",
-				defaultImplementationModel: { provider: "provider", modelId: "model" },
+				defaultImplementationModel: { provider: "  provider  ", modelId: "  model  " },
 				defaultImplementationThinkingLevel: "high",
 				defaultPlanExportPath: "docs/PLAN.md",
 			},
 			{ settingsPath },
 		);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			thinkingLevel: "low",
+			future: { kept: true },
+			implementationPlanRetention: "clear-after-first-run",
+			defaultImplementationModel: { provider: "provider", modelId: "model" },
+			defaultImplementationThinkingLevel: "high",
+			defaultPlanExportPath: "docs/PLAN.md",
+		});
 		await updatePlanModeSettings(
 			{
 				defaultImplementationModel: null,


### PR DESCRIPTION
## Summary

- add persistent fresh implementation model and thinking defaults to Plan Settings and `pi-plan-mode.json`
- keep same-as-plan as the default and fall back safely when a configured model is unavailable
- seed ready-plan one-shot choices and saved-plan fresh handoffs from the persistent defaults
- document the settings and add a minor Changeset

Closes #1232 

## Verification

- `npm run check`
- `npm test` (392 files, 4580 tests)
- `npx vitest run packages/pi-plan-mode/test` (28 files, 301 tests)
- `npm run package:pack -- plan-mode`
- offline Pi package loader smoke with `PI_OFFLINE=1 pi --no-extensions ... -e ./packages/pi-plan-mode -p '/plan start'`
- `git diff --check`