### PR TITLE
feat(dotenv): add explicit env file loading

### DIFF
--- a/.changeset/fresh-dotenv-startup.md
+++ b/.changeset/fresh-dotenv-startup.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-dotenv": minor
+---
+
+Add a Pi extension that loads missing environment variables from one explicit `--env-file` before post-extension provider discovery.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The deprecated combined `pi-workflow` package has no atomic Plan-to-Goal replace
 | Package | Use it for | Install |
 | --- | --- | --- |
 | [`pi-accounts`](./packages/pi-accounts) | Switch named OpenAI Codex, Anthropic, GitHub Copilot, Kimi For Coding, OpenRouter, Radius, and xAI OAuth accounts with `/accounts`. | `pi install npm:@narumitw/pi-accounts` |
+| [`pi-dotenv`](./packages/pi-dotenv) | Load one explicit dotenv file early enough for provider credential discovery during normal Pi startup. | `pi install npm:@narumitw/pi-dotenv` |
 | [`pi-recall`](./packages/pi-recall) | Save selected text messages locally and preview or quote them across Pi sessions. | `pi install npm:@narumitw/pi-recall` |
 | [`pi-usage`](./packages/pi-usage) | View current-account Codex subscription limits or OpenRouter API-key spend limits with `/usage`. | `pi install npm:@narumitw/pi-usage` |
 | [`pi-sync`](./packages/pi-sync) | Sync allowlisted Pi settings and optional sessions through Cloudflare R2 or S3-compatible storage. | `pi install npm:@narumitw/pi-sync` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2382,6 +2382,10 @@
       "resolved": "packages/pi-codex-compact",
       "link": true
     },
+    "node_modules/@narumitw/pi-dotenv": {
+      "resolved": "packages/pi-dotenv",
+      "link": true
+    },
     "node_modules/@narumitw/pi-file-context": {
       "resolved": "packages/pi-file-context",
       "link": true
@@ -4459,6 +4463,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -7018,6 +7034,22 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "packages/pi-dotenv": {
+      "name": "@narumitw/pi-dotenv",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^17.4.2"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.85.0",
+        "@types/node": "26.4.1",
+        "typescript": "7.0.2"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*"
       }
     },
     "packages/pi-file-context": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4465,18 +4465,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -7040,9 +7028,6 @@
       "name": "@narumitw/pi-dotenv",
       "version": "0.0.1",
       "license": "MIT",
-      "dependencies": {
-        "dotenv": "^17.4.2"
-      },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.85.0",
         "@types/node": "26.4.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "./packages/pi-chat/src/index.ts",
       "./packages/pi-chrome-devtools/src/index.ts",
       "./packages/pi-codex-compact/src/index.ts",
+      "./packages/pi-dotenv/src/index.ts",
       "./packages/pi-file-context/src/index.ts",
       "./packages/pi-firecrawl/src/index.ts",
       "./packages/pi-fleet/src/index.ts",

