### PR TITLE
fix(plan-mode): defer fresh handoff after settled dispatch

### DIFF
--- a/.changeset/quiet-plans-settle.md
+++ b/.changeset/quiet-plans-settle.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-plan-mode": patch
+---
+
+Defer automatic ready-plan fresh session handoffs until lifecycle dispatch and prompt cleanup finish.

--- a/packages/pi-plan-mode/src/fresh-handoff-coordinator.ts
+++ b/packages/pi-plan-mode/src/fresh-handoff-coordinator.ts
@@ -1,0 +1,55 @@
+export interface DeferredFreshHandoffDependencies {
+	schedule(callback: () => void): unknown;
+	cancel(handle: unknown): void;
+}
+
+export interface DeferredFreshHandoffCoordinator {
+	schedule(
+		run: (isCurrent: () => boolean) => Promise<void>,
+		onError: (error: unknown) => void,
+	): void;
+	cancel(): void;
+}
+
+const defaultDependencies: DeferredFreshHandoffDependencies = {
+	schedule: (callback) => setTimeout(callback, 0),
+	cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export function createDeferredFreshHandoffCoordinator(
+	dependencies: DeferredFreshHandoffDependencies = defaultDependencies,
+): DeferredFreshHandoffCoordinator {
+	let generation = 0;
+	let pending: { generation: number; handle: unknown } | undefined;
+
+	const cancel = () => {
+		generation += 1;
+		if (!pending) return;
+		dependencies.cancel(pending.handle);
+		pending = undefined;
+	};
+
+	return {
+		schedule(run, onError) {
+			cancel();
+			const taskGeneration = generation;
+			const handle = dependencies.schedule(() => {
+				if (pending?.generation !== taskGeneration || generation !== taskGeneration) return;
+				pending = undefined;
+				const isCurrent = () => generation === taskGeneration;
+				void Promise.resolve()
+					.then(() => run(isCurrent))
+					.catch((error: unknown) => {
+						if (!isCurrent()) return;
+						try {
+							onError(error);
+						} catch {
+							// Detached error reporting must not create another unhandled rejection.
+						}
+					});
+			});
+			pending = { generation: taskGeneration, handle };
+		},
+		cancel,
+	};
+}

--- a/packages/pi-plan-mode/src/plan-action-controller.ts
+++ b/packages/pi-plan-mode/src/plan-action-controller.ts
@@ -19,6 +19,8 @@ interface MenuLifecycle {
 	isCurrent(): boolean;
 }
 
+export type FreshImplementationTiming = "immediate" | "after-settled";
+
 interface PlanActionControllerOptions {
 	loadInteractiveUi(): Promise<InteractiveUi>;
 	getState(): PlanModeState;
@@ -34,7 +36,8 @@ interface PlanActionControllerOptions {
 	implementFresh(
 		ctx: ExtensionContext,
 		isCurrent: () => boolean,
-		runtime?: ImplementationRuntimeSelection,
+		runtime: ImplementationRuntimeSelection | undefined,
+		timing: FreshImplementationTiming,
 	): void | Promise<void>;
 	exportPlan(
 		ctx: ExtensionContext,
@@ -87,8 +90,16 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 		ctx: ExtensionContext,
 		lifecycle: MenuLifecycle,
 		signal: AbortSignal,
-		runtime?: ImplementationRuntimeSelection,
-	) => options.implementFresh(ctx, () => lifecycle.isCurrent() && !signal.aborted, runtime);
+		runtime: ImplementationRuntimeSelection | undefined,
+		timing: FreshImplementationTiming,
+	) => {
+		if (signal.aborted) return;
+		const isCurrent =
+			timing === "after-settled"
+				? lifecycle.isCurrent
+				: () => lifecycle.isCurrent() && !signal.aborted;
+		return options.implementFresh(ctx, isCurrent, runtime, timing);
+	};
 
 	return {
 		async showSaved(ctx: ExtensionContext) {
@@ -104,7 +115,8 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				isCurrent: lifecycle.isCurrent,
 				show: () => options.show(ctx),
 				implementHere: () => options.implementHere(ctx),
-				implementFresh: (signal) => freshAction(ctx, lifecycle, signal, effectiveDefaults(ctx)),
+				implementFresh: (signal) =>
+					freshAction(ctx, lifecycle, signal, effectiveDefaults(ctx), "immediate"),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				settings: (signal) => options.settings(ctx, signal, lifecycle.isCurrent),
 				clear: () => options.clearSaved(ctx),
@@ -130,7 +142,8 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				show: () => options.show(ctx),
 				finalize: () => options.finalize(ctx),
 				implementHere: () => options.implementHere(ctx),
-				implementFresh: (runtime, signal) => freshAction(ctx, lifecycle, signal, runtime),
+				implementFresh: (runtime, signal) =>
+					freshAction(ctx, lifecycle, signal, runtime, "immediate"),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),
 				stay: () => options.stay(ctx),
@@ -149,7 +162,8 @@ export function createPlanActionController(options: PlanActionControllerOptions)
 				implementationOutcome: options.implementationOutcome,
 				getExportDestination: () => options.getExportDestination(ctx),
 				implementHere: () => options.implementHere(ctx),
-				implementFresh: (runtime, signal) => freshAction(ctx, lifecycle, signal, runtime),
+				implementFresh: (runtime, signal) =>
+					freshAction(ctx, lifecycle, signal, runtime, "after-settled"),
 				exportPlan: (path, signal) => options.exportPlan(ctx, path, signal, lifecycle.isCurrent),
 				save: () => options.save(ctx),
 				stay: () => undefined,

--- a/packages/pi-plan-mode/src/plan-mode.ts
+++ b/packages/pi-plan-mode/src/plan-mode.ts
@@ -24,6 +24,7 @@ import {
 	type FinalizationRunOutcome,
 	RETRY_FINALIZE_PLAN_PROMPT,
 } from "./finalization-request.js";
+import { createDeferredFreshHandoffCoordinator } from "./fresh-handoff-coordinator.js";
 import {
 	formatHistoryImplementationPrompt,
 	formatImplementationHandoff,
@@ -49,7 +50,10 @@ import {
 	type PlanModeContract,
 	reconcileModeContract,
 } from "./mode-contract.js";
-import { createPlanActionController } from "./plan-action-controller.js";
+import {
+	createPlanActionController,
+	type FreshImplementationTiming,
+} from "./plan-action-controller.js";
 import { createPlanExportController } from "./plan-export-controller.js";
 import {
 	clearPlanModeUi,
@@ -77,6 +81,7 @@ import {
 	configuredImplementationPlanRetention,
 	configuredPlanModeToggleShortcut,
 	configuredThinkingLevel,
+	type ImplementationPlanRetention,
 	type PlanModeSettings,
 	type PlanModeSettingsPatch,
 	planModeSettingsPath,
@@ -110,6 +115,20 @@ interface ReadyPresentationIntent {
 	nonce: number;
 	plan: string;
 	source: PlanCompletionSource;
+}
+interface DeferredFreshImplementation {
+	ctx: ExtensionContext;
+	sourceSession: object;
+	menuGeneration: number;
+	workflowGeneration: number;
+	workflowOwner: WorkflowMutexOwner | undefined;
+	enabled: boolean;
+	plan: string;
+	source: PlanCompletionSource;
+	savedPlan: PlanModeState["savedPlan"];
+	retention: ImplementationPlanRetention;
+	runtime: ImplementationRuntimeSelection | undefined;
+	menuIsCurrent(): boolean;
 }
 interface PendingWorkflowToolPolicy {
 	generation: number;
@@ -169,6 +188,8 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	let modeContractsRelevant = false;
 	let readyPresentationIntent: ReadyPresentationIntent | undefined;
 	let latestCommandContext: ExtensionCommandContext | undefined;
+	let stagedFreshImplementation: DeferredFreshImplementation | undefined;
+	const deferredFreshHandoff = createDeferredFreshHandoffCoordinator();
 	let nextReadyPresentationNonce = 0;
 	let menuGeneration = 0;
 	let workflowGeneration = 0;
@@ -475,6 +496,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	};
 
 	pi.on("session_start", async (event, ctx) => {
+		cancelDeferredFreshImplementation();
 		const generation = ++menuGeneration;
 		finalizationRequest.reset();
 		currentSession = ctx.sessionManager;
@@ -532,6 +554,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
+		cancelDeferredFreshImplementation();
 		advanceWorkflowGeneration();
 		menuGeneration += 1;
 		menuController.abort(new DOMException("Plan-mode tree branch changed", "AbortError"));
@@ -565,6 +588,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
+		cancelDeferredFreshImplementation();
 		const shutdownSession = ctx.sessionManager;
 		const runtimeApplication =
 			activeImplementationRuntimeApplication?.sessionManager === shutdownSession &&
@@ -769,6 +793,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		refreshStateForFirstPrompt(ctx);
 		if (!state.enabled || !workflowMutex.isOwner(workflowOwner)) return;
 		if (state.latestPlan || state.awaitingAction) {
+			cancelDeferredFreshImplementation();
 			readyPresentationIntent = undefined;
 			state = {
 				...state,
@@ -828,6 +853,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 		if (!ctx.isIdle() || ctx.hasPendingMessages()) return;
 
 		readyPresentationIntent = undefined;
+		stagedFreshImplementation = undefined;
 		try {
 			if (intent.source === "legacy_proposed_plan") {
 				pi.sendMessage(
@@ -842,7 +868,11 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 			if (ctx.hasUI && completedPlanIsCurrent(intent)) {
 				await planActions.showReady(latestCommandContext ?? ctx);
 			}
+			const request = stagedFreshImplementation;
+			stagedFreshImplementation = undefined;
+			if (request) armDeferredFreshImplementation(request);
 		} catch (error: unknown) {
+			stagedFreshImplementation = undefined;
 			if (!isStaleExtensionContextError(error)) throw error;
 		}
 	});
@@ -1091,15 +1121,95 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	async function startFreshImplementation(
 		ctx: ExtensionContext,
 		menuIsCurrent: () => boolean,
-		runtime?: ImplementationRuntimeSelection,
+		runtime: ImplementationRuntimeSelection | undefined,
+		timing: FreshImplementationTiming,
 	) {
-		await startFreshImplementationFromState(ctx, {
-			getState: () => state,
+		const retention = configuredImplementationPlanRetention(settings);
+		if (timing === "immediate") {
+			await startFreshImplementationFromState(ctx, {
+				getState: () => state,
+				menuIsCurrent,
+				retention,
+				stateEntryType: STATE_ENTRY_TYPE,
+				runtime,
+			});
+			return;
+		}
+
+		const initialState = state;
+		const savedPlan = initialState.enabled ? undefined : initialState.savedPlan;
+		const plan = (initialState.enabled ? initialState.latestPlan : savedPlan?.plan)?.trim();
+		const source = initialState.enabled ? initialState.latestPlanSource : savedPlan?.source;
+		if (!plan || !source || !menuIsCurrent()) return;
+		stagedFreshImplementation = {
+			ctx,
+			sourceSession: ctx.sessionManager,
+			menuGeneration,
+			workflowGeneration,
+			workflowOwner,
+			enabled: initialState.enabled,
+			plan,
+			source,
+			savedPlan,
+			retention,
+			runtime: runtime
+				? {
+						...(runtime.model ? { model: { ...runtime.model } } : {}),
+						...(runtime.thinkingLevel ? { thinkingLevel: runtime.thinkingLevel } : {}),
+					}
+				: undefined,
 			menuIsCurrent,
-			retention: configuredImplementationPlanRetention(settings),
-			stateEntryType: STATE_ENTRY_TYPE,
-			runtime,
-		});
+		};
+	}
+
+	function armDeferredFreshImplementation(request: DeferredFreshImplementation) {
+		deferredFreshHandoff.schedule(
+			async (taskIsCurrent) => {
+				const isCurrent = () => taskIsCurrent() && deferredFreshImplementationIsCurrent(request);
+				if (!isCurrent()) return;
+				await startFreshImplementationFromState(request.ctx, {
+					getState: () => state,
+					menuIsCurrent: isCurrent,
+					retention: request.retention,
+					stateEntryType: STATE_ENTRY_TYPE,
+					runtime: request.runtime,
+				});
+			},
+			(error) => {
+				if (!deferredFreshImplementationIsCurrent(request)) return;
+				try {
+					request.ctx.ui.notify(
+						`Unable to start the deferred fresh implementation: ${terminalErrorDetail(error)}`,
+						"error",
+					);
+				} catch {
+					// The source context can become stale while a detached failure is reported.
+				}
+			},
+		);
+	}
+
+	function deferredFreshImplementationIsCurrent(request: DeferredFreshImplementation) {
+		if (
+			currentSession !== request.sourceSession ||
+			menuGeneration !== request.menuGeneration ||
+			workflowGeneration !== request.workflowGeneration ||
+			workflowOwner !== request.workflowOwner ||
+			!request.menuIsCurrent() ||
+			state.enabled !== request.enabled
+		) {
+			return false;
+		}
+		return request.enabled
+			? workflowMutex.isOwner(request.workflowOwner) &&
+					state.latestPlan === request.plan &&
+					state.latestPlanSource === request.source
+			: state.savedPlan === request.savedPlan;
+	}
+
+	function cancelDeferredFreshImplementation() {
+		stagedFreshImplementation = undefined;
+		deferredFreshHandoff.cancel();
 	}
 
 	async function startImplementation(ctx: ExtensionContext) {
@@ -1388,6 +1498,7 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	}
 
 	function advanceWorkflowGeneration() {
+		cancelDeferredFreshImplementation();
 		workflowGeneration += 1;
 		pendingWorkflowToolPolicy = undefined;
 		finalizationRequest.reset();
@@ -2014,6 +2125,12 @@ export default function planMode(pi: ExtensionAPI, dependencies: PlanModeDepende
 	function terminalModelReference(model: { provider: string; modelId: string }) {
 		const safe = safeTerminalText(`${model.provider}/${model.modelId}`) || "(unnamed model)";
 		return safe.length > 160 ? `${safe.slice(0, 159)}…` : safe;
+	}
+
+	function terminalErrorDetail(error: unknown) {
+		const safe = safeTerminalText(error instanceof Error ? error.message : String(error));
+		if (!safe) return "unknown error";
+		return safe.length > 500 ? `${safe.slice(0, 499)}…` : safe;
 	}
 
 	function safeTerminalText(value: string) {

--- a/packages/pi-plan-mode/test/fresh-handoff-coordinator.test.ts
+++ b/packages/pi-plan-mode/test/fresh-handoff-coordinator.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+	createDeferredFreshHandoffCoordinator,
+	type DeferredFreshHandoffDependencies,
+} from "../src/fresh-handoff-coordinator.js";
+
+function failOnError(error: unknown): never {
+	throw error;
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function createControlledScheduler() {
+	const callbacks = new Map<number, () => void>();
+	const cancelled: number[] = [];
+	let nextHandle = 0;
+	const dependencies: DeferredFreshHandoffDependencies = {
+		schedule(callback) {
+			const handle = ++nextHandle;
+			callbacks.set(handle, callback);
+			return handle;
+		},
+		cancel(handle) {
+			const numericHandle = handle as number;
+			cancelled.push(numericHandle);
+			callbacks.delete(numericHandle);
+		},
+	};
+	return {
+		dependencies,
+		cancelled,
+		flush(handle = nextHandle) {
+			const callback = callbacks.get(handle);
+			callbacks.delete(handle);
+			callback?.();
+		},
+	};
+}
+
+test("deferred fresh handoff runs only after its scheduled boundary", async () => {
+	const scheduler = createControlledScheduler();
+	const coordinator = createDeferredFreshHandoffCoordinator(scheduler.dependencies);
+	const completed = deferred<void>();
+	let runs = 0;
+	coordinator.schedule(async (isCurrent) => {
+		runs += 1;
+		assert.equal(isCurrent(), true);
+		completed.resolve();
+	}, failOnError);
+
+	assert.equal(runs, 0);
+	scheduler.flush();
+	await completed.promise;
+	assert.equal(runs, 1);
+});
+
+test("new and repeated cancellation release pending fresh handoffs", () => {
+	const scheduler = createControlledScheduler();
+	const coordinator = createDeferredFreshHandoffCoordinator(scheduler.dependencies);
+	let firstRuns = 0;
+	let secondRuns = 0;
+	coordinator.schedule(async () => {
+		firstRuns += 1;
+	}, failOnError);
+	coordinator.schedule(async () => {
+		secondRuns += 1;
+	}, failOnError);
+	coordinator.cancel();
+	coordinator.cancel();
+
+	scheduler.flush(1);
+	scheduler.flush(2);
+	assert.equal(firstRuns, 0);
+	assert.equal(secondRuns, 0);
+	assert.deepEqual(scheduler.cancelled, [1, 2]);
+});
+
+test("cancellation invalidates running work without awaiting it", async () => {
+	const scheduler = createControlledScheduler();
+	const coordinator = createDeferredFreshHandoffCoordinator(scheduler.dependencies);
+	const started = deferred<() => boolean>();
+	const release = deferred<void>();
+	const completed = deferred<void>();
+	coordinator.schedule(async (isCurrent) => {
+		started.resolve(isCurrent);
+		await release.promise;
+		completed.resolve();
+	}, failOnError);
+	scheduler.flush();
+	const isCurrent = await started.promise;
+	assert.equal(isCurrent(), true);
+
+	coordinator.cancel();
+	assert.equal(isCurrent(), false);
+	release.resolve();
+	await completed.promise;
+});
+
+test("detached reporter failures do not become unhandled rejections", async () => {
+	const scheduler = createControlledScheduler();
+	const coordinator = createDeferredFreshHandoffCoordinator(scheduler.dependencies);
+	const reported = deferred<void>();
+	coordinator.schedule(
+		async () => {
+			throw new Error("task failure");
+		},
+		() => {
+			reported.resolve();
+			throw new Error("reporter failure");
+		},
+	);
+	scheduler.flush();
+	await reported.promise;
+	await Promise.resolve();
+});
+
+test("detached failures are reported only while their handoff is current", async () => {
+	for (const cancelled of [false, true]) {
+		const scheduler = createControlledScheduler();
+		const coordinator = createDeferredFreshHandoffCoordinator(scheduler.dependencies);
+		const started = deferred<void>();
+		const release = deferred<void>();
+		const reported = deferred<unknown>();
+		let reports = 0;
+		coordinator.schedule(
+			async () => {
+				started.resolve();
+				await release.promise;
+				throw new Error("deferred failure");
+			},
+			(error) => {
+				reports += 1;
+				reported.resolve(error);
+			},
+		);
+		scheduler.flush();
+		await started.promise;
+		if (cancelled) coordinator.cancel();
+		release.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		if (cancelled) {
+			assert.equal(reports, 0);
+		} else {
+			assert.match(String(await reported.promise), /deferred failure/u);
+			assert.equal(reports, 1);
+		}
+	}
+});

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import {
 	formatImplementationHandoff,
 	formatTransferredPlanPrompt,
@@ -423,6 +423,151 @@ test("fresh menu work stops after source session shutdown while waiting for idle
 	assert.equal(newSessionCalls, 0);
 	const persisted = mock.entries.at(-1)?.data as { latestPlan?: string };
 	assert.equal(persisted.latestPlan, PLAN);
+});
+
+test("automatic fresh handoff is cancelled before its deferred turn becomes stale", async () => {
+	for (const invalidation of ["shutdown", "reload", "new-turn", "workflow-exit"] as const) {
+		vi.useFakeTimers();
+		try {
+			let newSessionCalls = 0;
+			const mock = createMockPi({ activeTools: ["read", "edit"] });
+			planMode(mock.pi, MISSING_SETTINGS);
+			const context = createMockContext({
+				mode: "rpc",
+				hasUI: true,
+				model: { provider: "test-provider", id: "test-model" },
+				modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+				select: async (_title: string, options: string[]) => {
+					if (options.includes("Start fresh and implement")) {
+						return "Start fresh and implement";
+					}
+					if (options.includes("Start fresh implementation")) {
+						return "Start fresh implementation";
+					}
+					return undefined;
+				},
+				newSession: async () => {
+					newSessionCalls += 1;
+					return { cancelled: false };
+				},
+			});
+			await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+			await mock.commands.get("plan")?.handler("start", context.ctx);
+			await completePlan(mock, context.ctx);
+			await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+			assert.equal(newSessionCalls, 0, invalidation);
+
+			if (invalidation === "new-turn") {
+				await mock.events.get("before_agent_start")?.[0]?.({ systemPrompt: "base" }, context.ctx);
+			} else if (invalidation === "workflow-exit") {
+				await mock.commands.get("plan")?.handler("exit", context.ctx);
+			} else {
+				await mock.events.get("session_shutdown")?.[0]?.(
+					{ reason: invalidation === "shutdown" ? "quit" : "reload" },
+					context.ctx,
+				);
+				if (invalidation === "reload") {
+					await mock.events.get("session_start")?.[0]?.({ reason: "reload" }, context.ctx);
+				}
+			}
+			await vi.runAllTimersAsync();
+			assert.equal(newSessionCalls, 0, invalidation);
+		} finally {
+			vi.useRealTimers();
+		}
+	}
+});
+
+test("running automatic fresh preflight stops after source shutdown", async () => {
+	vi.useFakeTimers();
+	try {
+		let markWaiting!: () => void;
+		let releaseIdle!: () => void;
+		const waiting = new Promise<void>((resolve) => {
+			markWaiting = resolve;
+		});
+		const idleGate = new Promise<void>((resolve) => {
+			releaseIdle = resolve;
+		});
+		let newSessionCalls = 0;
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi, MISSING_SETTINGS);
+		const context = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			model: { provider: "test-provider", id: "test-model" },
+			modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+			select: async (_title: string, options: string[]) => {
+				if (options.includes("Start fresh and implement")) return "Start fresh and implement";
+				if (options.includes("Start fresh implementation")) {
+					return "Start fresh implementation";
+				}
+				return undefined;
+			},
+			waitForIdle: async () => {
+				markWaiting();
+				await idleGate;
+			},
+			newSession: async () => {
+				newSessionCalls += 1;
+				return { cancelled: false };
+			},
+		});
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, context.ctx);
+		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		await vi.runAllTimersAsync();
+		await waiting;
+		await mock.events.get("session_shutdown")?.[0]?.({ reason: "new" }, context.ctx);
+		releaseIdle();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.equal(newSessionCalls, 0);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("unexpected deferred fresh failures are reported without terminal controls", async () => {
+	vi.useFakeTimers();
+	try {
+		const mock = createMockPi({ activeTools: ["read", "edit"] });
+		planMode(mock.pi, MISSING_SETTINGS);
+		const context = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			model: { provider: "test-provider", id: "test-model" },
+			modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true as const }) },
+			select: async (_title: string, options: string[]) => {
+				if (options.includes("Start fresh and implement")) return "Start fresh and implement";
+				if (options.includes("Start fresh implementation")) {
+					return "Start fresh implementation";
+				}
+				return undefined;
+			},
+			waitForIdle: async () => {
+				throw new Error(`deferred \u001b[31mfailure ${"x".repeat(1_000)}`);
+			},
+			newSession: async () => ({ cancelled: false }),
+		});
+		await mock.events.get("session_start")?.[0]?.({ reason: "startup" }, context.ctx);
+		await mock.commands.get("plan")?.handler("start", context.ctx);
+		await completePlan(mock, context.ctx);
+		await mock.events.get("agent_settled")?.[0]?.({}, context.ctx);
+		await vi.runAllTimersAsync();
+		await Promise.resolve();
+
+		const notification = context.notifications.at(-1);
+		assert.match(notification?.message ?? "", /deferred fresh implementation: deferred failure/u);
+		assert.equal(notification?.message.includes("\u001b"), false);
+		assert.ok((notification?.message.length ?? Number.POSITIVE_INFINITY) < 560);
+		assert.match(notification?.message ?? "", /…$/u);
+		assert.equal(notification?.level, "error");
+	} finally {
+		vi.useRealTimers();
+	}
 });
 
 test("fresh destination adopts setup state before kickoff for guaranteed-plan policies", async () => {

--- a/packages/pi-plan-mode/test/issue-1263-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-1263-repro.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+	DefaultResourceLoader,
+	ExtensionRunner,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { test } from "vitest";
+import { builtinTool, createMockContext, extensionTool } from "../../../test/support.js";
+
+const EVENT_RECORDER = Symbol.for("pi-plan-mode.issue-1263-events");
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+test("ready-menu fresh handoff waits for settled and prompt-end dispatch", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-issue-1263-"));
+	const agentDir = join(root, "agent");
+	const followerPath = join(root, "later-extension.ts");
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const events: string[] = [];
+	Reflect.set(globalThis, EVENT_RECORDER, (event: string) => events.push(event));
+	try {
+		await mkdir(agentDir, { recursive: true });
+		await writeFile(
+			followerPath,
+			`const recorder = globalThis[Symbol.for("pi-plan-mode.issue-1263-events")];
+export default function laterExtension(pi) {
+	pi.on("agent_settled", (_event, ctx) => {
+		void ctx.sessionManager;
+		recorder("later-agent-settled");
+	});
+	pi.on("ui_prompt_end", (_event, ctx) => {
+		void ctx.sessionManager;
+		recorder("later-ui-prompt-end");
+	});
+}
+`,
+			"utf8",
+		);
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const loader = new DefaultResourceLoader({
+			cwd: root,
+			agentDir,
+			settingsManager: SettingsManager.inMemory({}),
+			additionalExtensionPaths: [resolve("packages/pi-plan-mode/src/index.ts"), followerPath],
+		});
+		await loader.reload();
+		const loaded = loader.getExtensions();
+		assert.deepEqual(loaded.errors, []);
+
+		const sourceSessionManager = {
+			getSessionId: () => "source",
+			getSessionName: () => undefined,
+			getSessionFile: () => "/sessions/source.jsonl",
+			getBranch: () => [],
+			getEntries: () => [],
+		};
+		const model = {
+			provider: "test-provider",
+			id: "test-model",
+			name: "Test model",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 100_000,
+			maxTokens: 10_000,
+		};
+		const modelRegistry = {
+			getAvailable: () => [model],
+			find: () => model,
+			getApiKeyAndHeaders: async () => ({ ok: true as const }),
+		};
+		const runner = new ExtensionRunner(
+			loaded.extensions,
+			loaded.runtime,
+			root,
+			sourceSessionManager as never,
+			modelRegistry as never,
+		);
+		let activeTools = ["read", "write", "plan_mode_question", "plan_mode_complete"];
+		runner.bindCore(
+			{
+				sendMessage: () => undefined,
+				sendUserMessage: () => undefined,
+				appendEntry: () => undefined,
+				setSessionName: () => undefined,
+				getSessionName: () => undefined,
+				setLabel: () => undefined,
+				getActiveTools: () => [...activeTools],
+				getAllTools: () => [
+					builtinTool("read"),
+					builtinTool("write"),
+					extensionTool("plan_mode_question"),
+					extensionTool("plan_mode_complete"),
+				],
+				setActiveTools: (names: string[]) => {
+					activeTools = [...names];
+				},
+				refreshTools: () => undefined,
+				getCommands: () => [],
+				setModel: async () => true,
+				getThinkingLevel: () => "medium",
+				setThinkingLevel: () => undefined,
+			} as never,
+			{
+				getModel: () => model,
+				getScopedModels: () => [],
+				isIdle: () => true,
+				isProjectTrusted: () => true,
+				getSignal: () => undefined,
+				waitForIdle: async () => undefined,
+				abort: () => undefined,
+				hasPendingMessages: () => false,
+				shutdown: () => undefined,
+				getContextUsage: () => undefined,
+				compact: () => undefined,
+				getSystemPrompt: () => "",
+				getSystemPromptOptions: () => ({ cwd: root }),
+			} as never,
+		);
+		const mockContext = createMockContext({
+			mode: "rpc",
+			hasUI: true,
+			select: async (_title: string, options: string[]) => {
+				if (options.includes("Start fresh and implement")) return "Start fresh and implement";
+				if (options.includes("Start fresh implementation")) return "Start fresh implementation";
+				return undefined;
+			},
+		});
+		runner.setUIContext((mockContext.ctx as { ui: never }).ui, "rpc");
+		const handoffFinished = deferred<void>();
+		let setupCalls = 0;
+		let kickoffCalls = 0;
+		runner.bindCommandContext({
+			waitForIdle: async () => undefined,
+			newSession: async (options) => {
+				events.push("replacement-started");
+				await runner.emit({ type: "session_shutdown", reason: "new" });
+				runner.invalidate();
+				if (options?.setup) setupCalls += 1;
+				await options?.setup?.({
+					appendCustomEntry: () => "state",
+					appendCustomMessageEntry: () => "contract",
+				} as never);
+				await options?.withSession?.({
+					sessionManager: { getBranch: () => [] },
+					ui: (mockContext.ctx as { ui: never }).ui,
+					sendUserMessage: async () => {
+						kickoffCalls += 1;
+					},
+				} as never);
+				handoffFinished.resolve();
+				return { cancelled: false };
+			},
+			fork: async () => ({ cancelled: false }),
+			navigateTree: async () => ({ cancelled: false }),
+			switchSession: async () => ({ cancelled: false }),
+			reload: async () => undefined,
+		});
+
+		const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
+		runner.onError((error) => errors.push(error));
+		await runner.emit({ type: "session_start", reason: "startup" });
+		const command = runner.getCommand("plan");
+		assert.ok(command);
+		await command.handler("start", runner.createCommandContext());
+		const complete = runner.getToolDefinition("plan_mode_complete");
+		assert.ok(complete);
+		await complete.execute(
+			"complete",
+			{ plan: "# Plan\n\nImplement it." },
+			new AbortController().signal,
+			undefined,
+			runner.createContext(),
+		);
+		await runner.emit({ type: "agent_settled" });
+		await handoffFinished.promise;
+		await Promise.resolve();
+
+		const replacementIndex = events.indexOf("replacement-started");
+		const settledIndex = events.indexOf("later-agent-settled");
+		const promptEndIndex = events.lastIndexOf("later-ui-prompt-end");
+		assert.ok(replacementIndex >= 0, JSON.stringify(events));
+		assert.ok(settledIndex >= 0 && settledIndex < replacementIndex, JSON.stringify(events));
+		assert.ok(promptEndIndex >= 0 && promptEndIndex < replacementIndex, JSON.stringify(events));
+		assert.equal(setupCalls, 1);
+		assert.equal(kickoffCalls, 1);
+		assert.deepEqual(errors, []);
+	} finally {
+		Reflect.deleteProperty(globalThis, EVENT_RECORDER);
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(root, { force: true, recursive: true });
+	}
+});

--- a/packages/pi-plan-mode/test/plan-action-controller.test.ts
+++ b/packages/pi-plan-mode/test/plan-action-controller.test.ts
@@ -40,6 +40,84 @@ test("stale Plan actions do not load interactive UI", async () => {
 	assert.equal(interactiveLoads, 0);
 });
 
+test("only ready-plan fresh actions survive normal menu disposal for deferred handoff", async () => {
+	const timings: string[] = [];
+	const currents: Array<() => boolean> = [];
+	const invokeFresh = async (
+		menuOptions: Record<string, unknown>,
+		kind: "saved" | "current" | "ready",
+	) => {
+		const controller = new AbortController();
+		if (kind === "saved") {
+			await (menuOptions.implementFresh as (signal: AbortSignal) => Promise<void>)(
+				controller.signal,
+			);
+		} else {
+			await (
+				menuOptions.implementFresh as (
+					runtime: Record<string, never>,
+					signal: AbortSignal,
+				) => Promise<void>
+			)({}, controller.signal);
+		}
+		controller.abort(new DOMException("Menu closed", "AbortError"));
+	};
+	const controller = createPlanActionController({
+		loadInteractiveUi: async () =>
+			({
+				showSavedPlanMenu: (_ctx: unknown, options: Record<string, unknown>) =>
+					invokeFresh(options, "saved"),
+				showPlanModeMenu: (_ctx: unknown, options: Record<string, unknown>) =>
+					invokeFresh(options, "current"),
+				showReadyPlanMenu: (_ctx: unknown, options: Record<string, unknown>) =>
+					invokeFresh(options, "ready"),
+			}) as never,
+		getState: () => ({
+			enabled: true,
+			awaitingAction: true,
+			latestPlan: "# Plan",
+			latestPlanSource: "plan_mode_complete",
+		}),
+		captureLifecycle: () => ({
+			signal: new AbortController().signal,
+			isCurrent: () => true,
+		}),
+		statusText: () => "ready",
+		getThinkingLevel: () => "medium",
+		getSettings: () => ({ thinkingLevel: "inherit" }),
+		implementationOutcome: () => "",
+		getExportDestination: () => ({ configuredPath: "plan.md", resolvedPath: "/tmp/plan.md" }),
+		show: () => undefined,
+		finalize: () => undefined,
+		implementHere: () => undefined,
+		implementFresh: (_ctx, isCurrent, _runtime, timing) => {
+			timings.push(timing);
+			currents.push(isCurrent);
+		},
+		exportPlan: async () => false,
+		settings: async () => false,
+		save: () => undefined,
+		stay: () => undefined,
+		exitReady: () => undefined,
+		clearSaved: () => undefined,
+	});
+	const context = createMockContext({
+		hasUI: true,
+		model: { provider: "planning-provider", id: "planning-model" },
+		modelRegistry: { getAvailable: () => [] },
+	});
+
+	await controller.showSaved(context.ctx);
+	await controller.showCurrent(context.ctx);
+	await controller.showReady(context.ctx);
+
+	assert.deepEqual(timings, ["immediate", "immediate", "after-settled"]);
+	assert.deepEqual(
+		currents.map((isCurrent) => isCurrent()),
+		[false, false, true],
+	);
+});
+
 test("saved-plan fresh actions use persistent defaults and fall back from missing models", async () => {
 	const target = { provider: "target-provider", id: "target-model" };
 	const scenarios = [


### PR DESCRIPTION
## Summary

- stage automatic ready-plan fresh handoffs and start them on the next event-loop turn
- revalidate source session, workflow/menu generations, ownership, selected plan, and cancellation before replacement
- cancel pending or running handoff ownership across turns, tree changes, replacement, reload, and shutdown
- preserve immediate current-plan and saved-plan `/plan` handoffs
- add a real `ExtensionRunner` regression for later `agent_settled` and `ui_prompt_end` handlers

Closes #1263.

## Verification

- `npm exec vitest -- run packages/pi-plan-mode/test/issue-1263-repro.test.ts packages/pi-plan-mode/test/fresh-handoff-coordinator.test.ts packages/pi-plan-mode/test/plan-action-controller.test.ts packages/pi-plan-mode/test/fresh-implementation-session.test.ts packages/pi-plan-mode/test/plan-mode.test.ts packages/pi-plan-mode/test/build-runtime.test.ts` — 83 passed
- `npm --workspace @narumitw/pi-plan-mode run build`
- `npm run check`
- `npm test` — 4,593 passed
- `npm run changeset:status`
- `npm run package:pack -- plan-mode` — 43-file tarball inventory includes the generated runtime and coordinator source
- `pi --no-extensions --no-skills -e ./packages/pi-plan-mode --list-models` — exit 0, no stderr

An initial full-test compile found an incompatible callback type in the new coordinator test; it was corrected before the final full check and test reruns.

## Risks and unverified paths

- No provider-backed interactive handoff smoke was run; the deterministic real-`ExtensionRunner` regression exercises source invalidation, dispatch ordering, destination setup, and kickoff without external model use.
- README and settings documentation are unchanged because commands, settings, menu copy, and fresh-session contents are unchanged.
