### PR TITLE
fix: add missing dependency changesets

### DIFF
--- a/.changeset/clean-langfuse-traces.md
+++ b/.changeset/clean-langfuse-traces.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-langfuse": patch
+---
+
+Publish the updated Langfuse tracing and OpenTelemetry runtime dependency ranges.

--- a/.changeset/clear-tuis-differ.md
+++ b/.changeset/clear-tuis-differ.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-tui-kit": patch
+---
+
+Publish and document Diff 9 as the runtime dependency used for text comparisons.

--- a/.changeset/steady-starships-parse.md
+++ b/.changeset/steady-starships-parse.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-starship": patch
+---
+
+Publish the updated YAML runtime dependency range.


### PR DESCRIPTION
## Summary

- add patch changesets for the published runtime dependency updates merged in #1294
- cover `@narumitw/pi-langfuse`, `@narumitw/pi-starship`, and `@narumitw/pi-tui-kit`
- ensure the release workflow publishes and documents each dependency update

## Evidence

The #1294 manifest diff changed runtime dependencies in exactly these three publishable packages. The registry already received Diff 9 through the unrelated TUI Kit 0.63.0 release, but its changelog did not record that update; the Langfuse and Starship registry manifests still contain their prior dependency ranges.

## Verification

- `npm run changeset:status`
- `npm run check`
- `npm test` — 400 files and 4,680 tests passed
- `npm run package:pack -- langfuse`
- `npm run package:pack -- starship`
- `npm run package:pack -- tui-kit`