--- a/packages/pi-dotenv/LICENSE
+++ b/packages/pi-dotenv/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-dotenv/README.md
+++ b/packages/pi-dotenv/README.md
@@ -1,0 +1,157 @@
+# 🌱 pi-dotenv — Load an Explicit Environment File for Pi
+
+[![npm](https://img.shields.io/npm/v/@narumitw/pi-dotenv)](https://www.npmjs.com/package/@narumitw/pi-dotenv) [![Pi extension](https://img.shields.io/badge/Pi-extension-blue)](https://pi.dev) [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+
+Load missing process environment variables from one explicitly selected dotenv file while Pi starts.
+The early factory-time load makes provider credentials available to Pi's post-extension model availability refresh.
+
+## ✨ Features
+
+- Adds `--env-file <path>` without implicitly reading `.env`.
+- Supports standard dotenv comments, quoting, multiline values, and empty values.
+- Loads before Pi's post-extension provider availability refresh in normal CLI startup.
+- Preserves every variable already inherited from the launching environment.
+- Keeps secret values out of extension output, Pi messages, tools, and session data.
+
+## 📦 Install
+
+Install the extension permanently:
+
+```bash
+pi install npm:@narumitw/pi-dotenv
+```
+
+Try it without installing permanently:
+
+```bash
+pi -e npm:@narumitw/pi-dotenv --env-file .env
+```
+
+Try this package locally from the repository root:
+
+```bash
+pi -e ./packages/pi-dotenv --env-file .env
+```
+
+Pi extensions run with the Pi process's user permissions, so install only trusted packages.
+The selected file may contain credentials that become available to Pi, every loaded extension, and inherited subprocesses.
+
+## 🚀 Quick start
+
+Create a dotenv file:
+
+```dotenv
+OPENAI_API_KEY=sk-example
+PI_CACHE_RETENTION=long
+```
+
+Then start Pi after installing the extension:
+
+```bash
+pi --env-file .env --provider openai --model gpt-5.4
+```
+
+A value exported by the launching shell takes precedence over the file:
+
+```bash
+OPENAI_API_KEY=from-shell pi --env-file .env
+```
+
+Relative paths resolve from the directory where Pi was launched.
+Use `--env-file=<path>` when a path begins with `-`; the last occurrence before the `--` argument terminator wins.
+
+## 🏁 CLI flag
+
+```text
+--env-file <path>  Load missing environment variables from a dotenv file
+```
+
+The flag is supported by normal interactive, print, JSON, and RPC startup, as well as `--help` and `--list-models` paths that load extensions.
+A missing or unreadable file fails extension loading without printing its contents or parsed values.
+
+Loading is process-wide and lasts until Pi exits.
+`/reload` reads the selected file again but does not replace values already loaded into the process, so restart Pi after changing a value.
+
+## ⏱️ Startup timing
+
+Current Pi help lists 42 provider or cloud variables and 6 Pi configuration variables.
+Pi's environment-variable documentation lists another 11 process configuration variables omitted from help.
+Of these 59 variables, a factory-time dotenv load can affect 55 before their relevant post-extension use, subject to provider and Pi setting precedence.
+
+The 13 late-read Pi variables are:
+
+```text
+PI_SKIP_VERSION_CHECK
+PI_TELEMETRY
+PI_CACHE_RETENTION
+PI_SHARE_VIEWER_URL
+PI_HARDWARE_CURSOR
+PI_HYPERLINKS
+PI_IMAGE_PROTOCOL
+PI_TRUE_COLOR
+PI_TUI_ESC_TIMEOUT
+VISUAL
+EDITOR
+HTTP_PROXY
+HTTPS_PROXY
+```
+
+Terminal settings override the corresponding capability environment variables.
+A startup selector may also initialize Pi's terminal capability cache before extensions load, so `PI_HYPERLINKS`, `PI_IMAGE_PROTOCOL`, and `PI_TRUE_COLOR` are not guaranteed to change an already initialized interface.
+
+`PI_OFFLINE` is only partially effective because Pi captures its main offline mode and model-network state before extension discovery.
+The following variables are too late to configure the current runtime correctly:
+
+```text
+PI_CODING_AGENT_DIR
+PI_CODING_AGENT_SESSION_DIR
+PI_PACKAGE_DIR
+```
+
+Set those variables before launching Pi instead.
+For complete pre-launch dotenv behavior, use a launcher such as:
+
+```bash
+dotenvx run -f .env -- pi
+```
+
+## 🔒 Security and privacy
+
+pi-dotenv reads only the file explicitly passed through `--env-file` and does not perform network requests.
+It does not log, render, persist, or send parsed values to the model.
+
+The values still become part of `process.env`.
+Pi extensions and commands spawned by Pi can read inherited variables, so use only trusted extensions and tools when loading credentials.
+Existing process variables are never overwritten, which also preserves Pi's process markers.
+Pi continues to inject its own session metadata into supported shell tools.
+
+## 🚧 Limitations
+
+- Pi applies registered extension flag values after extension factories finish, so pi-dotenv reparses the raw CLI arguments with Pi's exported parser during factory loading instead of calling `pi.getFlag()` there.
+- Provider discovery depends on Pi's current post-extension offline refresh sequence; compatibility tests cover that sequence for the supported Pi runtime.
+- `pi auth`, `pi install`, `pi remove`, `pi uninstall`, `pi update`, `pi list`, `pi config`, `--version`, and `--export` finish or branch before normal extension loading and cannot use this flag.
+- The extension loads one file and does not expand values such as `${OTHER_VARIABLE}`.
+- Use a pre-launch dotenv tool when every Pi startup stage must observe the file.
+
+## 🗂️ Package layout
+
+```text
+packages/pi-dotenv/
+├── src/
+│   ├── index.ts        # Thin Pi entrypoint
+│   └── dotenv.ts       # CLI resolution and environment loading
+├── test/               # Argument, lifecycle, failure, and provider-refresh tests
+├── package.json
+├── README.md
+└── LICENSE
+```
+
+The package publishes its TypeScript source entrypoint for Pi's Jiti runtime and needs no build step.
+
+## 🔎 Keywords
+
+Pi extension, Pi coding agent, dotenv, environment variables, provider credentials, API keys, startup configuration.
+
+## 📄 License
+
+MIT. See [`LICENSE`](./LICENSE).

--- a/packages/pi-dotenv/README.md
+++ b/packages/pi-dotenv/README.md
@@ -66,13 +66,18 @@ Use `--env-file=<path>` when a path begins with `-`; the last occurrence before 
 --env-file <path>  Load missing environment variables from a dotenv file
 ```
 
-The flag is supported by normal interactive, print, JSON, and RPC startup, as well as `--help` and `--list-models` paths that load extensions.
-A missing or unreadable file fails extension loading without printing its contents or parsed values.
+The flag is supported by normal interactive, print, JSON, and RPC startup.
+A valid, readable file also affects `--help` and `--list-models` paths that load extensions, but current Pi metadata paths can exit without reporting extension-load diagnostics, so do not use them to validate the file.
+Normal startup reports a missing or unreadable file as an extension-load failure without printing its contents or parsed values.
 
 Loading is process-wide and lasts until Pi exits.
 `/reload` reads the selected file again but does not replace values already loaded into the process, so restart Pi after changing a value.
 
 ## ⏱️ Startup timing
+
+These limits apply when the runtime passes `--env-file` to Pi unchanged.
+Some Node.js versions process this option themselves before Pi starts; on those launches, Node's dotenv parser and earlier timing apply, and pi-dotenv preserves the values Node already loaded.
+Use a pre-launch tool when behavior must be consistent across runtimes.
 
 Current Pi help lists 42 provider or cloud variables and 6 Pi configuration variables.
 Pi's environment-variable documentation lists another 11 process configuration variables omitted from help.

--- a/packages/pi-dotenv/package.json
+++ b/packages/pi-dotenv/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@narumitw/pi-dotenv",
+  "version": "0.0.1",
+  "description": "Pi extension that loads an explicit dotenv file during startup.",
+  "type": "module",
+  "license": "MIT",
+  "private": false,
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi",
+    "dotenv",
+    "environment-variables"
+  ],
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "check": "biome check . && npm run typecheck",
+    "format": "biome check --write .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^17.4.2"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.85.0",
+    "@types/node": "26.4.1",
+    "typescript": "7.0.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/narumiruna/pi-extensions",
+    "directory": "packages/pi-dotenv"
+  }
+}

--- a/packages/pi-dotenv/package.json
+++ b/packages/pi-dotenv/package.json
@@ -27,9 +27,6 @@
     "format": "biome check --write .",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "dotenv": "^17.4.2"
-  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"
   },

--- a/packages/pi-dotenv/src/dotenv.ts
+++ b/packages/pi-dotenv/src/dotenv.ts
@@ -27,8 +27,9 @@ export function loadEnvFile(
     throw new Error(`Could not read the file passed to ${ENV_FILE_OPTION}`);
   }
 
+  const text = content.startsWith("\uFEFF") ? content.slice(1) : content;
   const parsed = Object.fromEntries(
-    Object.entries(parseEnv(content)).filter((entry): entry is [string, string] => entry[1] !== undefined),
+    Object.entries(parseEnv(text)).filter((entry): entry is [string, string] => entry[1] !== undefined),
   );
   const env = options.env ?? process.env;
   for (const [name, value] of Object.entries(parsed)) {

--- a/packages/pi-dotenv/src/dotenv.ts
+++ b/packages/pi-dotenv/src/dotenv.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { parseEnv } from "node:util";
 import { type ExtensionAPI, parseArgs } from "@earendil-works/pi-coding-agent";
-import { parse } from "dotenv";
 
 const ENV_FILE_FLAG = "env-file";
 const ENV_FILE_OPTION = `--${ENV_FILE_FLAG}`;
@@ -27,7 +27,9 @@ export function loadEnvFile(
     throw new Error(`Could not read the file passed to ${ENV_FILE_OPTION}`);
   }
 
-  const parsed = parse(content);
+  const parsed = Object.fromEntries(
+    Object.entries(parseEnv(content)).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
   const env = options.env ?? process.env;
   for (const [name, value] of Object.entries(parsed)) {
     if (env[name] === undefined) env[name] = value;

--- a/packages/pi-dotenv/src/dotenv.ts
+++ b/packages/pi-dotenv/src/dotenv.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { type ExtensionAPI, parseArgs } from "@earendil-works/pi-coding-agent";
+import { parse } from "dotenv";
+
+const ENV_FILE_FLAG = "env-file";
+const ENV_FILE_OPTION = `--${ENV_FILE_FLAG}`;
+
+export function resolveEnvFileArgument(args: readonly string[]): string | undefined {
+  const value = parseArgs([...args]).unknownFlags.get(ENV_FILE_FLAG);
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${ENV_FILE_OPTION} requires a path`);
+  }
+  return value;
+}
+
+export function loadEnvFile(
+  path: string,
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+): Record<string, string> {
+  const filePath = resolve(options.cwd ?? process.cwd(), path);
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch {
+    throw new Error(`Could not read the file passed to ${ENV_FILE_OPTION}`);
+  }
+
+  const parsed = parse(content);
+  const env = options.env ?? process.env;
+  for (const [name, value] of Object.entries(parsed)) {
+    if (env[name] === undefined) env[name] = value;
+  }
+  return parsed;
+}
+
+export default function registerDotenvExtension(pi: ExtensionAPI): void {
+  pi.registerFlag(ENV_FILE_FLAG, {
+    description: "Load missing environment variables from a dotenv file",
+    type: "string",
+  });
+
+  const path = resolveEnvFileArgument(process.argv.slice(2));
+  if (path !== undefined) loadEnvFile(path);
+}

