### PR TITLE
chore: move pre-commit checks into shell script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run precommit
+./scripts/pre-commit.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@
 - Run commands from the repository root unless their documentation says otherwise.
 - Use `npm install` to install dependencies, `npm run format` to apply Biome formatting, and `npm run typecheck` to typecheck every workspace.
 - Run `npm run` before adding or documenting a root workflow command.
-- Keep root npm scripts as canonical entrypoints, add them only for workflows users run from the root, and move complex implementations under `scripts/`.
+- Keep root npm scripts as canonical entrypoints only for workflows users run from the root, and move complex implementations under `scripts/`.
+- Keep pre-commit hook logic in `scripts/pre-commit.sh`, invoke it directly from `.husky/pre-commit`, and do not add a duplicate root npm script.
 - Do not run root checks concurrently with a `pi-tui-kit` build or check because both clear `packages/pi-tui-kit/dist`.
 - Rebuild `pi-tui-kit` before consumer tests because consumers resolve its built output.
 - After raising a consumer's Kit floor, run root `npm install`, verify the resolution with `npm ls @narumitw/pi-tui-kit`, and then typecheck.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
 		"smoke:caffeinate-dbus": "node ./packages/pi-caffeinate/test/docker/run-docker.mjs",
 		"smoke:pi-fleet:ghostty": "cd packages/pi-fleet && tsc -p tsconfig.process-smoke.json && node ../../node_modules/.cache/pi-fleet-process/scripts/ghostty-smoke.js",
 		"check": "npm run build && node ./scripts/run-checks.mjs",
-		"precommit": "biome check --staged --no-errors-on-unmatched && node ./scripts/run-typechecks.mjs --staged",
 		"prepare": "node .husky/install.mjs",
 		"update:lock": "node ./scripts/run-dependency-update.mjs lock",
 		"update:verify": "node ./scripts/run-dependency-update.mjs verify",

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -3,7 +3,5 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-./node_modules/.bin/biome migrate --write
-./node_modules/.bin/biome format --write
-./node_modules/.bin/biome check --write
+./node_modules/.bin/biome check --staged --no-errors-on-unmatched
 node ./scripts/run-typechecks.mjs --staged

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+./node_modules/.bin/biome migrate --write
+./node_modules/.bin/biome format --write
+./node_modules/.bin/biome check --write
+node ./scripts/run-typechecks.mjs --staged

--- a/test/affected-precommit-typechecks.test.ts
+++ b/test/affected-precommit-typechecks.test.ts
@@ -211,9 +211,9 @@ test("the pre-commit hook delegates checks without narrowing the repository gate
 	);
 
 	assert.equal(hook, "./scripts/pre-commit.sh\n");
-	assert.match(preCommitScript, /biome migrate --write/u);
-	assert.match(preCommitScript, /biome format --write/u);
-	assert.match(preCommitScript, /biome check --write/u);
+	assert.equal(manifest.scripts.precommit, undefined);
+	assert.match(preCommitScript, /biome check --staged --no-errors-on-unmatched/u);
+	assert.doesNotMatch(preCommitScript, /--write/u);
 	assert.match(preCommitScript, /run-typechecks\.mjs --staged/u);
 	assert.doesNotMatch(manifest.scripts.typecheck, /--staged/u);
 });

--- a/test/affected-precommit-typechecks.test.ts
+++ b/test/affected-precommit-typechecks.test.ts
@@ -132,6 +132,7 @@ test("shared root inputs and removed workspaces fall back to all workspaces", ()
 		["package-lock.json"],
 		["tsconfig.json"],
 		["biome.json"],
+		["scripts/pre-commit.sh"],
 		["scripts/run-typechecks.mjs"],
 		["packages/removed/src/index.ts"],
 		["../outside.ts"],
@@ -199,11 +200,21 @@ test("staged file discovery tracks both rename paths and rejects unstaged manife
 	}
 });
 
-test("the pre-commit hook narrows typechecks without narrowing the repository gate", () => {
+test("the pre-commit hook delegates checks without narrowing the repository gate", () => {
 	const manifest = JSON.parse(readFileSync(path.join(repositoryRoot, "package.json"), "utf8")) as {
 		scripts: Record<string, string>;
 	};
-	assert.match(manifest.scripts.precommit, /run-typechecks\.mjs --staged/u);
+	const hook = readFileSync(path.join(repositoryRoot, ".husky", "pre-commit"), "utf8");
+	const preCommitScript = readFileSync(
+		path.join(repositoryRoot, "scripts", "pre-commit.sh"),
+		"utf8",
+	);
+
+	assert.equal(hook, "./scripts/pre-commit.sh\n");
+	assert.match(preCommitScript, /biome migrate --write/u);
+	assert.match(preCommitScript, /biome format --write/u);
+	assert.match(preCommitScript, /biome check --write/u);
+	assert.match(preCommitScript, /run-typechecks\.mjs --staged/u);
 	assert.doesNotMatch(manifest.scripts.typecheck, /--staged/u);
 });
 


### PR DESCRIPTION
## Summary

- delegate the Husky pre-commit hook directly to `scripts/pre-commit.sh` and remove the duplicate root npm script
- run staged-only, non-mutating Biome validation and affected staged typechecks from the shell script
- document and test the hook-only pre-commit workflow contract

## Checks

- `npx vitest run test/affected-precommit-typechecks.test.ts`
- `npm run check`
- `npm test`
- signed commit hook: staged Biome validation and workspace typechecks

## Changeset

- Not required; this only changes repository tooling and repository guidance.
