### PR TITLE
feat(pi-herdr): clean up completed task panes

### DIFF
--- a/.changeset/calm-herdr-panes-close.md
+++ b/.changeset/calm-herdr-panes-close.md
@@ -1,5 +1,5 @@
 ---
-"@narumitw/pi-herdr": patch
+"@narumitw/pi-herdr": minor
 ---
 
-Close no-longer-needed task-owned Herdr panes promptly after their results are collected and their live state is safe.
+Add guarded automatic cleanup guidance for temporary task-owned Herdr panes, with explicit retention and safe fallback behavior.

--- a/.changeset/calm-herdr-panes-close.md
+++ b/.changeset/calm-herdr-panes-close.md
@@ -2,4 +2,4 @@
 "@narumitw/pi-herdr": patch
 ---
 
-Close completed task-owned Herdr panes proactively after their results are collected.
+Close no-longer-needed task-owned Herdr panes promptly after their results are collected and their live state is safe.

--- a/.changeset/calm-herdr-panes-close.md
+++ b/.changeset/calm-herdr-panes-close.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-herdr": patch
+---
+
+Close completed task-owned Herdr panes proactively after their results are collected.

--- a/packages/pi-herdr/README.md
+++ b/packages/pi-herdr/README.md
@@ -56,6 +56,13 @@ rm -rf ~/.agents/skills/herdr
 
 Run `/reload` or restart Pi after changing the installed resources.
 
+## 🧠 Skills
+
+The bundled `herdr` skill loads version-matched operating guidance after an explicit Herdr request.
+It treats panes created for background work as temporary and attempts to close them after collecting the required output.
+Ask Pi explicitly to keep a pane open after the task when you want to inspect or use it later.
+Automatic cleanup runs only when the installed Herdr guidance provides a conditional close that atomically confirms the recorded pane ownership and acceptable agent or shell state; otherwise Pi leaves the pane open and reports the limitation.
+
 ## 💬 Commands
 
 `/herdr` opens a menu to toggle the agent widget and view status or help, inspired by `/tool`.
@@ -166,6 +173,7 @@ Command recipes, approval handling, and other operating safety rules come from t
 - Integration requires a running compatible Herdr session and valid injected environment variables.
 - Model control requires an installed Herdr CLI that supports `herdr --skill`.
 - Socket failures are intentionally silent after the bounded retry.
+- Skill cleanup tracking exists only in the active model context, so compaction, session replacement, `/reload`, or shutdown can leave temporary panes open.
 - The package does not install, start, update, or configure Herdr itself.
 
 ## 🗂️ Package layout

--- a/packages/pi-herdr/skills/herdr/SKILL.md
+++ b/packages/pi-herdr/skills/herdr/SKILL.md
@@ -23,13 +23,12 @@ Run it again only after compaction removes those instructions or when the user e
 
 Apply this cleanup policy in addition to those version-specific instructions:
 
-- Maintain a cleanup ledger for the Herdr session with each pane ID you create, its intended lifetime, and, for an agent pane, the assigned agent identity plus the strongest stable session or process identity that Herdr exposes.
-- Mark a pane as retained when the user asks to keep, inspect, or use it later, or when its continued existence is part of the requested result, and never close a retained pane automatically.
-- For a temporary pane, collect the required output, decide that no follow-up is needed, and clean it up as soon as its work is no longer needed.
-- Immediately before cleanup, use the loaded version-specific instructions to read live state and confirm that the pane is still the recorded resource instead of relying on an earlier result or status alone.
-- Clean up an agent pane only when its current agent and every recorded stable identity match the ledger and its state is `idle` or `done`; if identity changed or cannot be confirmed, leave the pane open.
-- If the recorded agent has exited, or an ordinary command has finished, clean up the pane only after it has returned to an available shell with no replacement occupant or foreground process.
-- Use the pane-closing operation documented by the loaded instructions; do not assume command syntax that they do not provide.
-- Keep unresolved temporary entries after cancellation or interruption, retry safe cleanup at the next recovery boundary before further Herdr work, and sweep them again before the final response.
+- Maintain an in-context cleanup ledger with each pane ID you create, its intended lifetime, and, for an agent pane, the assigned agent identity plus the strongest stable session or process identity that Herdr exposes.
+- Mark a pane as retained only when the user explicitly asks it to remain open after the task for later inspection or use, or when its continued existence is itself part of the requested result, and never close a retained pane automatically.
+- For a temporary pane, collect the required output, decide that no follow-up is needed, and attempt cleanup as soon as its work is no longer needed.
+- Automatically close a pane only through an operation documented by the loaded instructions that atomically checks the recorded pane and occupant identity together with an acceptable live state at mutation time.
+- For an agent pane, the atomic guard must match every recorded stable identity and require `idle` or `done`; for a returned shell, it must require no replacement occupant or foreground process.
+- A separate state read followed by an unconditional close is unsafe; if the installed Herdr version provides no suitable guarded close, leave the pane open and report that limitation.
+- Keep unresolved temporary entries after cancellation or interruption while the current model context survives, retry guarded cleanup at the next recovery boundary before further Herdr work, and sweep them again before the final response.
 - Never close the calling pane, a pre-existing pane, or a pane created by the user or another agent.