--- a/packages/pi-dotenv/src/index.ts
+++ b/packages/pi-dotenv/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./dotenv.js";

--- a/packages/pi-dotenv/test/dotenv-lifecycle.test.ts
+++ b/packages/pi-dotenv/test/dotenv-lifecycle.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test, vi } from "vitest";
+
+const EXTENSION_ENTRY = resolve(process.cwd(), "packages/pi-dotenv/src/index.ts");
+
+async function withTempDir(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "pi-dotenv-lifecycle-test-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function withProcessState(names: string[], run: () => Promise<void>): Promise<void> {
+  const argv = [...process.argv];
+  const values = new Map(names.map((name) => [name, process.env[name]]));
+  try {
+    await run();
+  } finally {
+    process.argv = argv;
+    for (const [name, value] of values) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+
+async function importPiWithAgentDir(agentDir: string) {
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  vi.resetModules();
+  return import("@earendil-works/pi-coding-agent");
+}
+
+test("loads through DefaultResourceLoader and remains idempotent across reload", async () => {
+  await withTempDir(async (root) => {
+    const agentDir = join(root, "agent");
+    const path = join(root, "reload.env");
+    const variable = "PI_DOTENV_RELOAD_TEST";
+    await writeFile(path, `${variable}=first\n`);
+
+    await withProcessState(["PI_CODING_AGENT_DIR", variable], async () => {
+      delete process.env[variable];
+      process.argv = [process.execPath, "pi", "--env-file", path];
+      const { DefaultResourceLoader, SettingsManager } = await importPiWithAgentDir(agentDir);
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir,
+        settingsManager: SettingsManager.inMemory(),
+        additionalExtensionPaths: [EXTENSION_ENTRY],
+        noExtensions: true,
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+        noContextFiles: true,
+      });
+
+      await loader.reload();
+      assert.deepEqual(loader.getExtensions().errors, []);
+      const flag = loader.getExtensions().extensions[0]?.flags.get("env-file");
+      assert.equal(flag?.type, "string");
+      assert.equal(flag?.description, "Load missing environment variables from a dotenv file");
+      assert.equal(process.env[variable], "first");
+
+      await writeFile(path, `${variable}=second\n`);
+      await loader.reload();
+      assert.deepEqual(loader.getExtensions().errors, []);
+      assert.equal(process.env[variable], "first");
+    });
+  });
+});
+
+test("reports an unreadable file as an extension error without exposing values or paths", async () => {
+  await withTempDir(async (root) => {
+    const agentDir = join(root, "agent");
+    const secretPath = join(root, "do-not-print-this-secret.env");
+
+    await withProcessState(["PI_CODING_AGENT_DIR"], async () => {
+      process.argv = [process.execPath, "pi", "--env-file", secretPath];
+      const { DefaultResourceLoader, SettingsManager } = await importPiWithAgentDir(agentDir);
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir,
+        settingsManager: SettingsManager.inMemory(),
+        additionalExtensionPaths: [EXTENSION_ENTRY],
+        noExtensions: true,
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+        noContextFiles: true,
+      });
+
+      await loader.reload();
+      const errors = loader.getExtensions().errors;
+      assert.equal(errors.length, 1);
+      assert.match(errors[0]?.error ?? "", /Could not read the file passed to --env-file/);
+      assert.doesNotMatch(errors[0]?.error ?? "", /do-not-print-this-secret/);
+    });
+  });
+});
+
+test("publishes a provider key before Pi's post-extension availability refresh", async () => {
+  await withTempDir(async (root) => {
+    const agentDir = join(root, "agent");
+    const path = join(root, "provider.env");
+    await writeFile(path, "OPENAI_API_KEY=pi-dotenv-fake-provider-key\n");
+
+    await withProcessState(["PI_CODING_AGENT_DIR", "OPENAI_API_KEY"], async () => {
+      delete process.env.OPENAI_API_KEY;
+      const { createAgentSessionServices, SettingsManager } = await importPiWithAgentDir(agentDir);
+      const commonOptions = {
+        cwd: root,
+        agentDir,
+        modelRuntimeSignal: AbortSignal.timeout(4_000),
+      };
+
+      const baseline = await createAgentSessionServices({
+        ...commonOptions,
+        settingsManager: SettingsManager.inMemory(),
+        resourceLoaderOptions: {
+          noExtensions: true,
+          noSkills: true,
+          noPromptTemplates: true,
+          noThemes: true,
+          noContextFiles: true,
+        },
+      });
+      assert.equal((await baseline.modelRuntime.getAvailable("openai")).length, 0);
+
+      process.argv = [process.execPath, "pi", "--env-file", path];
+      const loaded = await createAgentSessionServices({
+        ...commonOptions,
+        settingsManager: SettingsManager.inMemory(),
+        resourceLoaderOptions: {
+          additionalExtensionPaths: [EXTENSION_ENTRY],
+          noExtensions: true,
+          noSkills: true,
+          noPromptTemplates: true,
+          noThemes: true,
+          noContextFiles: true,
+        },
+      });
+
+      assert.deepEqual(loaded.resourceLoader.getExtensions().errors, []);
+      assert.ok((await loaded.modelRuntime.getAvailable("openai")).length > 0);
+    });
+  });
+});

