### PR TITLE
chore: disallow wildcard re-exports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,6 +20,9 @@
 			"complexity": {
 				"noUselessTypeConstraint": "error"
 			},
+			"performance": {
+				"noReExportAll": "error"
+			},
 			"style": {
 				"useAsConstAssertion": "error",
 				"useConsistentArrayType": "error",

--- a/packages/pi-plan-mode/test/support.ts
+++ b/packages/pi-plan-mode/test/support.ts
@@ -1,6 +1,12 @@
 import { createMockPi as createBaseMockPi } from "../../../test/support.js";
 
-export * from "../../../test/support.js";
+export {
+	builtinTool,
+	createCustomSelectorHarness,
+	createMockContext,
+	driveCustomSelector,
+	extensionTool,
+} from "../../../test/support.js";
 
 const PLAN_HELPERS = ["plan_mode_question", "plan_mode_complete"];
 


### PR DESCRIPTION
## Summary

- enable Biome’s `noReExportAll` performance rule
- replace the remaining wildcard test-helper export with explicit named exports
- keep the public test-support surface unchanged while making exports auditable

## Checks

- `npx biome migrate --write`
- `npx biome lint --only=lint/performance/noReExportAll .`
- `npm run check`
- `npm test` — 394 files, 4593 tests
- signed pre-commit staged Biome check and full workspace typechecks

## Changeset

- Not required; this changes repository lint policy and test support only.