-- If safe cleanup cannot be confirmed or closure fails, keep the ledger entry and report the pane ID and reason.
+- If guarded closure fails, keep the ledger entry and report the pane ID and reason.

--- a/packages/pi-herdr/skills/herdr/SKILL.md
+++ b/packages/pi-herdr/skills/herdr/SKILL.md
@@ -23,11 +23,11 @@ Run it again only after compaction removes those instructions or when the user e
 
 Apply this cleanup policy in addition to those version-specific instructions:
 
-- Maintain an in-context cleanup ledger with each pane ID you create, its intended lifetime, and, for an agent pane, the assigned agent identity plus the strongest stable session or process identity that Herdr exposes.
+- Maintain an in-context cleanup ledger with each pane ID you create, its intended lifetime, and every stable pane-generation, terminal, and shell identity that Herdr exposes; for an agent pane, also record the assigned agent and stable agent-session or occupant-process identity.
 - Mark a pane as retained only when the user explicitly asks it to remain open after the task for later inspection or use, or when its continued existence is itself part of the requested result, and never close a retained pane automatically.
 - For a temporary pane, collect the required output, decide that no follow-up is needed, and attempt cleanup as soon as its work is no longer needed.
 - Automatically close a pane only through an operation documented by the loaded instructions that atomically checks the recorded pane and occupant identity together with an acceptable live state at mutation time.
-- For an agent pane, the atomic guard must match every recorded stable identity and require `idle` or `done`; for a returned shell, it must require no replacement occupant or foreground process.
+- For an agent pane, the atomic guard must match the assigned agent and every recorded stable identity and require `idle` or `done`; for a returned shell, it must match the recorded pane-generation, terminal, and shell identities and require no replacement occupant or foreground process.
 - A separate state read followed by an unconditional close is unsafe; if the installed Herdr version provides no suitable guarded close, leave the pane open and report that limitation.
 - Keep unresolved temporary entries after cancellation or interruption while the current model context survives, retry guarded cleanup at the next recovery boundary before further Herdr work, and sweep them again before the final response.
 - Never close the calling pane, a pre-existing pane, or a pane created by the user or another agent.

--- a/packages/pi-herdr/skills/herdr/SKILL.md
+++ b/packages/pi-herdr/skills/herdr/SKILL.md
@@ -23,10 +23,10 @@ Run it again only after compaction removes those instructions or when the user e
 
 Apply this cleanup policy in addition to those version-specific instructions:
 
-- Track every pane that you create for the current task.
-- Treat `idle` and `done` as ready states, not proof that a pane is disposable.
-- After collecting the result and deciding that no follow-up is needed, inspect an agent again and close its pane with `herdr pane close <pane-id>` only when the agent is still `idle` or `done`; closing the pane also ends that agent.
-- Close an ordinary command pane only after its command has finished and the shell is available again.
-- Never close the calling pane, a pre-existing pane, or a pane created by the user or another agent.
-- Never close an agent in `working`, `blocked`, or `unknown`; leave it open and report why cleanup was deferred.
-- Before the final response, make a cleanup pass over panes you created so completed background work does not remain open.
+- Record the ID of every pane that you create for the current task; discovering a pane later is not proof that you own it.
+- Clean up each owned pane as soon as its work is no longer needed, and sweep owned panes again before the final response.
+- Immediately before closing a pane, read its live pane and agent state again instead of relying on an earlier result.
+- For an agent pane, first collect the required output and decide that no follow-up is needed, then close it with `herdr pane close <pane-id>` only when the agent is `idle` or `done`; closing the pane also ends that agent.
+- If an owned agent has already exited, or an ordinary command has finished, close the pane only after it has returned to an available shell.
+- Never close the calling pane, a pre-existing pane, a pane created by the user or another agent, an agent in `working`, `blocked`, or `unknown`, or a pane with another foreground process.
+- If safe cleanup cannot be confirmed or the close fails, leave the pane open and report the pane ID and reason.