--- a/packages/pi-dotenv/test/dotenv.test.ts
+++ b/packages/pi-dotenv/test/dotenv.test.ts
@@ -1,11 +1,9 @@
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { test } from "vitest";
-import registerDotenvExtension, { loadEnvFile, resolveEnvFileArgument } from "../src/dotenv.js";
-
-const EXTENSION_ENTRY = resolve(process.cwd(), "packages/pi-dotenv/src/index.ts");
+import { loadEnvFile, resolveEnvFileArgument } from "../src/dotenv.js";
 
 async function withTempDir(run: (root: string) => Promise<void>): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), "pi-dotenv-test-"));
@@ -13,20 +11,6 @@ async function withTempDir(run: (root: string) => Promise<void>): Promise<void> 
     await run(root);
   } finally {
     await rm(root, { recursive: true, force: true });
-  }
-}
-
-async function withProcessState(names: string[], run: () => Promise<void> | void): Promise<void> {
-  const argv = [...process.argv];
-  const values = new Map(names.map((name) => [name, process.env[name]]));
-  try {
-    await run();
-  } finally {
-    process.argv = argv;
-    for (const [name, value] of values) {
-      if (value === undefined) delete process.env[name];
-      else process.env[name] = value;
-    }
   }
 }
 
@@ -134,150 +118,5 @@ test("does not mutate the environment when the selected file is unreadable", asy
       /^Error: Could not read the file passed to --env-file$/,
     );
     assert.deepEqual(env, { PI_DOTENV_STABLE: "before" });
