### PR TITLE
fix(pi-usage): accept kimi-coding responses that omit counters when quota is untouched

### DIFF
--- a/.changeset/kimi-coding-untouched-counters.md
+++ b/.changeset/kimi-coding-untouched-counters.md
@@ -1,0 +1,5 @@
+---
+"@narumitw/pi-usage": patch
+---
+
+Accept Kimi Coding usage responses that omit `used`/`remaining` counters when the quota is untouched, deriving missing counters from `limit` instead of reporting usage as unavailable.

--- a/packages/pi-usage/docs/providers.md
+++ b/packages/pi-usage/docs/providers.md
@@ -54,7 +54,8 @@ The extension queries the fixed usage endpoint only when both the selected model
 Custom and proxy origins fail before network access, redirects are rejected, and the credential is never sent to an override from Kimi Code's environment-specific development path.
 
 Plan buckets remain integer request counts and are rendered with their source-defined windows.
-Unknown units, duplicate windows, missing counts, invalid timestamps, and malformed rows remain unavailable rather than receiving guessed semantics.
+Live responses omit both `used` and `remaining` on untouched rows and may report only `remaining` once usage starts, so a row with a positive `limit` and no counters means zero usage, and when only one counter is present the other is derived from `limit`.
+Counters that are present but malformed, unknown units, duplicate windows, invalid timestamps, and malformed rows remain unavailable rather than receiving guessed semantics.
 Booster-wallet `amount` and `amountLeft` values use Kimi's first-party conversion of 1,000,000 fixed-point units per cent, while monthly values already arrive in cents.
 Wallet values retain their currency and stay separate from plan requests and percentages in reports and the statusline.
 Wallet fields remain unavailable unless the response supplies one consistent currency; missing monthly values are omitted, and an enabled zero cap is shown as zero.

--- a/packages/pi-usage/src/providers/kimi-coding.ts
+++ b/packages/pi-usage/src/providers/kimi-coding.ts
@@ -15,6 +15,9 @@ const FIXED_POINT_UNITS_PER_CENT = 1_000_000;
  * Kimi Code 676e4d82240855044fe809fea89ce1dbe8e512cf defines `GET /coding/v1/usages`,
  * numeric-string plan rows, proto-style windows, and 1,000,000 fixed-point units per cent:
  * https://github.com/MoonshotAI/kimi-code/blob/676e4d82240855044fe809fea89ce1dbe8e512cf/packages/oauth/src/managed-usage.ts
