### PR TITLE
feat(statusline): session segment and a flush-right rightSegments column

### DIFF
--- a/.changeset/lucky-sessions-shine.md
+++ b/.changeset/lucky-sessions-shine.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-statusline": minor
+---
+
+Add a `session` segment that shows the current Pi session name (set via `/name`) in the footer. It stays hidden until the session is named and refreshes on rename.

--- a/.changeset/thin-rivers-double.md
+++ b/.changeset/thin-rivers-double.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-statusline": minor
+---
+
+Add a `rightSegments` field that renders a flush-right column beside the existing segments on the same rows, with each column fitting independently when the terminal narrows. Information levels now place session, provider, and model in the right column, and data segments stay unique across both columns.

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -7,7 +7,7 @@ Add a Powerline-style footer that works without setup and keeps important Pi, wo
 A representative uncolored layout:
 
 ```text
-░▒▓ 🤖 sonnet-4 🧠 high 📁 pi-extensions 🌿 main ~2 🪟 ctx 42.0%/200k 🕒 16:42
+░▒▓ 🧠 high 📁 pi-extensions 🌿 main ~2🧿 ctx 42.0%/200k 🕒 16:42     🏷️ openai-pr 🔌 openai 🤖 sonnet-4 
 ```
 
 ## ✨ Features
@@ -74,12 +74,12 @@ Help
 
 Selecting a level replaces only `segments` and preserves unrelated JSON fields.
 
-| Level | Included segments |
-| --- | --- |
-| **Minimal** | `model cwd branch context` |
-| **Balanced** (default) | `model thinking cwd branch tools context time` |
-| **Detailed** | `provider model thinking cwd branch tools context tokens cache cost time` |
-| **Custom** | Any other segment order, including explicit line breaks |
+| Level | Left column segments | Right column segments |
+| --- | --- | --- |
+| **Minimal** | `cwd branch context` | `model` |
+| **Balanced** (default) | `thinking cwd branch tools context time` | `session provider model` |
+| **Detailed** | `thinking cwd branch tools context tokens cache cost time` | `session provider model` |
+| **Custom** | Any other order in either column, including explicit line breaks | |
 
 The `tools` segment takes no space while idle.
 `cache` takes no space when Pi has reported no cache reads or writes.
@@ -103,9 +103,9 @@ Palette previews save on Enter and revert on Escape, but layout changes save imm
 
 ### Responsive fitting
 
-Each row keeps its configured segment order.
-If it is too wide, pi-statusline removes the lowest-priority segment, recomputes the powerline transitions, and repeats until the row fits.
-Retention priority is highest to lowest:
+Each row keeps its configured segment order in both columns.
+The right column renders flush against the right edge; when the row is too wide, the left column fits into the remaining width first, then each column removes its own lowest-priority segment and recomputes the powerline transitions until the row fits.
+Retention priority is highest to lowest within each column:
 
 ```text
 context model branch tools cwd session thinking cost provider cache tokens time turn brand
@@ -152,7 +152,8 @@ A minimal customization selects a palette and a few segments:
 ```json
 {
   "palettePreset": "ocean",
-  "segments": ["model", "cwd", "branch", "context"]
+  "segments": ["cwd", "branch", "context"],
+  "rightSegments": ["model"]
 }
 ```
 
@@ -171,7 +172,7 @@ Read the [configuration reference](./docs/configuration.md) for all settings, pa
 
 - The footer needs Powerline glyphs and emoji for its intended appearance.
 - Pi does not arbitrate footer ownership, so another footer extension can replace pi-statusline.
-- Custom layouts support ordered segments and line breaks, not a variable or format language.
+- Custom segments support ordered segments, line breaks, and a second flush-right column, but not a variable or format language.
 
 ## 🛠️ Troubleshooting
 

--- a/packages/pi-statusline/README.md
+++ b/packages/pi-statusline/README.md
@@ -83,6 +83,7 @@ Selecting a level replaces only `segments` and preserves unrelated JSON fields.
 
 The `tools` segment takes no space while idle.
 `cache` takes no space when Pi has reported no cache reads or writes.
+`session` stays hidden until Pi names the session via `/name` and follows renames immediately.
 
 ## 💬 Commands
 
@@ -107,7 +108,7 @@ If it is too wide, pi-statusline removes the lowest-priority segment, recomputes
 Retention priority is highest to lowest:
 
 ```text
-context model branch tools cwd thinking cost provider cache tokens time turn brand
+context model branch tools cwd session thinking cost provider cache tokens time turn brand
 ```
 
 Explicit `line_break` entries remain row boundaries.

--- a/packages/pi-statusline/docs/configuration.md
+++ b/packages/pi-statusline/docs/configuration.md
@@ -33,7 +33,8 @@ If both files exist, `pi-statusline.json` wins.
 | `palette` | Per-segment `fg`/`bg` `#RRGGBB` colors | Define colors used by `custom` |
 | `density` | `compact`, `cozy` | Control horizontal padding |
 | `separator` | `none`, `dot`, `bar`, `powerline`, `round` | Separate adjacent segments in one color block |
-| `segments` | Ordered unique segment names and `line_break` | Control visibility, order, and rows |
+| `segments` | Ordered unique segment names and `line_break` | Control visibility, order, and rows of the left column |
+| `rightSegments` | Ordered unique segment names and `line_break` | Control the flush-right column |
 | `segmentText` | Per-segment `prefix` and `suffix`; model truncation fields | Format Pi-owned dynamic values |
 | `extensionStatusIcons` | Raw status key or `namespace:*` to icon string | Customize extension status icons |
 
@@ -153,19 +154,23 @@ Available data segments:
 brand provider model thinking cwd session branch tools context tokens cache cost time turn
 ```
 
-Data segments must be unique.
-`line_break` may repeat when data segments separate occurrences, but consecutive breaks are invalid.
+Data segments must be unique across `segments` and `rightSegments`.
+In each column, `line_break` may repeat when data segments separate occurrences, but consecutive breaks are invalid.
 It has no `segmentText` entry.
 The menu cleans up leading, trailing, and newly consecutive breaks after visibility changes.
 Manually authored leading/trailing breaks represent empty rows.
+Rows pair up by index across the two columns; a column with fewer rows leaves the remaining lines to the other.
+When a row is too wide, the left column fits into the width left by the right column first, then each column drops its own lowest-priority segments.
+Use the `· right` marker in the layout menu to identify right-column segments.
 
 ```json
 {
-  "segments": ["model", "line_break", "cwd", "branch", "context"]
+  "segments": ["thinking", "cwd", "branch", "context"],
+  "rightSegments": ["session", "model"]
 }
 ```
 
-An empty `segments` array hides the main powerline while extension statuses can still render.
+Empty column arrays hide that column while the other and extension statuses still render.
 
 ## 🔌 Extension statuses and icons
 

--- a/packages/pi-statusline/docs/configuration.md
+++ b/packages/pi-statusline/docs/configuration.md
@@ -150,7 +150,7 @@ Closing the screen does not roll it back.
 Available data segments:
 
 ```text