-  });
-});
-
-test("registers the flag and loads the file before the factory returns", async () => {
-  await withTempDir(async (root) => {
-    const path = join(root, "factory.env");
-    const variable = "PI_DOTENV_FACTORY_TEST";
-    await writeFile(path, `${variable}=factory-loaded\n`);
-
-    await withProcessState([variable], () => {
-      delete process.env[variable];
-      process.argv = [process.execPath, "pi", "--env-file", path];
-      let registered: { name: string; options: unknown } | undefined;
-
-      registerDotenvExtension({
-        registerFlag(name: string, options: unknown) {
-          registered = { name, options };
-        },
-      } as never);
-
-      assert.deepEqual(registered, {
-        name: "env-file",
-        options: {
-          description: "Load missing environment variables from a dotenv file",
-          type: "string",
-        },
-      });
-      assert.equal(process.env[variable], "factory-loaded");
-    });
-  });
-});
-
-test("loads through DefaultResourceLoader and remains idempotent across reload", async () => {
-  await withTempDir(async (root) => {
-    const agentDir = join(root, "agent");
-    const path = join(root, "reload.env");
-    const variable = "PI_DOTENV_RELOAD_TEST";
-    await writeFile(path, `${variable}=first\n`);
-
-    await withProcessState(["PI_CODING_AGENT_DIR", variable], async () => {
-      process.env.PI_CODING_AGENT_DIR = agentDir;
-      delete process.env[variable];
-      process.argv = [process.execPath, "pi", "--env-file", path];
-      const { DefaultResourceLoader, SettingsManager } = await import("@earendil-works/pi-coding-agent");
-      const loader = new DefaultResourceLoader({
-        cwd: root,
-        agentDir,
-        settingsManager: SettingsManager.inMemory(),
-        additionalExtensionPaths: [EXTENSION_ENTRY],
-        noExtensions: true,
-        noSkills: true,
-        noPromptTemplates: true,
-        noThemes: true,
-        noContextFiles: true,
-      });
-
-      await loader.reload();
-      assert.deepEqual(loader.getExtensions().errors, []);
-      assert.ok(loader.getExtensions().extensions[0]?.flags.has("env-file"));
-      assert.equal(process.env[variable], "first");
-
-      await writeFile(path, `${variable}=second\n`);
-      await loader.reload();
-      assert.deepEqual(loader.getExtensions().errors, []);
-      assert.equal(process.env[variable], "first");
-    });
-  });
-});
-
-test("reports an unreadable file as an extension error without exposing values or paths", async () => {
-  await withTempDir(async (root) => {
-    const agentDir = join(root, "agent");
-    const secretPath = join(root, "do-not-print-this-secret.env");
-
-    await withProcessState(["PI_CODING_AGENT_DIR"], async () => {
-      process.env.PI_CODING_AGENT_DIR = agentDir;
-      process.argv = [process.execPath, "pi", "--env-file", secretPath];
-      const { DefaultResourceLoader, SettingsManager } = await import("@earendil-works/pi-coding-agent");
-      const loader = new DefaultResourceLoader({
-        cwd: root,
-        agentDir,
-        settingsManager: SettingsManager.inMemory(),
-        additionalExtensionPaths: [EXTENSION_ENTRY],
-        noExtensions: true,
-        noSkills: true,
-        noPromptTemplates: true,
-        noThemes: true,
-        noContextFiles: true,
-      });
-
-      await loader.reload();
-      const errors = loader.getExtensions().errors;
-      assert.equal(errors.length, 1);
-      assert.match(errors[0]?.error ?? "", /Could not read the file passed to --env-file/);
-      assert.doesNotMatch(errors[0]?.error ?? "", /do-not-print-this-secret/);
-    });
-  });
-});
-
-test("publishes a provider key before Pi's post-extension availability refresh", async () => {
-  await withTempDir(async (root) => {
-    const agentDir = join(root, "agent");
-    const path = join(root, "provider.env");
-    await writeFile(path, "OPENAI_API_KEY=pi-dotenv-fake-provider-key\n");
-
-    await withProcessState(["PI_CODING_AGENT_DIR", "OPENAI_API_KEY"], async () => {
-      process.env.PI_CODING_AGENT_DIR = agentDir;
-      delete process.env.OPENAI_API_KEY;
-      const { createAgentSessionServices, SettingsManager } = await import("@earendil-works/pi-coding-agent");
-      const commonOptions = {
-        cwd: root,
-        agentDir,
-        modelRuntimeSignal: AbortSignal.timeout(4_000),
-      };
-
-      const baseline = await createAgentSessionServices({
-        ...commonOptions,
-        settingsManager: SettingsManager.inMemory(),
-        resourceLoaderOptions: {
-          noExtensions: true,
-          noSkills: true,
-          noPromptTemplates: true,
-          noThemes: true,
-          noContextFiles: true,
-        },
-      });
-      assert.equal((await baseline.modelRuntime.getAvailable("openai")).length, 0);
-
-      process.argv = [process.execPath, "pi", "--env-file", path];
-      const loaded = await createAgentSessionServices({
-        ...commonOptions,
-        settingsManager: SettingsManager.inMemory(),
-        resourceLoaderOptions: {
-          additionalExtensionPaths: [EXTENSION_ENTRY],
-          noExtensions: true,
-          noSkills: true,
-          noPromptTemplates: true,
-          noThemes: true,
-          noContextFiles: true,
-        },
-      });
-
-      assert.deepEqual(loaded.resourceLoader.getExtensions().errors, []);
-      assert.ok((await loaded.modelRuntime.getAvailable("openai")).length > 0);
-    });
   });
 });