+ * Live responses observed on 2026-09-12 omit both `used` and `remaining` on untouched rows and may report only
+ * `remaining` once usage starts, so a row with a positive `limit` and no counters means zero usage, and when only
+ * one counter is present the other is derived from `limit`. Counters that are present but malformed stay rejected.
  */
 export function normalizeKimiCodingUsagePayload(payload: KimiCodingUsagePayload, capturedAt: number): UsageReport {
   const root = asObject(payload);
@@ -74,15 +77,26 @@ export function normalizeKimiCodingUsagePayload(payload: KimiCodingUsagePayload,
 function parseUsageRow(value: unknown, windowMinutes: number, label: string): UsageBucket | undefined {
   const row = asObject(value);
   if (!row) return undefined;
-  const used = asNonnegativeInteger(row.used);
   const limit = asNonnegativeInteger(row.limit);
-  if (used === undefined || limit === undefined || limit === 0) return undefined;
+  if (limit === undefined || limit === 0) return undefined;
+  const usedRaw = asNonnegativeInteger(row.used);
+  const remainingRaw = asNonnegativeInteger(row.remaining);
+  // Counters that are present but malformed reject the row instead of silently inventing a count.
+  if (
+    (row.used !== undefined && usedRaw === undefined) ||
+    (row.remaining !== undefined && remainingRaw === undefined)
+  ) {
+    return undefined;
+  }
+  // Live responses omit both counters on untouched rows, so a bare `limit` means zero usage.
+  const used = usedRaw ?? (remainingRaw === undefined ? 0 : Math.max(0, limit - remainingRaw));
+  const remaining = remainingRaw ?? Math.max(0, limit - used);
   const resetsAt = asIsoEpochSeconds(row.resetTime);
   return {
     id: windowId(windowMinutes),
     label,
     used,
-    remaining: Math.max(0, limit - used),
+    remaining,
     limit,
     unit: "count",
     windowMinutes,

--- a/packages/pi-usage/test/fixtures/kimi-coding-malformed.json
+++ b/packages/pi-usage/test/fixtures/kimi-coding-malformed.json
@@ -51,7 +51,7 @@
       }
     },
     {
-      "name": "missing-used",
+      "name": "limit-only",
       "window": {
         "duration": 7,
         "timeUnit": "TIME_UNIT_DAY"

--- a/packages/pi-usage/test/fixtures/kimi-coding-remaining-only.json
+++ b/packages/pi-usage/test/fixtures/kimi-coding-remaining-only.json
@@ -1,0 +1,76 @@
+{
+  "user": {
+    "userId": "<uid>",
+    "region": "REGION_CN",
+    "membership": {
+      "level": "LEVEL_INTERMEDIATE"
+    },
+    "businessId": ""
+  },
+  "usage": {
+    "limit": "100",
+    "remaining": "100",
+    "resetTime": "2026-09-19T12:43:48.701124Z"
+  },
+  "limits": [
+    {
+      "window": {
+        "duration": 300,
+        "timeUnit": "TIME_UNIT_MINUTE"
+      },
+      "detail": {
+        "limit": "100",
+        "used": "2",
+        "remaining": "98",
+        "resetTime": "2026-09-12T16:43:48.701124Z"
+      }
+    }
+  ],
+  "parallel": {
+    "limit": "20"
+  },
+  "totalQuota": {},
+  "subType": "TYPE_PURCHASE",
+  "boosterWallet": {
+    "id": "<uuid>",
+    "userId": "<uid>",
+    "balance": {
+      "id": "<uuid>",
+      "feature": "FEATURE_OMNI",
+      "type": "BOOSTER",
+      "unit": "UNIT_CURRENCY",
+      "periodStart": "2026-07-13T08:00:04.688184Z",
+      "periodEnd": "2126-07-13T08:00:05.688184Z",
+      "subscriptionId": "<uuid>",
+      "userId": "<uid>",
+      "createTime": "2026-07-13T08:00:05.688184Z",
+      "updateTime": "2026-07-13T08:00:05.688184Z"
+    },
+    "status": "STATUS_DISABLED",
+    "allowTopup": true,
+    "topupLimit": {
+      "currency": "CNY",
+      "priceInCents": "300000"
+    },
+    "autoRefillCharge": {
+      "currency": "CNY",
+      "priceInCents": "0"
+    },
+    "autoRefillThreshold": {
+      "currency": "CNY",
+      "priceInCents": "0"
+    },
+    "monthlyChargeLimit": {
+      "currency": "CNY",
+      "priceInCents": "10000"
+    },
+    "monthlyUsed": {
+      "currency": "CNY",
+      "priceInCents": "0"
+    },
+    "createdAt": "2026-07-13T08:00:05.688184Z",
+    "updatedAt": "2026-09-04T14:21:59.493659Z"
+  },
+  "domain": "DOMAIN_NEXUS",
+  "version": "GOODS_VERSION_V1"
+}

--- a/packages/pi-usage/test/kimi-coding.test.ts
+++ b/packages/pi-usage/test/kimi-coding.test.ts
@@ -48,7 +48,7 @@ function combinedPlanFixture(): KimiCodingUsagePayload {
 }
 
 test("Kimi fixtures are sanitized and contain no credential or account fields", () => {
-  for (const name of ["weekly", "five-hour", "daily", "malformed", "booster-wallet", "empty"]) {
+  for (const name of ["weekly", "five-hour", "daily", "malformed", "booster-wallet", "remaining-only", "empty"]) {
     const text = readFileSync(new URL(`./fixtures/kimi-coding-${name}.json`, import.meta.url), "utf8");
     assert.doesNotMatch(text, /authorization|access_token|refresh_token|api[_-]?key|email/iu);
   }
@@ -105,16 +105,26 @@ test("Kimi adapter normalizes weekly, five-hour, and daily numeric-string window
 
 test("Kimi adapter omits malformed, duplicate, unknown, and unsafe window fields", () => {
   const report = normalizeKimiCodingUsagePayload(fixture("malformed"), 700);
-  assert.equal(report.buckets.length, 1);
-  assert.deepEqual(report.buckets[0], {
-    id: "daily",
-    label: "Daily cap",
-    used: 5,
-    remaining: 95,
-    limit: 100,
-    unit: "count",
-    windowMinutes: 1_440,
-  });
+  assert.deepEqual(report.buckets, [
+    {
+      id: "daily",
+      label: "Daily cap",
+      used: 5,
+      remaining: 95,
+      limit: 100,
+      unit: "count",
+      windowMinutes: 1_440,
+    },
+    {
+      id: "weekly",
+      label: "limit-only",
+      used: 0,
+      remaining: 100,
+      limit: 100,
+      unit: "count",
+      windowMinutes: 10_080,
+    },
+  ]);
   assert.deepEqual(report.notes, ["Unsupported, malformed, or duplicate plan windows were unavailable."]);
   const rendered = formatUsageReport(report, "current");
   assert.equal(rendered.includes(TERMINAL_ESCAPE), false);
@@ -131,6 +141,56 @@ test("Kimi adapter omits malformed, duplicate, unknown, and unsafe window fields
   const detail = impossibleTimestamp.limits?.[0]?.detail as Record<string, unknown> | undefined;
   if (detail) detail.resetTime = "2030-02-30T00:00:00Z";
   assert.equal(normalizeKimiCodingUsagePayload(impossibleTimestamp, 850).buckets[0]?.resetsAt, undefined);
+});
+
+test("Kimi adapter derives missing counters from limit on remaining-only and untouched rows", () => {
+  const report = normalizeKimiCodingUsagePayload(fixture("remaining-only"), 550);
+  assert.deepEqual(report.buckets, [
+    {
+      id: "five-hour",
+      label: "5h window",
+      used: 2,
+      remaining: 98,
+      limit: 100,
+      unit: "count",
+      windowMinutes: 300,
+      resetsAt: 1_789_231_428,
+    },
+    {
+      id: "weekly",
+      label: "Weekly window",
+      used: 0,
+      remaining: 100,
+      limit: 100,
+      unit: "count",
+      windowMinutes: 10_080,
+      resetsAt: 1_789_821_828,
+    },
+  ]);
+  assert.equal(report.notes, undefined);
+  assert.equal(formatUsageStatusline(report), "kimi 98% 5h 100% wk");
+  assert.match(formatUsageReport(report, "current"), /0 of 100 used · 100% left/);
+
+  // The disabled booster wallet in the live response carries no balance amounts, so no metrics are invented.
+  assert.deepEqual(report.metrics, []);
+
+  // A row with a bare `limit` and no counters is untouched: zero used, everything remaining.
+  const untouched = normalizeKimiCodingUsagePayload(
+    { usage: { limit: "100", resetTime: "2026-09-19T12:43:48.701124Z" } },
+    0,
+  );
+  assert.deepEqual(untouched.buckets, [
+    {
+      id: "weekly",
+      label: "Weekly window",
+      used: 0,
+      remaining: 100,
+      limit: 100,
+      unit: "count",
+      windowMinutes: 10_080,
+      resetsAt: 1_789_821_828,
+    },
+  ]);
 });
 
 test("Kimi adapter keeps booster-wallet currency separate from plan counts", () => {
@@ -247,7 +307,7 @@ test("Kimi booster wallet preserves first-party minimum cents and unlimited mont
   assert.match(formatUsageReport(report, "current"), /Balance:\s+¥0\.00 of ¥0\.01/);
 });
 
-test("Kimi adapter rejects empty data and never invents missing counts or future units", () => {
+test("Kimi adapter rejects empty data, malformed counters, and future units", () => {
   assert.throws(() => normalizeKimiCodingUsagePayload(fixture("empty"), 0), /no displayable usage data/iu);
   assert.throws(
     () =>
@@ -264,7 +324,11 @@ test("Kimi adapter rejects empty data and never invents missing counts or future
       ),
     /no displayable usage data/iu,
   );
-  assert.throws(() => normalizeKimiCodingUsagePayload({ usage: { limit: "10" } }, 0), /no displayable usage data/iu);
+  // A counter that is present but malformed still rejects the row instead of silently inventing a count.
+  assert.throws(
+    () => normalizeKimiCodingUsagePayload({ usage: { limit: "10", used: "1,000" } }, 0),
+    /no displayable usage data/iu,
+  );
 });
 
 test("Kimi runtime auth accepts fresh OAuth and API-key bearers only at the official origin", async () => {


### PR DESCRIPTION
## Summary

   Fix Kimi Coding usage parsing when the plan quota is untouched. Live responses
   observed on 2026-09-12 omit the `used`/`remaining` counters on rows with zero
   consumption, and may report only `remaining` once usage starts. Previously
   `parseUsageRow` required `used`, so a fresh/unused account's payload had no
   parseable rows and the extension reported usage as unavailable.

   Related issue: #1297.

   ## Root cause

   `parseUsageRow` rejected any row without a valid `used` counter, but the server
   only includes counters after consumption begins:

   - Untouched row: `{ "limit": "100", "resetTime": "…" }` (both counters absent)
   - After usage: `{ "limit": "100", "used": "2", "remaining": "98", "resetTime": "…" }`
   - Transitional: only `remaining` present

   ## Changes

   - `packages/pi-usage/src/providers/kimi-coding.ts`
     - A row with a positive `limit` and no counters is treated as untouched:
       `used = 0`, `remaining = limit`.
     - When only one counter is present, the other is derived from `limit`.
     - Counters that are **present but malformed** (e.g. `"used": "1,000"`) still
       reject the row instead of silently inventing a count, preserving the
       "unavailable rather than guessed" semantics.
   - Tests
     - New fixture `kimi-coding-remaining-only.json` from a sanitized live
       response (covers remaining-only row + disabled booster wallet without
       balance amounts).
     - Malformed fixture's `missing-used` entry renamed to `limit-only` and now
       asserted to parse as an untouched bucket.
     - Inline case: bare-`limit` summary row parses as 0/limit; malformed counter
       (`"1,000"`) still throws.
   - Docs: `docs/providers.md` updated with the new counter-derivation semantics.

   ## Verification

   - `npx vitest run packages/pi-usage/test/kimi-coding.test.ts` — 12/12 passed
   - `npx biome check packages/pi-usage` — clean
   - `tsc -p packages/pi-usage/tsconfig.json --noEmit` — clean
   - Root `npm run check` was not fully green before this change: `pi-lsp` has a
     pre-existing Biome formatting error on committed code (unrelated, untouched
     by this PR).