### PR TITLE
chore: enforce additional Biome rules

### DIFF
--- a/.pi/extensions/cache-hit-monitor/index.test.ts
+++ b/.pi/extensions/cache-hit-monitor/index.test.ts
@@ -105,7 +105,7 @@ function createContext(
 ) {
 	let entries = initialEntries;
 	const widgets: WidgetRecord[] = [];
-	const notifications: Array<[string, "info" | "warning" | "error" | undefined]> = [];
+	const notifications: [string, "info" | "warning" | "error" | undefined][] = [];
 	const sessionManager = {
 		getBranch: () => entries,
 	} as unknown as ExtensionContext["sessionManager"];

--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,7 @@
 				"noUselessTypeConstraint": "error"
 			},
 			"style": {
+				"useAsConstAssertion": "error",
 				"useConsistentArrayType": "error",
 				"useConst": "error",
 				"useShorthandFunctionType": "error",

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,19 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"preset": "recommended"
+			"preset": "recommended",
+			"complexity": {
+				"noUselessTypeConstraint": "error"
+			},
+			"style": {
+				"useConsistentArrayType": "error",
+				"useConst": "error",
+				"useShorthandFunctionType": "error",
+				"useSingleVarDeclarator": "error"
+			},
+			"suspicious": {
+				"noExtraNonNullAssertion": "error"
+			}
 		}
 	},
 	"javascript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"packages/*"
 			],
 			"devDependencies": {
-				"@biomejs/biome": "^2.5.11",
+				"@biomejs/biome": "2.5.11",
 				"@changesets/cli": "3.0.1",
 				"@earendil-works/pi-agent-core": "0.85.0",
 				"@earendil-works/pi-ai": "0.85.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"publish-packages:sequential": "node ./scripts/publish-packages-sequentially.mjs"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.11",
+		"@biomejs/biome": "2.5.11",
 		"@changesets/cli": "3.0.1",
 		"@earendil-works/pi-agent-core": "0.85.0",
 		"@earendil-works/pi-ai": "0.85.0",

--- a/packages/pi-btw/src/bring-to-main.ts
+++ b/packages/pi-btw/src/bring-to-main.ts
@@ -54,7 +54,7 @@ export type BtwTextRangeSelectorAction =
 
 export function getAnsweredTurns(
 	turns: readonly SideThreadTurn[],
-): Array<Extract<SideThreadTurn, { kind: "answered" }>> {
+): Extract<SideThreadTurn, { kind: "answered" }>[] {
 	return turns.filter(
 		(turn): turn is Extract<SideThreadTurn, { kind: "answered" }> => turn.kind === "answered",
 	);

--- a/packages/pi-chat/scripts/network-smoke.ts
+++ b/packages/pi-chat/scripts/network-smoke.ts
@@ -232,7 +232,7 @@ await smoke("two separate Node processes connect through a local DHT bootstrap",
 	const bootstrapArg = Buffer.from(JSON.stringify(testnet.bootstrap)).toString("base64url");
 	const fixturePath = fileURLToPath(new URL("./network-peer-fixture.js", import.meta.url));
 	const children: ChildProcess[] = [];
-	const messages = new Map<ChildProcess, Array<Record<string, unknown>>>();
+	const messages = new Map<ChildProcess, Record<string, unknown>[]>();
 	const errors = new Map<ChildProcess, string>();
 	const startChild = (index: number): ChildProcess => {
 		const child = fork(
@@ -385,7 +385,7 @@ async function waitFor(
 
 function childDetails(
 	children: readonly ChildProcess[],
-	messages: ReadonlyMap<ChildProcess, Array<Record<string, unknown>>>,
+	messages: ReadonlyMap<ChildProcess, Record<string, unknown>[]>,
 	errors: ReadonlyMap<ChildProcess, string>,
 ): string {
 	return children

--- a/packages/pi-chat/test/settings.test.ts
+++ b/packages/pi-chat/test/settings.test.ts
@@ -104,7 +104,7 @@ test("resume updates preserve nested unknown fields and explicit clearing remove
 		const updated = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
 		assert.deepEqual(updated.future, { keep: true });
 		assert.deepEqual(Reflect.get(updated.resume as object, "resumeFuture"), { keep: true });
-		const rooms = Reflect.get(updated.resume as object, "rooms") as Array<Record<string, unknown>>;
+		const rooms = Reflect.get(updated.resume as object, "rooms") as Record<string, unknown>[];
 		assert.equal(rooms[0]?.roomFuture, 1);
 		await updateChatSettings({ resume: null }, { settingsPath: path });
 		const cleared = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
@@ -160,7 +160,7 @@ test("v1 room ids and invites migrate in memory without side effects and preserv
 
 		await updateChatSettings({ resume: loaded.settings.resume }, { settingsPath: path });
 		const migrated = JSON.parse(await readFile(path, "utf8")) as {
-			resume: { rooms: Array<Record<string, unknown>>; resumeFuture: boolean };
+			resume: { rooms: Record<string, unknown>[]; resumeFuture: boolean };
 		};
 		assert.deepEqual(
 			migrated.resume.rooms.map(({ id, roomFuture }) => ({ id, roomFuture })),

--- a/packages/pi-codex-compact/src/settings.ts
+++ b/packages/pi-codex-compact/src/settings.ts
@@ -74,9 +74,10 @@ export function normalizeCodexCompactSettings(value: unknown): CodexCompactSetti
 	if (Object.hasOwn(value, "notifyOnFallback") && typeof value.notifyOnFallback !== "boolean") {
 		return undefined;
 	}
-	for (const [field, limits] of Object.entries(LIMITS) as Array<
-		[keyof typeof LIMITS, { minimum: number; maximum: number }]
-	>) {
+	for (const [field, limits] of Object.entries(LIMITS) as [
+		keyof typeof LIMITS,
+		{ minimum: number; maximum: number },
+	][]) {
 		if (
 			Object.hasOwn(value, field) &&
 			!validInteger(value[field], limits.minimum, limits.maximum)

--- a/packages/pi-codex-compact/test/lifecycle.test.ts
+++ b/packages/pi-codex-compact/test/lifecycle.test.ts
@@ -92,7 +92,7 @@ function fakeProvider(
 					});
 					const payload = await options?.onPayload?.({ model: activeModel.id, input }, activeModel);
 					onPreparedPayload?.(payload);
-					const payloadInput = (payload as { input: Array<Record<string, unknown>> }).input;
+					const payloadInput = (payload as { input: Record<string, unknown>[] }).input;
 					assert.equal(
 						payloadInput.at(-1)?.type === "compaction_trigger",
 						protocol === "remote-v2",
@@ -350,7 +350,7 @@ test("custom Codex Responses providers compact and replay by API and exact model
 			},
 		},
 		replayContext,
-	)) as { input: Array<Record<string, unknown>> };
+	)) as { input: Record<string, unknown>[] };
 	assert.equal(rewritten.input.at(-2)?.type, "compaction");
 	assert.match(JSON.stringify(rewritten.input.at(-1)), /later/);
 

--- a/packages/pi-codex-compact/test/remote-compact.test.ts
+++ b/packages/pi-codex-compact/test/remote-compact.test.ts
@@ -190,13 +190,13 @@ test("unary compact expands a previous checkpoint without adding a trigger", asy
 
 	assert.ok(body);
 	assert.equal(
-		(body.input as Array<Record<string, unknown>>).some(
+		(body.input as Record<string, unknown>[]).some(
 			(item) => item.type === "compaction" && item.encrypted_content === "prior",
 		),
 		true,
 	);
 	assert.equal(
-		(body.input as Array<Record<string, unknown>>).some(
+		(body.input as Record<string, unknown>[]).some(
 			(item) =>
 				item.type === "compaction_trigger" || JSON.stringify(item).includes("checkpoint marker"),
 		),

--- a/packages/pi-fleet/test/launch-integration.test.ts
+++ b/packages/pi-fleet/test/launch-integration.test.ts
@@ -18,7 +18,7 @@ posixTest(
 		const canonicalChildCwd = await realpath(childCwd);
 		const fixturePath = compiledFixture("launch-child-fixture.js");
 		let child: ChildProcessWithoutNullStreams | undefined;
-		const childEvents: Array<Record<string, unknown>> = [];
+		const childEvents: Record<string, unknown>[] = [];
 		let buffer = "";
 		const mock = createMockPi();
 		const spawnChild = async (
@@ -140,7 +140,7 @@ posixTest(
 );
 
 async function waitForChildEvent(
-	events: Array<Record<string, unknown>>,
+	events: Record<string, unknown>[],
 	predicate: (event: Record<string, unknown>) => boolean,
 ) {
 	const deadline = Date.now() + 2_000;

--- a/packages/pi-goal/src/runtime.ts
+++ b/packages/pi-goal/src/runtime.ts
@@ -172,7 +172,7 @@ export interface GoalSettingsRuntimeSnapshot {
 	budgetWrapUp?: BudgetWrapUp;
 	guardAbortGoalId?: string;
 	staleGoalToolCallsBlocked: boolean;
-	cancelledContinuationMarkers: Array<[string, string]>;
+	cancelledContinuationMarkers: [string, string][];
 	terminalDetails?: GoalTerminalDetails;
 }
 

--- a/packages/pi-goal/test/goal-budget-lifecycle.test.ts
+++ b/packages/pi-goal/test/goal-budget-lifecycle.test.ts
@@ -38,7 +38,7 @@ test("tool_execution_end pauses a goal before another turn when terminal tools d
 });
 
 test("tool_execution_end stops budget work, blocks stale tools, and releases the workflow", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	let aborts = 0;
 	const budgeted = await startGoalForTest(
 		{
@@ -93,7 +93,7 @@ test("tool_execution_end stops budget work, blocks stale tools, and releases the
 });
 
 test("rejected completion cannot revive a budget-limited goal", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -127,7 +127,7 @@ test("rejected completion cannot revive a budget-limited goal", async () => {
 });
 
 test("stale completion cannot revive a budget-limited goal", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -162,7 +162,7 @@ test("stale completion cannot revive a budget-limited goal", async () => {
 });
 
 test("budget exhaustion never queues or retries a follow-up wrap-up", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -198,7 +198,7 @@ test("budget exhaustion never queues or retries a follow-up wrap-up", async () =
 });
 
 test("budget wrap-up permission closes at agent_end and stale context is filtered", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -237,7 +237,7 @@ test("budget wrap-up permission closes at agent_end and stale context is filtere
 });
 
 test("budget stop preserves a pending transformed follow-up without resuming Goal work", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -277,7 +277,7 @@ test("budget stop preserves a pending transformed follow-up without resuming Goa
 });
 
 test("budget stop queues no custom work and remains stopped through agent_end", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -303,7 +303,7 @@ test("budget stop queues no custom work and remains stopped through agent_end", 
 });
 
 test("compaction cancels before retry when persisted usage has exhausted the budget", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -328,7 +328,7 @@ test("compaction cancels before retry when persisted usage has exhausted the bud
 });
 
 test("budget edits require an actual increase before rotating the stale id", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",
@@ -361,7 +361,7 @@ test("budget edits require an actual increase before rotating the stale id", asy
 });
 
 test("failed budget-increase edit delivery restores the limited goal and stale id", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 original objective",

--- a/packages/pi-goal/test/goal-cache-contract.test.ts
+++ b/packages/pi-goal/test/goal-cache-contract.test.ts
@@ -227,7 +227,7 @@ test("Goal activation appends its contract without changing the stable tool sche
 });
 
 test("goal_complete persists one real provider output before the inactive contract", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const allTools = [builtinTool("read"), builtinTool("bash")];
 	const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(mock.pi, DEFAULT_SETTINGS_PATH);
@@ -312,7 +312,7 @@ test("goal_complete persists one real provider output before the inactive contra
 		userMessage(followUpPrompt),
 	]);
 	const payload = await serializeProviderRequest(followUp);
-	const providerInput = payload.input as Array<Record<string, unknown>>;
+	const providerInput = payload.input as Record<string, unknown>[];
 	const outputs = providerInput.filter(
 		(item) => item.type === "function_call_output" && item.call_id === toolCallId,
 	);
@@ -328,7 +328,7 @@ test("goal_complete persists one real provider output before the inactive contra
 });
 
 test("goal_blocked persists one real provider output before the inactive contract", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const allTools = [builtinTool("read"), builtinTool("bash")];
 	const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(mock.pi, DEFAULT_SETTINGS_PATH);
@@ -418,7 +418,7 @@ test("goal_blocked persists one real provider output before the inactive contrac
 		userMessage(followUpPrompt),
 	]);
 	const payload = await serializeProviderRequest(followUp);
-	const providerInput = payload.input as Array<Record<string, unknown>>;
+	const providerInput = payload.input as Record<string, unknown>[];
 	const outputs = providerInput.filter(
 		(item) => item.type === "function_call_output" && item.call_id === toolCallId,
 	);
@@ -434,7 +434,7 @@ test("goal_blocked persists one real provider output before the inactive contrac
 });
 
 test("token-budgeted continuation and wait resume preserve the post-activation request prefix", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const allTools = [builtinTool("read"), builtinTool("bash")];
 	const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(mock.pi, DEFAULT_SETTINGS_PATH);
@@ -543,7 +543,7 @@ test("token-budgeted continuation and wait resume preserve the post-activation r
 });
 
 test("Goal identity rotation and clearing preserve the full serialized history", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const allTools = [builtinTool("read"), builtinTool("bash")];
 	const mock = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(mock.pi, DEFAULT_SETTINGS_PATH);
@@ -655,7 +655,7 @@ test("failed Goal delivery persists no undelivered contract", async () => {
 		undefined,
 	);
 
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const edited = createMockPi({ activeTools: ["read", "bash"], allTools });
 	registerGoalWithSettingsPath(edited.pi, DEFAULT_SETTINGS_PATH);
 	const editedContext = createMockContext({
@@ -803,7 +803,7 @@ test("persisting a restored waiting Goal contract does not wake the Goal", async
 });
 
 test("compacted active Goal receives one cache-stable contract after summary messages", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const mock = createMockPi();
 	registerGoalWithSettingsPath(mock.pi, DEFAULT_SETTINGS_PATH);
 	const context = createMockContext({

--- a/packages/pi-goal/test/goal-command-transitions.test.ts
+++ b/packages/pi-goal/test/goal-command-transitions.test.ts
@@ -515,7 +515,7 @@ test("failed start delivery clears a new goal and restores a replaced stopped go
 	assert.match(freshContext.notifications.at(-1)?.message ?? "", /start delivery failed/i);
 
 	let activeReplacementAborts = 0;
-	const activeReplacementBranch: Array<Record<string, unknown>> = [];
+	const activeReplacementBranch: Record<string, unknown>[] = [];
 	const activeReplacement = await startGoalForTest({
 		abort: () => activeReplacementAborts++,
 		sessionManager: {

--- a/packages/pi-goal/test/goal-contracts.test.ts
+++ b/packages/pi-goal/test/goal-contracts.test.ts
@@ -151,7 +151,7 @@ test("assistant token accounting prefers totalTokens and uses a cache-inclusive 
 });
 
 test("goal token usage subtracts its baseline and clamps branch rewinds", async () => {
-	const branch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 100 })];
+	const branch: Record<string, unknown>[] = [assistantUsageEntry({ totalTokens: 100 })];
 	const tracked = await startGoalForTest({
 		sessionManager: { getBranch: () => branch, getEntries: () => branch },
 	});

--- a/packages/pi-goal/test/goal-error-lifecycle.test.ts
+++ b/packages/pi-goal/test/goal-error-lifecycle.test.ts
@@ -522,7 +522,7 @@ test("stale exhausted recovery cannot block a replacement goal", async () => {
 });
 
 test("an exhausted goal does not remain active for a retryable provider error", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const budgeted = await startGoalForTest(
 		{ sessionManager: { getBranch: () => branch, getEntries: () => branch } },
 		"--tokens 10 finish",

--- a/packages/pi-goal/test/goal-factory-isolation.test.ts
+++ b/packages/pi-goal/test/goal-factory-isolation.test.ts
@@ -68,7 +68,7 @@ test("parent and child stable Goal tool envelopes stay isolated", async () => {
 });
 
 test("child session initialization does not erase or reroute the parent goal", async () => {
-	const rootBranch: Array<Record<string, unknown>> = [];
+	const rootBranch: Record<string, unknown>[] = [];
 	const root = createMockPi();
 	registerGoal(root.pi);
 	const rootContext = createMockContext({
@@ -214,7 +214,7 @@ test("independent goal instances keep completion local", async () => {
 });
 
 test("tool lifecycle persistence stays on the owning goal instance", async () => {
-	const rootBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 1 })];
+	const rootBranch: Record<string, unknown>[] = [assistantUsageEntry({ totalTokens: 1 })];
 	const root = createMockPi();
 	registerGoal(root.pi);
 	const rootContext = createMockContext({
@@ -223,7 +223,7 @@ test("tool lifecycle persistence stays on the owning goal instance", async () =>
 	root.events.get("session_start")?.[0]?.({}, rootContext.ctx);
 	await root.commands.get("goal")?.handler("root objective", rootContext.ctx);
 
-	const childBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 2 })];
+	const childBranch: Record<string, unknown>[] = [assistantUsageEntry({ totalTokens: 2 })];
 	const child = createMockPi();
 	registerGoal(child.pi);
 	const childContext = createMockContext({
@@ -307,7 +307,7 @@ test("goal_blocked ownership stays on the root instance after child start", asyn
 });
 
 test("pending continuation and stopped budget state survive later child startup", async () => {
-	const rootBranch: Array<Record<string, unknown>> = [assistantUsageEntry({ totalTokens: 0 })];
+	const rootBranch: Record<string, unknown>[] = [assistantUsageEntry({ totalTokens: 0 })];
 	const root = createMockPi();
 	registerGoal(root.pi);
 	const rootContext = createMockContext({

--- a/packages/pi-goal/test/goal-run-protocol.test.ts
+++ b/packages/pi-goal/test/goal-run-protocol.test.ts
@@ -671,7 +671,7 @@ test("blocked and usage-limited transitions preserve terminal reasons", async ()
 });
 
 test("budget exhaustion emits the budget-limited terminal state", async () => {
-	const branch: Array<Record<string, unknown>> = [];
+	const branch: Record<string, unknown>[] = [];
 	const mock = createMockPi({ activeTools: ["read", "bash"] });
 	registerGoal(mock);
 	const context = bindSession(

--- a/packages/pi-goal/test/support/goal-fixture.ts
+++ b/packages/pi-goal/test/support/goal-fixture.ts
@@ -186,7 +186,7 @@ export function restoreGoalForTest(
 
 export function restoreStoredGoalForTest(
 	sessionGoal: StoredGoal,
-	extraEntries: Array<Record<string, unknown>> = [],
+	extraEntries: Record<string, unknown>[] = [],
 	contextOverrides: Record<string, unknown> = {},
 	settingsPath?: string,
 ) {

--- a/packages/pi-goal/test/workflow-mutex.test.ts
+++ b/packages/pi-goal/test/workflow-mutex.test.ts
@@ -153,7 +153,7 @@ test("active and waiting Goals hold while paused and budget-limited Goals releas
 	active.mock.eventBus.emit(WORKFLOW_MUTEX_CHANNEL, pausedAttempt);
 	assert.equal(pausedAttempt.busy, false);
 
-	const budgetBranch: Array<Record<string, unknown>> = [];
+	const budgetBranch: Record<string, unknown>[] = [];
 	const budgetSession = { getBranch: () => budgetBranch, getEntries: () => budgetBranch };
 	const budget = await startGoalForTest({ sessionManager: budgetSession }, "--tokens 1 bounded");
 	budgetBranch.push(assistantUsageEntry({ totalTokens: 2 }));

--- a/packages/pi-herdr/test/herdr-observer.test.ts
+++ b/packages/pi-herdr/test/herdr-observer.test.ts
@@ -107,7 +107,7 @@ test("publishes initial siblings and applies live status and exit events", async
 		async subscribe(_endpoint, request, signal, nextEvent) {
 			assert.equal(request.method, "events.subscribe");
 			assert.deepEqual(
-				(request.params.subscriptions as Array<Record<string, unknown>>).filter(
+				(request.params.subscriptions as Record<string, unknown>[]).filter(
 					(entry) => entry.type === "pane.agent_status_changed",
 				),
 				[

--- a/packages/pi-plan-mode/src/settings.ts
+++ b/packages/pi-plan-mode/src/settings.ts
@@ -281,7 +281,7 @@ export function normalizeKeyId(value: unknown): KeyId | undefined {
 
 function normalizeSafeSubcommands(value: unknown): SafeSubcommands | undefined {
 	if (!isSettingsDocument(value)) return undefined;
-	const entries: Array<[string, string[]]> = [];
+	const entries: [string, string[]][] = [];
 	for (const [command, subcommands] of Object.entries(value)) {
 		const normalizedCommand = command.trim();
 		if (

--- a/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-runtime.test.ts
@@ -508,7 +508,7 @@ test("destination applies restored runtime during resumed session startup", asyn
 });
 
 test("destination applies restored runtime during tree navigation", async () => {
-	const branch: Array<ReturnType<typeof stateEntry>> = [];
+	const branch: ReturnType<typeof stateEntry>[] = [];
 	const mock = createMockPi({ thinkingLevel: "low" });
 	planMode(mock.pi, { readSettings: async () => ({ kind: "missing" as const }) });
 	const context = createMockContext({

--- a/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
+++ b/packages/pi-plan-mode/test/fresh-implementation-session.test.ts
@@ -671,7 +671,7 @@ test("conversation-history fresh kickoff skips active state and recovers in the 
 });
 
 test("fresh handoff treats a handled runtime kickoff as partial and restores the prompt", async () => {
-	const destinationBranch: Array<ReturnType<typeof stateEntry>> = [];
+	const destinationBranch: ReturnType<typeof stateEntry>[] = [];
 	const replacement = createMockContext({
 		mode: "rpc",
 		hasUI: true,

--- a/packages/pi-plan-mode/test/issue-471-repro.test.ts
+++ b/packages/pi-plan-mode/test/issue-471-repro.test.ts
@@ -217,7 +217,7 @@ test("issue 471: an active implementation plan is restored after compaction remo
 		{ role: "assistant", content: [{ type: "text", text: "Continuing after compaction." }] },
 	];
 	const transformed = (await contextHook({ messages: compactedMessages }, context.ctx)) as {
-		messages: Array<Record<string, unknown>>;
+		messages: Record<string, unknown>[];
 	};
 
 	assert.equal(transformed.messages.length, 4);
@@ -387,7 +387,7 @@ test("active context avoids exact handoff duplication and replaces stale injecte
 	const withHandoff = (await contextHook(
 		{ messages: [{ role: "user", content: "plan it" }, handoff] },
 		context.ctx,
-	)) as { messages: Array<Record<string, unknown>> };
+	)) as { messages: Record<string, unknown>[] };
 	assert.equal(
 		withHandoff.messages.filter(
 			(message) => message.customType === "plan-mode-implementation-context",
@@ -404,7 +404,7 @@ test("active context avoids exact handoff duplication and replaces stale injecte
 	const withStaleHandoff = (await contextHook(
 		{ messages: [staleHandoff, handoff, handoff] },
 		context.ctx,
-	)) as { messages: Array<Record<string, unknown>> };
+	)) as { messages: Record<string, unknown>[] };
 	assert.match(String(withStaleHandoff.messages[0]?.content), /CONTRACT v1: NORMAL/u);
 	assert.deepEqual(withStaleHandoff.messages.slice(1), [handoff]);
 
@@ -429,10 +429,10 @@ test("active context avoids exact handoff duplication and replaces stale injecte
 		toolResult,
 	];
 	const once = (await contextHook({ messages: compacted }, context.ctx)) as {
-		messages: Array<Record<string, unknown>>;
+		messages: Record<string, unknown>[];
 	};
 	const twice = (await contextHook({ messages: once.messages }, context.ctx)) as {
-		messages: Array<Record<string, unknown>>;
+		messages: Record<string, unknown>[];
 	};
 	for (const transformed of [once.messages, twice.messages]) {
 		assert.deepEqual(transformed[0], compacted[0]);
@@ -480,7 +480,7 @@ test("active plans can be shown and cleared through existing direct routes", asy
 			],
 		},
 		context.ctx,
-	)) as { messages: Array<Record<string, unknown>> };
+	)) as { messages: Record<string, unknown>[] };
 	assert.deepEqual(transformed.messages[0], { role: "compactionSummary", summary: "lossy" });
 	assert.match(String(transformed.messages[1]?.content), /CONTRACT v1: NORMAL/u);
 	assert.equal(transformed.messages.length, 2);
@@ -713,7 +713,7 @@ test("starting a new Plan-mode workflow supersedes the active implementation", a
 	const transformed = (await contextHook(
 		{ messages: [oldHandoff, { role: "user", content: "design a replacement" }] },
 		context.ctx,
-	)) as { messages: Array<Record<string, unknown>> };
+	)) as { messages: Record<string, unknown>[] };
 	assert.match(String(transformed.messages[0]?.content), /CONTRACT v1: PLAN/u);
 	assert.deepEqual(transformed.messages.slice(1), [
 		{ role: "user", content: "design a replacement" },
@@ -721,7 +721,7 @@ test("starting a new Plan-mode workflow supersedes the active implementation", a
 });
 
 test("a superseded session start cannot publish stale settings or UI state", async () => {
-	const settingsLoads: Array<ReturnType<typeof deferred<{ kind: "missing" }>>> = [];
+	const settingsLoads: ReturnType<typeof deferred<{ kind: "missing" }>>[] = [];
 	const mock = createMockPi({ activeTools: ["read", "edit"] });
 	planMode(mock.pi, {
 		readSettings: () => {
@@ -765,7 +765,7 @@ test("a superseded session start cannot publish stale settings or UI state", asy
 	const transformed = (await contextHook(
 		{ messages: [{ role: "branchSummary", summary: "current session" }] },
 		currentContext.ctx,
-	)) as { messages: Array<Record<string, unknown>> };
+	)) as { messages: Record<string, unknown>[] };
 	assert.deepEqual(transformed.messages, [{ role: "branchSummary", summary: "current session" }]);
 });
 
@@ -797,7 +797,7 @@ test("resume and shutdown retain branch-local implementation state while clearin
 	const transformed = (await contextHook(
 		{ messages: [{ role: "branchSummary", summary: "continued branch" }] },
 		context.ctx,
-	)) as { messages: Array<Record<string, unknown>> };
+	)) as { messages: Record<string, unknown>[] };
 	assert.match(String(transformed.messages[1]?.content), /CONTRACT v1: NORMAL/u);
 	assert.equal(transformed.messages[2]?.customType, "plan-mode-implementation-context");
 	assert.match(String(transformed.messages[2]?.content), /PLAN-PERSIST-TEST-42/);

--- a/packages/pi-starship/src/effective-config.ts
+++ b/packages/pi-starship/src/effective-config.ts
@@ -59,7 +59,7 @@ function sortedRecord(values: Readonly<Record<string, string>>): Record<string, 
 	return Object.fromEntries(sortedEntries(values));
 }
 
-function sortedEntries<Value>(values: Readonly<Record<string, Value>>): Array<[string, Value]> {
+function sortedEntries<Value>(values: Readonly<Record<string, Value>>): [string, Value][] {
 	return Object.entries(values).sort(([left], [right]) =>
 		left < right ? -1 : left > right ? 1 : 0,
 	);

--- a/packages/pi-starship/test/github-pr.test.ts
+++ b/packages/pi-starship/test/github-pr.test.ts
@@ -105,7 +105,7 @@ test("github_pr exposes compact checks, review, and prioritized status", () => {
 		`123|\u001b]8;;https://github.com/o/r/pull/123\u0007#123\u001b]8;;\u0007|open|✓1 ×2 …1|R×|×2`,
 	);
 
-	const cases: Array<[Record<string, unknown>, string]> = [
+	const cases: [Record<string, unknown>, string][] = [
 		[
 			{
 				state: "MERGED",
@@ -145,7 +145,7 @@ test("github_pr exposes compact checks, review, and prioritized status", () => {
 });
 
 test("compact PR values omit zero check categories and cover bounded decisions", () => {
-	const checkCases: Array<[unknown[], string]> = [
+	const checkCases: [unknown[], string][] = [
 		[[{ status: "COMPLETED", conclusion: "SUCCESS" }], "✓1"],
 		[[{ status: "COMPLETED", conclusion: "FAILURE" }], "×1"],
 		[[{ status: "IN_PROGRESS", conclusion: null }], "…1"],
@@ -164,7 +164,7 @@ test("compact PR values omit zero check categories and cover bounded decisions",
 		assert.equal(buildGithubPrSnapshot(rawPr({ statusCheckRollup }), NOW)?.checks, expected);
 	}
 
-	const reviewCases: Array<[unknown, string]> = [
+	const reviewCases: [unknown, string][] = [
 		["APPROVED", "R✓"],
 		["CHANGES_REQUESTED", "R×"],
 		["REVIEW_REQUIRED", "R?"],
@@ -294,7 +294,7 @@ test("queryGithubPr executes one direct cancellable bounded gh query", async () 
 });
 
 test("no PR, missing gh or auth, timeout, malformed, and oversized output degrade empty", async () => {
-	const results: Array<unknown> = [
+	const results: unknown[] = [
 		{ stdout: "", stderr: "no pull requests found", code: 1, killed: false },
 		{ stdout: "", stderr: "run gh auth login", code: 1, killed: false },
 		{ stdout: "", stderr: "", code: 1, killed: true },

--- a/packages/pi-starship/test/lifecycle.test.ts
+++ b/packages/pi-starship/test/lifecycle.test.ts
@@ -259,7 +259,7 @@ test("native PR refresh clears branch state, aborts stale work, and stops on foo
 	const stale = deferred<ExecResult>();
 	const fresh = deferred<ExecResult>();
 	const disposal = deferred<ExecResult>();
-	const prResults: Array<Promise<ExecResult>> = [
+	const prResults: Promise<ExecResult>[] = [
 		Promise.resolve(pullRequestResult(123)),
 		stale.promise,
 		fresh.promise,

--- a/packages/pi-starship/test/workspace-runtime.test.ts
+++ b/packages/pi-starship/test/workspace-runtime.test.ts
@@ -299,7 +299,7 @@ test("language commands are required by active variables and parsed strictly", a
 	const root = mkdtempSync(join(tmpdir(), "pi-starship-language-"));
 	try {
 		writeFileSync(join(root, "package.json"), "{}");
-		const calls: Array<[string, string[]]> = [];
+		const calls: [string, string[]][] = [];
 		const snapshot = await collectWorkspaceSnapshot({
 			cwd: root,
 			config: config("$nodejs", { nodejs: { format: "$symbol $version" } }),

--- a/packages/pi-subagents/test/child-communication.test.ts
+++ b/packages/pi-subagents/test/child-communication.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 test("registers fixed send and wait schemas and returns bounded results", async () => {
-	const calls: Array<Record<string, unknown>> = [];
+	const calls: Record<string, unknown>[] = [];
 	const client: ChildCommunicationClient = {
 		async send(params, signal) {
 			calls.push({ type: "send", params, signal });

--- a/packages/pi-ticker/test/menu.test.ts
+++ b/packages/pi-ticker/test/menu.test.ts
@@ -48,7 +48,7 @@ function tuiContext(
 	tui: ReturnType<typeof createTuiHarness>,
 	input: ExtensionCommandContext["ui"]["input"] = async () => undefined,
 ) {
-	const notifications: Array<[string, string | undefined]> = [];
+	const notifications: [string, string | undefined][] = [];
 	const ctx = {
 		mode: "tui",
 		hasUI: true,
@@ -64,7 +64,7 @@ function tuiContext(
 }
 
 function rpcContext(rpc: ReturnType<typeof createRpcHarness>) {
-	const notifications: Array<[string, string | undefined]> = [];
+	const notifications: [string, string | undefined][] = [];
 	const ctx = {
 		mode: "rpc",
 		hasUI: true,

--- a/packages/pi-ticker/test/ticker.test.ts
+++ b/packages/pi-ticker/test/ticker.test.ts
@@ -73,7 +73,7 @@ async function createContext(mode: ExtensionContext["mode"] = "tui") {
 	temporaryDirectories.push(cwd);
 	vi.stubEnv("PI_CODING_AGENT_DIR", cwd);
 	const widgets: WidgetRecord[] = [];
-	const notifications: Array<[string, string | undefined]> = [];
+	const notifications: [string, string | undefined][] = [];
 	const sessionManager = {} as ExtensionContext["sessionManager"];
 	const ctx = {
 		cwd,

--- a/packages/pi-ticker/test/tui-menu.test.ts
+++ b/packages/pi-ticker/test/tui-menu.test.ts
@@ -60,7 +60,7 @@ function context(
 	tui: ReturnType<typeof createTuiHarness>,
 	input: ExtensionCommandContext["ui"]["input"] = async () => undefined,
 ) {
-	const notifications: Array<[string, string | undefined]> = [];
+	const notifications: [string, string | undefined][] = [];
 	const ctx = {
 		mode: "tui",
 		hasUI: true,

--- a/packages/pi-todo/test/todo-harness.ts
+++ b/packages/pi-todo/test/todo-harness.ts
@@ -130,7 +130,7 @@ export function createContext(
 }
 
 export function identityTheme() {
-	const calls: Array<[string, string]> = [];
+	const calls: [string, string][] = [];
 	const theme = {
 		fg(role: string, text: string) {
 			calls.push(["fg", role]);

--- a/packages/pi-todo/test/todo-widget-enhancements.test.ts
+++ b/packages/pi-todo/test/todo-widget-enhancements.test.ts
@@ -229,7 +229,7 @@ test("cancels completion timers on updates, clears, tree changes, and session re
 });
 
 test("returns actionable validation errors before schema validation and direct execution", async () => {
-	const cases: Array<[unknown, RegExp]> = [
+	const cases: [unknown, RegExp][] = [
 		[null, /input must be an object.*resubmit the complete todos array/iu],
 		[{}, /todos must be an array.*resubmit/iu],
 		[

--- a/packages/pi-tool/test/tool.test.ts
+++ b/packages/pi-tool/test/tool.test.ts
@@ -620,7 +620,7 @@ test("an empty catalog remains bounded and can close", async () => {
 });
 
 test("each command reads a fresh sorted catalog and active state", async () => {
-	const allTools: Array<(typeof configuredTools)[number]> = [configuredTools[0]];
+	const allTools: (typeof configuredTools)[number][] = [configuredTools[0]];
 	const mock = createMockPi({ allTools, activeTools: [] });
 	startToolExtension(mock.pi);
 	await mock.events.get("session_start")?.[0]?.({}, createMockContext({ hasUI: true }).ctx);

--- a/packages/pi-tui-kit/src/components/document-formatting.ts
+++ b/packages/pi-tui-kit/src/components/document-formatting.ts
@@ -256,7 +256,7 @@ function markdownTableCellSources(lines: readonly string[]) {
 			continue;
 		}
 		const boundaries = markdownTableBoundaries(plainLines, index, tableStart);
-		const rows: Array<ReturnType<typeof markdownTableCells>> = [];
+		const rows: ReturnType<typeof markdownTableCells>[] = [];
 		while (index < plainLines.length && tableRowStarts[index] === tableStart) {
 			rows.push(markdownTableCells(plainLines[index] ?? "", index, boundaries));
 			index += 1;

--- a/packages/pi-tui-kit/src/components/document-search.ts
+++ b/packages/pi-tui-kit/src/components/document-search.ts
@@ -476,12 +476,12 @@ export class DocumentSearchController implements Focusable {
 		);
 	}
 
-	private highlightMatches(): Array<[number, DocumentMatch]> {
+	private highlightMatches(): [number, DocumentMatch][] {
 		if (this.count > MAX_HIGHLIGHTED_MATCHES) {
 			const current = this.currentMatch();
 			return current ? [[this.currentIndex, current]] : [];
 		}
-		const matches: Array<[number, DocumentMatch]> = [];
+		const matches: [number, DocumentMatch][] = [];
 		for (let index = 0; index < this.count; index += 1) {
 			const match = this.matchAt(index);
 			if (match) matches.push([index, match]);

--- a/packages/pi-usage/test/deepseek.test.ts
+++ b/packages/pi-usage/test/deepseek.test.ts
@@ -116,7 +116,7 @@ test("DeepSeek API balance reports provider availability without inventing quota
 });
 
 test("DeepSeek API balance rejects malformed, ambiguous, or hostile response fields", () => {
-	const invalid: Array<[DeepSeekBalancePayload, RegExp]> = [
+	const invalid: [DeepSeekBalancePayload, RegExp][] = [
 		[{}, /availability/iu],
 		[{ is_available: "yes", balance_infos: [] }, /availability/iu],
 		[{ is_available: true }, /no balance information/iu],

--- a/packages/pi-usage/test/fireworks.test.ts
+++ b/packages/pi-usage/test/fireworks.test.ts
@@ -145,7 +145,7 @@ test("Fireworks billing summary accepts empty rated line items without inventing
 });
 
 test("Fireworks billing summary rejects malformed, ambiguous, or hostile payloads", () => {
-	const invalid: Array<[Record<string, unknown>, RegExp]> = [
+	const invalid: [Record<string, unknown>, RegExp][] = [
 		[{ lineItems: "nope" }, /lineItems was not an array/iu],
 		[{ lineItems: [null] }, /line item was not an object/iu],
 		[{ lineItems: [{ category: "x" }] }, /total cost.*money object/iu],
@@ -260,7 +260,7 @@ test("Fireworks account discovery normalizes and validates the documented listin
 		}),
 		["acme", "b.io"],
 	);
-	const invalid: Array<[Record<string, unknown>, RegExp]> = [
+	const invalid: [Record<string, unknown>, RegExp][] = [
 		[{}, /did not contain an accounts array/iu],
 		[{ accounts: "acme" }, /did not contain an accounts array/iu],
 		[{ accounts: [null] }, /row was not an object/iu],

--- a/packages/pi-usage/test/kimi-coding.test.ts
+++ b/packages/pi-usage/test/kimi-coding.test.ts
@@ -125,14 +125,14 @@ test("Kimi adapter omits malformed, duplicate, unknown, and unsafe window fields
 	assert.equal(rendered.includes(TERMINAL_ESCAPE), false);
 	assert.doesNotMatch(rendered, /unknown-window/u);
 
-	const oversized = fixture("daily") as { limits?: Array<Record<string, unknown>> };
+	const oversized = fixture("daily") as { limits?: Record<string, unknown>[] };
 	const first = oversized.limits?.[0];
 	if (first) first.name = `safe${"x".repeat(10_000)}\u001b[31m`;
 	const oversizedReport = normalizeKimiCodingUsagePayload(oversized, 800);
 	assert.ok((oversizedReport.buckets[0]?.label.length ?? 0) <= 80);
 	assert.equal((oversizedReport.buckets[0]?.label ?? "").includes(TERMINAL_ESCAPE), false);
 
-	const impossibleTimestamp = fixture("daily") as { limits?: Array<Record<string, unknown>> };
+	const impossibleTimestamp = fixture("daily") as { limits?: Record<string, unknown>[] };
 	const detail = impossibleTimestamp.limits?.[0]?.detail as Record<string, unknown> | undefined;
 	if (detail) detail.resetTime = "2030-02-30T00:00:00Z";
 	assert.equal(

--- a/test/plan-goal-coexistence.test.ts
+++ b/test/plan-goal-coexistence.test.ts
@@ -92,7 +92,7 @@ async function emitLifecycle(
 function createFixture(
 	loadOrder: LoadOrder,
 	options: {
-		branch?: Array<Record<string, unknown>>;
+		branch?: Record<string, unknown>[];
 		goalRpc?: boolean;
 		planShortcut?: boolean;
 		capturePlanUi?: CapturedPlanUi;


### PR DESCRIPTION
## Summary

- enable explicit Biome rules for const assertions, consistent arrays, const declarations, shorthand function types, single variable declarators, extra non-null assertions, and useless type constraints
- apply the required shorthand array type fixes across the repository
- pin the root Biome dependency to the workspace version so CI uses the matching configuration schema

## Checks

- `npm run check`
- `npm test` — 394 files, 4593 tests
- pre-commit staged Biome check and full workspace typechecks

## Changeset

- Not required; this changes repository lint policy and source style only.