-brand provider model thinking cwd branch tools context tokens cache cost time turn
+brand provider model thinking cwd session branch tools context tokens cache cost time turn
 ```
 
 Data segments must be unique.

--- a/packages/pi-statusline/src/commands.ts
+++ b/packages/pi-statusline/src/commands.ts
@@ -40,6 +40,7 @@ const SEGMENT_DESCRIPTIONS: Record<SegmentName, string> = {
   model: "Current model name",
   thinking: "Current thinking level",
   cwd: "Current working directory",
+  session: "Current session name (hidden until named)",
   branch: "Git branch, status, and linked pull request",
   tools: "Current tool and streaming activity",
   context: "Current context-window usage",

--- a/packages/pi-statusline/src/commands.ts
+++ b/packages/pi-statusline/src/commands.ts
@@ -29,6 +29,7 @@ import {
   type PalettePreset,
   SEGMENT_NAMES,
   type SegmentName,
+  type StatuslineConfig,
 } from "./types.js";
 
 const EDIT_SETTINGS_LABEL = "Edit settings JSON";
@@ -139,7 +140,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
             },
             {
               id: "information",
-              label: `Information (${inferInformationProfile(config.segments)})`,
+              label: `Information (${inferInformationProfile(config)})`,
               to: "information",
             },
             { id: "advanced", label: "Advanced", to: "advanced" },
@@ -150,17 +151,21 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
         };
       },
       information: () => {
-        const current = inferInformationProfile(options.getLoaded().config.segments);
+        const current = inferInformationProfile(options.getLoaded().config);
+        const items = INFORMATION_PROFILE_NAMES.map((profile) => {
+          const layout = INFORMATION_PROFILES[profile];
+          return {
+            id: profile,
+            label: `${profile[0]?.toUpperCase() ?? ""}${profile.slice(1)}`,
+            description: `${layout.left.length + layout.right.length} segments`,
+            details: [`Left: ${layout.left.join(" · ") || "none"}`, `Right: ${layout.right.join(" · ") || "none"}`],
+          };
+        });
         return {
           kind: "choice",
           title: "Information level",
           lines: [`Current profile: ${current}`],
-          items: INFORMATION_PROFILE_NAMES.map((profile) => ({
-            id: profile,
-            label: `${profile[0]?.toUpperCase() ?? ""}${profile.slice(1)}`,
-            description: `${INFORMATION_PROFILES[profile].length} segments`,
-            details: [`Segments: ${INFORMATION_PROFILES[profile].join(" · ")}`],
-          })),
+          items,
           action: "setInformation",
           currentItemId: current,
           initialItemId: current === "custom" ? "balanced" : current,
@@ -169,7 +174,7 @@ async function showMainMenu(ctx: ExtensionCommandContext, options: StatuslineCom
       },
       advanced: () => {
         const config = options.getLoaded().config;
-        const visibleSegmentCount = config.segments.filter(
+        const visibleSegmentCount = [...config.segments, ...config.rightSegments].filter(
           (segment): segment is SegmentName => segment !== LINE_BREAK_SEGMENT_NAME,
         ).length;
         return {
@@ -319,7 +324,7 @@ function applyInformationProfile(
   try {
     const change = informationProfileDocument(current, selection);
     const loaded = applySegmentsDocumentChange(change, ctx, options);
-    ctx.ui.notify(`Information level applied: ${inferInformationProfile(loaded.config.segments)}.`, "info");
+    ctx.ui.notify(`Information level applied: ${inferInformationProfile(loaded.config)}.`, "info");
   } catch (error) {
     ctx.ui.notify(`Information level was not saved: ${formatError(error)}`, "error");
   }
@@ -354,22 +359,26 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
       const name = names[selectedIndex];
       if (!name) return;
       moveMode = false;
-      commit(name, segmentsDocument(current, name, !current.config.segments.includes(name)));
+      commit(name, segmentsDocument(current, name, !isSegmentShown(current.config, name)));
     };
 
     const toggleLineBreakAfterSelected = () => {
       const name = names[selectedIndex];
       if (!name) return;
       moveMode = false;
-      const segmentIndex = current.config.segments.indexOf(name);
+      const column = segmentColumn(current.config, name);
+      if (!column) {
+        feedback = `Show ${name} before adding a line break.`;
+        return;
+      }
+      const list = current.config[column];
+      const segmentIndex = list.indexOf(name);
       if (segmentIndex < 0) {
         feedback = `Show ${name} before adding a line break.`;
         return;
       }
-      const hasLineBreak = current.config.segments[segmentIndex + 1] === LINE_BREAK_SEGMENT_NAME;
-      const hasFollowingSegment = current.config.segments
-        .slice(segmentIndex + 1)
-        .some((segment) => segment !== LINE_BREAK_SEGMENT_NAME);
+      const hasLineBreak = list[segmentIndex + 1] === LINE_BREAK_SEGMENT_NAME;
+      const hasFollowingSegment = list.slice(segmentIndex + 1).some((segment) => segment !== LINE_BREAK_SEGMENT_NAME);
       if (!hasLineBreak && !hasFollowingSegment) {
         feedback = `Add another visible segment after ${name} before adding a line break.`;
         return;
@@ -398,7 +407,7 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
     const enterMoveMode = () => {
       const name = names[selectedIndex];
       if (!name) return;
-      if (!current.config.segments.includes(name)) {
+      if (!isSegmentShown(current.config, name)) {
         feedback = `Show ${name} before moving it.`;
         return;
       }
@@ -415,7 +424,7 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
       const safeWidth = Math.max(1, width);
       const visibleNames = visibleSegmentNames(current);
       const visible = new Set(visibleNames);
-      const placements = segmentPlacements(current.config.segments);
+      const placements = segmentPlacements(current.config);
       const viewportSize = safeWidth < 30 ? NARROW_SEGMENT_VIEWPORT_SIZE : SEGMENT_VIEWPORT_SIZE;
       const startIndex = Math.max(
         0,
@@ -436,9 +445,11 @@ async function chooseSegments(ctx: ExtensionCommandContext, options: StatuslineC
         const isSelected = index === selectedIndex;
         const prefix = isSelected ? "→ " : "  ";
         const placement = placements.get(name);
-        const lineBreakLabel = hasLineBreakAfter(current.config.segments, name) ? " · break after" : "";
+        const column = placement?.column ?? segmentColumn(current.config, name) ?? "segments";
+        const rightLabel = column === "rightSegments" ? " · right" : "";
+        const lineBreakLabel = hasLineBreakAfter(current.config[column], name) ? " · break after" : "";
         const row = placement
-          ? `${prefix}${`${placement.order}.`.padStart(3)} row ${placement.row} · ${name.padEnd(8)} · visible${lineBreakLabel}`
+          ? `${prefix}${`${placement.order}.`.padStart(3)} row ${placement.row} · ${name.padEnd(8)} · visible${rightLabel}${lineBreakLabel}`
           : `${prefix}  · ${name.padEnd(8)} · hidden`;
         const truncated = truncateToWidth(row, safeWidth);
         if (isSelected) lines.push(theme.fg("accent", truncated));
@@ -587,7 +598,8 @@ function informationProfileDocument(
   profile: InformationProfileName,
 ): { nextDocument: string; previousDocument: string } {
   const { parsed, rawDocument: previousDocument } = editableSettings(current, "changing information level");
-  parsed.segments = [...INFORMATION_PROFILES[profile]];
+  parsed.segments = [...INFORMATION_PROFILES[profile].left];
+  parsed.rightSegments = [...INFORMATION_PROFILES[profile].right];
   return {
     nextDocument: `${JSON.stringify(parsed, null, "\t")}\n`,
     previousDocument,
@@ -595,7 +607,9 @@ function informationProfileDocument(
 }
 
 function visibleSegmentNames(current: LoadedStatuslineSettings): SegmentName[] {
-  return current.config.segments.filter((segment): segment is SegmentName => segment !== LINE_BREAK_SEGMENT_NAME);
+  return [...current.config.segments, ...current.config.rightSegments].filter(
+    (segment): segment is SegmentName => segment !== LINE_BREAK_SEGMENT_NAME,
+  );
 }
 
 function segmentMenuOrder(current: LoadedStatuslineSettings): SegmentName[] {
@@ -609,18 +623,32 @@ function hasLineBreakAfter(segments: readonly ConfigSegmentName[], name: Segment
   return index >= 0 && segments[index + 1] === LINE_BREAK_SEGMENT_NAME;
 }
 
-function segmentPlacements(segments: readonly ConfigSegmentName[]): Map<SegmentName, { order: number; row: number }> {
-  const placements = new Map<SegmentName, { order: number; row: number }>();
+function segmentPlacements(
+  config: StatuslineConfig,
+): Map<SegmentName, { order: number; row: number; column: "segments" | "rightSegments" }> {
+  const placements = new Map<SegmentName, { order: number; row: number; column: "segments" | "rightSegments" }>();
   let order = 0;
-  let row = 1;
-  for (const segment of segments) {
-    if (segment === LINE_BREAK_SEGMENT_NAME) {
-      row += 1;
-      continue;
+  for (const column of ["segments", "rightSegments"] as const) {
+    let row = 1;
+    for (const segment of config[column]) {
+      if (segment === LINE_BREAK_SEGMENT_NAME) {
+        row += 1;
+        continue;
+      }
+      placements.set(segment, { order: ++order, row, column });
     }
-    placements.set(segment, { order: ++order, row });
   }
   return placements;
+}
+
+function isSegmentShown(config: StatuslineConfig, name: SegmentName): boolean {
+  return segmentColumn(config, name) !== undefined;
+}
+
+function segmentColumn(config: StatuslineConfig, name: SegmentName): "segments" | "rightSegments" | undefined {
+  if (config.segments.includes(name)) return "segments";
+  if (config.rightSegments.includes(name)) return "rightSegments";
+  return undefined;
 }
 
 function segmentControlHints(
@@ -681,10 +709,15 @@ function segmentsDocument(
   shouldShow: boolean,
 ): { nextDocument: string; previousDocument: string } {
   const { parsed, rawDocument: previousDocument } = editableSettings(current, "changing segments");
-  const segments = shouldShow
-    ? [...current.config.segments, ...(current.config.segments.includes(name) ? [] : [name])]
-    : current.config.segments.filter((segment) => segment !== name);
-  parsed.segments = normalizeLineBreaks(segments);
+  const column = segmentColumn(current.config, name) ?? "segments";
+  const segments = [...current.config[column]];
+  const index = segments.indexOf(name);
+  if (shouldShow) {
+    if (index < 0) segments.push(name);
+  } else if (index >= 0) {
+    segments.splice(index, 1);
+  }
+  parsed[column] = normalizeLineBreaks(segments);
   return {
     nextDocument: `${JSON.stringify(parsed, null, "\t")}\n`,
     previousDocument,
@@ -696,14 +729,15 @@ function lineBreakAfterDocument(
   name: SegmentName,
 ): { nextDocument: string; previousDocument: string } {
   const { parsed, rawDocument: previousDocument } = editableSettings(current, "changing line breaks");
-  const segments = [...current.config.segments];
+  const column = segmentColumn(current.config, name) ?? "segments";
+  const segments = [...current.config[column]];
   const segmentIndex = segments.indexOf(name);
   if (segments[segmentIndex + 1] === LINE_BREAK_SEGMENT_NAME) {
     segments.splice(segmentIndex + 1, 1);
   } else {
     segments.splice(segmentIndex + 1, 0, LINE_BREAK_SEGMENT_NAME);
   }
-  parsed.segments = segments;
+  parsed[column] = segments;
   return {
     nextDocument: `${JSON.stringify(parsed, null, "\t")}\n`,
     previousDocument,
@@ -715,21 +749,22 @@ function reorderedSegmentsDocument(
   name: SegmentName,
   direction: -1 | 1,
 ): { nextDocument: string; previousDocument: string } | undefined {
-  const dataIndexes = current.config.segments.flatMap((segment, index) =>
-    segment === LINE_BREAK_SEGMENT_NAME ? [] : [index],
-  );
-  const currentDataIndex = dataIndexes.findIndex((index) => current.config.segments[index] === name);
+  const column = segmentColumn(current.config, name);
+  if (!column) return undefined;
+  const columnSegments = current.config[column];
+  const dataIndexes = columnSegments.flatMap((segment, index) => (segment === LINE_BREAK_SEGMENT_NAME ? [] : [index]));
+  const currentDataIndex = dataIndexes.findIndex((index) => columnSegments[index] === name);
   const targetDataIndex = currentDataIndex + direction;
   if (currentDataIndex < 0 || targetDataIndex < 0 || targetDataIndex >= dataIndexes.length) {
     return undefined;
   }
   const { parsed, rawDocument: previousDocument } = editableSettings(current, "reordering segments");
-  const segments = [...current.config.segments];
+  const segments = [...columnSegments];
   const currentIndex = dataIndexes[currentDataIndex];
   const targetIndex = dataIndexes[targetDataIndex];
   if (currentIndex === undefined || targetIndex === undefined) return undefined;
   [segments[currentIndex], segments[targetIndex]] = [segments[targetIndex], segments[currentIndex]];
-  parsed.segments = segments;
+  parsed[column] = segments;
   return {
     nextDocument: `${JSON.stringify(parsed, null, "\t")}\n`,
     previousDocument,
@@ -829,8 +864,9 @@ function showStatus(ctx: ExtensionCommandContext, options: StatuslineCommandOpti
       `palette preset: ${loaded.config.palettePreset}`,
       `density: ${loaded.config.density}`,
       `separator: ${loaded.config.separator}`,
-      `information: ${inferInformationProfile(loaded.config.segments)}`,
+      `information: ${inferInformationProfile(loaded.config)}`,
       `segments: ${loaded.config.segments.join(", ") || "none"}`,
+      `rightSegments: ${loaded.config.rightSegments.join(", ") || "none"}`,
       diagnostics ? `warnings: ${diagnostics}` : "warnings: none",
     ].join("\n"),
     loaded.diagnostics.length > 0 ? "warning" : "info",
@@ -846,13 +882,13 @@ function showHelp(ctx: ExtensionCommandContext, settingsPath: string) {
       "/statusline status — show source, path, information level, and warnings",
       "/statusline help — show this help",
       "Menu actions: Appearance, Information, Advanced, Status, Help.",
-      "Information levels: minimal, balanced, detailed; any other segment array is custom.",
+      "Information levels: minimal, balanced, detailed; any other segments or rightSegments arrays are custom.",
       "Advanced actions: Custom layout, Edit settings JSON, Back.",
       `Settings: ${settingsPath}`,
-      "Fields: palettePreset, palette, density, separator, segments, segmentText, extensionStatusIcons",
+      "Fields: palettePreset, palette, density, separator, segments, rightSegments, segmentText, extensionStatusIcons",
       "Named presets ignore but preserve palette; custom uses its per-segment fg/bg colors.",
       "Responsive rows retain context, model, location, and active work before decorative data.",
-      "Custom layout can show, hide, reorder, or split data segments across rows.",
+      "Custom layout can show, hide, reorder, or split data segments across rows and columns.",
       "Press M for move mode, Alt+Up/Alt+Down for quick move, and B for a line break.",
       "Line breaks (line_break) may repeat when separated by data segments, but cannot be consecutive.",
       "segmentText supports prefix and suffix strings around Pi-owned dynamic values.",

--- a/packages/pi-statusline/src/information-profiles.ts
+++ b/packages/pi-statusline/src/information-profiles.ts
@@ -4,18 +4,37 @@ export const INFORMATION_PROFILE_NAMES = ["minimal", "balanced", "detailed"] as 
 export type InformationProfileName = (typeof INFORMATION_PROFILE_NAMES)[number];
 export type InformationProfile = InformationProfileName | "custom";
 
-export const INFORMATION_PROFILES: Readonly<Record<InformationProfileName, readonly SegmentName[]>> = {
-  minimal: ["model", "cwd", "branch", "context"],
-  balanced: ["model", "thinking", "cwd", "branch", "tools", "context", "time"],
-  detailed: ["provider", "model", "thinking", "cwd", "branch", "tools", "context", "tokens", "cache", "cost", "time"],
+/** Per-profile column layout: `rightSegments` renders flush against the right edge. */
+export interface InformationProfileLayout {
+  left: SegmentName[];
+  right: SegmentName[];
+}
+
+export const INFORMATION_PROFILES: Readonly<Record<InformationProfileName, InformationProfileLayout>> = {
+  minimal: { left: ["cwd", "branch", "context"], right: ["model"] },
+  balanced: {
+    left: ["thinking", "cwd", "branch", "tools", "context", "time"],
+    right: ["session", "provider", "model"],
+  },
+  detailed: {
+    left: ["thinking", "cwd", "branch", "tools", "context", "tokens", "cache", "cost", "time"],
+    right: ["session", "provider", "model"],
+  },
 };
 
-export function inferInformationProfile(segments: readonly ConfigSegmentName[]): InformationProfile {
+export function inferInformationProfile(config: {
+  segments: readonly ConfigSegmentName[];
+  rightSegments: readonly ConfigSegmentName[];
+}): InformationProfile {
   for (const name of INFORMATION_PROFILE_NAMES) {
     const profile = INFORMATION_PROFILES[name];
-    if (segments.length === profile.length && segments.every((segment, index) => segment === profile[index])) {
+    if (columnsEqual(config.segments, profile.left) && columnsEqual(config.rightSegments, profile.right)) {
       return name;
     }
   }
   return "custom";
+}
+
+function columnsEqual(actual: readonly ConfigSegmentName[], expected: readonly SegmentName[]): boolean {
+  return actual.length === expected.length && actual.every((segment, index) => segment === expected[index]);
 }

--- a/packages/pi-statusline/src/powerline.ts
+++ b/packages/pi-statusline/src/powerline.ts
@@ -41,7 +41,7 @@ function splitLines(items: RenderItem[]): RenderSegment[][] {
   return lines;
 }
 
-const SEGMENT_RETENTION_PRIORITY: Readonly<Record<RenderSegment["name"], number>> = {
+export const SEGMENT_RETENTION_PRIORITY: Readonly<Record<RenderSegment["name"], number>> = {
   context: 120,
   model: 110,
   branch: 100,
@@ -58,7 +58,7 @@ const SEGMENT_RETENTION_PRIORITY: Readonly<Record<RenderSegment["name"], number>
   brand: 10,
 };
 
-function fitPowerlineSegments(
+export function fitPowerlineSegments(
   segments: readonly RenderSegment[],
   width: number,
   config: Pick<StatuslineConfig, "palettePreset" | "palette" | "density" | "separator">,

--- a/packages/pi-statusline/src/powerline.ts
+++ b/packages/pi-statusline/src/powerline.ts
@@ -47,6 +47,7 @@ const SEGMENT_RETENTION_PRIORITY: Readonly<Record<RenderSegment["name"], number>
   branch: 100,
   tools: 90,
   cwd: 80,
+  session: 75,
   thinking: 70,
   cost: 60,
   provider: 50,

--- a/packages/pi-statusline/src/presets/index.ts
+++ b/packages/pi-statusline/src/presets/index.ts
@@ -33,6 +33,7 @@ const SEGMENT_BLOCKS: Record<SegmentName, PowerlineBlockName> = {
   model: "header",
   thinking: "header",
   cwd: "directory",
+  session: "directory",
   branch: "git",
   tools: "runtime",
   context: "runtime",

--- a/packages/pi-statusline/src/render.ts
+++ b/packages/pi-statusline/src/render.ts
@@ -135,6 +135,10 @@ function buildSegment(
         "accent",
         "directory",
       );
+    case "session": {
+      const sessionName = sanitizeTerminalText(ctx.sessionManager.getSessionName() ?? "");
+      return sessionName ? segment(name, sessionName, config, "accent", "directory") : undefined;
+    }
     case "tools": {
       const activity = formatToolActivity(runtime);
       return activity ? segment(name, activity, config, "accent", "runtime") : undefined;

--- a/packages/pi-statusline/src/render.ts
+++ b/packages/pi-statusline/src/render.ts
@@ -11,11 +11,11 @@ import { sanitizeTerminalText } from "@narumitw/pi-tui-kit/terminal-text";
 import { formatDirectoryPath } from "./directory.js";
 import { type ExtensionStatusRuntime, formatExtensionStatuses, wrapExtensionStatusline } from "./extension-status.js";
 import { formatGitBranchValue, type GitStatusSummary } from "./git-status.js";
-import { renderPowerlineStatusline } from "./powerline.js";
+import { fitPowerlineSegments, SEGMENT_RETENTION_PRIORITY } from "./powerline.js";
 import {
+  type ConfigSegmentName,
   LINE_BREAK_SEGMENT_NAME,
   type PowerlineBlockName,
-  type RenderItem,
   type RenderSegment,
   type SegmentName,
   type StatuslineConfig,
@@ -36,6 +36,8 @@ export interface RuntimeState extends ExtensionStatusRuntime {
 }
 const GITHUB_PR_KEY = "github-pr";
 const GITHUB_PR_STATUS_KEYS = new Set([GITHUB_PR_KEY]);
+const COLUMN_GAP = 1;
+
 export function renderStatusline(
   width: number,
   ctx: ExtensionContext,
@@ -48,10 +50,91 @@ export function renderStatusline(
   if (width <= 0) return "";
 
   const usageSummary = summarizeFooterUsage(ctx.sessionManager.getEntries());
+  const leftRows = buildColumnRows(config.segments, ctx, footerData, config, runtime, usageSummary);
+  const rightRows = buildColumnRows(config.rightSegments, ctx, footerData, config, runtime, usageSummary);
+  const rowCount = Math.max(leftRows.length, rightRows.length);
+  const lines: string[] = [];
+
+  for (let row = 0; row < rowCount; row += 1) {
+    const rightSegments = rightRows[row] ?? [];
+    const leftSegments = leftRows[row] ?? [];
+    const [fittedLeft, fittedRight] = fitColumnsRow(leftSegments, rightSegments, width, config, trueColor);
+    const rightLine = fitPowerlineSegments(fittedRight, width, config, trueColor);
+    const rightWidth = visibleWidth(rightLine);
+    const leftLine = fitPowerlineSegments(
+      fittedLeft,
+      rightLine ? Math.max(width - rightWidth - COLUMN_GAP, 0) : width,
+      config,
+      trueColor,
+    );
+    if (!leftLine && !rightLine) {
+      lines.push("");
+      continue;
+    }
+    const leftWidth = visibleWidth(leftLine);
+    const padWidth = rightLine ? Math.max(width - leftWidth - rightWidth, leftLine ? COLUMN_GAP : 0) : 0;
+    lines.push(`${leftLine}${" ".repeat(padWidth)}${rightLine}`);
+  }
+
+  return lines.join("\n");
+}
+
+// Drops the globally lowest-priority segment across both columns until both natural
+// widths plus the column gap fit within one row.
+function fitColumnsRow(
+  left: RenderSegment[],
+  right: RenderSegment[],
+  width: number,
+  config: StatuslineConfig,
+  trueColor: boolean,
+): [RenderSegment[], RenderSegment[]] {
+  const columnLeft = [...left];
+  const columnRight = [...right];
+  const columns: ["left" | "right", RenderSegment[]][] = [
+    ["left", columnLeft],
+    ["right", columnRight],
+  ];
+  const naturalWidth = (segments: RenderSegment[]) =>
+    segments.length === 0
+      ? 0
+      : visibleWidth(fitPowerlineSegments(segments, Number.MAX_SAFE_INTEGER, config, trueColor));
+
+  for (;;) {
+    const leftWidth = naturalWidth(columnLeft);
+    const rightWidth = naturalWidth(columnRight);
+    const gap = leftWidth > 0 && rightWidth > 0 ? COLUMN_GAP : 0;
+    if (leftWidth + rightWidth + gap <= width) return [columnLeft, columnRight];
+
+    let target: "left" | "right" | undefined;
+    let removalIndex = -1;
+    let removalPriority = Number.POSITIVE_INFINITY;
+    for (const [key, segments] of columns) {
+      for (const [index, segment] of segments.entries()) {
+        const priority = SEGMENT_RETENTION_PRIORITY[segment.name];
+        if (priority < removalPriority) {
+          removalPriority = priority;
+          removalIndex = index;
+          target = key;
+        }
+      }
+    }
+    if (target === undefined || removalIndex < 0) return [columnLeft, columnRight];
+    (target === "left" ? columnLeft : columnRight).splice(removalIndex, 1);
+  }
+}
+
+function buildColumnRows(
+  names: readonly ConfigSegmentName[],
+  ctx: ExtensionContext,
+  footerData: ReadonlyFooterDataProvider,
+  config: StatuslineConfig,
+  runtime: RuntimeState,
+  usageSummary: FooterUsageSummary,
+): RenderSegment[][] {
   const rows: Array<{ configuredSegments: number; segments: RenderSegment[] }> = [
     { configuredSegments: 0, segments: [] },
   ];
-  for (const name of config.segments) {
+  for (const name of names) {
     if (name === LINE_BREAK_SEGMENT_NAME) {
       rows.push({ configuredSegments: 0, segments: [] });
       continue;
@@ -63,15 +146,7 @@ export function renderStatusline(
     const rendered = buildSegment(name, ctx, footerData, config, runtime, usageSummary);
     if (rendered && rendered.text.length > 0) row.segments.push(rendered);
   }
-
-  const segments: RenderItem[] = [];
-  const renderedRows = rows.filter((row) => row.configuredSegments === 0 || row.segments.length > 0);
-  for (const [index, row] of renderedRows.entries()) {
-    if (index > 0) segments.push({ name: LINE_BREAK_SEGMENT_NAME });
-    segments.push(...row.segments);
-  }
-
-  return renderPowerlineStatusline(width, segments, config, trueColor);
+  return rows.filter((row) => row.configuredSegments === 0 || row.segments.length > 0).map((row) => row.segments);
 }
 
 export function renderExtensionStatusline(

--- a/packages/pi-statusline/src/settings.ts
+++ b/packages/pi-statusline/src/settings.ts
@@ -70,6 +70,7 @@ export const DEFAULT_STATUSLINE_CONFIG: StatuslineConfig = {
     },
     thinking: { prefix: "🧠 ", suffix: "" },
     cwd: { prefix: "📁 ", suffix: "" },
+    session: { prefix: "🏷️ ", suffix: "" },
     branch: { prefix: "🌿 ", suffix: "" },
     tools: { prefix: "", suffix: "" },
     context: { prefix: "🪟 ctx ", suffix: "" },

--- a/packages/pi-statusline/src/settings.ts
+++ b/packages/pi-statusline/src/settings.ts
@@ -50,7 +50,8 @@ const LEGACY_STATUS_ICON_KEYS = {
   "unknown-error-retry": "retry",
 } as const;
 
-const DEFAULT_SEGMENTS: SegmentName[] = [...INFORMATION_PROFILES.balanced];
+const DEFAULT_SEGMENTS: SegmentName[] = [...INFORMATION_PROFILES.balanced.left];
+const DEFAULT_RIGHT_SEGMENTS: SegmentName[] = [...INFORMATION_PROFILES.balanced.right];
 
 export const DEFAULT_STATUSLINE_CONFIG: StatuslineConfig = {
   palettePreset: "tokyo-night",
@@ -58,6 +59,7 @@ export const DEFAULT_STATUSLINE_CONFIG: StatuslineConfig = {
   density: "compact",
   separator: "none",
   segments: DEFAULT_SEGMENTS,
+  rightSegments: DEFAULT_RIGHT_SEGMENTS,
   segmentText: {
     brand: { prefix: "", suffix: "" },
     provider: { prefix: "🔌 ", suffix: "" },
@@ -88,6 +90,7 @@ const DEFAULT_STATUSLINE_DOCUMENT_CONFIG = {
   density: DEFAULT_STATUSLINE_CONFIG.density,
   separator: DEFAULT_STATUSLINE_CONFIG.separator,
   segments: DEFAULT_SEGMENTS,
+  rightSegments: DEFAULT_RIGHT_SEGMENTS,
   segmentText: DEFAULT_STATUSLINE_CONFIG.segmentText,
   extensionStatusIcons: DEFAULT_DOCUMENT_EXTENSION_STATUS_ICONS,
 } satisfies Omit<StatuslineConfig, "palette">;
@@ -145,6 +148,7 @@ export function normalizeStatuslineConfig(value: unknown): {
     "density",
     "separator",
     "segments",
+    "rightSegments",
     "segmentText",
     "extensionStatusIcons",
   ]);
@@ -160,35 +164,23 @@ export function normalizeStatuslineConfig(value: unknown): {
   normalizeEnum(value, "density", DENSITIES, config, diagnostics);
   normalizeEnum(value, "separator", SEPARATOR_NAMES, config, diagnostics);
 
-  if (value.segments !== undefined) {
-    if (!Array.isArray(value.segments)) {
-      diagnostics.push(invalidDiagnostic("segments", "Expected an array of segment names"));
-    } else {
-      const segments: ConfigSegmentName[] = [];
-      const seen = new Set<SegmentName>();
-      for (const [index, item] of value.segments.entries()) {
-        const path = `segments[${index}]`;
-        if (typeof item !== "string" || !isConfigSegmentName(item)) {
-          diagnostics.push(invalidDiagnostic(path, "Unknown or non-string segment name"));
-          continue;
-        }
-        if (item === LINE_BREAK_SEGMENT_NAME) {
-          if (segments.at(-1) === LINE_BREAK_SEGMENT_NAME) {
-            diagnostics.push(invalidDiagnostic(path, "Consecutive line_break segments are not allowed"));
-            continue;
-          }
-          segments.push(item);
-          continue;
-        }
-        if (seen.has(item)) {
-          diagnostics.push(invalidDiagnostic(path, `Duplicate segment ${JSON.stringify(item)}`));
-          continue;
-        }
-        seen.add(item);
-        segments.push(item);
-      }
-      config.segments = segments;
-    }
+  const explicitLeft = value.segments !== undefined;
+  const explicitRight = value.rightSegments !== undefined;
+  const left = [...parseColumn(value, "segments", diagnostics)];
+  const right = [...parseColumn(value, "rightSegments", diagnostics)];
+  const rightNames = new Set(right.filter(isSegmentName));
+  // An explicit column is the user's full intent: writing segments without rightSegments
+  // keeps the right column empty, while writing only rightSegments prunes default left
+  // duplicates so the built-in layout never repeats a segment across columns.
+  if (explicitLeft && !explicitRight) {
+    config.segments = left;
+    config.rightSegments = [];
+  } else if (!explicitLeft && explicitRight) {
+    config.segments = left.filter((segment) => segment === LINE_BREAK_SEGMENT_NAME || !rightNames.has(segment));
+    config.rightSegments = right;
+  } else {
+    config.segments = left;
+    config.rightSegments = right;
   }
 
   if (value.segmentText !== undefined) {
@@ -425,6 +417,55 @@ export function normalizeStatuslineSettings(value: unknown): StatuslineConfig {
   return normalizeStatuslineConfig(value).config;
 }
 
+function parseColumn(
+  value: Record<string, unknown>,
+  column: "segments" | "rightSegments",
+  diagnostics: StatuslineConfigDiagnostic[],
+): ConfigSegmentName[] {
+  const raw = value[column];
+  if (raw === undefined) {
+    return column === "segments" ? [...DEFAULT_SEGMENTS] : [...DEFAULT_RIGHT_SEGMENTS];
+  }
+  const parsed: ConfigSegmentName[] = [];
+  if (!Array.isArray(raw)) {
+    diagnostics.push(invalidDiagnostic(column, "Expected an array of segment names"));
+    return column === "segments" ? [...DEFAULT_SEGMENTS] : [...DEFAULT_RIGHT_SEGMENTS];
+  }
+  const other = value[column === "segments" ? "rightSegments" : "segments"];
+  const otherNames = new Set(
+    Array.isArray(other)
+      ? other.filter((segment): segment is SegmentName => typeof segment === "string" && isSegmentName(segment))
+      : [],
+  );
+  const seen = new Set<SegmentName>();
+  for (const [index, item] of raw.entries()) {
+    const path = `${column}[${index}]`;
+    if (typeof item !== "string" || !isConfigSegmentName(item)) {
+      diagnostics.push(invalidDiagnostic(path, "Unknown or non-string segment name"));
+      continue;
+    }
+    if (item === LINE_BREAK_SEGMENT_NAME) {
+      if (parsed.at(-1) === LINE_BREAK_SEGMENT_NAME) {
+        diagnostics.push(invalidDiagnostic(path, "Consecutive line_break segments are not allowed"));
+        continue;
+      }
+      parsed.push(item);
+      continue;
+    }
+    if (otherNames.has(item)) {
+      diagnostics.push(invalidDiagnostic(path, `Segment ${JSON.stringify(item)} already shown in the other column`));
+      continue;
+    }
+    if (seen.has(item)) {
+      diagnostics.push(invalidDiagnostic(path, `Duplicate segment ${JSON.stringify(item)}`));
+      continue;
+    }
+    seen.add(item);
+    parsed.push(item);
+  }
+  return parsed;
+}
+
 function normalizePalette(value: unknown, config: StatuslineConfig, diagnostics: StatuslineConfigDiagnostic[]) {
   if (value === undefined) return;
   if (typeof value === "string") {
@@ -547,6 +588,7 @@ function cloneConfig(config: StatuslineConfig): StatuslineConfig {
     ...config,
     palette: cloneSegmentPalette(config.palette),
     segments: [...config.segments],
+    rightSegments: [...config.rightSegments],
     segmentText: Object.fromEntries(
       SEGMENT_NAMES.map((name) => [name, { ...config.segmentText[name] }]),
     ) as StatuslineConfig["segmentText"],

--- a/packages/pi-statusline/src/statusline.ts
+++ b/packages/pi-statusline/src/statusline.ts
@@ -278,6 +278,8 @@ export default function statusline(pi: ExtensionAPI) {
 
   pi.on("model_select", () => refresh());
 
+  pi.on("session_info_changed", () => refresh());
+
   pi.on("thinking_level_select", (event) => {
     runtime.thinkingLevel = event.level;
     refresh();

--- a/packages/pi-statusline/src/types.ts
+++ b/packages/pi-statusline/src/types.ts
@@ -62,6 +62,7 @@ export interface StatuslineConfig {
   density: Density;
   separator: SeparatorName;
   segments: ConfigSegmentName[];
+  rightSegments: ConfigSegmentName[];
   segmentText: Record<SegmentName, SegmentTextConfig> & { model: ModelSegmentTextConfig };
   extensionStatusIcons: Record<string, string>;
 }

--- a/packages/pi-statusline/src/types.ts
+++ b/packages/pi-statusline/src/types.ts
@@ -6,6 +6,7 @@ export const SEGMENT_NAMES = [
   "model",
   "thinking",
   "cwd",
+  "session",
   "branch",
   "tools",
   "context",

--- a/packages/pi-statusline/test/commands.test.ts
+++ b/packages/pi-statusline/test/commands.test.ts
@@ -447,7 +447,7 @@ test("segment menu toggles displayed segments and preserves JSON fields and layo
       "Status",
       "Help",
     ]);
-    assert.deepEqual(selections[1]?.choices, ["Custom layout (2/13 shown)", "Edit settings JSON", "Back"]);
+    assert.deepEqual(selections[1]?.choices, ["Custom layout (2/14 shown)", "Edit settings JSON", "Back"]);
     assert.match(initialScreen, /Statusline segments/u);
     assert.match(initialScreen.split("\n").find((line) => line.includes("brand")) ?? "", /hidden/u);
     assert.match(initialScreen.split("\n").find((line) => line.includes("model")) ?? "", /visible/u);
@@ -1234,7 +1234,7 @@ test("custom selection materializes the active legacy preset without losing unkn
     const saved = JSON.parse(readFileSync(path, "utf8"));
     assert.equal(saved.palettePreset, "custom");
     assert.equal(saved.future, true);
-    assert.equal(Object.keys(saved.palette).length, 13);
+    assert.equal(Object.keys(saved.palette).length, 14);
     assert.equal(saved.palette.model.bg, "#a7c080");
     assert.equal(saved.palette.cwd.bg, "#83c092");
     assert.equal(saved.palette.branch.bg, "#5f9f75");

--- a/packages/pi-statusline/test/information-command.test.ts
+++ b/packages/pi-statusline/test/information-command.test.ts
@@ -66,12 +66,15 @@ test("information picker previews exact contents and atomically applies a curate
     for (const label of ["Minimal", "Balanced", "Detailed"]) {
       assert.match(pickerText, new RegExp(label, "u"));
     }
-    assert.match(pickerText, /Segments: model · thinking · cwd · branch · tools · context · time/u);
+    assert.match(pickerText, /Left: thinking · cwd · branch · tools · context · time/u);
+    assert.match(pickerText, /Right: session · provider · model/u);
     assert.ok(narrowLines.length > 0);
     assert.ok(narrowLines.every((line) => visibleWidth(line) <= 20));
-    assert.deepEqual(loaded.config.segments, ["model", "thinking", "cwd", "branch", "tools", "context", "time"]);
+    assert.deepEqual(loaded.config.segments, ["thinking", "cwd", "branch", "tools", "context", "time"]);
+    assert.deepEqual(loaded.config.rightSegments, ["session", "provider", "model"]);
     assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
-      segments: ["model", "thinking", "cwd", "branch", "tools", "context", "time"],
+      segments: ["thinking", "cwd", "branch", "tools", "context", "time"],
+      rightSegments: ["session", "provider", "model"],
       future: true,
     });
     assert.equal(applied, 1);

--- a/packages/pi-statusline/test/information-profiles.test.ts
+++ b/packages/pi-statusline/test/information-profiles.test.ts
@@ -3,28 +3,47 @@ import { test } from "vitest";
 import { INFORMATION_PROFILES, inferInformationProfile } from "../src/information-profiles.js";
 
 test("information profiles expose curated segment sets in deterministic order", () => {
-  assert.deepEqual(INFORMATION_PROFILES.minimal, ["model", "cwd", "branch", "context"]);
-  assert.deepEqual(INFORMATION_PROFILES.balanced, ["model", "thinking", "cwd", "branch", "tools", "context", "time"]);
-  assert.deepEqual(INFORMATION_PROFILES.detailed, [
-    "provider",
-    "model",
-    "thinking",
-    "cwd",
-    "branch",
-    "tools",
-    "context",
-    "tokens",
-    "cache",
-    "cost",
-    "time",
-  ]);
+  assert.deepEqual(INFORMATION_PROFILES.minimal, { left: ["cwd", "branch", "context"], right: ["model"] });
+  assert.deepEqual(INFORMATION_PROFILES.balanced, {
+    left: ["thinking", "cwd", "branch", "tools", "context", "time"],
+    right: ["session", "provider", "model"],
+  });
+  assert.deepEqual(INFORMATION_PROFILES.detailed, {
+    left: ["thinking", "cwd", "branch", "tools", "context", "tokens", "cache", "cost", "time"],
+    right: ["session", "provider", "model"],
+  });
 });
 
 test("information profile inference recognizes exact profiles and reports custom layouts", () => {
-  assert.equal(inferInformationProfile(INFORMATION_PROFILES.minimal), "minimal");
-  assert.equal(inferInformationProfile(INFORMATION_PROFILES.balanced), "balanced");
-  assert.equal(inferInformationProfile(INFORMATION_PROFILES.detailed), "detailed");
-  assert.equal(inferInformationProfile(["model", "context"]), "custom");
-  assert.equal(inferInformationProfile(["context", "model", "cwd", "branch"]), "custom");
-  assert.equal(inferInformationProfile(["model", "line_break", "cwd", "branch", "context"]), "custom");
+  assert.equal(
+    inferInformationProfile({
+      segments: INFORMATION_PROFILES.minimal.left,
+      rightSegments: INFORMATION_PROFILES.minimal.right,
+    }),
+    "minimal",
+  );
+  assert.equal(
+    inferInformationProfile({
+      segments: INFORMATION_PROFILES.balanced.left,
+      rightSegments: INFORMATION_PROFILES.balanced.right,
+    }),
+    "balanced",
+  );
+  assert.equal(
+    inferInformationProfile({
+      segments: INFORMATION_PROFILES.detailed.left,
+      rightSegments: INFORMATION_PROFILES.detailed.right,
+    }),
+    "detailed",
+  );
+  assert.equal(inferInformationProfile({ segments: ["cwd", "context"], rightSegments: ["model"] }), "custom");
+  assert.equal(inferInformationProfile({ segments: ["context", "cwd", "branch"], rightSegments: ["model"] }), "custom");
+  assert.equal(
+    inferInformationProfile({ segments: ["cwd", "line_break", "branch", "context"], rightSegments: ["model"] }),
+    "custom",
+  );
+  assert.equal(
+    inferInformationProfile({ segments: INFORMATION_PROFILES.minimal.left, rightSegments: ["provider", "model"] }),
+    "custom",
+  );
 });

--- a/packages/pi-statusline/test/renderer.test.ts
+++ b/packages/pi-statusline/test/renderer.test.ts
@@ -26,8 +26,15 @@ function segment(name: SegmentName, text: string, block: RenderSegment["block"])
   return { name, text, block, color: "accent" };
 }
 
-test("powerline renderer preserves configured segment order across repeated blocks", () => {
+/** Single-column test configuration: defaults carry a right column, so most tests clear it. */
+function createTestConfig() {
   const config = createDefaultConfig();
+  config.rightSegments = [];
+  return config;
+}
+
+test("powerline renderer preserves configured segment order across repeated blocks", () => {
+  const config = createTestConfig();
   const rendered = renderPowerlineStatusline(
     300,
     [segment("model", "model", "header"), segment("time", "time", "meter"), segment("provider", "provider", "header")],
@@ -56,7 +63,7 @@ test("powerline colors fall back to ANSI-256 when true color is disabled", () =>
 });
 
 test("configured palette joins reordered time to an adjacent header block", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.palettePreset = "custom";
   config.palette.time = { fg: "#090c0c", bg: "#a3aed2" };
   const rendered = renderPowerlineStatusline(
@@ -86,7 +93,7 @@ test("empty custom palette renders without ANSI color fallback", () => {
 });
 
 test("different final segment colors retain the powerline transition", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.palettePreset = "custom";
   config.palette.time = { ...config.palette.time, bg: "#123456" };
   const rendered = renderPowerlineStatusline(
@@ -98,7 +105,7 @@ test("different final segment colors retain the powerline transition", () => {
 });
 
 test("line breaks render separated repeated markers as independent powerline rows", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   const items: RenderItem[] = [
     segment("model", "model", "header"),
     { name: "line_break" },
@@ -111,7 +118,7 @@ test("line breaks render separated repeated markers as independent powerline row
 });
 
 test("idle contextual activity rows collapse while explicit empty rows remain", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["model", "line_break", "tools", "line_break", "context"];
   const context = createMockContext({
     model: { id: "claude-sonnet-4", provider: "anthropic", contextWindow: 1000 },
@@ -180,8 +187,55 @@ test("UI prompt activity sanitizes and bounds titles with kind-only fallbacks", 
   assert.ok(visibleWidth(zeroWidthTitle) <= 40);
 });
 
+test("rightSegments renders a flush-right column beside padded left segments", () => {
+  const config = createTestConfig();
+  config.segments = ["cwd"];
+  config.rightSegments = ["branch", "session"];
+  const context = createMockContext({
+    cwd: "/home/alice/repo",
+    sessionManager: {
+      getEntries: () => [],
+      getBranch: () => [],
+      getSessionName: () => "auth work",
+    },
+  });
+  const footerData: ReadonlyFooterDataProvider = {
+    getGitBranch: () => "main",
+    getExtensionStatuses: () => new Map(),
+    onBranchChange: () => () => undefined,
+    getAvailableProviderCount: () => 1,
+  };
+  const runtime: RuntimeState = {
+    homeDir: "/home/alice",
+    turnCount: 0,
+    activeTools: new Map(),
+    isStreaming: false,
+    thinkingLevel: "off",
+    duplicateExtensions: [],
+    extensionStatusIconAliases: new Map(),
+  };
+
+  const wide = plain(renderStatusline(60, context.ctx, footerData, {} as Theme, config, runtime));
+  assert.match(wide, /📁 ~\/repo/u);
+  assert.match(wide, /🏷️ auth work/u);
+  assert.equal(visibleWidth(wide), 60);
+
+  // At a narrow width the right column keeps its high-priority segments flush right
+  // while the left column is trimmed first.
+  const narrow = plain(renderStatusline(24, context.ctx, footerData, {} as Theme, config, runtime));
+  assert.doesNotMatch(narrow, /📁 ~\/repo/u);
+  assert.match(narrow, /🌿 main/u);
+  assert.ok(visibleWidth(narrow) <= 24);
+
+  // An unnamed session hides the session segment without leaving a placeholder.
+  (context.ctx.sessionManager as { getSessionName: () => string | undefined }).getSessionName = () => undefined;
+  const unnamed = plain(renderStatusline(60, context.ctx, footerData, {} as Theme, config, runtime));
+  assert.doesNotMatch(unnamed, /auth work/u);
+  assert.match(unnamed, /🌿 main/u);
+});
+
 test("cwd uses Starship repository and three-component directory defaults", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["cwd"];
   const context = createMockContext({
     cwd: "/home/alice/work/repository/src",
@@ -236,7 +290,7 @@ test("cwd uses Starship repository and three-component directory defaults", () =
 });
 
 test("session segment shows the session name only when one is set", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["session"];
   const footerData: ReadonlyFooterDataProvider = {
     getGitBranch: () => null,
@@ -275,7 +329,7 @@ test("session segment shows the session name only when one is set", () => {
 });
 
 test("cwd preserves POSIX backslashes and strips terminal controls", { skip: sep !== "/" }, () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["cwd"];
   const context = createMockContext({ cwd: "/home/alice/team\\name/project" });
   const footerData: ReadonlyFooterDataProvider = {
@@ -311,7 +365,7 @@ test("cwd preserves POSIX backslashes and strips terminal controls", { skip: sep
 });
 
 test("model truncation supports all directions before prefixes and responsive fitting", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["model"];
   config.segmentText.model.truncationLength = 6;
   const footerData: ReadonlyFooterDataProvider = {
@@ -367,7 +421,8 @@ test("model rendering strips terminal sequences from runtime IDs and truncation 
 });
 
 test("default model truncation retains useful llama.cpp path detail at standard width", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
+  config.rightSegments = ["model"];
   const id = "/home/willow/program/llama.cpp/models/Qwen3.6-35B-A3B-UDT-Q4_K_XL_MTP.gguf";
   const model = { id, provider: "llama.cpp", contextWindow: 72_000 };
   const context = createMockContext({
@@ -398,7 +453,7 @@ test("default model truncation retains useful llama.cpp path detail at standard 
 });
 
 test("responsive fitting keeps primary and active information ahead of decorative segments", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   const items = [
     segment("brand", "BRAND", "header"),
     segment("provider", "PROVIDER", "header"),
@@ -431,7 +486,7 @@ test("responsive fitting keeps primary and active information ahead of decorativ
 });
 
 test("responsive fitting preserves explicit row boundaries and fits every rendered line", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   const rendered = renderPowerlineStatusline(
     15,
     [
@@ -453,7 +508,7 @@ test("responsive fitting preserves explicit row boundaries and fits every render
 });
 
 test("responsive fitting removes one oversized segment and preserves empty explicit rows", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   const oversized = renderPowerlineStatusline(8, [segment("model", "A VERY LONG MODEL", "header")], config);
   assert.equal(oversized, "");
 
@@ -470,7 +525,7 @@ test("responsive fitting removes one oversized segment and preserves empty expli
 });
 
 test("density and separator configure text inside a contiguous block", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.separator = "dot";
   config.density = "compact";
   assert.equal(
@@ -491,7 +546,7 @@ test("density and separator configure text inside a contiguous block", () => {
 test("all named palettes render deterministic distinct ANSI output", () => {
   const outputs = new Set<string>();
   for (const palette of ["tokyo-night", "ocean", "sunset", "forest", "candy", "neon", "mono"] as const) {
-    const config = createDefaultConfig();
+    const config = createTestConfig();
     config.palettePreset = palette;
     config.palette.model = { fg: "#ffffff", bg: "#ffffff" };
     const output = renderPowerlineStatusline(
@@ -523,7 +578,7 @@ test("named palettes use cohesive preset-specific background ramps", () => {
   ];
 
   for (const [palettePreset, colors] of Object.entries(expected)) {
-    const config = createDefaultConfig();
+    const config = createTestConfig();
     config.palettePreset = palettePreset as keyof typeof expected;
     const actual = samples.map((item) => backgroundColor(renderPowerlineStatusline(80, [item], config)));
     assert.deepEqual(actual, colors, palettePreset);
@@ -540,7 +595,7 @@ test("named palette block text meets WCAG AA contrast", () => {
   ];
 
   for (const palettePreset of ["ocean", "sunset", "forest", "candy", "neon", "mono"] as const) {
-    const config = createDefaultConfig();
+    const config = createTestConfig();
     config.palettePreset = palettePreset;
     for (const item of samples) {
       const rendered = renderPowerlineStatusline(80, [item], config);
@@ -582,7 +637,7 @@ function relativeLuminance(hex: string): number {
 }
 
 test("usage segments match native cache, context-window, and subscription presentation", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["context", "cache", "tokens", "cost"];
   const makeUsage = (input: number, output: number, cacheRead: number, cacheWrite: number, cost: number) => ({
     input,
@@ -637,7 +692,7 @@ test("usage segments match native cache, context-window, and subscription presen
 });
 
 test("empty cache activity collapses its configured row and context falls back to model window", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["model", "line_break", "cache", "line_break", "context"];
   const context = createMockContext({
     model: { id: "claude-sonnet-4", provider: "anthropic", contextWindow: 200_000 },
@@ -666,7 +721,7 @@ test("empty cache activity collapses its configured row and context falls back t
 });
 
 test("Kimi subscription cost is marked while API-key cost is unchanged", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   config.segments = ["cost"];
   const footerData: ReadonlyFooterDataProvider = {
     getGitBranch: () => null,
@@ -708,7 +763,7 @@ test("Kimi subscription cost is marked while API-key cost is unchanged", () => {
 });
 
 test("segment presentation wraps canonical dynamic values with configured text", () => {
-  const config = createDefaultConfig();
+  const config = createTestConfig();
   assert.equal(formatConfiguredSegment("provider", "anthropic", config), "🔌 anthropic");
   assert.equal(formatConfiguredSegment("session", "auth work", config), "🏷️ auth work");
   config.segmentText.provider = { prefix: "Provider[", suffix: "]" };

--- a/packages/pi-statusline/test/renderer.test.ts
+++ b/packages/pi-statusline/test/renderer.test.ts
@@ -235,6 +235,45 @@ test("cwd uses Starship repository and three-component directory defaults", () =
   assert.equal(plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)), "░▒▓ 📁 ~");
 });
 
+test("session segment shows the session name only when one is set", () => {
+  const config = createDefaultConfig();
+  config.segments = ["session"];
+  const footerData: ReadonlyFooterDataProvider = {
+    getGitBranch: () => null,
+    getExtensionStatuses: () => new Map(),
+    onBranchChange: () => () => undefined,
+    getAvailableProviderCount: () => 1,
+  };
+  const runtime: RuntimeState = {
+    turnCount: 0,
+    activeTools: new Map(),
+    isStreaming: false,
+    thinkingLevel: "off",
+    duplicateExtensions: [],
+    extensionStatusIconAliases: new Map(),
+  };
+  const context = createMockContext({
+    sessionManager: {
+      getEntries: () => [],
+      getBranch: () => [],
+      getSessionName: () => undefined,
+    },
+  });
+
+  assert.equal(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime), "");
+
+  const sessionManager = (context.ctx as { sessionManager: { getSessionName: () => string | undefined } })
+    .sessionManager;
+  sessionManager.getSessionName = () => "Refactor auth module";
+  assert.equal(
+    plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)),
+    "░▒▓ 🏷️ Refactor auth module",
+  );
+
+  sessionManager.getSessionName = () => "fix\x1b]8;;https://evil.example\x07click\x1b]8;;\x07";
+  assert.equal(plain(renderStatusline(300, context.ctx, footerData, {} as Theme, config, runtime)), "░▒▓ 🏷️ fixclick");
+});
+
 test("cwd preserves POSIX backslashes and strips terminal controls", { skip: sep !== "/" }, () => {
   const config = createDefaultConfig();
   config.segments = ["cwd"];
@@ -574,7 +613,7 @@ test("usage segments match native cache, context-window, and subscription presen
     model: { id: "gpt-5", provider: "openai", contextWindow: 272_000 },
     modelRegistry: { isUsingOAuth: () => true },
     getContextUsage: () => ({ percent: 2.4, tokens: 6528, contextWindow: 272_000 }),
-    sessionManager: { getEntries: () => entries, getBranch: () => [latest] },
+    sessionManager: { getEntries: () => entries, getBranch: () => [latest], getSessionName: () => undefined },
   });
   const footerData: ReadonlyFooterDataProvider = {
     getGitBranch: () => null,
@@ -658,6 +697,7 @@ test("Kimi subscription cost is marked while API-key cost is unchanged", () => {
       sessionManager: {
         getEntries: () => [{ type: "message", message: { role: "assistant", usage } }],
         getBranch: () => [],
+        getSessionName: () => undefined,
       },
     });
     return plain(renderStatusline(100, context.ctx, footerData, {} as Theme, config, runtime));
@@ -670,6 +710,7 @@ test("Kimi subscription cost is marked while API-key cost is unchanged", () => {
 test("segment presentation wraps canonical dynamic values with configured text", () => {
   const config = createDefaultConfig();
   assert.equal(formatConfiguredSegment("provider", "anthropic", config), "🔌 anthropic");
+  assert.equal(formatConfiguredSegment("session", "auth work", config), "🏷️ auth work");
   config.segmentText.provider = { prefix: "Provider[", suffix: "]" };
   assert.equal(formatConfiguredSegment("provider", "anthropic", config), "Provider[anthropic]");
   config.segmentText.cost = { prefix: "cost=", suffix: " USD" };

--- a/packages/pi-statusline/test/settings.test.ts
+++ b/packages/pi-statusline/test/settings.test.ts
@@ -25,15 +25,8 @@ test("initial JSON exposes active defaults without materializing an inactive pal
   });
   assert.equal(DEFAULT_STATUSLINE_CONFIG.density, "compact");
   assert.equal(DEFAULT_STATUSLINE_CONFIG.separator, "none");
-  assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.segments, [
-    "model",
-    "thinking",
-    "cwd",
-    "branch",
-    "tools",
-    "context",
-    "time",
-  ]);
+  assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.segments, ["thinking", "cwd", "branch", "tools", "context", "time"]);
+  assert.deepEqual(DEFAULT_STATUSLINE_CONFIG.rightSegments, ["session", "provider", "model"]);
   assert.equal(DEFAULT_STATUSLINE_CONFIG.segmentText.provider.prefix, "🔌 ");
   assert.equal(DEFAULT_STATUSLINE_CONFIG.segmentText.cache.prefix, "📦 ");
   assert.equal(DEFAULT_STATUSLINE_CONFIG.segmentText.turn.prefix, "🔁 #");
@@ -49,7 +42,8 @@ test("initial JSON exposes active defaults without materializing an inactive pal
     palettePreset: "tokyo-night",
     density: "compact",
     separator: "none",
-    segments: ["model", "thinking", "cwd", "branch", "tools", "context", "time"],
+    segments: ["thinking", "cwd", "branch", "tools", "context", "time"],
+    rightSegments: ["session", "provider", "model"],
     segmentText: DEFAULT_STATUSLINE_CONFIG.segmentText,
     extensionStatusIcons: {
       accounts: "👤",

--- a/packages/pi-statusline/test/statusline.test.ts
+++ b/packages/pi-statusline/test/statusline.test.ts
@@ -229,7 +229,7 @@ test("statusline renders max thinking in the Tokyo Night footer", async () => {
   }
 });
 
-test("balanced default renders the model without a separate provider segment", async () => {
+test("balanced default renders provider and model in the flush-right column", async () => {
   const mock = createMockPi();
   statusline(mock.pi);
   const context = createMockContext({
@@ -263,8 +263,9 @@ test("balanced default renders the model without a separate provider segment", a
   );
 
   const line = footer.render(200)[0] ?? "";
-  assert.doesNotMatch(line, /🔌 anthropic/);
+  assert.match(line, /🔌 anthropic/);
   assert.match(line, /🤖 sonnet-4/);
+  assert.match(line, /🔌 anthropic 🤖 sonnet-4[^░▒▓]*$/u);
   footer.dispose();
 });
 


### PR DESCRIPTION
## Summary

Two related additions to the pi-statusline powerline footer.

### 1. `session` segment

- Shows the current Pi session name (set via `/name`, read from `ctx.sessionManager.getSessionName()`) with a `🏷️` prefix in the directory color block. Terminal control sequences in the name are stripped at render time.
- Stays hidden until the session is named and follows renames immediately by re-rendering on `session_info_changed`.
- Joins `SEGMENT_NAMES` with retention priority between `cwd` and `thinking`; not added to any information level preset, so existing defaults are unchanged.

### 2. `rightSegments` column

- New optional settings field renders beside `segments` on rows paired by index, flush against the right edge with elastic spacing between the columns.
- Responsive fitting becomes cross-column: the globally lowest-priority segment across both columns is dropped first (`SEGMENT_RETENTION_PRIORITY` is now exported), so a right column can never push a higher-priority left segment such as `context` off a narrow row.
- Information levels become two-column layouts: balanced and detailed place `session provider model` in the right column; minimal keeps its four segments with `model` moved to the right.
- Backward compatibility: an explicit `segments` field without `rightSegments` keeps the right column empty (existing documents render exactly as before); writing only `rightSegments` prunes default left duplicates; writing both reports cross-column duplicates as diagnostics.
- The Custom layout menu marks right-column segments (`· right`), and moves and line breaks apply within the owning column; Status and Help cover the new field.

## Documentation

README layout example, information-level table, and responsive-fitting section are updated; `docs/configuration.md` documents the `rightSegments` field, cross-column uniqueness, and row pairing rules. A changeset is included for each feature.

## Testing

- New renderer coverage: unnamed session hides the segment, unsafe names are sanitized, right column padding, narrow-width global fitting, unnamed session hiding in the right column.
- Updated segment-count, information-picker, and default-config assertions; the full package suite passes (143 tests) along with workspace typecheck and Biome.

Feedback welcome — happy to split this into two PRs (the first commit is independent) or adjust the defaults if you prefer a different two-column presentation.