--- a/packages/pi-dotenv/test/dotenv.test.ts
+++ b/packages/pi-dotenv/test/dotenv.test.ts
@@ -98,6 +98,20 @@ test("loads parsed values atomically while preserving the existing environment",
   });
 });
 
+test("strips a UTF-8 BOM from the first variable name", async () => {
+  await withTempDir(async (root) => {
+    const path = join(root, "bom.env");
+    await writeFile(path, "\uFEFFOPENAI_API_KEY=sk-dummy\nSECOND=yes\n");
+    const env: NodeJS.ProcessEnv = {};
+
+    const parsed = loadEnvFile(path, { env });
+
+    assert.deepEqual(parsed, { OPENAI_API_KEY: "sk-dummy", SECOND: "yes" });
+    assert.equal(env.OPENAI_API_KEY, "sk-dummy");
+    assert.equal(env["\uFEFFOPENAI_API_KEY"], undefined);
+  });
+});
+
 test("resolves relative paths from the supplied working directory", async () => {
   await withTempDir(async (root) => {
     await writeFile(join(root, ".env.local"), "PI_DOTENV_RELATIVE=loaded\n");

--- a/packages/pi-dotenv/test/dotenv.test.ts
+++ b/packages/pi-dotenv/test/dotenv.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "vitest";
+import registerDotenvExtension, { loadEnvFile, resolveEnvFileArgument } from "../src/dotenv.js";
+
+const EXTENSION_ENTRY = resolve(process.cwd(), "packages/pi-dotenv/src/index.ts");
+
+async function withTempDir(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "pi-dotenv-test-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function withProcessState(names: string[], run: () => Promise<void> | void): Promise<void> {
+  const argv = [...process.argv];
+  const values = new Map(names.map((name) => [name, process.env[name]]));
+  try {
+    await run();
+  } finally {
+    process.argv = argv;
+    for (const [name, value] of values) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+
+const argumentCases: Array<{ name: string; args: string[]; expected: string | undefined }> = [
+  { name: "absent", args: ["--model", "gpt-5"], expected: undefined },
+  { name: "spaced value", args: ["--env-file", ".env"], expected: ".env" },
+  { name: "equals value", args: ["--env-file=config/dev.env"], expected: "config/dev.env" },
+  {
+    name: "last occurrence",
+    args: ["--env-file", "first.env", "--env-file=second.env"],
+    expected: "second.env",
+  },
+  {
+    name: "later valid occurrence replaces a missing one",
+    args: ["--env-file", "--verbose", "--env-file", "valid.env"],
+    expected: "valid.env",
+  },
+  {
+    name: "terminator ignores later occurrences",
+    args: ["--env-file", "active.env", "--", "--env-file", "ignored.env"],
+    expected: "active.env",
+  },
+  {
+    name: "equals form accepts a dash-prefixed path",
+    args: ["--env-file=--local.env"],
+    expected: "--local.env",
+  },
+  {
+    name: "Pi option values are not reinterpreted as extension flags",
+    args: ["--system-prompt", "--env-file", ".env"],
+    expected: undefined,
+  },
+];
+
+for (const { name, args, expected } of argumentCases) {
+  test(`resolves ${name}`, () => {
+    assert.equal(resolveEnvFileArgument(args), expected);
+  });
+}
+
+const invalidArgumentCases = [
+  ["--env-file"],
+  ["--env-file="],
+  ["--env-file", ""],
+  ["--env-file", "-invalid.env"],
+  ["--env-file", "@prompt.env"],
+  ["--env-file", "valid.env", "--env-file"],
+];
+
+for (const args of invalidArgumentCases) {
+  test(`rejects an invalid final env-file occurrence: ${JSON.stringify(args)}`, () => {
+    assert.throws(() => resolveEnvFileArgument(args), /--env-file requires a path/);
+  });
+}
+
+test("loads parsed values atomically while preserving the existing environment", async () => {
+  await withTempDir(async (root) => {
+    const path = join(root, "values.env");
+    await writeFile(
+      path,
+      [
+        "# ignored comment",
+        "PI_DOTENV_NEW=from-file",
+        "PI_DOTENV_EXISTING=from-file",
+        'PI_DOTENV_QUOTED="hello world"',
+        "PI_DOTENV_EMPTY=",
+      ].join("\n"),
+    );
+    const env: NodeJS.ProcessEnv = { PI_DOTENV_EXISTING: "from-shell" };
+
+    const parsed = loadEnvFile(path, { env });
+
+    assert.deepEqual(parsed, {
+      PI_DOTENV_NEW: "from-file",
+      PI_DOTENV_EXISTING: "from-file",
+      PI_DOTENV_QUOTED: "hello world",
+      PI_DOTENV_EMPTY: "",
+    });
+    assert.deepEqual(env, {
+      PI_DOTENV_NEW: "from-file",
+      PI_DOTENV_EXISTING: "from-shell",
+      PI_DOTENV_QUOTED: "hello world",
+      PI_DOTENV_EMPTY: "",
+    });
+  });
+});
+
+test("resolves relative paths from the supplied working directory", async () => {
+  await withTempDir(async (root) => {
+    await writeFile(join(root, ".env.local"), "PI_DOTENV_RELATIVE=loaded\n");
+    const env: NodeJS.ProcessEnv = {};
+
+    loadEnvFile(".env.local", { cwd: root, env });
+
+    assert.equal(env.PI_DOTENV_RELATIVE, "loaded");
+  });
+});
+
+test("does not mutate the environment when the selected file is unreadable", async () => {
+  await withTempDir(async (root) => {
+    const env: NodeJS.ProcessEnv = { PI_DOTENV_STABLE: "before" };
+
+    assert.throws(
+      () => loadEnvFile(join(root, "missing-secret-name.env"), { env }),
+      /^Error: Could not read the file passed to --env-file$/,
+    );
+    assert.deepEqual(env, { PI_DOTENV_STABLE: "before" });
+  });
+});
+
+test("registers the flag and loads the file before the factory returns", async () => {
+  await withTempDir(async (root) => {
+    const path = join(root, "factory.env");
+    const variable = "PI_DOTENV_FACTORY_TEST";
+    await writeFile(path, `${variable}=factory-loaded\n`);
+
+    await withProcessState([variable], () => {
+      delete process.env[variable];
+      process.argv = [process.execPath, "pi", "--env-file", path];
+      let registered: { name: string; options: unknown } | undefined;
+
+      registerDotenvExtension({
+        registerFlag(name: string, options: unknown) {
+          registered = { name, options };
+        },
+      } as never);
+
+      assert.deepEqual(registered, {
+        name: "env-file",
+        options: {
+          description: "Load missing environment variables from a dotenv file",
+          type: "string",
+        },
+      });
+      assert.equal(process.env[variable], "factory-loaded");
+    });
+  });
+});
+
+test("loads through DefaultResourceLoader and remains idempotent across reload", async () => {
+  await withTempDir(async (root) => {
+    const agentDir = join(root, "agent");
+    const path = join(root, "reload.env");
+    const variable = "PI_DOTENV_RELOAD_TEST";
+    await writeFile(path, `${variable}=first\n`);
+
+    await withProcessState(["PI_CODING_AGENT_DIR", variable], async () => {
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+      delete process.env[variable];
+      process.argv = [process.execPath, "pi", "--env-file", path];
+      const { DefaultResourceLoader, SettingsManager } = await import("@earendil-works/pi-coding-agent");
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir,
+        settingsManager: SettingsManager.inMemory(),
+        additionalExtensionPaths: [EXTENSION_ENTRY],
+        noExtensions: true,
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+        noContextFiles: true,
+      });
+
+      await loader.reload();
+      assert.deepEqual(loader.getExtensions().errors, []);
+      assert.ok(loader.getExtensions().extensions[0]?.flags.has("env-file"));
+      assert.equal(process.env[variable], "first");
+
+      await writeFile(path, `${variable}=second\n`);
+      await loader.reload();
+      assert.deepEqual(loader.getExtensions().errors, []);
+      assert.equal(process.env[variable], "first");
+    });
+  });
+});
+
+test("reports an unreadable file as an extension error without exposing values or paths", async () => {
+  await withTempDir(async (root) => {
+    const agentDir = join(root, "agent");
+    const secretPath = join(root, "do-not-print-this-secret.env");
+
+    await withProcessState(["PI_CODING_AGENT_DIR"], async () => {
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+      process.argv = [process.execPath, "pi", "--env-file", secretPath];
+      const { DefaultResourceLoader, SettingsManager } = await import("@earendil-works/pi-coding-agent");
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir,
+        settingsManager: SettingsManager.inMemory(),
+        additionalExtensionPaths: [EXTENSION_ENTRY],
+        noExtensions: true,
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+        noContextFiles: true,
+      });
+
+      await loader.reload();
+      const errors = loader.getExtensions().errors;
+      assert.equal(errors.length, 1);
+      assert.match(errors[0]?.error ?? "", /Could not read the file passed to --env-file/);
+      assert.doesNotMatch(errors[0]?.error ?? "", /do-not-print-this-secret/);
+    });
+  });
+});
+
+test("publishes a provider key before Pi's post-extension availability refresh", async () => {
+  await withTempDir(async (root) => {
+    const agentDir = join(root, "agent");
+    const path = join(root, "provider.env");
+    await writeFile(path, "OPENAI_API_KEY=pi-dotenv-fake-provider-key\n");
+
+    await withProcessState(["PI_CODING_AGENT_DIR", "OPENAI_API_KEY"], async () => {
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+      delete process.env.OPENAI_API_KEY;
+      const { createAgentSessionServices, SettingsManager } = await import("@earendil-works/pi-coding-agent");
+      const commonOptions = {
+        cwd: root,
+        agentDir,
+        modelRuntimeSignal: AbortSignal.timeout(4_000),
+      };
+
+      const baseline = await createAgentSessionServices({
+        ...commonOptions,
+        settingsManager: SettingsManager.inMemory(),
+        resourceLoaderOptions: {
+          noExtensions: true,
+          noSkills: true,
+          noPromptTemplates: true,
+          noThemes: true,
+          noContextFiles: true,
+        },
+      });
+      assert.equal((await baseline.modelRuntime.getAvailable("openai")).length, 0);
+
+      process.argv = [process.execPath, "pi", "--env-file", path];
+      const loaded = await createAgentSessionServices({
+        ...commonOptions,
+        settingsManager: SettingsManager.inMemory(),
+        resourceLoaderOptions: {
+          additionalExtensionPaths: [EXTENSION_ENTRY],
+          noExtensions: true,
+          noSkills: true,
+          noPromptTemplates: true,
+          noThemes: true,
+          noContextFiles: true,
+        },
+      });
+
+      assert.deepEqual(loaded.resourceLoader.getExtensions().errors, []);
+      assert.ok((await loaded.modelRuntime.getAvailable("openai")).length > 0);
+    });
+  });
+});

--- a/packages/pi-dotenv/tsconfig.json
+++ b/packages/pi-dotenv/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "types": ["node"],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add the publishable `@narumitw/pi-dotenv` extension with `--env-file <path>` and shell-environment precedence
- load the selected dotenv file synchronously during extension factory evaluation so Pi's post-extension provider refresh sees new credentials
- use Node's built-in `parseEnv()` with no third-party runtime dependency and normalize a leading UTF-8 BOM
- document startup timing, the 55 affectable Pi/provider variables, partial `PI_OFFLINE` behavior, the three too-early startup variables, metadata-diagnostic limits, Node-native option handling, and process-wide secret exposure
- add workspace discovery, package metadata, isolated lifecycle coverage, and a minor Changeset

## Verification

- `npx vitest run packages/pi-dotenv/test/dotenv.test.ts packages/pi-dotenv/test/dotenv-lifecycle.test.ts` — 21 tests passed in 2 files
- `npm run check` — passed builds, Biome, boundaries, and all workspace typechecks
- `npm test` — 4,614 tests passed in 396 files
- `npm run package:pack -- dotenv` — dry-run package contained only the manifest, README, license, and two source files; the package has no third-party runtime dependencies
- isolated Pi Jiti smokes passed for provider loading, a BOM-prefixed provider credential, and extension flag display in `--help`
- direct Pi `main()` metadata smoke confirmed current extension-load diagnostics are suppressed on missing-file `--help`
- fenced-code-aware README heading audit passed for all 30 packages

## Risks and unverified paths

- Provider discovery relies on Pi's current post-extension offline refresh sequence; the integration test and package smoke cover the supported runtime sequence.
- Current Pi metadata paths can suppress extension-load diagnostics; the README limits those paths to valid readable files and warns against using them for validation.
- Some Node.js versions process `--env-file` before Pi starts; the README distinguishes Node-owned parsing and timing from extension factory timing.
- Loaded values are process-wide and visible to trusted extensions and inherited subprocesses; the README documents this boundary.
- No live provider API request was made because credential discovery is covered deterministically with a fake key and offline runtime.