--- a/packages/pi-herdr/skills/herdr/SKILL.md
+++ b/packages/pi-herdr/skills/herdr/SKILL.md
@@ -23,10 +23,13 @@ Run it again only after compaction removes those instructions or when the user e
 
 Apply this cleanup policy in addition to those version-specific instructions:
 
-- Record the ID of every pane that you create for the current task; discovering a pane later is not proof that you own it.
-- Clean up each owned pane as soon as its work is no longer needed, and sweep owned panes again before the final response.
-- Immediately before closing a pane, read its live pane and agent state again instead of relying on an earlier result.
-- For an agent pane, first collect the required output and decide that no follow-up is needed, then close it with `herdr pane close <pane-id>` only when the agent is `idle` or `done`; closing the pane also ends that agent.
-- If an owned agent has already exited, or an ordinary command has finished, close the pane only after it has returned to an available shell.
-- Never close the calling pane, a pre-existing pane, a pane created by the user or another agent, an agent in `working`, `blocked`, or `unknown`, or a pane with another foreground process.
-- If safe cleanup cannot be confirmed or the close fails, leave the pane open and report the pane ID and reason.
+- Maintain a cleanup ledger for the Herdr session with each pane ID you create, its intended lifetime, and, for an agent pane, the assigned agent identity plus the strongest stable session or process identity that Herdr exposes.
+- Mark a pane as retained when the user asks to keep, inspect, or use it later, or when its continued existence is part of the requested result, and never close a retained pane automatically.
+- For a temporary pane, collect the required output, decide that no follow-up is needed, and clean it up as soon as its work is no longer needed.
+- Immediately before cleanup, use the loaded version-specific instructions to read live state and confirm that the pane is still the recorded resource instead of relying on an earlier result or status alone.
+- Clean up an agent pane only when its current agent and every recorded stable identity match the ledger and its state is `idle` or `done`; if identity changed or cannot be confirmed, leave the pane open.
+- If the recorded agent has exited, or an ordinary command has finished, clean up the pane only after it has returned to an available shell with no replacement occupant or foreground process.
+- Use the pane-closing operation documented by the loaded instructions; do not assume command syntax that they do not provide.
+- Keep unresolved temporary entries after cancellation or interruption, retry safe cleanup at the next recovery boundary before further Herdr work, and sweep them again before the final response.
+- Never close the calling pane, a pre-existing pane, or a pane created by the user or another agent.
+- If safe cleanup cannot be confirmed or closure fails, keep the ledger entry and report the pane ID and reason.

--- a/packages/pi-herdr/skills/herdr/SKILL.md
+++ b/packages/pi-herdr/skills/herdr/SKILL.md
@@ -20,3 +20,13 @@ herdr --skill
 If the environment check or command fails, report the error and stop.
 Read the returned skill completely and follow it as the authoritative operating instructions for the installed Herdr version.
 Run it again only after compaction removes those instructions or when the user explicitly asks to refresh them.
+
+Apply this cleanup policy in addition to those version-specific instructions:
+
+- Track every pane that you create for the current task.
+- Treat `idle` and `done` as ready states, not proof that a pane is disposable.
+- After collecting the result and deciding that no follow-up is needed, inspect an agent again and close its pane with `herdr pane close <pane-id>` only when the agent is still `idle` or `done`; closing the pane also ends that agent.
+- Close an ordinary command pane only after its command has finished and the shell is available again.
+- Never close the calling pane, a pre-existing pane, or a pane created by the user or another agent.
+- Never close an agent in `working`, `blocked`, or `unknown`; leave it open and report why cleanup was deferred.
+- Before the final response, make a cleanup pass over panes you created so completed background work does not remain open.


### PR DESCRIPTION
## Summary

- track temporary and explicitly retained task-owned panes in the active model context
- record stable pane, terminal, shell, agent, session, and occupant identities when exposed
- preserve panes requested for use after task completion
- allow automatic cleanup only through an installed version's atomic conditional close operation
- leave panes open when ownership and acceptable agent or shell state cannot be guarded at mutation time
- document automatic cleanup behavior and context-lifetime limitations
- add a minor changeset for `@narumitw/pi-herdr`

## Verification

- `npx vitest run packages/pi-herdr/test/herdr-skill.test.ts`
- `npm --workspace @narumitw/pi-herdr run check`
- fenced-code-aware active-package README heading audit
- `npm run check`
- `npm test`
- `npm run package:pack -- herdr`
- `npm run changeset:status`
