### PR TITLE
fix(tui-kit): preserve queued setting revisions

### DIFF
--- a/.changeset/quiet-settings-revisions.md
+++ b/.changeset/quiet-settings-revisions.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": patch
+---
+
+Keep optimistic setting values stable when an older rejected save requests the same value as a newer queued change.

--- a/packages/pi-tui-kit/src/components/index.ts
+++ b/packages/pi-tui-kit/src/components/index.ts
@@ -372,7 +372,7 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
   let filteredItems = searchableItems;
   const committed = new Map(options.screen.items.map((item) => [item.id, item.currentValue]));
   const displayed = new Map(committed);
-  const latestRequested = new Map<string, string>();
+  const revisions = new Map<string, number>();
   let selectedIndex = Math.max(
     0,
     filteredItems.findIndex(({ item }) => item.id === options.selectedItemId),
@@ -409,7 +409,8 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
     const currentIndex = values.indexOf(currentValue);
     const value = values[(currentIndex + 1) % values.length] ?? currentValue;
     displayed.set(item.id, value);
-    latestRequested.set(item.id, value);
+    const revision = (revisions.get(item.id) ?? 0) + 1;
+    revisions.set(item.id, revision);
     const operation = pending.then(async () => {
       if (disposed) return;
       const previousValue = committed.get(item.id) ?? item.currentValue;
@@ -427,7 +428,7 @@ function createSettingsComponent<ScreenId extends string, ActionId extends strin
       if (disposed) return;
       const accepted = typeof response === "boolean" ? response : response.accepted;
       if (accepted) committed.set(item.id, value);
-      else if (latestRequested.get(item.id) === value) displayed.set(item.id, previousValue);
+      else if (revisions.get(item.id) === revision) displayed.set(item.id, previousValue);
       options.tui.requestRender();
       if (accepted && typeof response !== "boolean") {
         closing = true;

--- a/packages/pi-tui-kit/test/screen-components.test.ts
+++ b/packages/pi-tui-kit/test/screen-components.test.ts
@@ -821,6 +821,54 @@ test("settings changes serialize, roll back rejection, and drain before Back", a
   assert.match(harness.component.render(80).join("\n"), /On/);
 });
 
+test("settings ignore stale rejection after a value cycles back to a newer request", async () => {
+  let releaseFirst: (() => void) | undefined;
+  let releaseSecond: (() => void) | undefined;
+  let markSecondStarted: (() => void) | undefined;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const secondGate = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
+  });
+  const secondStarted = new Promise<void>((resolve) => {
+    markSecondStarted = resolve;
+  });
+  let calls = 0;
+  const setting = settingsScreen.items[0];
+  assert.ok(setting);
+  const harness = componentHarness(
+    {
+      ...settingsScreen,
+      items: [setting],
+    },
+    {
+      plainTheme: true,
+      onSettingChange: async () => {
+        calls += 1;
+        if (calls === 1) await firstGate;
+        if (calls === 2) {
+          markSecondStarted?.();
+          await secondGate;
+        }
+        return false;
+      },
+    },
+  );
+
+  harness.component.handleInput("l");
+  harness.component.handleInput("l");
+  harness.component.handleInput("l");
+  releaseFirst?.();
+  await secondStarted;
+  assert.match(harness.component.render(80).join("\n"), /On/);
+
+  releaseSecond?.();
+  await harness.component.waitForPending();
+  assert.equal(calls, 3);
+  assert.match(harness.component.render(80).join("\n"), /Off/);
+});
+
 test("accepted setting transitions fire only after pending state is settled", async () => {
   const harness = componentHarness(settingsScreen, {
     onSettingChange: async () => ({ accepted: true, transition: { kind: "close" } }),


### PR DESCRIPTION
## Summary

- track optimistic setting saves by per-row revision instead of requested value
- prevent an older rejected save from rolling back a newer queued request when values cycle
- add deterministic regression coverage and a patch Changeset

## Verification

- `npm --workspace @narumitw/pi-tui-kit run check`
- `npx vitest run packages/pi-tui-kit/test/*.test.ts` (368 tests)
- `npm run check`
- `npm test` (4,614 tests)

## Semantic audit

- reviewed against `docs/extension-conventions.md` and `packages/pi-tui-kit/AGENTS.md`
- settings serialization, cancellation, disposal, pending-work draining, and transitions remain unchanged
- package loading smoke not required because exports, metadata, and runtime loading are unchanged
